### PR TITLE
fix: sync schema.sql with migrations 003-008

### DIFF
--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -13,6 +13,9 @@ CREATE TABLE IF NOT EXISTS friends (
   is_following     INTEGER NOT NULL DEFAULT 1,
   user_id          TEXT,
   score            INTEGER NOT NULL DEFAULT 0,
+  ref_code         TEXT,                                                          -- 003
+  metadata         TEXT NOT NULL DEFAULT '{}',                                    -- 004
+  line_account_id  TEXT REFERENCES line_accounts(id),                             -- 008
   created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   updated_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
@@ -52,6 +55,7 @@ CREATE TABLE IF NOT EXISTS scenarios (
   trigger_type    TEXT NOT NULL CHECK (trigger_type IN ('friend_add', 'tag_added', 'manual')),
   trigger_tag_id  TEXT REFERENCES tags (id) ON DELETE SET NULL,
   is_active       INTEGER NOT NULL DEFAULT 1,
+  line_account_id TEXT,                                                           -- 008
   created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
@@ -60,13 +64,16 @@ CREATE TABLE IF NOT EXISTS scenarios (
 -- Scenario Steps
 -- ============================================================
 CREATE TABLE IF NOT EXISTS scenario_steps (
-  id              TEXT PRIMARY KEY,
-  scenario_id     TEXT NOT NULL REFERENCES scenarios (id) ON DELETE CASCADE,
-  step_order      INTEGER NOT NULL,
-  delay_minutes   INTEGER NOT NULL DEFAULT 0,
-  message_type    TEXT NOT NULL CHECK (message_type IN ('text', 'image', 'flex')),
-  message_content TEXT NOT NULL,
-  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  id                TEXT PRIMARY KEY,
+  scenario_id       TEXT NOT NULL REFERENCES scenarios (id) ON DELETE CASCADE,
+  step_order        INTEGER NOT NULL,
+  delay_minutes     INTEGER NOT NULL DEFAULT 0,
+  message_type      TEXT NOT NULL CHECK (message_type IN ('text', 'image', 'flex')),
+  message_content   TEXT NOT NULL,
+  condition_type    TEXT,                                                          -- 005
+  condition_value   TEXT,                                                          -- 005
+  next_step_on_false INTEGER,                                                     -- 005
+  created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   UNIQUE (scenario_id, step_order)
 );
 
@@ -105,6 +112,7 @@ CREATE TABLE IF NOT EXISTS broadcasts (
   sent_at         TEXT,
   total_count     INTEGER NOT NULL DEFAULT 0,
   success_count   INTEGER NOT NULL DEFAULT 0,
+  line_account_id TEXT,                                                           -- 008
   created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
 
@@ -137,6 +145,7 @@ CREATE TABLE IF NOT EXISTS auto_replies (
   response_type    TEXT NOT NULL DEFAULT 'text',
   response_content TEXT NOT NULL,
   is_active        INTEGER NOT NULL DEFAULT 1,
+  line_account_id  TEXT,                                                          -- 008
   created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
 
@@ -177,6 +186,9 @@ CREATE TABLE IF NOT EXISTS line_accounts (
   channel_access_token TEXT NOT NULL,
   channel_secret       TEXT NOT NULL,
   is_active            INTEGER NOT NULL DEFAULT 1,
+  login_channel_id     TEXT,                                                      -- 008
+  login_channel_secret TEXT,                                                      -- 008
+  liff_id              TEXT,                                                      -- 008
   created_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   updated_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
@@ -294,12 +306,13 @@ CREATE INDEX IF NOT EXISTS idx_calendar_bookings_start ON calendar_bookings (sta
 -- Round 3: リマインダ配信
 -- ============================================================
 CREATE TABLE IF NOT EXISTS reminders (
-  id          TEXT PRIMARY KEY,
-  name        TEXT NOT NULL,
-  description TEXT,
-  is_active   INTEGER NOT NULL DEFAULT 1,
-  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
-  updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+  id              TEXT PRIMARY KEY,
+  name            TEXT NOT NULL,
+  description     TEXT,
+  is_active       INTEGER NOT NULL DEFAULT 1,
+  line_account_id TEXT,                                                           -- 008
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
 
 CREATE TABLE IF NOT EXISTS reminder_steps (
@@ -388,14 +401,15 @@ CREATE TABLE IF NOT EXISTS operators (
 );
 
 CREATE TABLE IF NOT EXISTS chats (
-  id            TEXT PRIMARY KEY,
-  friend_id     TEXT NOT NULL REFERENCES friends (id) ON DELETE CASCADE,
-  operator_id   TEXT REFERENCES operators (id) ON DELETE SET NULL,
-  status        TEXT NOT NULL DEFAULT 'unread' CHECK (status IN ('unread', 'in_progress', 'resolved')),
-  notes         TEXT,
+  id              TEXT PRIMARY KEY,
+  friend_id       TEXT NOT NULL REFERENCES friends (id) ON DELETE CASCADE,
+  operator_id     TEXT REFERENCES operators (id) ON DELETE SET NULL,
+  status          TEXT NOT NULL DEFAULT 'unread' CHECK (status IN ('unread', 'in_progress', 'resolved')),
+  notes           TEXT,
   last_message_at TEXT,
-  created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
-  updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+  line_account_id TEXT,                                                           -- 008
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_chats_friend ON chats (friend_id);
@@ -478,16 +492,17 @@ CREATE TABLE IF NOT EXISTS account_migrations (
 -- Round 3: アクション自動化
 -- ============================================================
 CREATE TABLE IF NOT EXISTS automations (
-  id          TEXT PRIMARY KEY,
-  name        TEXT NOT NULL,
-  description TEXT,
-  event_type  TEXT NOT NULL,
-  conditions  TEXT NOT NULL DEFAULT '{}',
-  actions     TEXT NOT NULL DEFAULT '[]',
-  is_active   INTEGER NOT NULL DEFAULT 1,
-  priority    INTEGER NOT NULL DEFAULT 0,
-  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
-  updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+  id              TEXT PRIMARY KEY,
+  name            TEXT NOT NULL,
+  description     TEXT,
+  event_type      TEXT NOT NULL,
+  conditions      TEXT NOT NULL DEFAULT '{}',
+  actions         TEXT NOT NULL DEFAULT '[]',
+  is_active       INTEGER NOT NULL DEFAULT 1,
+  priority        INTEGER NOT NULL DEFAULT 0,
+  line_account_id TEXT,                                                           -- 008
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_automations_event ON automations (event_type);
@@ -504,3 +519,85 @@ CREATE TABLE IF NOT EXISTS automation_logs (
 );
 
 CREATE INDEX IF NOT EXISTS idx_automation_logs_automation ON automation_logs (automation_id);
+
+-- ============================================================
+-- Round 3.5: Entry Routes (ref code tracking)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS entry_routes (
+  id           TEXT PRIMARY KEY,
+  ref_code     TEXT UNIQUE NOT NULL,
+  name         TEXT NOT NULL,
+  tag_id       TEXT REFERENCES tags (id) ON DELETE SET NULL,
+  scenario_id  TEXT REFERENCES scenarios (id) ON DELETE SET NULL,
+  redirect_url TEXT,
+  is_active    INTEGER NOT NULL DEFAULT 1,
+  created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_entry_routes_ref ON entry_routes (ref_code);
+
+CREATE TABLE IF NOT EXISTS ref_tracking (
+  id             TEXT PRIMARY KEY,
+  ref_code       TEXT NOT NULL,
+  friend_id      TEXT REFERENCES friends (id) ON DELETE CASCADE,
+  entry_route_id TEXT REFERENCES entry_routes (id) ON DELETE SET NULL,
+  source_url     TEXT,
+  created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ref_tracking_ref ON ref_tracking (ref_code);
+CREATE INDEX IF NOT EXISTS idx_ref_tracking_friend ON ref_tracking (friend_id);
+
+-- ============================================================
+-- Round 3.5: Tracked Links
+-- ============================================================
+CREATE TABLE IF NOT EXISTS tracked_links (
+  id           TEXT PRIMARY KEY,
+  name         TEXT NOT NULL,
+  original_url TEXT NOT NULL,
+  tag_id       TEXT REFERENCES tags (id) ON DELETE SET NULL,
+  scenario_id  TEXT REFERENCES scenarios (id) ON DELETE SET NULL,
+  is_active    INTEGER NOT NULL DEFAULT 1,
+  click_count  INTEGER NOT NULL DEFAULT 0,
+  created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+);
+
+CREATE TABLE IF NOT EXISTS link_clicks (
+  id              TEXT PRIMARY KEY,
+  tracked_link_id TEXT NOT NULL REFERENCES tracked_links (id) ON DELETE CASCADE,
+  friend_id       TEXT REFERENCES friends (id) ON DELETE SET NULL,
+  clicked_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_link_clicks_link ON link_clicks (tracked_link_id);
+CREATE INDEX IF NOT EXISTS idx_link_clicks_friend ON link_clicks (friend_id);
+
+-- ============================================================
+-- Round 3.5: LIFF Forms
+-- ============================================================
+CREATE TABLE IF NOT EXISTS forms (
+  id                    TEXT PRIMARY KEY,
+  name                  TEXT NOT NULL,
+  description           TEXT,
+  fields                TEXT NOT NULL DEFAULT '[]',
+  on_submit_tag_id      TEXT REFERENCES tags (id) ON DELETE SET NULL,
+  on_submit_scenario_id TEXT REFERENCES scenarios (id) ON DELETE SET NULL,
+  save_to_metadata      INTEGER NOT NULL DEFAULT 1,
+  is_active             INTEGER NOT NULL DEFAULT 1,
+  submit_count          INTEGER NOT NULL DEFAULT 0,
+  created_at            TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at            TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+);
+
+CREATE TABLE IF NOT EXISTS form_submissions (
+  id        TEXT PRIMARY KEY,
+  form_id   TEXT NOT NULL REFERENCES forms (id) ON DELETE CASCADE,
+  friend_id TEXT REFERENCES friends (id) ON DELETE SET NULL,
+  data      TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_form_submissions_form ON form_submissions (form_id);
+CREATE INDEX IF NOT EXISTS idx_form_submissions_friend ON form_submissions (friend_id);


### PR DESCRIPTION
## Summary

`schema.sql` was out of sync with migrations 003–008. A fresh deployment using only `schema.sql` (without running migrations) would be missing columns and tables that the application code depends on, causing 500 errors.

### Changes

**New columns added to existing tables:**
- `friends`: `ref_code` (003), `metadata` (004), `line_account_id` (008)
- `scenario_steps`: `condition_type`, `condition_value`, `next_step_on_false` (005)
- `scenarios`, `broadcasts`, `reminders`, `automations`, `chats`, `auto_replies`: `line_account_id` (008)
- `line_accounts`: `login_channel_id`, `login_channel_secret`, `liff_id` (008)

**New tables:**
- `entry_routes` + `ref_tracking` (003)
- `tracked_links` + `link_clicks` (006)
- `forms` + `form_submissions` (007)

### How I found this

Deployed a fresh D1 database using only `schema.sql`, then hit 500 errors on scenario step creation and `/api/line-accounts` stats aggregation. Traced back to missing columns that the Worker code references.

### Testing

- Verified the updated `schema.sql` creates all tables successfully on a clean D1 instance
- Confirmed column definitions match the corresponding migration files exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)