### PR TITLE
feat: auto-refresh LINE channel access tokens before expiry

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,6 +6,7 @@ import { processStepDeliveries } from './services/step-delivery.js';
 import { processScheduledBroadcasts } from './services/broadcast.js';
 import { processReminderDeliveries } from './services/reminder-delivery.js';
 import { checkAccountHealth } from './services/ban-monitor.js';
+import { refreshLineAccessTokens } from './services/token-refresh.js';
 import { authMiddleware } from './middleware/auth.js';
 import { webhook } from './routes/webhook.js';
 import { friends } from './routes/friends.js';
@@ -151,6 +152,7 @@ async function scheduled(
     );
   }
   jobs.push(checkAccountHealth(env.DB));
+  jobs.push(refreshLineAccessTokens(env.DB));
 
   await Promise.allSettled(jobs);
 }

--- a/apps/worker/src/services/token-refresh.ts
+++ b/apps/worker/src/services/token-refresh.ts
@@ -1,0 +1,80 @@
+/**
+ * Token auto-refresh — proactively renew LINE channel access tokens before expiry.
+ *
+ * LINE's stateless token API uses client_credentials grant:
+ * POST channel_id + channel_secret → new access_token (30 days).
+ * No refresh_token needed.
+ *
+ * Runs every cron cycle (5 min). Only refreshes when:
+ * - token_expires_at is within 7 days, OR
+ * - token_expires_at is NULL (legacy, unknown expiry — refresh once to start tracking)
+ */
+
+import { getLineAccounts, updateLineAccount } from '@line-crm/db';
+import type { LineAccount } from '@line-crm/db';
+
+const REFRESH_THRESHOLD_MS = 7 * 24 * 60 * 60_000; // 7 days
+const JST_OFFSET_MS = 9 * 60 * 60_000;
+
+function jstNow(): string {
+  const jst = new Date(Date.now() + JST_OFFSET_MS);
+  return jst.toISOString().slice(0, -1) + '+09:00';
+}
+
+function shouldRefresh(account: LineAccount): boolean {
+  if (!account.token_expires_at) return true; // unknown expiry
+  const expiresAt = new Date(account.token_expires_at).getTime();
+  return expiresAt - Date.now() < REFRESH_THRESHOLD_MS;
+}
+
+interface TokenResponse {
+  access_token: string;
+  expires_in: number; // seconds
+  token_type: string;
+}
+
+async function issueNewToken(
+  channelId: string,
+  channelSecret: string,
+): Promise<TokenResponse> {
+  const res = await fetch('https://api.line.me/v2/oauth/accessToken', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: channelId,
+      client_secret: channelSecret,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`LINE token API ${res.status}: ${body}`);
+  }
+
+  return res.json() as Promise<TokenResponse>;
+}
+
+export async function refreshLineAccessTokens(db: D1Database): Promise<void> {
+  const accounts = await getLineAccounts(db);
+
+  for (const account of accounts) {
+    if (!account.is_active) continue;
+    if (!shouldRefresh(account)) continue;
+
+    try {
+      const token = await issueNewToken(account.channel_id, account.channel_secret);
+      const expiresAt = new Date(Date.now() + token.expires_in * 1000 + JST_OFFSET_MS);
+      const expiresAtJst = expiresAt.toISOString().slice(0, -1) + '+09:00';
+
+      await updateLineAccount(db, account.id, {
+        channel_access_token: token.access_token,
+        token_expires_at: expiresAtJst,
+      });
+
+      console.log(`🔄 Token refreshed: ${account.name} (expires ${expiresAtJst})`);
+    } catch (err) {
+      console.error(`❌ Token refresh failed for ${account.name}:`, err);
+    }
+  }
+}

--- a/packages/db/migrations/009_token_expiry.sql
+++ b/packages/db/migrations/009_token_expiry.sql
@@ -1,0 +1,6 @@
+-- Migration 009: Track token expiration for auto-refresh
+-- Run: wrangler d1 execute line-crm --file=packages/db/migrations/009_token_expiry.sql --remote
+
+ALTER TABLE line_accounts ADD COLUMN token_expires_at TEXT;
+-- ISO8601 timestamp (JST). NULL = unknown expiry (legacy tokens).
+-- Auto-refresh service will populate this on next refresh cycle.

--- a/packages/db/src/line-accounts.ts
+++ b/packages/db/src/line-accounts.ts
@@ -13,6 +13,7 @@ export interface LineAccount {
   login_channel_secret: string | null;
   liff_id: string | null;
   is_active: number;
+  token_expires_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -70,7 +71,7 @@ export async function getLineAccountByChannelId(
 }
 
 export type UpdateLineAccountInput = Partial<
-  Pick<LineAccount, 'name' | 'channel_access_token' | 'channel_secret' | 'is_active'>
+  Pick<LineAccount, 'name' | 'channel_access_token' | 'channel_secret' | 'is_active' | 'token_expires_at'>
 >;
 
 export async function updateLineAccount(
@@ -96,6 +97,10 @@ export async function updateLineAccount(
   if (updates.is_active !== undefined) {
     fields.push('is_active = ?');
     values.push(updates.is_active);
+  }
+  if (updates.token_expires_at !== undefined) {
+    fields.push('token_expires_at = ?');
+    values.push(updates.token_expires_at);
   }
 
   if (fields.length === 0) return getLineAccountById(db, id);


### PR DESCRIPTION
## Summary

LINE channel access tokens expire after 30 days. Currently there's no refresh mechanism, so all operations (step delivery, broadcasts, reminders, webhooks) silently fail when the token expires. This adds proactive auto-refresh.

### How it works

- Runs alongside existing cron jobs (every 5 minutes)
- Checks `token_expires_at` for each active account
- Refreshes when **< 7 days** until expiry (or NULL for legacy tokens)
- Uses LINE's `client_credentials` grant — no refresh_token needed, just `channel_id` + `channel_secret` (already stored in DB)
- Updates `channel_access_token` and `token_expires_at` in the database

### Changes

| File | Change |
|------|--------|
| `packages/db/migrations/009_token_expiry.sql` | Add `token_expires_at` column to `line_accounts` |
| `packages/db/src/line-accounts.ts` | Add `token_expires_at` to interface + update function |
| `apps/worker/src/services/token-refresh.ts` | New service: refresh logic + LINE API call |
| `apps/worker/src/index.ts` | Hook `refreshLineAccessTokens()` into `scheduled()` |

### Testing

- Verified wrangler dry-run build succeeds (368 KiB)
- Token refresh is non-blocking (uses `Promise.allSettled` with other jobs)
- Errors are logged but don't affect other scheduled operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)