### PR TITLE
feat: support {{message}} variable in set_metadata action

### DIFF
--- a/apps/worker/src/services/event-bus.ts
+++ b/apps/worker/src/services/event-bus.ts
@@ -327,7 +327,11 @@ async function executeAction(
         .bind(friendId)
         .first<{ metadata: string }>();
       const current = JSON.parse(existing?.metadata || '{}') as Record<string, unknown>;
-      const patch = JSON.parse(action.params.data || '{}') as Record<string, unknown>;
+      // {{message}} を受信メッセージ内容に置換してからパース
+      // JSON文字列内に埋め込むため、ダブルクォートとバックスラッシュをエスケープ
+      const raw = (action.params.data || '{}')
+        .replace(/\{\{message\}\}/g, (payload.eventData?.text || '').replace(/[\\\"]/g, '\\$&'));
+      const patch = JSON.parse(raw) as Record<string, unknown>;
       const merged = { ...current, ...patch };
       await db
         .prepare('UPDATE friends SET metadata = ?, updated_at = ? WHERE id = ?')


### PR DESCRIPTION
Replace {{message}} placeholder with the received message text before JSON.parse in set_metadata action. Includes escaping for double quotes and backslashes to prevent JSON injection.