### PR TITLE
友だち一覧から選択した人への一斉配信機能

### DIFF
--- a/apps/web/src/app/friends/page.tsx
+++ b/apps/web/src/app/friends/page.tsx
@@ -3,10 +3,11 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { Tag } from '@line-crm/shared'
 import { api } from '@/lib/api'
-import type { FriendWithTags } from '@/lib/api'
+import type { FriendWithTags, ApiBroadcast } from '@/lib/api'
 import Header from '@/components/layout/header'
 import FriendTable from '@/components/friends/friend-table'
 import CcPromptButton from '@/components/cc-prompt-button'
+import FlexPreviewComponent from '@/components/flex-preview'
 import { useAccount } from '@/contexts/account-context'
 
 const ccPrompts = [
@@ -40,6 +41,16 @@ export default function FriendsPage() {
   const [selectedTagId, setSelectedTagId] = useState('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+
+  // Selection & multicast state
+  const [selectedFriendIds, setSelectedFriendIds] = useState<Set<string>>(new Set())
+  const [showMulticastModal, setShowMulticastModal] = useState(false)
+  const [multicastForm, setMulticastForm] = useState({
+    messageType: 'text' as ApiBroadcast['messageType'],
+    messageContent: '',
+  })
+  const [multicastSending, setMulticastSending] = useState(false)
+  const [multicastResult, setMulticastResult] = useState<{ totalCount: number; successCount: number; skippedCount: number } | null>(null)
 
   const loadTags = useCallback(async () => {
     try {
@@ -92,6 +103,38 @@ export default function FriendsPage() {
     setSelectedTagId(tagId)
   }
 
+  const handleMulticastSend = async () => {
+    if (selectedFriendIds.size === 0) return
+    if (!multicastForm.messageContent.trim()) return
+
+    if (multicastForm.messageType === 'flex') {
+      try { JSON.parse(multicastForm.messageContent) } catch { setError('FlexメッセージのJSONが無効です'); return }
+    }
+
+    setMulticastSending(true)
+    setError('')
+    setMulticastResult(null)
+    try {
+      const res = await api.broadcasts.multicast({
+        friendIds: Array.from(selectedFriendIds),
+        messageType: multicastForm.messageType,
+        messageContent: multicastForm.messageContent,
+      })
+      if (res.success) {
+        setMulticastResult(res.data)
+        setSelectedFriendIds(new Set())
+        setMulticastForm({ messageType: 'text', messageContent: '' })
+        setShowMulticastModal(false)
+      } else {
+        setError(res.error)
+      }
+    } catch {
+      setError('送信に失敗しました')
+    } finally {
+      setMulticastSending(false)
+    }
+  }
+
   return (
     <div>
       <Header title="友だち管理" />
@@ -115,6 +158,45 @@ export default function FriendsPage() {
           {loading ? '読み込み中...' : `${total.toLocaleString('ja-JP')} 件`}
         </span>
       </div>
+
+      {/* Selection action bar */}
+      {selectedFriendIds.size > 0 && (
+        <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <span className="text-sm font-medium text-green-800">
+            {selectedFriendIds.size}人 選択中
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowMulticastModal(true)}
+              className="px-4 py-2 min-h-[44px] text-sm font-medium text-white rounded-lg transition-opacity"
+              style={{ backgroundColor: '#06C755' }}
+            >
+              選択した人に配信
+            </button>
+            <button
+              onClick={() => setSelectedFriendIds(new Set())}
+              className="px-3 py-2 min-h-[44px] text-sm font-medium text-gray-600 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              選択解除
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Multicast result */}
+      {multicastResult && (
+        <div className="mb-4 p-4 bg-green-50 border border-green-200 rounded-lg text-green-800 text-sm flex items-center justify-between">
+          <span>
+            配信完了: {multicastResult.successCount}/{multicastResult.totalCount}人に送信
+            {multicastResult.skippedCount > 0 && (
+              <span className="text-gray-500 ml-1">({multicastResult.skippedCount}人はブロック/退会のためスキップ)</span>
+            )}
+          </span>
+          <button onClick={() => setMulticastResult(null)} className="text-green-600 hover:text-green-800 text-xs">
+            閉じる
+          </button>
+        </div>
+      )}
 
       {/* Error */}
       {error && (
@@ -144,6 +226,8 @@ export default function FriendsPage() {
           friends={friends}
           allTags={allTags}
           onRefresh={loadFriends}
+          selectedIds={selectedFriendIds}
+          onSelectionChange={setSelectedFriendIds}
         />
       )}
 
@@ -174,6 +258,127 @@ export default function FriendsPage() {
       )}
 
       <CcPromptButton prompts={ccPrompts} />
+
+      {/* Multicast modal */}
+      {showMulticastModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => !multicastSending && setShowMulticastModal(false)}>
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-lg mx-4 p-6" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-base font-semibold text-gray-900 mb-4">
+              {selectedFriendIds.size}人に配信
+            </h3>
+
+            <div className="space-y-4">
+              {/* Message type */}
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-2">メッセージ種別</label>
+                <div className="flex gap-2">
+                  {(['text', 'image', 'flex'] as const).map((type) => (
+                    <button
+                      key={type}
+                      type="button"
+                      onClick={() => setMulticastForm({ ...multicastForm, messageType: type })}
+                      className={`px-3 py-1.5 min-h-[44px] text-xs font-medium rounded-md border transition-colors ${
+                        multicastForm.messageType === type
+                          ? 'border-green-500 text-green-700 bg-green-50'
+                          : 'border-gray-300 text-gray-600 bg-white hover:border-gray-400'
+                      }`}
+                    >
+                      {type === 'text' ? 'テキスト' : type === 'image' ? '画像' : 'Flexメッセージ'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Image helper */}
+              {multicastForm.messageType === 'image' && (() => {
+                let parsed: { originalContentUrl?: string; previewImageUrl?: string } = {}
+                try { parsed = JSON.parse(multicastForm.messageContent) } catch { /* not yet valid */ }
+                return (
+                  <div className="space-y-2">
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">元画像URL</label>
+                      <input
+                        type="url"
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
+                        placeholder="https://example.com/image.png"
+                        value={parsed.originalContentUrl ?? ''}
+                        onChange={(e) => {
+                          const orig = e.target.value
+                          const prev = parsed.previewImageUrl ?? orig
+                          setMulticastForm({ ...multicastForm, messageContent: JSON.stringify({ originalContentUrl: orig, previewImageUrl: prev }) })
+                        }}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">プレビュー画像URL</label>
+                      <input
+                        type="url"
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
+                        placeholder="空欄で元画像と同じ"
+                        value={parsed.previewImageUrl ?? ''}
+                        onChange={(e) => {
+                          const prev = e.target.value
+                          setMulticastForm({ ...multicastForm, messageContent: JSON.stringify({ originalContentUrl: parsed.originalContentUrl ?? '', previewImageUrl: prev }) })
+                        }}
+                      />
+                    </div>
+                  </div>
+                )
+              })()}
+
+              {/* Message content */}
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">
+                  メッセージ内容 <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 resize-y"
+                  rows={multicastForm.messageType === 'flex' ? 8 : 4}
+                  placeholder={
+                    multicastForm.messageType === 'text'
+                      ? '配信するメッセージを入力...'
+                      : multicastForm.messageType === 'image'
+                      ? '{"originalContentUrl":"...","previewImageUrl":"..."}'
+                      : '{"type":"bubble","body":{...}}'
+                  }
+                  value={multicastForm.messageContent}
+                  onChange={(e) => setMulticastForm({ ...multicastForm, messageContent: e.target.value })}
+                  style={{ fontFamily: multicastForm.messageType !== 'text' ? 'monospace' : 'inherit' }}
+                />
+              </div>
+
+              {/* Flex preview */}
+              {multicastForm.messageType === 'flex' && multicastForm.messageContent && (() => {
+                try { JSON.parse(multicastForm.messageContent); return true } catch { return false }
+              })() && (
+                <div>
+                  <p className="text-xs font-medium text-gray-500 mb-2">プレビュー</p>
+                  <FlexPreviewComponent content={multicastForm.messageContent} maxWidth={280} />
+                </div>
+              )}
+
+              {/* Actions */}
+              <div className="flex gap-2 pt-2">
+                <button
+                  onClick={handleMulticastSend}
+                  disabled={multicastSending || !multicastForm.messageContent.trim()}
+                  className="px-4 py-2 min-h-[44px] text-sm font-medium text-white rounded-lg disabled:opacity-50 transition-opacity"
+                  style={{ backgroundColor: '#06C755' }}
+                >
+                  {multicastSending ? '送信中...' : `${selectedFriendIds.size}人に送信`}
+                </button>
+                <button
+                  onClick={() => setShowMulticastModal(false)}
+                  disabled={multicastSending}
+                  className="px-4 py-2 min-h-[44px] text-sm font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+                >
+                  キャンセル
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/friends/friend-table.tsx
+++ b/apps/web/src/components/friends/friend-table.tsx
@@ -10,9 +10,39 @@ interface FriendTableProps {
   friends: FriendWithTags[]
   allTags: Tag[]
   onRefresh: () => void
+  selectedIds?: Set<string>
+  onSelectionChange?: (ids: Set<string>) => void
 }
 
-export default function FriendTable({ friends, allTags, onRefresh }: FriendTableProps) {
+export default function FriendTable({ friends, allTags, onRefresh, selectedIds, onSelectionChange }: FriendTableProps) {
+  const selectable = !!onSelectionChange
+  const selected = selectedIds ?? new Set<string>()
+
+  const allChecked = friends.length > 0 && friends.every((f) => selected.has(f.id))
+  const someChecked = friends.some((f) => selected.has(f.id))
+
+  const handleToggleAll = () => {
+    if (!onSelectionChange) return
+    const next = new Set(selected)
+    if (allChecked) {
+      friends.forEach((f) => next.delete(f.id))
+    } else {
+      friends.forEach((f) => next.add(f.id))
+    }
+    onSelectionChange(next)
+  }
+
+  const handleToggle = (id: string) => {
+    if (!onSelectionChange) return
+    const next = new Set(selected)
+    if (next.has(id)) {
+      next.delete(id)
+    } else {
+      next.add(id)
+    }
+    onSelectionChange(next)
+  }
+
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [addingTagForFriend, setAddingTagForFriend] = useState<string | null>(null)
   const [selectedTagId, setSelectedTagId] = useState('')
@@ -82,6 +112,17 @@ export default function FriendTable({ friends, allTags, onRefresh }: FriendTable
       <table className="w-full min-w-[640px]">
         <thead>
           <tr className="bg-gray-50 border-b border-gray-200">
+            {selectable && (
+              <th className="px-4 py-3 w-10">
+                <input
+                  type="checkbox"
+                  className="w-4 h-4 rounded border-gray-300 text-green-600 focus:ring-green-500 cursor-pointer"
+                  checked={allChecked}
+                  ref={(el) => { if (el) el.indeterminate = someChecked && !allChecked }}
+                  onChange={handleToggleAll}
+                />
+              </th>
+            )}
             <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
               アイコン / 表示名
             </th>
@@ -109,9 +150,20 @@ export default function FriendTable({ friends, allTags, onRefresh }: FriendTable
               <>
                 <tr
                   key={friend.id}
-                  className="hover:bg-gray-50 cursor-pointer transition-colors"
+                  className={`hover:bg-gray-50 cursor-pointer transition-colors ${selected.has(friend.id) ? 'bg-green-50' : ''}`}
                   onClick={() => toggleExpand(friend.id)}
                 >
+                  {/* Checkbox */}
+                  {selectable && (
+                    <td className="px-4 py-3 w-10" onClick={(e) => e.stopPropagation()}>
+                      <input
+                        type="checkbox"
+                        className="w-4 h-4 rounded border-gray-300 text-green-600 focus:ring-green-500 cursor-pointer"
+                        checked={selected.has(friend.id)}
+                        onChange={() => handleToggle(friend.id)}
+                      />
+                    </td>
+                  )}
                   {/* Avatar + Name */}
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-3">
@@ -183,7 +235,7 @@ export default function FriendTable({ friends, allTags, onRefresh }: FriendTable
                 {/* Expanded detail row */}
                 {isExpanded && (
                   <tr key={`${friend.id}-detail`} className="bg-gray-50">
-                    <td colSpan={5} className="px-6 py-4">
+                    <td colSpan={selectable ? 6 : 5} className="px-6 py-4">
                       <div className="space-y-3">
                         <div>
                           <p className="text-xs font-semibold text-gray-500 mb-1">LINE ユーザーID</p>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -187,6 +187,16 @@ export const api = {
       fetchApi<ApiResponse<null>>(`/api/broadcasts/${id}`, { method: 'DELETE' }),
     send: (id: string) =>
       fetchApi<ApiResponse<ApiBroadcast>>(`/api/broadcasts/${id}/send`, { method: 'POST' }),
+    multicast: (data: {
+      friendIds: string[]
+      messageType: string
+      messageContent: string
+      altText?: string | null
+    }) =>
+      fetchApi<ApiResponse<{ totalCount: number; successCount: number; skippedCount: number }>>('/api/multicast', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
   },
 
   // ── Round 2 APIs ─────────────────────────────────────────────────────────
@@ -354,10 +364,18 @@ export const api = {
         method: 'PUT',
         body: JSON.stringify(data),
       }),
-    send: (id: string, data: { content: string; messageType?: string }) =>
+    send: (id: string, data: { content: string; messageType?: string; sendAt?: string }) =>
       fetchApi<ApiResponse<unknown>>(`/api/chats/${id}/send`, {
         method: 'POST',
         body: JSON.stringify(data),
+      }),
+    scheduledList: (id: string) =>
+      fetchApi<ApiResponse<{ id: string; messageType: string; content: string; sendAt: string; status: string; createdAt: string }[]>>(
+        `/api/chats/${id}/scheduled`,
+      ),
+    cancelScheduled: (chatId: string, messageId: string) =>
+      fetchApi<ApiResponse<{ cancelled: boolean; id: string }>>(`/api/chats/${chatId}/scheduled/${messageId}`, {
+        method: 'DELETE',
       }),
   },
   reminders: {

--- a/apps/worker/src/routes/broadcasts.ts
+++ b/apps/worker/src/routes/broadcasts.ts
@@ -242,4 +242,112 @@ broadcasts.post('/api/broadcasts/:id/send-segment', async (c) => {
   }
 });
 
+// POST /api/multicast - send message to specific friend IDs
+broadcasts.post('/api/multicast', async (c) => {
+  try {
+    const body = await c.req.json<{
+      friendIds: string[];
+      messageType: string;
+      messageContent: string;
+      altText?: string | null;
+    }>();
+
+    if (!Array.isArray(body.friendIds) || body.friendIds.length === 0) {
+      return c.json({ success: false, error: 'friendIds array is required' }, 400);
+    }
+    if (!body.messageType || !body.messageContent) {
+      return c.json({ success: false, error: 'messageType and messageContent are required' }, 400);
+    }
+
+    // Fetch friends and get their LINE user IDs
+    const placeholders = body.friendIds.map(() => '?').join(',');
+    const result = await c.env.DB
+      .prepare(`SELECT id, line_user_id, is_following FROM friends WHERE id IN (${placeholders})`)
+      .bind(...body.friendIds)
+      .all<{ id: string; line_user_id: string; is_following: number }>();
+
+    const followingFriends = result.results.filter((f) => f.is_following);
+    if (followingFriends.length === 0) {
+      return c.json({ success: false, error: 'No following friends found in the selection' }, 400);
+    }
+
+    const lineUserIds = followingFriends.map((f) => f.line_user_id);
+
+    // Build message
+    const { extractFlexAltText } = await import('../utils/flex-alt-text.js');
+    let message: import('@line-crm/line-sdk').Message;
+    if (body.messageType === 'text') {
+      message = { type: 'text', text: body.messageContent };
+    } else if (body.messageType === 'flex') {
+      const contents = JSON.parse(body.messageContent);
+      message = { type: 'flex', altText: body.altText || extractFlexAltText(contents), contents };
+    } else if (body.messageType === 'image') {
+      const parsed = JSON.parse(body.messageContent);
+      message = { type: 'image', originalContentUrl: parsed.originalContentUrl, previewImageUrl: parsed.previewImageUrl };
+    } else if (body.messageType === 'video') {
+      const parsed = JSON.parse(body.messageContent);
+      message = { type: 'video', originalContentUrl: parsed.originalContentUrl, previewImageUrl: parsed.previewImageUrl } as import('@line-crm/line-sdk').Message;
+    } else {
+      message = { type: 'text', text: body.messageContent };
+    }
+
+    // Send via multicast in 500-batch chunks
+    const lineClient = new LineClient(c.env.LINE_CHANNEL_ACCESS_TOKEN);
+    const { calculateStaggerDelay, sleep, addMessageVariation } = await import('../services/stealth.js');
+    const BATCH_SIZE = 500;
+    const totalBatches = Math.ceil(lineUserIds.length / BATCH_SIZE);
+    let successCount = 0;
+
+    const { jstNow } = await import('@line-crm/db');
+    const now = jstNow();
+
+    for (let i = 0; i < lineUserIds.length; i += BATCH_SIZE) {
+      const batchIndex = Math.floor(i / BATCH_SIZE);
+      const batch = lineUserIds.slice(i, i + BATCH_SIZE);
+      const batchFriends = followingFriends.slice(i, i + BATCH_SIZE);
+
+      if (batchIndex > 0) {
+        const delay = calculateStaggerDelay(lineUserIds.length, batchIndex);
+        await sleep(delay);
+      }
+
+      let batchMessage = message;
+      if (message.type === 'text' && totalBatches > 1) {
+        batchMessage = { ...message, text: addMessageVariation(message.text, batchIndex) };
+      }
+
+      try {
+        await lineClient.multicast(batch, [batchMessage]);
+        successCount += batch.length;
+
+        // Log messages
+        for (const friend of batchFriends) {
+          const logId = crypto.randomUUID();
+          await c.env.DB
+            .prepare(
+              `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, created_at)
+               VALUES (?, ?, 'outgoing', ?, ?, NULL, NULL, ?)`,
+            )
+            .bind(logId, friend.id, body.messageType, body.messageContent, now)
+            .run();
+        }
+      } catch (err) {
+        console.error(`Multicast batch ${batchIndex} failed:`, err);
+      }
+    }
+
+    return c.json({
+      success: true,
+      data: {
+        totalCount: followingFriends.length,
+        successCount,
+        skippedCount: body.friendIds.length - followingFriends.length,
+      },
+    });
+  } catch (err) {
+    console.error('POST /api/multicast error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
 export { broadcasts };


### PR DESCRIPTION
## Summary
- 友だち一覧テーブルにチェックボックスを追加（全選択 / 個別選択）
- 選択した友だちにメッセージを一斉配信できるモーダルUI
- `POST /api/multicast` エンドポイント追加（500人バッチ + ステルス遅延対応）

## 変更ファイル
- `apps/worker/src/routes/broadcasts.ts` — multicastエンドポイント
- `apps/web/src/lib/api.ts` — APIクライアント
- `apps/web/src/components/friends/friend-table.tsx` — チェックボックス列
- `apps/web/src/app/friends/page.tsx` — 選択管理 + 配信モーダル

## Test plan
- [ ] 友だち一覧でチェックボックスが表示される
- [ ] 全選択 / 個別選択が動作する
- [ ] 「選択した人に配信」ボタンでモーダルが開く
- [ ] テキスト / 画像 / Flex メッセージが送信できる
- [ ] ブロック/退会者はスキップされる
- [ ] 送信結果が正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)