### PR TITLE
fix: マルチアカウント環境で返信元アカウントが入れ替わる不具合を修正

### DIFF
--- a/apps/worker/src/routes/chats.ts
+++ b/apps/worker/src/routes/chats.ts
@@ -9,6 +9,8 @@ import {
   getChats,
   getChatById,
   createChat,
+  getFriendById,
+  getLineAccountById,
   updateChat,
   jstNow,
 } from '@line-crm/db';
@@ -43,6 +45,28 @@ async function startLoadingAnimation(
         : `LINE API error: ${response.status}`,
     );
   }
+}
+
+async function resolveFriendAndAccessToken(
+  db: D1Database,
+  friendId: string,
+  defaultAccessToken: string,
+) {
+  const friend = await getFriendById(db, friendId);
+  if (!friend) {
+    return { friend: null, accessToken: defaultAccessToken };
+  }
+
+  if (!friend.line_account_id) {
+    return { friend, accessToken: defaultAccessToken };
+  }
+
+  const account = await getLineAccountById(db, friend.line_account_id);
+  if (!account) {
+    return { friend, accessToken: defaultAccessToken };
+  }
+
+  return { friend, accessToken: account.channel_access_token };
 }
 
 // ========== オペレーターCRUD ==========
@@ -258,14 +282,15 @@ chats.post('/api/chats/:id/loading', async (c) => {
     }
     const loadingSeconds = clampLoadingSeconds(loadingSecondsInput);
 
-    const friend = await c.env.DB
-      .prepare(`SELECT * FROM friends WHERE id = ?`)
-      .bind(chat.friend_id)
-      .first<{ id: string; line_user_id: string }>();
+    const { friend, accessToken } = await resolveFriendAndAccessToken(
+      c.env.DB,
+      chat.friend_id,
+      c.env.LINE_CHANNEL_ACCESS_TOKEN,
+    );
     if (!friend) return c.json({ success: false, error: 'Friend not found' }, 404);
 
     await startLoadingAnimation(
-      c.env.LINE_CHANNEL_ACCESS_TOKEN,
+      accessToken,
       friend.line_user_id,
       loadingSeconds,
     );
@@ -288,15 +313,16 @@ chats.post('/api/chats/:id/send', async (c) => {
     const body = await c.req.json<{ messageType?: string; content: string }>();
     if (!body.content) return c.json({ success: false, error: 'content is required' }, 400);
 
-    const friend = await c.env.DB
-      .prepare(`SELECT * FROM friends WHERE id = ?`)
-      .bind(chat.friend_id)
-      .first<{ id: string; line_user_id: string }>();
+    const { friend, accessToken } = await resolveFriendAndAccessToken(
+      c.env.DB,
+      chat.friend_id,
+      c.env.LINE_CHANNEL_ACCESS_TOKEN,
+    );
     if (!friend) return c.json({ success: false, error: 'Friend not found' }, 404);
 
     // LINE APIでメッセージ送信
     const { LineClient } = await import('@line-crm/line-sdk');
-    const lineClient = new LineClient(c.env.LINE_CHANNEL_ACCESS_TOKEN);
+    const lineClient = new LineClient(accessToken);
     const messageType = body.messageType ?? 'text';
 
     if (messageType === 'text') {


### PR DESCRIPTION
## 概要
- マルチアカウント環境で、返信時に送信元LINEアカウントが入れ替わってしまう不具合を修正
- `/api/chats/:id/loading` と `/api/chats/:id/send` の両方で、返信対象の友だちに紐づく `line_account_id` から `channel_access_token` を解決するように変更
- 友だちやLINEアカウントの紐付けがない場合のみ、既存どおり `LINE_CHANNEL_ACCESS_TOKEN` にフォールバック

## 不具合の内容
マルチアカウント機能の確認中、同じユーザーが複数のLINE公式アカウントと会話しているケースで問題がありました。

例えば以下のようなケースです。
- 同じユーザーがアカウント1、アカウント2の両方と会話している
- 先にアカウント1で会話する
- その後、アカウント2に届いたメッセージへ返信する

このとき、本来はアカウント2から返信されるべきところ、誤ってアカウント1から送信されてしまっていました。

## 修正内容
返信時にグローバルなデフォルトトークンをそのまま使うのではなく、返信対象の友だちに紐づくLINEアカウントを解決し、そのアカウントの `channel_access_token` を使って送信するようにしています。
これにより、どのアカウント上の会話に対する返信なのかに応じて、正しいLINE公式アカウントから送信されます。

## 主な変更点
- `getFriendById`
- `getLineAccountById`
- `resolveFriendAndAccessToken` を追加
- `/api/chats/:id/loading`
- `/api/chats/:id/send`

## 補足
- このPRでは追加のテスト実行は行っていません*実環境での動作では修正を確認しています。
