### PR TITLE
fix: シナリオ・オートメーション一覧ページのレースコンディションを修正

### DIFF
--- a/apps/web/src/app/automations/page.tsx
+++ b/apps/web/src/app/automations/page.tsx
@@ -91,7 +91,7 @@ const ccPrompts = [
 ]
 
 export default function AutomationsPage() {
-  const { selectedAccountId } = useAccount()
+  const { selectedAccountId, loading: accountLoading } = useAccount()
   const [automations, setAutomations] = useState<Automation[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -118,8 +118,37 @@ export default function AutomationsPage() {
   }, [selectedAccountId])
 
   useEffect(() => {
-    loadAutomations()
-  }, [loadAutomations])
+    if (accountLoading) return
+    
+    let cancelled = false
+    
+    const fetchData = async () => {
+      setLoading(true)
+      setError('')
+      try {
+        const res = await api.automations.list({ accountId: selectedAccountId || undefined })
+        if (cancelled) return
+        if (res.success) {
+          setAutomations(res.data)
+        } else {
+          setError(res.error)
+        }
+      } catch {
+        if (cancelled) return
+        setError('オートメーションの読み込みに失敗しました。もう一度お試しください。')
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+    
+    fetchData()
+    
+    return () => {
+      cancelled = true
+    }
+  }, [selectedAccountId, accountLoading])
 
   const handleCreate = async () => {
     if (!form.name.trim()) {

--- a/apps/web/src/app/scenarios/page.tsx
+++ b/apps/web/src/app/scenarios/page.tsx
@@ -1,16 +1,16 @@
-'use client'
+"use client";
 
-import { useState, useEffect, useCallback } from 'react'
-import type { Scenario, ScenarioTriggerType } from '@line-crm/shared'
-import { api } from '@/lib/api'
-import { useAccount } from '@/contexts/account-context'
-import Header from '@/components/layout/header'
-import ScenarioList from '@/components/scenarios/scenario-list'
-import CcPromptButton from '@/components/cc-prompt-button'
+import { useState, useEffect, useCallback } from "react";
+import type { Scenario, ScenarioTriggerType } from "@line-crm/shared";
+import { api } from "@/lib/api";
+import { useAccount } from "@/contexts/account-context";
+import Header from "@/components/layout/header";
+import ScenarioList from "@/components/scenarios/scenario-list";
+import CcPromptButton from "@/components/cc-prompt-button";
 
 const ccPrompts = [
   {
-    title: '新しいシナリオを作成',
+    title: "新しいシナリオを作成",
     prompt: `新しいシナリオ配信を作成してください。
 1. ターゲット: [対象を指定]
 2. トリガー: 友だち追加 / タグ変更 / 手動
@@ -19,75 +19,108 @@ const ccPrompts = [
 各ステップの配信間隔も含めて構成してください。`,
   },
   {
-    title: 'シナリオの効果分析',
+    title: "シナリオの効果分析",
     prompt: `現在のシナリオ配信の効果を分析してください。
 1. 各シナリオの配信実績を確認
 2. ステップごとの離脱率を分析
 3. 改善が必要なシナリオを特定
 具体的な改善案を提示してください。`,
   },
-]
+];
 
-type ScenarioWithCount = Scenario & { stepCount?: number }
+type ScenarioWithCount = Scenario & { stepCount?: number };
 
 const triggerOptions: { value: ScenarioTriggerType; label: string }[] = [
-  { value: 'friend_add', label: '友だち追加時' },
-  { value: 'tag_added', label: 'タグ付与時' },
-  { value: 'manual', label: '手動' },
-]
+  { value: "friend_add", label: "友だち追加時" },
+  { value: "tag_added", label: "タグ付与時" },
+  { value: "manual", label: "手動" },
+];
 
 interface CreateFormState {
-  name: string
-  description: string
-  triggerType: ScenarioTriggerType
-  triggerTagId: string
-  isActive: boolean
+  name: string;
+  description: string;
+  triggerType: ScenarioTriggerType;
+  triggerTagId: string;
+  isActive: boolean;
 }
 
 export default function ScenariosPage() {
-  const { selectedAccountId } = useAccount()
-  const [scenarios, setScenarios] = useState<ScenarioWithCount[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
-  const [showCreate, setShowCreate] = useState(false)
+  const { selectedAccountId, loading: accountLoading } = useAccount();
+  const [scenarios, setScenarios] = useState<ScenarioWithCount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [showCreate, setShowCreate] = useState(false);
   const [form, setForm] = useState<CreateFormState>({
-    name: '',
-    description: '',
-    triggerType: 'friend_add',
-    triggerTagId: '',
+    name: "",
+    description: "",
+    triggerType: "friend_add",
+    triggerTagId: "",
     isActive: true,
-  })
-  const [saving, setSaving] = useState(false)
-  const [formError, setFormError] = useState('')
+  });
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState("");
 
   const loadScenarios = useCallback(async () => {
-    setLoading(true)
-    setError('')
+    setLoading(true);
+    setError("");
     try {
-      const res = await api.scenarios.list({ accountId: selectedAccountId || undefined })
+      const res = await api.scenarios.list({
+        accountId: selectedAccountId || undefined,
+      });
       if (res.success) {
-        setScenarios(res.data)
+        setScenarios(res.data);
       } else {
-        setError(res.error)
+        setError(res.error);
       }
     } catch {
-      setError('シナリオの読み込みに失敗しました。もう一度お試しください。')
+      setError("シナリオの読み込みに失敗しました。もう一度お試しください。");
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }, [selectedAccountId])
+  }, [selectedAccountId]);
 
   useEffect(() => {
-    loadScenarios()
-  }, [loadScenarios])
+    if (accountLoading) return;
+
+    let cancelled = false;
+
+    const fetchData = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const res = await api.scenarios.list({
+          accountId: selectedAccountId || undefined,
+        });
+        if (cancelled) return;
+        if (res.success) {
+          setScenarios(res.data);
+        } else {
+          setError(res.error);
+        }
+      } catch {
+        if (cancelled) return;
+        setError("シナリオの読み込みに失敗しました。もう一度お試しください。");
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAccountId, accountLoading]);
 
   const handleCreate = async () => {
     if (!form.name.trim()) {
-      setFormError('シナリオ名を入力してください')
-      return
+      setFormError("シナリオ名を入力してください");
+      return;
     }
-    setSaving(true)
-    setFormError('')
+    setSaving(true);
+    setFormError("");
     try {
       const res = await api.scenarios.create({
         name: form.name,
@@ -95,38 +128,44 @@ export default function ScenariosPage() {
         triggerType: form.triggerType,
         triggerTagId: form.triggerTagId || null,
         isActive: form.isActive,
-      })
+      });
       if (res.success) {
-        setShowCreate(false)
-        setForm({ name: '', description: '', triggerType: 'friend_add', triggerTagId: '', isActive: true })
-        loadScenarios()
+        setShowCreate(false);
+        setForm({
+          name: "",
+          description: "",
+          triggerType: "friend_add",
+          triggerTagId: "",
+          isActive: true,
+        });
+        loadScenarios();
       } else {
-        setFormError(res.error)
+        setFormError(res.error);
       }
     } catch {
-      setFormError('作成に失敗しました')
+      setFormError("作成に失敗しました");
     } finally {
-      setSaving(false)
+      setSaving(false);
     }
-  }
+  };
 
   const handleToggleActive = async (id: string, current: boolean) => {
     try {
-      await api.scenarios.update(id, { isActive: !current })
-      loadScenarios()
+      await api.scenarios.update(id, { isActive: !current });
+      loadScenarios();
     } catch {
-      setError('ステータスの変更に失敗しました')
+      setError("ステータスの変更に失敗しました");
     }
-  }
+  };
 
   const handleDelete = async (id: string) => {
     try {
-      await api.scenarios.delete(id)
-      loadScenarios()
+      await api.scenarios.delete(id);
+      loadScenarios();
     } catch {
-      setError('削除に失敗しました')
+      setError("削除に失敗しました");
     }
-  }
+  };
 
   return (
     <div>
@@ -136,7 +175,7 @@ export default function ScenariosPage() {
           <button
             onClick={() => setShowCreate(true)}
             className="px-4 py-2 min-h-[44px] text-sm font-medium text-white rounded-lg transition-opacity hover:opacity-90"
-            style={{ backgroundColor: '#06C755' }}
+            style={{ backgroundColor: "#06C755" }}
           >
             + 新規シナリオ
           </button>
@@ -153,10 +192,14 @@ export default function ScenariosPage() {
       {/* Create form */}
       {showCreate && (
         <div className="mb-6 bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-          <h2 className="text-sm font-semibold text-gray-800 mb-4">新規シナリオを作成</h2>
+          <h2 className="text-sm font-semibold text-gray-800 mb-4">
+            新規シナリオを作成
+          </h2>
           <div className="space-y-4 max-w-lg">
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">シナリオ名 <span className="text-red-500">*</span></label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">
+                シナリオ名 <span className="text-red-500">*</span>
+              </label>
               <input
                 type="text"
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
@@ -166,24 +209,37 @@ export default function ScenariosPage() {
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">説明</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">
+                説明
+              </label>
               <textarea
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 resize-none"
                 rows={2}
                 placeholder="シナリオの説明 (省略可)"
                 value={form.description}
-                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                onChange={(e) =>
+                  setForm({ ...form, description: e.target.value })
+                }
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">トリガー</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">
+                トリガー
+              </label>
               <select
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 bg-white"
                 value={form.triggerType}
-                onChange={(e) => setForm({ ...form, triggerType: e.target.value as ScenarioTriggerType })}
+                onChange={(e) =>
+                  setForm({
+                    ...form,
+                    triggerType: e.target.value as ScenarioTriggerType,
+                  })
+                }
               >
                 {triggerOptions.map((opt) => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
                 ))}
               </select>
             </div>
@@ -192,10 +248,14 @@ export default function ScenariosPage() {
                 type="checkbox"
                 id="isActive"
                 checked={form.isActive}
-                onChange={(e) => setForm({ ...form, isActive: e.target.checked })}
+                onChange={(e) =>
+                  setForm({ ...form, isActive: e.target.checked })
+                }
                 className="w-4 h-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
               />
-              <label htmlFor="isActive" className="text-sm text-gray-600">作成後すぐに有効にする</label>
+              <label htmlFor="isActive" className="text-sm text-gray-600">
+                作成後すぐに有効にする
+              </label>
             </div>
 
             {formError && <p className="text-xs text-red-600">{formError}</p>}
@@ -205,12 +265,15 @@ export default function ScenariosPage() {
                 onClick={handleCreate}
                 disabled={saving}
                 className="px-4 py-2 min-h-[44px] text-sm font-medium text-white rounded-lg disabled:opacity-50 transition-opacity"
-                style={{ backgroundColor: '#06C755' }}
+                style={{ backgroundColor: "#06C755" }}
               >
-                {saving ? '作成中...' : '作成'}
+                {saving ? "作成中..." : "作成"}
               </button>
               <button
-                onClick={() => { setShowCreate(false); setFormError('') }}
+                onClick={() => {
+                  setShowCreate(false);
+                  setFormError("");
+                }}
                 className="px-4 py-2 min-h-[44px] text-sm font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
               >
                 キャンセル
@@ -224,7 +287,10 @@ export default function ScenariosPage() {
       {loading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
           {[...Array(3)].map((_, i) => (
-            <div key={i} className="bg-white rounded-lg border border-gray-200 p-5 animate-pulse space-y-3">
+            <div
+              key={i}
+              className="bg-white rounded-lg border border-gray-200 p-5 animate-pulse space-y-3"
+            >
               <div className="h-4 bg-gray-200 rounded w-3/4" />
               <div className="h-3 bg-gray-100 rounded w-full" />
               <div className="flex gap-4">
@@ -245,5 +311,5 @@ export default function ScenariosPage() {
 
       <CcPromptButton prompts={ccPrompts} />
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary

- シナリオ一覧ページで、APIからデータ取得に成功しているにもかかわらず「シナリオがありません」と表示される問題を修正
- オートメーション一覧ページにも同様の修正を適用

## Problem

`AccountContext`の初期化時に`selectedAccountId`が`null`から有効なIDに変化することで、複数のAPIリクエストが発生します。レスポンスの到着順序によっては、古いリクエスト（accountIdなし）の結果が新しいリクエストの結果を上書きし、データが消えてしまう問題がありました。

**症状:**
- 更新ボタンをクリックすると、一瞬シナリオが表示された後「シナリオがありません」が表示される
- Network タブでは200 OKでデータが返っているがUIに反映されない

## Solution

- `accountLoading`が完了するまでデータ取得を待機
- `cancelled`フラグで古いリクエストの結果を無視
- クリーンアップ関数で適切にキャンセル処理を実行

## Test plan

- [x] ローカル環境でシナリオ一覧ページをリロードし、データが正常に表示されることを確認
- [x] 複数回リロードしてもデータが消えないことを確認

Made with [Cursor](https://cursor.com)