### PR TITLE
feat(auth): add LEGACY_API_KEY fallback for dual-key rotation (T1-B-0)

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -54,6 +54,7 @@ export type Env = {
     LINE_CHANNEL_SECRET: string;
     LINE_CHANNEL_ACCESS_TOKEN: string;
     API_KEY: string;
+    LEGACY_API_KEY?: string;
     LIFF_URL: string;
     LINE_CHANNEL_ID: string;
     LINE_LOGIN_CHANNEL_ID: string;

--- a/apps/worker/src/middleware/auth.ts
+++ b/apps/worker/src/middleware/auth.ts
@@ -44,9 +44,18 @@ export async function authMiddleware(c: Context<Env>, next: Next): Promise<Respo
     return next();
   }
 
-  // Fallback: env API_KEY acts as owner
+  // Fallback: env API_KEY acts as owner (current rotation slot)
   if (token === c.env.API_KEY) {
     c.set('staff', { id: 'env-owner', name: 'Owner', role: 'owner' as const });
+    console.log('[auth] accept_via=API_KEY');
+    return next();
+  }
+
+  // Legacy fallback: LEGACY_API_KEY accepted during rotation grace period.
+  // Delete this secret after soak (accept_via=LEGACY_API_KEY count = 0) to revoke old key.
+  if (c.env.LEGACY_API_KEY && token === c.env.LEGACY_API_KEY) {
+    c.set('staff', { id: 'env-owner-legacy', name: 'Owner (legacy)', role: 'owner' as const });
+    console.log('[auth] accept_via=LEGACY_API_KEY');
     return next();
   }
 


### PR DESCRIPTION
## Summary

- Add `LEGACY_API_KEY?: string` to `Env.Bindings` and a fallback check in `auth.ts` so the Worker accepts both the current and legacy API keys during a rotation grace period.
- Slot-name-only logging (`accept_via=API_KEY` / `accept_via=LEGACY_API_KEY`); no token values are logged.
- Code only — this PR does not deploy, does not register `LEGACY_API_KEY`, and does not rotate `API_KEY`. Those are separate Ao approvals.

## Why

Atomic rotation of `API_KEY` requires a synchronized swap across multiple callers (talmudo-api, mogbiz-app), which is risky. With this fallback in place, the Worker can accept the old key via `LEGACY_API_KEY` while callers update independently, eliminating the rotation downtime window. Full design: `.planning/t1-b-0-dual-key-rotation-design-20260428.md`.

## Changes

| File | +/− | Notes |
|---|---|---|
| `apps/worker/src/index.ts` | +1 | `LEGACY_API_KEY?: string` in `Env.Bindings` (optional) |
| `apps/worker/src/middleware/auth.ts` | +10 / -1 | LEGACY fallback after `API_KEY` check, slot-name log lines |

Total: 2 files, +11 / -1 lines.

### Behavior

`auth.ts` evaluates `API_KEY` first, then `LEGACY_API_KEY`. The legacy path is only reachable when:

1. `c.env.LEGACY_API_KEY` is set (so a missing secret is a no-op — safe to deploy without `LEGACY_API_KEY` configured)
2. `token === c.env.LEGACY_API_KEY`
3. `token !== c.env.API_KEY` (i.e. the API_KEY check above did not match)

When both secrets equal the same value, every request is accepted via the `API_KEY` path, and the legacy log line never fires. This is the expected behavior at rotation phase P3.

## Verification

- `pnpm typecheck` (`tsc --noEmit`): no new errors. The single existing error (`src/index.ts(9,37): error TS2307: Cannot find module './services/synthetic-monitor.js'`) is present on `main` prior to this change and is unrelated. Tracked separately.
- `wrangler dev` smoke not run locally: would require importing several secrets, conflicts with the secret-handling discipline in this engagement.
- The `LEGACY_API_KEY` secret is **not** registered as part of this PR — `if (c.env.LEGACY_API_KEY && ...)` short-circuits to `false` until the secret is registered. Production behavior is unchanged at deploy time.

## Deploy plan (out of scope for this PR)

Deploy is a separate Ao-approved step. Outline:

1. Merge to `main`.
2. `vite build && wrangler deploy` (apps/worker). LEGACY path inert until P3.
3. P3 (separate approval): `wrangler secret put LEGACY_API_KEY` = current value.
4. P4 (separate approval): `wrangler secret put API_KEY` = new value. LEGACY now carries the old key.
5. P5/P6: callers (talmudo-api, mogbiz-app) swap to the new key independently.
6. P9 (separate approval after 24h soak with 0 LEGACY accepts): `wrangler secret delete LEGACY_API_KEY`.

## Rollback

| Stage | Rollback | Time |
|---|---|---|
| Pre-merge | Close PR | instant |
| Post-merge, pre-deploy | `git revert` and re-merge | < 5 min |
| Post-deploy, pre-LEGACY | `git revert` + `wrangler deploy` (existing API_KEY behavior restored) | < 5 min |
| Post-LEGACY (P3+) | `wrangler secret delete LEGACY_API_KEY` (LEGACY path becomes inert) | < 1 min |

## Test plan

- [ ] `pnpm typecheck` shows no new errors (existing synthetic-monitor error remains, unrelated).
- [ ] `git diff main...feat/auth-legacy-api-key` matches the design contract.
- [ ] Code review confirms slot-name-only logging (no token values, no Authorization header values).
- [ ] (Post-deploy, separate approval) `wrangler tail` shows `accept_via=API_KEY` log lines on existing traffic, no 401 regression.

## Linked

- Design: `.planning/t1-b-0-dual-key-rotation-design-20260428.md`
- Predecessor task: T1-C GLM5_API_KEY removal (closed 2026-04-28)
