### PR TITLE
fix(scenarios): init current_step_order to -1 so step_order=0 fires

### DIFF
--- a/packages/db/src/scenarios.ts
+++ b/packages/db/src/scenarios.ts
@@ -345,10 +345,17 @@ export async function enrollFriendInScenario(
   }
   const nextDeliveryAt = rawDate.toISOString().slice(0, -1) + '+09:00';
 
+  // current_step_order is initialized to -1 (NOT 0) so that the step-delivery
+  // service's `steps.find(s => s.step_order > fs.current_step_order)` lookup
+  // matches the very first step (step_order=0).
+  // If we initialize to 0, scenarios that only have a step_order=0 step are
+  // silently completed without delivering anything (because no step has
+  // step_order > 0). This was observed in production on 2026-04-27 where
+  // ~10 friend_scenarios silently completed for a 46-hour window.
   const result = await db
     .prepare(
       `INSERT OR IGNORE INTO friend_scenarios (id, friend_id, scenario_id, current_step_order, status, started_at, next_delivery_at, updated_at)
-       VALUES (?, ?, ?, 0, 'active', ?, ?, ?)`,
+       VALUES (?, ?, ?, -1, 'active', ?, ?, ?)`,
     )
     .bind(id, friendId, scenarioId, now, nextDeliveryAt, now)
     .run();


### PR DESCRIPTION
## Problem

`step-delivery.ts:processSingleDelivery` looks up the next step using:

```ts
steps.find((s) => s.step_order > fs.current_step_order)
```

When a scenario has only one step at `step_order=0` (a very common case for "single greeting" scenarios), starting `current_step_order` at `0` means `step_order > 0` never matches, and the scenario silently transitions to `status='completed'` without delivering anything.

The pre-v0.10.2 code initialized to `-1`, but the v0.10.2 race-condition fix changed it to `0` along with several other improvements (`INSERT OR IGNORE`, `claimFriendScenarioForDelivery`, etc.). Those other improvements are correct, but the `0` initialization breaks the lookup invariant.

## Production impact

Detected 2026-04-29 in our deployment: about **19 `friend_scenarios` rows across 3 active scenarios silently completed** without delivery during a **46-hour window**. Affected scenarios:

- A "申し込み完了 → Stripe 支払い案内" (step_order=0) — 1 row
- A "友だち追加 → 説明会案内" (step_order=0) — 9 rows
- A "STEP1_年代選択" (step_order=1) — 9 rows (step_order≥1 also affected because the comparison still misses index 0; in our case the find-result was the step_order=1 row which happened to work, but other 0-only scenarios silently broke)

Detection was hard because the rows look exactly like a successfully-completed scenario in the DB; we only noticed because users reported that follow-up messages never arrived.

## Fix

One-character change (`0` → `-1`) so `step_order > -1` matches `step_order=0` on the first delivery. All other v0.10.2 improvements stay intact.

## Test plan

- [x] In our fork, integration tests verify that step_order=0 scenarios now fire correctly (they previously silent-completed)
- [x] Deployed to production 2026-04-29; subsequent enrollments deliver as expected
- [x] No regression in step_order≥1 scenarios

If you'd like, I can also push the integration tests we added on our fork (`tests/integration/scenarios-enroll.test.ts` and `tests/integration/step-delivery-step-zero.test.ts`).