### PR TITLE
fix: verify webhook signature before parsing body to mitigate DoS (#104)

### DIFF
--- a/apps/worker/src/routes/webhook.test.ts
+++ b/apps/worker/src/routes/webhook.test.ts
@@ -1,38 +1,86 @@
-import { describe, expect, test } from 'vitest';
+import {
+  describe,
+  expect,
+  test,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
 import { Hono } from 'hono';
 import { webhook } from './webhook.js';
 
+async function signBody(secret: string, body: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(body));
+  const bytes = new Uint8Array(sig);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
 function recordingDb() {
-  let accessed = false;
-  const statement: Record<string, unknown> = {};
-  Object.assign(statement, {
-    bind: () => statement,
-    all: async () => ({ results: [] }),
-    first: async () => null,
-    run: async () => ({ meta: { changes: 0 } }),
-  });
-  return {
-    db: {
-      prepare: () => {
-        accessed = true;
-        return statement;
-      },
+  const calls: { sql: string; binds: unknown[] }[] = [];
+  let prepareCount = 0;
+  const db = {
+    prepare(sql: string) {
+      prepareCount += 1;
+      let bindArgs: unknown[] = [];
+      const stmt: Record<string, unknown> = {};
+      Object.assign(stmt, {
+        bind: (...args: unknown[]) => {
+          bindArgs = args;
+          return stmt;
+        },
+        all: async () => {
+          calls.push({ sql, binds: bindArgs });
+          return { results: [] };
+        },
+        first: async () => {
+          calls.push({ sql, binds: bindArgs });
+          return null;
+        },
+        run: async () => {
+          calls.push({ sql, binds: bindArgs });
+          return { meta: { changes: 0 } };
+        },
+      });
+      return stmt;
     },
-    accessed: () => accessed,
+  };
+  return {
+    db,
+    calls: () => calls,
+    prepareCount: () => prepareCount,
   };
 }
 
 const baseEnv = (db: unknown) => ({
-  LINE_CHANNEL_SECRET: 'test-secret',
-  LINE_CHANNEL_ACCESS_TOKEN: 'test-access-token',
+  LINE_CHANNEL_SECRET: 'env-secret',
+  LINE_CHANNEL_ACCESS_TOKEN: 'env-access-token',
   DB: db,
 });
 
-describe('POST /webhook — DoS protection', () => {
-  test('rejects bodies larger than 512KB with 413 before reaching DB', async () => {
+describe('POST /webhook — payload size limits', () => {
+  let consoleErrorSpy: MockInstance;
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('rejects bodies larger than 512KB via Content-Length pre-check (413, no DB access)', async () => {
     const app = new Hono();
     app.route('/', webhook);
-    const { db, accessed } = recordingDb();
+    const { db, prepareCount } = recordingDb();
 
     const oversized = 'x'.repeat(513 * 1024);
     const res = await app.request(
@@ -46,13 +94,91 @@ describe('POST /webhook — DoS protection', () => {
     );
 
     expect(res.status).toBe(413);
-    expect(accessed()).toBe(false);
+    expect(prepareCount()).toBe(0);
   });
 
-  test('returns 200 without DB access when X-Line-Signature is missing', async () => {
+  test('uses UTF-8 byte length, not UTF-16 code units, for size check', async () => {
+    // 'あ' is 1 UTF-16 code unit but 3 UTF-8 bytes.
+    // 200K chars: String.length 200K (under 512KB if mistakenly counted as
+    // code units) vs byteLength ~600KB (must be rejected).
+    const body = 'あ'.repeat(200 * 1024);
+    expect(body.length).toBeLessThan(512 * 1024);
+    expect(new TextEncoder().encode(body).byteLength).toBeGreaterThan(512 * 1024);
+
     const app = new Hono();
     app.route('/', webhook);
-    const { db, accessed } = recordingDb();
+    const { db } = recordingDb();
+    const res = await app.request(
+      '/webhook',
+      {
+        method: 'POST',
+        headers: { 'X-Line-Signature': 'dummy' },
+        body,
+      },
+      baseEnv(db),
+    );
+
+    expect(res.status).toBe(413);
+  });
+});
+
+describe('POST /webhook — signature gates JSON.parse', () => {
+  let consoleErrorSpy: MockInstance;
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('valid signature with malformed JSON reaches parser (logs parse failure)', async () => {
+    const app = new Hono();
+    app.route('/', webhook);
+    const { db } = recordingDb();
+
+    const body = 'this is { not valid json';
+    const sig = await signBody('env-secret', body);
+
+    const res = await app.request(
+      '/webhook',
+      {
+        method: 'POST',
+        headers: { 'X-Line-Signature': sig },
+        body,
+      },
+      baseEnv(db),
+    );
+
+    expect(res.status).toBe(200);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to parse verified webhook body');
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith('Invalid LINE signature');
+  });
+
+  test('invalid signature with malformed JSON stops before the parser', async () => {
+    const app = new Hono();
+    app.route('/', webhook);
+    const { db } = recordingDb();
+
+    const body = 'this is { not valid json';
+    const res = await app.request(
+      '/webhook',
+      {
+        method: 'POST',
+        headers: { 'X-Line-Signature': 'aW52YWxpZA==' },
+        body,
+      },
+      baseEnv(db),
+    );
+
+    expect(res.status).toBe(200);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Invalid LINE signature');
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith('Failed to parse verified webhook body');
+  });
+
+  test('missing X-Line-Signature returns 200 without DB access', async () => {
+    const app = new Hono();
+    app.route('/', webhook);
+    const { db, prepareCount } = recordingDb();
 
     const res = await app.request(
       '/webhook',
@@ -64,28 +190,9 @@ describe('POST /webhook — DoS protection', () => {
     );
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { status: string };
-    expect(body.status).toBe('ok');
-    expect(accessed()).toBe(false);
-  });
-
-  test('returns 200 on invalid signature without crashing on malformed JSON', async () => {
-    const app = new Hono();
-    app.route('/', webhook);
-    const { db } = recordingDb();
-
-    const res = await app.request(
-      '/webhook',
-      {
-        method: 'POST',
-        headers: { 'X-Line-Signature': 'aW52YWxpZA==' },
-        body: 'this is { not valid json',
-      },
-      baseEnv(db),
-    );
-
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as { status: string };
-    expect(body.status).toBe('ok');
+    const json = (await res.json()) as { status: string };
+    expect(json.status).toBe('ok');
+    expect(prepareCount()).toBe(0);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Invalid LINE signature');
   });
 });

--- a/apps/worker/src/routes/webhook.test.ts
+++ b/apps/worker/src/routes/webhook.test.ts
@@ -120,6 +120,33 @@ describe('POST /webhook — payload size limits', () => {
 
     expect(res.status).toBe(413);
   });
+
+  test('post-read fallback rejects oversized body when Content-Length is absent', async () => {
+    // ReadableStream bodies do not get an automatic Content-Length, so the
+    // pre-check is bypassed and only the post-read fallback can reject.
+    const oversized = 'x'.repeat(600 * 1024);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(oversized));
+        controller.close();
+      },
+    });
+
+    const req = new Request('http://localhost/webhook', {
+      method: 'POST',
+      headers: { 'X-Line-Signature': 'dummy' },
+      body: stream,
+      // @ts-expect-error duplex is required for streaming bodies in Node fetch
+      duplex: 'half',
+    });
+    expect(req.headers.get('Content-Length')).toBeNull();
+
+    const app = new Hono();
+    app.route('/', webhook);
+    const { db } = recordingDb();
+    const res = await app.fetch(req, baseEnv(db));
+    expect(res.status).toBe(413);
+  });
 });
 
 describe('POST /webhook — signature gates JSON.parse', () => {

--- a/apps/worker/src/routes/webhook.test.ts
+++ b/apps/worker/src/routes/webhook.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'vitest';
+import { Hono } from 'hono';
+import { webhook } from './webhook.js';
+
+function recordingDb() {
+  let accessed = false;
+  const statement: Record<string, unknown> = {};
+  Object.assign(statement, {
+    bind: () => statement,
+    all: async () => ({ results: [] }),
+    first: async () => null,
+    run: async () => ({ meta: { changes: 0 } }),
+  });
+  return {
+    db: {
+      prepare: () => {
+        accessed = true;
+        return statement;
+      },
+    },
+    accessed: () => accessed,
+  };
+}
+
+const baseEnv = (db: unknown) => ({
+  LINE_CHANNEL_SECRET: 'test-secret',
+  LINE_CHANNEL_ACCESS_TOKEN: 'test-access-token',
+  DB: db,
+});
+
+describe('POST /webhook — DoS protection', () => {
+  test('rejects bodies larger than 512KB with 413 before reaching DB', async () => {
+    const app = new Hono();
+    app.route('/', webhook);
+    const { db, accessed } = recordingDb();
+
+    const oversized = 'x'.repeat(513 * 1024);
+    const res = await app.request(
+      '/webhook',
+      {
+        method: 'POST',
+        headers: { 'X-Line-Signature': 'dummy' },
+        body: oversized,
+      },
+      baseEnv(db),
+    );
+
+    expect(res.status).toBe(413);
+    expect(accessed()).toBe(false);
+  });
+
+  test('returns 200 without DB access when X-Line-Signature is missing', async () => {
+    const app = new Hono();
+    app.route('/', webhook);
+    const { db, accessed } = recordingDb();
+
+    const res = await app.request(
+      '/webhook',
+      {
+        method: 'POST',
+        body: '{"events":[]}',
+      },
+      baseEnv(db),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('ok');
+    expect(accessed()).toBe(false);
+  });
+
+  test('returns 200 on invalid signature without crashing on malformed JSON', async () => {
+    const app = new Hono();
+    app.route('/', webhook);
+    const { db } = recordingDb();
+
+    const res = await app.request(
+      '/webhook',
+      {
+        method: 'POST',
+        headers: { 'X-Line-Signature': 'aW52YWxpZA==' },
+        body: 'this is { not valid json',
+      },
+      baseEnv(db),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe('ok');
+  });
+});

--- a/apps/worker/src/routes/webhook.test.ts
+++ b/apps/worker/src/routes/webhook.test.ts
@@ -26,9 +26,25 @@ async function signBody(secret: string, body: string): Promise<string> {
   return btoa(binary);
 }
 
-function recordingDb() {
-  const calls: { sql: string; binds: unknown[] }[] = [];
+interface MockAccountRow {
+  id: string;
+  channel_id?: string;
+  name?: string;
+  channel_secret: string;
+  channel_access_token: string;
+  is_active: number;
+}
+
+interface RecordedCall {
+  sql: string;
+  binds: unknown[];
+}
+
+function recordingDb(opts: { accounts?: MockAccountRow[] } = {}) {
+  const accounts = opts.accounts ?? [];
+  const calls: RecordedCall[] = [];
   let prepareCount = 0;
+
   const db = {
     prepare(sql: string) {
       prepareCount += 1;
@@ -41,10 +57,31 @@ function recordingDb() {
         },
         all: async () => {
           calls.push({ sql, binds: bindArgs });
+          if (sql.includes('FROM line_accounts')) {
+            return { results: accounts };
+          }
           return { results: [] };
         },
         first: async () => {
           calls.push({ sql, binds: bindArgs });
+          // Return a synthetic friend row for the post-INSERT lookup so the
+          // follow-event flow can continue and we can observe matchedAccountId.
+          if (/^SELECT \* FROM friends WHERE id =/.test(sql.trim())) {
+            return {
+              id: bindArgs[0],
+              line_user_id: 'U-fake',
+              display_name: null,
+              picture_url: null,
+              status_message: null,
+              is_following: 1,
+              user_id: null,
+              line_account_id: null,
+              metadata: '{}',
+              first_tracked_link_id: null,
+              created_at: '2026-01-01T00:00:00+09:00',
+              updated_at: '2026-01-01T00:00:00+09:00',
+            };
+          }
           return null;
         },
         run: async () => {
@@ -55,10 +92,28 @@ function recordingDb() {
       return stmt;
     },
   };
+
   return {
     db,
     calls: () => calls,
     prepareCount: () => prepareCount,
+  };
+}
+
+function createCtx() {
+  const promises: Promise<unknown>[] = [];
+  const ctx = {
+    waitUntil: (p: Promise<unknown>) => {
+      promises.push(p);
+    },
+    passThroughOnException: () => {},
+    props: {},
+  } as unknown as ExecutionContext;
+  return {
+    ctx,
+    flush: async () => {
+      await Promise.allSettled(promises);
+    },
   };
 }
 
@@ -166,6 +221,7 @@ describe('POST /webhook — signature gates JSON.parse', () => {
     const body = 'this is { not valid json';
     const sig = await signBody('env-secret', body);
 
+    const { ctx } = createCtx();
     const res = await app.request(
       '/webhook',
       {
@@ -174,6 +230,7 @@ describe('POST /webhook — signature gates JSON.parse', () => {
         body,
       },
       baseEnv(db),
+      ctx,
     );
 
     expect(res.status).toBe(200);
@@ -220,6 +277,129 @@ describe('POST /webhook — signature gates JSON.parse', () => {
     const json = (await res.json()) as { status: string };
     expect(json.status).toBe('ok');
     expect(prepareCount()).toBe(0);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Invalid LINE signature');
+  });
+});
+
+describe('POST /webhook — multi-account routing', () => {
+  let consoleErrorSpy: MockInstance;
+  let fetchSpy: MockInstance;
+  let fetchCalls: { url: string; auth: string | null }[];
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchCalls = [];
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: Request | string | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+        const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+        fetchCalls.push({ url, auth: headers.get('Authorization') });
+        return new Response(JSON.stringify({ displayName: 'Test User' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      });
+  });
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    fetchSpy.mockRestore();
+  });
+
+  test('signature signed with a DB-registered account secret routes matchedAccountId and channelAccessToken to that account', async () => {
+    // Env secret check fails; the DB-registered account's secret matches, so
+    // both matchedAccountId and channelAccessToken must switch to the DB row.
+    // Observed via:
+    //   (1) UPDATE friends SET line_account_id = ? — bind[0] is the DB account id
+    //   (2) Outbound LINE API call's Authorization header uses the DB token
+    const accId = 'db-account-uuid';
+    const dbSecret = 'db-channel-secret';
+    const dbToken = 'db-channel-access-token';
+    const { db, calls } = recordingDb({
+      accounts: [
+        {
+          id: accId,
+          channel_id: 'C-db',
+          name: 'DB Account',
+          channel_secret: dbSecret,
+          channel_access_token: dbToken,
+          is_active: 1,
+        },
+      ],
+    });
+
+    const body = JSON.stringify({
+      destination: 'U-destination',
+      events: [
+        {
+          type: 'follow',
+          mode: 'active',
+          timestamp: 1700000000000,
+          source: { type: 'user', userId: 'U-test-user' },
+          replyToken: 'rt-test-token',
+        },
+      ],
+    });
+    const sig = await signBody(dbSecret, body);
+
+    const app = new Hono();
+    app.route('/', webhook);
+    const { ctx, flush } = createCtx();
+    const res = await app.request(
+      '/webhook',
+      {
+        method: 'POST',
+        headers: { 'X-Line-Signature': sig },
+        body,
+      },
+      baseEnv(db),
+      ctx,
+    );
+    await flush();
+
+    expect(res.status).toBe(200);
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith('Invalid LINE signature');
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith('Failed to parse verified webhook body');
+
+    const updateAccountIdCall = calls().find((c) =>
+      c.sql.includes('UPDATE friends SET line_account_id'),
+    );
+    expect(updateAccountIdCall, 'UPDATE friends SET line_account_id should be issued').toBeDefined();
+    expect(updateAccountIdCall!.binds[0]).toBe(accId);
+
+    const profileFetch = fetchCalls.find((c) => c.url.includes('/v2/bot/profile/'));
+    expect(profileFetch, 'getProfile fetch to LINE API should occur').toBeDefined();
+    expect(profileFetch!.auth).toBe(`Bearer ${dbToken}`);
+    expect(profileFetch!.auth).not.toBe('Bearer env-access-token');
+  });
+
+  test('inactive DB account is skipped during signature matching', async () => {
+    const inactiveSecret = 'inactive-secret';
+    const { db } = recordingDb({
+      accounts: [
+        {
+          id: 'inactive-acc',
+          channel_secret: inactiveSecret,
+          channel_access_token: 'inactive-token',
+          is_active: 0,
+        },
+      ],
+    });
+    const body = JSON.stringify({ events: [] });
+    const sig = await signBody(inactiveSecret, body);
+
+    const app = new Hono();
+    app.route('/', webhook);
+    const res = await app.request(
+      '/webhook',
+      {
+        method: 'POST',
+        headers: { 'X-Line-Signature': sig },
+        body,
+      },
+      baseEnv(db),
+    );
+
+    expect(res.status).toBe(200);
     expect(consoleErrorSpy).toHaveBeenCalledWith('Invalid LINE signature');
   });
 });

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -36,10 +36,12 @@ webhook.post('/webhook', async (c) => {
     }
   }
 
-  // Read the body, then double-check the size in case Content-Length was
-  // missing or untrustworthy (chunked transfer encoding etc.).
+  // Post-read fallback for missing/untrustworthy Content-Length (chunked etc.).
+  // Use UTF-8 byte length, not String.prototype.length (UTF-16 code units would
+  // undercount multi-byte payloads and let oversized JP bodies slip through).
   const rawBody = await c.req.text();
-  if (rawBody.length > MAX_WEBHOOK_BODY_SIZE) {
+  const rawBodyByteLength = new TextEncoder().encode(rawBody).byteLength;
+  if (rawBodyByteLength > MAX_WEBHOOK_BODY_SIZE) {
     return c.json({ status: 'payload too large' }, 413);
   }
 

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -20,43 +20,72 @@ import type { Env } from '../index.js';
 
 const webhook = new Hono<Env>();
 
-webhook.post('/webhook', async (c) => {
-  const rawBody = await c.req.text();
-  const signature = c.req.header('X-Line-Signature') ?? '';
-  const db = c.env.DB;
+// Maximum accepted webhook body size. 512KB leaves ample headroom while
+// bounding the memory + CPU an unauthenticated request can force the
+// worker to spend.
+const MAX_WEBHOOK_BODY_SIZE = 512 * 1024;
 
-  let body: WebhookRequestBody;
-  try {
-    body = JSON.parse(rawBody) as WebhookRequestBody;
-  } catch {
-    console.error('Failed to parse webhook body');
+webhook.post('/webhook', async (c) => {
+  // Reject oversized payloads via Content-Length before reading the body.
+  // This avoids buffering attacker-controlled bytes into worker memory at all.
+  const contentLengthHeader = c.req.header('Content-Length');
+  if (contentLengthHeader) {
+    const contentLength = parseInt(contentLengthHeader, 10);
+    if (Number.isFinite(contentLength) && contentLength > MAX_WEBHOOK_BODY_SIZE) {
+      return c.json({ status: 'payload too large' }, 413);
+    }
+  }
+
+  // Read the body, then double-check the size in case Content-Length was
+  // missing or untrustworthy (chunked transfer encoding etc.).
+  const rawBody = await c.req.text();
+  if (rawBody.length > MAX_WEBHOOK_BODY_SIZE) {
+    return c.json({ status: 'payload too large' }, 413);
+  }
+
+  const signature = c.req.header('X-Line-Signature') ?? '';
+  if (!signature) {
+    console.error('Invalid LINE signature');
     return c.json({ status: 'ok' }, 200);
   }
 
-  // Multi-account: resolve credentials from DB by destination (channel user ID)
-  // or fall back to environment variables (default account)
+  // Verify the HMAC signature BEFORE JSON.parse so that unverified input
+  // never reaches the parser. Try the env default secret first as a fast
+  // path, then fall back to DB-registered accounts.
+  const db = c.env.DB;
   let channelSecret = c.env.LINE_CHANNEL_SECRET;
   let channelAccessToken = c.env.LINE_CHANNEL_ACCESS_TOKEN;
   let matchedAccountId: string | null = null;
+  let valid = false;
 
-  if ((body as { destination?: string }).destination) {
+  if (channelSecret) {
+    valid = await verifySignature(channelSecret, rawBody, signature);
+  }
+
+  if (!valid) {
     const accounts = await getLineAccounts(db);
     for (const account of accounts) {
       if (!account.is_active) continue;
-      const isValid = await verifySignature(account.channel_secret, rawBody, signature);
-      if (isValid) {
+      if (await verifySignature(account.channel_secret, rawBody, signature)) {
         channelSecret = account.channel_secret;
         channelAccessToken = account.channel_access_token;
         matchedAccountId = account.id;
+        valid = true;
         break;
       }
     }
   }
 
-  // Verify with resolved secret
-  const valid = await verifySignature(channelSecret, rawBody, signature);
   if (!valid) {
     console.error('Invalid LINE signature');
+    return c.json({ status: 'ok' }, 200);
+  }
+
+  let body: WebhookRequestBody;
+  try {
+    body = JSON.parse(rawBody) as WebhookRequestBody;
+  } catch {
+    console.error('Failed to parse verified webhook body');
     return c.json({ status: 'ok' }, 200);
   }
 


### PR DESCRIPTION
## Summary

Closes #104.

The LINE webhook handler previously called `c.req.text()` and `JSON.parse()` unconditionally before any signature verification, so an unauthenticated attacker could force the worker to spend memory and CPU on arbitrarily large payloads.

This PR addresses all three completion criteria from #104 in one change:

- **Content-Length pre-check** before reading the body (early reject with `413`)
- **Post-read size guard** as a fallback when `Content-Length` is missing or untrustworthy
- **Signature verification before `JSON.parse`** so that unverified input never reaches the parser

## What changed

- `apps/worker/src/routes/webhook.ts`
  - New `MAX_WEBHOOK_BODY_SIZE = 512 * 1024` cap
  - Reordered handler: size guard → signature verification → JSON parse → event handling
  - Dropped the `body.destination`-based account-routing branch. The previous flow read `body.destination` (attacker-controlled, unverified at that point) to decide whether to try DB-registered accounts. The new flow always tries the env default secret first, then iterates DB-registered accounts on miss. Net effect: same set of secrets is checked, no parser attack surface.
- `apps/worker/src/routes/webhook.test.ts` (new) — three tests covering the added DoS defenses

## Notes 

- HMAC verification with `crypto.subtle.sign` is non-streaming on Workers, so this PR cannot read the body in a streaming fashion; the 512KB cap is the primary defense and signature-first is the secondary defense (parser attack surface reduction).
- Behavior on invalid signature or malformed body is unchanged (`200 OK` with status `ok` — LINE expects 2xx). Only the `413 Payload Too Large` case is new on the response surface.
