### PR TITLE
Bypass token-revoked problem due to LIFF browser cache

### DIFF
--- a/apps/worker/src/client/main.ts
+++ b/apps/worker/src/client/main.ts
@@ -188,12 +188,38 @@ function showCompletion(profile: { displayName: string; pictureUrl?: string }, i
 
 function showError(message: string) {
   const container = document.getElementById('app')!;
+  const resetUrl = new URL(window.location.href);
+  resetUrl.searchParams.set('reset', '1');
   container.innerHTML = `
     <div class="card">
       <h2>エラー</h2>
       <p class="error">${escapeHtml(message)}</p>
+      <a class="add-friend-btn" href="${escapeHtml(resetUrl.toString())}">ログアウトする</a>
     </div>
   `;
+}
+
+function showResetDone() {
+  const container = document.getElementById('app')!;
+  container.innerHTML = `
+    <div class="card">
+      <h2>ログアウトしました</h2>
+      <p class="message">右上の × ボタンで画面を閉じ、もう一度LIFFを開き直してください。</p>
+      <button id="lh-close-btn" class="add-friend-btn" type="button">画面を閉じる</button>
+    </div>
+  `;
+  const btn = document.getElementById('lh-close-btn');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      try {
+        if (typeof liff !== 'undefined' && typeof liff.closeWindow === 'function') {
+          liff.closeWindow();
+          return;
+        }
+      } catch { /* fall through */ }
+      try { window.close(); } catch { /* no-op */ }
+    });
+  }
 }
 
 // ─── Core Flow ──────────────────────────────────────────
@@ -447,6 +473,24 @@ async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void
 
 async function main() {
   try {
+    // Escape hatch: ?reset=1 clears all LIFF/local cache and shows a
+    // close-window page (does NOT proceed to liff.init). Use when a revoked
+    // LINE access token leaves the SDK stuck "logged in" with an unusable
+    // token. Re-opening the LIFF without ?reset=1 then triggers a fresh
+    // OAuth flow.
+    if (new URLSearchParams(window.location.search).get('reset') === '1') {
+      try {
+        for (let i = localStorage.length - 1; i >= 0; i--) {
+          const k = localStorage.key(i);
+          if (k && (/^LIFF/i.test(k) || /^liff[-_]/i.test(k) || k === UUID_STORAGE_KEY)) {
+            localStorage.removeItem(k);
+          }
+        }
+      } catch { /* private mode etc. */ }
+      showResetDone();
+      return;
+    }
+
     await liff.init({ liffId: LIFF_ID });
 
     if (!liff.isLoggedIn()) {

--- a/apps/worker/src/client/salon-booking/pages/BookingHistory.tsx
+++ b/apps/worker/src/client/salon-booking/pages/BookingHistory.tsx
@@ -83,6 +83,18 @@ export default function BookingHistory() {
           ))}
         </ul>
       )}
+      <button
+        type="button"
+        onClick={() => {
+          const url = new URL(window.location.href);
+          url.searchParams.set('view', 'new');
+          window.location.href = url.toString();
+        }}
+        className="w-full py-3 rounded-xl text-white font-semibold mt-2"
+        style={{ background: '#06C755' }}
+      >
+        新規予約をする
+      </button>
       <p className="text-xs text-gray-400 text-center pt-2">
         変更・キャンセルはお店に LINE で直接ご連絡ください
       </p>


### PR DESCRIPTION
アプリ再連携時などに無効なトークンエラーが出てしまい、LIFFブラウザはローカルストレージを明示的に消す手段が無いので詰んでしまう事がありました。
ページ表示時にエラーとなった場合、ログアウトボタンを表示するようにし、そのボタンを押下した際に強制的にトークンを消すようにする機能を追加します。