### PR TITLE
fix: scope LINE account data by account

### DIFF
--- a/apps/web/src/app/broadcasts/page.tsx
+++ b/apps/web/src/app/broadcasts/page.tsx
@@ -104,7 +104,7 @@ function BroadcastList() {
     try {
       const [broadcastsRes, tagsRes] = await Promise.all([
         api.broadcasts.list({ accountId: selectedAccountId || undefined }),
-        api.tags.list(),
+        api.tags.list({ accountId: selectedAccountId || undefined }),
       ])
       if (broadcastsRes.success) setBroadcasts(broadcastsRes.data)
       else setError(broadcastsRes.error)

--- a/apps/web/src/app/friends/page.tsx
+++ b/apps/web/src/app/friends/page.tsx
@@ -50,12 +50,12 @@ export default function FriendsPage() {
 
   const loadTags = useCallback(async () => {
     try {
-      const res = await api.tags.list()
+      const res = await api.tags.list({ accountId: selectedAccountId || undefined })
       if (res.success) setAllTags(res.data)
     } catch {
       // Non-blocking — tags used for filter
     }
-  }, [])
+  }, [selectedAccountId])
 
   const loadFriends = useCallback(async () => {
     setLoading(true)

--- a/apps/web/src/app/scenarios/detail/scenario-detail-client.tsx
+++ b/apps/web/src/app/scenarios/detail/scenario-detail-client.tsx
@@ -194,7 +194,7 @@ export default function ScenarioDetailClient({ scenarioId }: { scenarioId: strin
     Promise.all([
       api.scenarios.stats(id).catch(() => null),
       api.templates.list().catch(() => null),
-      api.tags.list().catch(() => null),
+      api.tags.list({ accountId: scenario?.lineAccountId || undefined }).catch(() => null),
     ]).then(([statsRes, tplRes, tagRes]) => {
       if (cancelled) return
       if (statsRes && statsRes.success) setStats(statsRes.data)
@@ -212,7 +212,7 @@ export default function ScenarioDetailClient({ scenarioId }: { scenarioId: strin
       }
     })
     return () => { cancelled = true }
-  }, [id])
+  }, [id, scenario?.lineAccountId])
 
   const reloadStats = useCallback(() => {
     api.scenarios.stats(id).then((r) => { if (r.success) setStats(r.data) }).catch(() => {})

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -156,9 +156,11 @@ export const api = {
       ),
   },
   tags: {
-    list: () =>
-      fetchApi<ApiResponse<Tag[]>>('/api/tags'),
-    create: (data: { name: string; color: string }) =>
+    list: (params?: { accountId?: string }) => {
+      const query = params?.accountId ? '?lineAccountId=' + params.accountId : ''
+      return fetchApi<ApiResponse<Tag[]>>('/api/tags' + query)
+    },
+    create: (data: { name: string; color: string; lineAccountId?: string | null }) =>
       fetchApi<ApiResponse<Tag>>('/api/tags', {
         method: 'POST',
         body: JSON.stringify(data),

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -873,10 +873,9 @@ liffRoutes.get('/auth/callback', async (c) => {
         resolveStepContent: resolveStepLiff,
         addTagToFriend: addTagLiff,
       } = await import('@line-crm/db');
-      const scenarios = runAccountScenariosLiff ? await getScenarios(db) : [];
+      const scenarios = runAccountScenariosLiff ? await getScenarios(db, matchedAccountId) : [];
       for (const scenario of scenarios) {
-        const scenarioAccountMatch = !scenario.line_account_id || !matchedAccountId || scenario.line_account_id === matchedAccountId;
-        if (scenario.trigger_type === 'friend_add' && scenario.is_active && scenarioAccountMatch) {
+        if (scenario.trigger_type === 'friend_add' && scenario.is_active) {
           const enrollment = await enroll(db, friend.id, scenario.id);
           if (enrollment) {
             // 即時送信は scenario.delivery_mode を踏まえて「now 以前にスケジュールされる」場合のみ。

--- a/apps/worker/src/routes/tags.ts
+++ b/apps/worker/src/routes/tags.ts
@@ -10,6 +10,7 @@ function serializeTag(row: DbTag) {
     id: row.id,
     name: row.name,
     color: row.color,
+    lineAccountId: row.line_account_id ?? null,
     createdAt: row.created_at,
   };
 }
@@ -17,7 +18,8 @@ function serializeTag(row: DbTag) {
 // GET /api/tags - list all tags
 tags.get('/api/tags', async (c) => {
   try {
-    const items = await getTags(c.env.DB);
+    const lineAccountId = c.req.query('lineAccountId') ?? null;
+    const items = await getTags(c.env.DB, lineAccountId);
     return c.json({ success: true, data: items.map(serializeTag) });
   } catch (err) {
     console.error('GET /api/tags error:', err);
@@ -28,7 +30,7 @@ tags.get('/api/tags', async (c) => {
 // POST /api/tags - create tag
 tags.post('/api/tags', async (c) => {
   try {
-    const body = await c.req.json<{ name: string; color?: string }>();
+    const body = await c.req.json<{ name: string; color?: string; lineAccountId?: string | null }>();
 
     if (!body.name) {
       return c.json({ success: false, error: 'name is required' }, 400);
@@ -37,6 +39,7 @@ tags.post('/api/tags', async (c) => {
     const tag = await createTag(c.env.DB, {
       name: body.name,
       color: body.color,
+      lineAccountId: body.lineAccountId ?? null,
     });
 
     return c.json({ success: true, data: serializeTag(tag) }, 201);

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -163,6 +163,7 @@ async function handleEvent(
 
     const friend = await upsertFriend(db, {
       lineUserId: userId,
+      lineAccountId,
       displayName: profile?.displayName ?? null,
       pictureUrl: profile?.pictureUrl ?? null,
       statusMessage: profile?.statusMessage ?? null,
@@ -204,11 +205,9 @@ async function handleEvent(
 
     // friend_add シナリオに登録（このアカウントのシナリオのみ）
     // Skip entirely when a referral link explicitly overrides (run_account_friend_add_scenarios=0).
-    const scenarios = runAccountScenarios ? await getScenarios(db) : [];
+    const scenarios = runAccountScenarios ? await getScenarios(db, lineAccountId) : [];
     for (const scenario of scenarios) {
-      // Only trigger scenarios belonging to this account (or unassigned for backward compat)
-      const scenarioAccountMatch = !scenario.line_account_id || !lineAccountId || scenario.line_account_id === lineAccountId;
-      if (scenario.trigger_type === 'friend_add' && scenario.is_active && scenarioAccountMatch) {
+      if (scenario.trigger_type === 'friend_add' && scenario.is_active) {
         try {
           // INSERT OR IGNORE handles dedup via UNIQUE(friend_id, scenario_id)
           const friendScenario = await enrollFriendInScenario(db, friend.id, scenario.id);
@@ -328,7 +327,7 @@ async function handleEvent(
       event.source.type === 'user' ? event.source.userId : undefined;
     if (!userId) return;
 
-    await updateFriendFollowStatus(db, userId, false);
+    await updateFriendFollowStatus(db, userId, false, lineAccountId);
     return;
   }
 
@@ -338,14 +337,14 @@ async function handleEvent(
     const userId = event.source.type === 'user' ? event.source.userId : undefined;
     if (!userId) return;
 
-    const friend = await getFriendByLineUserId(db, userId);
+    const friend = await getFriendByLineUserId(db, userId, lineAccountId);
     if (!friend) return;
 
     const postbackData = (event as unknown as { postback: { data: string } }).postback.data;
 
     // Match postback data against auto_replies (exact match on keyword)
     const autoReplyQuery = lineAccountId
-      ? `SELECT * FROM auto_replies WHERE is_active = 1 AND (line_account_id IS NULL OR line_account_id = ?) ORDER BY created_at ASC`
+      ? `SELECT * FROM auto_replies WHERE is_active = 1 AND line_account_id = ? ORDER BY created_at ASC`
       : `SELECT * FROM auto_replies WHERE is_active = 1 AND line_account_id IS NULL ORDER BY created_at ASC`;
     const autoReplyStmt = db.prepare(autoReplyQuery);
     const autoReplies = await (lineAccountId ? autoReplyStmt.bind(lineAccountId) : autoReplyStmt)
@@ -418,7 +417,7 @@ async function handleEvent(
   if (event.type === 'message' && event.message.type !== 'text') {
     const userId = event.source.type === 'user' ? event.source.userId : undefined;
     if (!userId) return;
-    const friend = await getFriendByLineUserId(db, userId);
+    const friend = await getFriendByLineUserId(db, userId, lineAccountId);
     if (!friend) return;
 
     const msg = event.message as { type: string; fileName?: string; title?: string };
@@ -448,7 +447,7 @@ async function handleEvent(
       event.source.type === 'user' ? event.source.userId : undefined;
     if (!userId) return;
 
-    const friend = await getFriendByLineUserId(db, userId);
+    const friend = await getFriendByLineUserId(db, userId, lineAccountId);
     if (!friend) return;
 
     const incomingText = textMessage.text;
@@ -520,7 +519,7 @@ async function handleEvent(
     // NOTE: Auto-replies use replyMessage (free, no quota) instead of pushMessage
     // The replyToken is only valid for ~1 minute after the message event
     const autoReplyQuery = lineAccountId
-      ? `SELECT * FROM auto_replies WHERE is_active = 1 AND (line_account_id IS NULL OR line_account_id = ?) ORDER BY created_at ASC`
+      ? `SELECT * FROM auto_replies WHERE is_active = 1 AND line_account_id = ? ORDER BY created_at ASC`
       : `SELECT * FROM auto_replies WHERE is_active = 1 AND line_account_id IS NULL ORDER BY created_at ASC`;
     const autoReplyStmt = db.prepare(autoReplyQuery);
     const autoReplies = await (lineAccountId ? autoReplyStmt.bind(lineAccountId) : autoReplyStmt)

--- a/apps/worker/src/services/event-bus.ts
+++ b/apps/worker/src/services/event-bus.ts
@@ -144,9 +144,8 @@ async function processAutomations(
 ): Promise<void> {
   try {
     const allAutomations = await getActiveAutomationsByEvent(db, eventType);
-    // Filter by account: match this account's automations + unassigned (backward compat)
     const automations = allAutomations.filter(
-      (a) => !a.line_account_id || !lineAccountId || a.line_account_id === lineAccountId,
+      (a) => lineAccountId ? a.line_account_id === lineAccountId : a.line_account_id === null,
     );
 
     for (const automation of automations) {
@@ -251,8 +250,8 @@ async function executeAction(
     case 'send_message': {
       if (!lineAccessToken || !friendId) break;
       const friend = await db
-        .prepare('SELECT line_user_id FROM friends WHERE id = ?')
-        .bind(friendId)
+        .prepare(lineAccountId ? 'SELECT line_user_id FROM friends WHERE id = ? AND line_account_id = ?' : 'SELECT line_user_id FROM friends WHERE id = ?')
+        .bind(...(lineAccountId ? [friendId, lineAccountId] : [friendId]))
         .first<{ line_user_id: string }>();
       if (!friend) break;
       const lineClient = new LineClient(lineAccessToken);
@@ -345,8 +344,8 @@ async function executeAction(
     case 'switch_rich_menu': {
       if (!lineAccessToken || !friendId) break;
       const friend = await db
-        .prepare('SELECT line_user_id FROM friends WHERE id = ?')
-        .bind(friendId)
+        .prepare(lineAccountId ? 'SELECT line_user_id FROM friends WHERE id = ? AND line_account_id = ?' : 'SELECT line_user_id FROM friends WHERE id = ?')
+        .bind(...(lineAccountId ? [friendId, lineAccountId] : [friendId]))
         .first<{ line_user_id: string }>();
       if (!friend) break;
       const lineClient = new LineClient(lineAccessToken);
@@ -357,8 +356,8 @@ async function executeAction(
     case 'remove_rich_menu': {
       if (!lineAccessToken || !friendId) break;
       const friend = await db
-        .prepare('SELECT line_user_id FROM friends WHERE id = ?')
-        .bind(friendId)
+        .prepare(lineAccountId ? 'SELECT line_user_id FROM friends WHERE id = ? AND line_account_id = ?' : 'SELECT line_user_id FROM friends WHERE id = ?')
+        .bind(...(lineAccountId ? [friendId, lineAccountId] : [friendId]))
         .first<{ line_user_id: string }>();
       if (!friend) break;
       const lineClient = new LineClient(lineAccessToken);

--- a/packages/db/migrations/041_strict_account_scope_friends_tags.sql
+++ b/packages/db/migrations/041_strict_account_scope_friends_tags.sql
@@ -1,0 +1,82 @@
+-- Migration 041: Strict account scoping for friends and tags.
+-- Rebuilds friends/tags to remove legacy single-column UNIQUE constraints:
+--   friends.line_user_id UNIQUE  -> unique per (line_user_id, line_account_id)
+--   tags.name UNIQUE             -> unique per (line_account_id, name)
+-- Existing rows are preserved. Existing NULL line_account_id rows stay NULL.
+
+PRAGMA foreign_keys = OFF;
+PRAGMA defer_foreign_keys = ON;
+PRAGMA legacy_alter_table = ON;
+
+DROP INDEX IF EXISTS idx_friends_line_user_account_unique;
+DROP INDEX IF EXISTS idx_friends_line_user_null_account_unique;
+DROP INDEX IF EXISTS idx_friends_line_user_id;
+DROP INDEX IF EXISTS idx_friends_account;
+DROP INDEX IF EXISTS idx_friends_user_id;
+DROP INDEX IF EXISTS idx_friends_ig_igsid;
+
+ALTER TABLE friends RENAME TO friends_old_041;
+
+CREATE TABLE friends (
+  id                    TEXT PRIMARY KEY,
+  line_user_id          TEXT NOT NULL,
+  display_name          TEXT,
+  picture_url           TEXT,
+  status_message        TEXT,
+  is_following          INTEGER NOT NULL DEFAULT 1,
+  line_account_id       TEXT REFERENCES line_accounts (id) ON DELETE SET NULL,
+  user_id               TEXT,
+  ig_igsid              TEXT,
+  score                 INTEGER NOT NULL DEFAULT 0,
+  metadata              TEXT NOT NULL DEFAULT '{}',
+  ref_code              TEXT,
+  first_tracked_link_id TEXT REFERENCES tracked_links (id) ON DELETE SET NULL,
+  created_at            TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at            TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+);
+
+INSERT INTO friends (
+  id, line_user_id, display_name, picture_url, status_message, is_following,
+  line_account_id, user_id, ig_igsid, score, metadata, ref_code,
+  first_tracked_link_id, created_at, updated_at
+)
+SELECT
+  id, line_user_id, display_name, picture_url, status_message, is_following,
+  line_account_id, user_id, ig_igsid, score, metadata, ref_code,
+  first_tracked_link_id, created_at, updated_at
+FROM friends_old_041;
+
+DROP TABLE friends_old_041;
+
+CREATE INDEX IF NOT EXISTS idx_friends_line_user_id ON friends (line_user_id);
+CREATE INDEX IF NOT EXISTS idx_friends_account ON friends (line_account_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_friends_line_user_account_unique ON friends (line_user_id, line_account_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_friends_line_user_null_account_unique ON friends (line_user_id) WHERE line_account_id IS NULL;
+CREATE INDEX IF NOT EXISTS idx_friends_user_id ON friends (user_id);
+CREATE INDEX IF NOT EXISTS idx_friends_ig_igsid ON friends (ig_igsid);
+
+DROP INDEX IF EXISTS idx_tags_account;
+DROP INDEX IF EXISTS idx_tags_account_name_unique;
+DROP INDEX IF EXISTS idx_tags_null_account_name_unique;
+
+ALTER TABLE tags RENAME TO tags_old_041;
+
+CREATE TABLE tags (
+  id              TEXT PRIMARY KEY,
+  name            TEXT NOT NULL,
+  color           TEXT NOT NULL DEFAULT '#3B82F6',
+  line_account_id TEXT REFERENCES line_accounts (id) ON DELETE SET NULL,
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+);
+
+INSERT INTO tags (id, name, color, line_account_id, created_at)
+SELECT id, name, color, NULL, created_at
+FROM tags_old_041;
+
+DROP TABLE tags_old_041;
+
+CREATE INDEX IF NOT EXISTS idx_tags_account ON tags (line_account_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_account_name_unique ON tags (line_account_id, name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_null_account_name_unique ON tags (name) WHERE line_account_id IS NULL;
+
+PRAGMA foreign_keys = ON;

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -6,11 +6,12 @@
 -- ============================================================
 CREATE TABLE IF NOT EXISTS friends (
   id               TEXT PRIMARY KEY,
-  line_user_id     TEXT UNIQUE NOT NULL,
+  line_user_id     TEXT NOT NULL,
   display_name     TEXT,
   picture_url      TEXT,
   status_message   TEXT,
   is_following     INTEGER NOT NULL DEFAULT 1,
+  line_account_id  TEXT REFERENCES line_accounts (id) ON DELETE SET NULL,
   user_id          TEXT,
   ig_igsid         TEXT,
   score            INTEGER NOT NULL DEFAULT 0,
@@ -19,6 +20,9 @@ CREATE TABLE IF NOT EXISTS friends (
 );
 
 CREATE INDEX IF NOT EXISTS idx_friends_line_user_id ON friends (line_user_id);
+CREATE INDEX IF NOT EXISTS idx_friends_account ON friends (line_account_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_friends_line_user_account_unique ON friends (line_user_id, line_account_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_friends_line_user_null_account_unique ON friends (line_user_id) WHERE line_account_id IS NULL;
 CREATE INDEX IF NOT EXISTS idx_friends_user_id ON friends (user_id);
 CREATE INDEX IF NOT EXISTS idx_friends_ig_igsid ON friends (ig_igsid);
 
@@ -27,10 +31,15 @@ CREATE INDEX IF NOT EXISTS idx_friends_ig_igsid ON friends (ig_igsid);
 -- ============================================================
 CREATE TABLE IF NOT EXISTS tags (
   id         TEXT PRIMARY KEY,
-  name       TEXT UNIQUE NOT NULL,
+  name       TEXT NOT NULL,
   color      TEXT NOT NULL DEFAULT '#3B82F6',
+  line_account_id TEXT REFERENCES line_accounts (id) ON DELETE SET NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
+
+CREATE INDEX IF NOT EXISTS idx_tags_account ON tags (line_account_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_account_name_unique ON tags (line_account_id, name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tags_null_account_name_unique ON tags (name) WHERE line_account_id IS NULL;
 
 -- ============================================================
 -- Friend <-> Tag join
@@ -53,6 +62,7 @@ CREATE TABLE IF NOT EXISTS scenarios (
   description     TEXT,
   trigger_type    TEXT NOT NULL CHECK (trigger_type IN ('friend_add', 'tag_added', 'manual')),
   trigger_tag_id  TEXT REFERENCES tags (id) ON DELETE SET NULL,
+  line_account_id TEXT REFERENCES line_accounts (id) ON DELETE SET NULL,
   is_active       INTEGER NOT NULL DEFAULT 1,
   delivery_mode   TEXT NOT NULL DEFAULT 'relative' CHECK (delivery_mode IN ('relative', 'elapsed', 'absolute_time')),
   created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),

--- a/packages/db/src/friends.ts
+++ b/packages/db/src/friends.ts
@@ -18,36 +18,35 @@ export interface GetFriendsOptions {
   limit?: number;
   offset?: number;
   tagId?: string;
+  lineAccountId?: string | null;
 }
 
 export async function getFriends(
   db: D1Database,
   opts: GetFriendsOptions = {},
 ): Promise<Friend[]> {
-  const { limit = 50, offset = 0, tagId } = opts;
+  const { limit = 50, offset = 0, tagId, lineAccountId } = opts;
+  const conditions: string[] = [];
+  const binds: unknown[] = [];
 
   if (tagId) {
-    const result = await db
-      .prepare(
-        `SELECT f.*
-         FROM friends f
-         INNER JOIN friend_tags ft ON ft.friend_id = f.id
-         WHERE ft.tag_id = ?
-         ORDER BY f.created_at DESC
-         LIMIT ? OFFSET ?`,
-      )
-      .bind(tagId, limit, offset)
-      .all<Friend>();
-    return result.results;
+    conditions.push('EXISTS (SELECT 1 FROM friend_tags ft WHERE ft.friend_id = f.id AND ft.tag_id = ?)');
+    binds.push(tagId);
+  }
+  if (lineAccountId) {
+    conditions.push('f.line_account_id = ?');
+    binds.push(lineAccountId);
   }
 
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
   const result = await db
     .prepare(
-      `SELECT * FROM friends
-       ORDER BY created_at DESC
+      `SELECT f.* FROM friends f
+       ${where}
+       ORDER BY f.created_at DESC
        LIMIT ? OFFSET ?`,
     )
-    .bind(limit, offset)
+    .bind(...binds, limit, offset)
     .all<Friend>();
   return result.results;
 }
@@ -93,7 +92,15 @@ export async function getFollowingLineUserIdsByTag(
 export async function getFriendByLineUserId(
   db: D1Database,
   lineUserId: string,
+  lineAccountId?: string | null,
 ): Promise<Friend | null> {
+  if (lineAccountId) {
+    return db
+      .prepare(`SELECT * FROM friends WHERE line_user_id = ? AND line_account_id = ?`)
+      .bind(lineUserId, lineAccountId)
+      .first<Friend>();
+  }
+
   return db
     .prepare(`SELECT * FROM friends WHERE line_user_id = ?`)
     .bind(lineUserId)
@@ -136,6 +143,7 @@ export async function setFriendFirstTrackedLinkIfNull(
 
 export interface UpsertFriendInput {
   lineUserId: string;
+  lineAccountId?: string | null;
   displayName?: string | null;
   pictureUrl?: string | null;
   statusMessage?: string | null;
@@ -146,7 +154,7 @@ export async function upsertFriend(
   input: UpsertFriendInput,
 ): Promise<Friend> {
   const now = jstNow();
-  const existing = await getFriendByLineUserId(db, input.lineUserId);
+  const existing = await getFriendByLineUserId(db, input.lineUserId, input.lineAccountId ?? null);
 
   if (existing) {
     await db
@@ -157,7 +165,7 @@ export async function upsertFriend(
              status_message = ?,
              is_following = 1,
              updated_at = ?
-         WHERE line_user_id = ?`,
+         WHERE line_user_id = ? AND (line_account_id = ? OR (? IS NULL AND line_account_id IS NULL))`,
       )
       .bind(
         'displayName' in input ? (input.displayName ?? null) : existing.display_name,
@@ -165,17 +173,19 @@ export async function upsertFriend(
         'statusMessage' in input ? (input.statusMessage ?? null) : existing.status_message,
         now,
         input.lineUserId,
+        input.lineAccountId ?? null,
+        input.lineAccountId ?? null,
       )
       .run();
 
-    return (await getFriendByLineUserId(db, input.lineUserId))!;
+    return (await getFriendByLineUserId(db, input.lineUserId, input.lineAccountId ?? null))!;
   }
 
   const id = crypto.randomUUID();
   await db
     .prepare(
-      `INSERT INTO friends (id, line_user_id, display_name, picture_url, status_message, is_following, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+      `INSERT INTO friends (id, line_user_id, display_name, picture_url, status_message, is_following, line_account_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?)`,
     )
     .bind(
       id,
@@ -183,6 +193,7 @@ export async function upsertFriend(
       input.displayName ?? null,
       input.pictureUrl ?? null,
       input.statusMessage ?? null,
+      input.lineAccountId ?? null,
       now,
       now,
     )
@@ -195,7 +206,20 @@ export async function updateFriendFollowStatus(
   db: D1Database,
   lineUserId: string,
   isFollowing: boolean,
+  lineAccountId?: string | null,
 ): Promise<void> {
+  if (lineAccountId) {
+    await db
+      .prepare(
+        `UPDATE friends
+         SET is_following = ?, updated_at = ?
+         WHERE line_user_id = ? AND line_account_id = ?`,
+      )
+      .bind(isFollowing ? 1 : 0, jstNow(), lineUserId, lineAccountId)
+      .run();
+    return;
+  }
+
   await db
     .prepare(
       `UPDATE friends

--- a/packages/db/src/scenarios.ts
+++ b/packages/db/src/scenarios.ts
@@ -57,16 +57,24 @@ export interface FriendScenario {
 
 export type ScenarioWithStepCount = Scenario & { step_count: number };
 
-export async function getScenarios(db: D1Database): Promise<ScenarioWithStepCount[]> {
-  const result = await db
-    .prepare(
-      `SELECT s.*, COUNT(ss.id) as step_count
-       FROM scenarios s
-       LEFT JOIN scenario_steps ss ON s.id = ss.scenario_id
-       GROUP BY s.id
-       ORDER BY s.created_at DESC`,
-    )
-    .all<ScenarioWithStepCount>();
+export async function getScenarios(db: D1Database, lineAccountId?: string | null): Promise<ScenarioWithStepCount[]> {
+  const stmt = lineAccountId
+    ? db.prepare(
+        `SELECT s.*, COUNT(ss.id) as step_count
+         FROM scenarios s
+         LEFT JOIN scenario_steps ss ON s.id = ss.scenario_id
+         WHERE s.line_account_id = ?
+         GROUP BY s.id
+         ORDER BY s.created_at DESC`,
+      ).bind(lineAccountId)
+    : db.prepare(
+        `SELECT s.*, COUNT(ss.id) as step_count
+         FROM scenarios s
+         LEFT JOIN scenario_steps ss ON s.id = ss.scenario_id
+         GROUP BY s.id
+         ORDER BY s.created_at DESC`,
+      );
+  const result = await stmt.all<ScenarioWithStepCount>();
   return result.results;
 }
 

--- a/packages/db/src/tags.ts
+++ b/packages/db/src/tags.ts
@@ -3,6 +3,7 @@ export interface Tag {
   id: string;
   name: string;
   color: string;
+  line_account_id: string | null;
   created_at: string;
 }
 
@@ -12,16 +13,18 @@ export interface FriendTag {
   assigned_at: string;
 }
 
-export async function getTags(db: D1Database): Promise<Tag[]> {
-  const result = await db
-    .prepare(`SELECT * FROM tags ORDER BY name ASC`)
-    .all<Tag>();
+export async function getTags(db: D1Database, lineAccountId?: string | null): Promise<Tag[]> {
+  const stmt = lineAccountId
+    ? db.prepare(`SELECT * FROM tags WHERE line_account_id = ? ORDER BY name ASC`).bind(lineAccountId)
+    : db.prepare(`SELECT * FROM tags ORDER BY name ASC`);
+  const result = await stmt.all<Tag>();
   return result.results;
 }
 
 export interface CreateTagInput {
   name: string;
   color?: string;
+  lineAccountId?: string | null;
 }
 
 export async function createTag(
@@ -34,10 +37,10 @@ export async function createTag(
 
   await db
     .prepare(
-      `INSERT INTO tags (id, name, color, created_at)
-       VALUES (?, ?, ?, ?)`,
+      `INSERT INTO tags (id, name, color, line_account_id, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
     )
-    .bind(id, input.name, color, now)
+    .bind(id, input.name, color, input.lineAccountId ?? null, now)
     .run();
 
   return (await db

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -85,6 +85,8 @@ export interface Tag {
   name: string;
   /** 表示色 (HEX: #RRGGBB) */
   color: string;
+  /** 紐づく LINE アカウント ID。null = レガシー/共通タグ */
+  lineAccountId: string | null;
   /** 作成日時 (ISO 8601) */
   createdAt: string;
 }

--- a/tests/account-scope-regression.test.mjs
+++ b/tests/account-scope-regression.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+const schema = read('packages/db/schema.sql');
+function tableBlock(name) {
+  const start = schema.indexOf(`CREATE TABLE IF NOT EXISTS ${name}`);
+  assert.notEqual(start, -1, `${name} table must exist`);
+  const end = schema.indexOf('\n);', start);
+  assert.notEqual(end, -1, `${name} table must close`);
+  return schema.slice(start, end + 3);
+}
+
+const friendsBlock = tableBlock('friends');
+assert.doesNotMatch(friendsBlock, /line_user_id\s+TEXT\s+UNIQUE\s+NOT NULL/, 'same LINE user id must be allowed in different LINE accounts');
+assert.match(friendsBlock, /line_account_id\s+TEXT/, 'friends must carry line_account_id');
+assert.match(schema, /idx_friends_line_user_account_unique ON friends \(line_user_id, line_account_id\)/, 'friends must be unique per LINE account');
+
+const tagsBlock = tableBlock('tags');
+assert.doesNotMatch(tagsBlock, /name\s+TEXT\s+UNIQUE\s+NOT NULL/, 'same tag name must be allowed in different LINE accounts');
+assert.match(tagsBlock, /line_account_id\s+TEXT/, 'tags must carry line_account_id');
+assert.match(schema, /idx_tags_account_name_unique ON tags \(line_account_id, name\)/, 'tags must be unique per LINE account');
+
+const scenariosBlock = tableBlock('scenarios');
+assert.match(scenariosBlock, /line_account_id\s+TEXT/, 'scenarios must belong to a LINE account');
+
+const friends = read('packages/db/src/friends.ts');
+assert.match(friends, /getFriendByLineUserId\(\s*db:\s*D1Database,\s*lineUserId:\s*string,\s*lineAccountId\?:/s, 'friend lookup must accept account scope');
+assert.match(friends, /WHERE line_user_id = \? AND line_account_id = \?/s, 'friend lookup must filter by line_account_id when provided');
+assert.match(friends, /INSERT INTO friends \([^)]*line_account_id/s, 'friend insert must persist line_account_id');
+
+const tags = read('packages/db/src/tags.ts');
+assert.match(tags, /getTags\(db:\s*D1Database,\s*lineAccountId\?:/s, 'tag listing must accept account scope');
+assert.match(tags, /WHERE line_account_id = \?/s, 'tag listing must filter by line_account_id');
+assert.match(tags, /INSERT INTO tags \([^)]*line_account_id/s, 'tag creation must persist line_account_id');
+
+const scenarios = read('packages/db/src/scenarios.ts');
+assert.match(scenarios, /getScenarios\(db:\s*D1Database,\s*lineAccountId\?:/s, 'scenarios listing must accept lineAccountId');
+assert.match(scenarios, /WHERE s\.line_account_id = \?/s, 'scenarios listing must scope by account');
+
+const webhook = read('apps/worker/src/routes/webhook.ts');
+assert.match(webhook, /upsertFriend\(db, \{[\s\S]*lineAccountId,/s, 'webhook follow must upsert friend with account scope');
+assert.doesNotMatch(webhook, /line_account_id IS NULL OR line_account_id = \?/s, 'auto replies must not include global/unassigned replies when account is known');
+assert.doesNotMatch(webhook, /!scenario\.line_account_id \|\| !lineAccountId \|\| scenario\.line_account_id === lineAccountId/s, 'friend_add scenarios must not include global/unassigned scenarios when account is known');
+
+const eventBus = read('apps/worker/src/services/event-bus.ts');
+assert.doesNotMatch(eventBus, /!a\.line_account_id \|\| !lineAccountId \|\| a\.line_account_id === lineAccountId/s, 'automations must not include global/unassigned rules when account is known');
+assert.doesNotMatch(eventBus, /!r\.line_account_id \|\| !lineAccountId \|\| r\.line_account_id === lineAccountId/s, 'notifications must not include global/unassigned rules when account is known');
+assert.match(eventBus, /SELECT line_user_id FROM friends WHERE id = \? AND line_account_id = \?/s, 'automation actions must filter friends by line_account_id');
+
+console.log('account scope regression checks passed');


### PR DESCRIPTION
## Summary
- Scope webhook friend upserts/lookups, friend_add scenarios, auto replies, and automation actions by LINE account
- Scope tag APIs/UI by selected LINE account and persist tag line_account_id
- Add strict account-scope schema/migration for friends/tags plus regression checks

## Verification
- node tests/account-scope-regression.test.mjs
- pnpm --filter @line-crm/shared build
- pnpm --filter worker build
- pnpm --filter web build

Note: direct push to Shudesu/line-harness-oss main failed because the authenticated GitHub account has READ permission only, so this PR is opened from a fork.