### PR TITLE
fix(worker): restore TypeScript baseline

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "dev": "vite dev",
     "test": "vitest run",
-    "build": "vite build",
+    "build:deps": "pnpm --filter @line-crm/shared --filter @line-crm/line-sdk run build",
+    "build": "pnpm run build:deps && vite build",
     "preview": "vite preview",
-    "deploy": "vite build && wrangler deploy",
+    "deploy": "pnpm run build:deps && vite build && wrangler deploy",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/worker/src/routes/capabilities.test.ts
+++ b/apps/worker/src/routes/capabilities.test.ts
@@ -21,7 +21,16 @@ describe('GET /api/capabilities', () => {
     const app = setupApp('owner');
     const res = await app.request('/api/capabilities');
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = (await res.json()) as {
+      success: boolean;
+      data: {
+        harness_kind: string;
+        harness_version: string;
+        api_version: number;
+        features: string[];
+        min_app_version: unknown;
+      };
+    };
     expect(body.success).toBe(true);
     expect(body.data.harness_kind).toBe('line');
     expect(body.data.harness_version).toMatch(/^\d+\.\d+\.\d+$/);

--- a/apps/worker/src/routes/events.test.ts
+++ b/apps/worker/src/routes/events.test.ts
@@ -77,6 +77,7 @@ interface SlotRow {
   is_active: number;
   sort_order: number;
   deleted_at: string | null;
+  [k: string]: unknown;
 }
 
 interface BookingRow {
@@ -85,6 +86,7 @@ interface BookingRow {
   status: string;
   slot_id?: string;
   friend_id?: string;
+  [k: string]: unknown;
 }
 
 interface LineAccount {

--- a/apps/worker/src/routes/events.ts
+++ b/apps/worker/src/routes/events.ts
@@ -912,6 +912,11 @@ events.post('/api/liff/events/:id/bookings', async (c) => {
   }
 
   async function runBookingFlow(): Promise<Response> {
+  // Hoisted function declarations lose narrowing of outer-scope `const`
+  // captures; re-assert here to keep `friend` / `callerLineUserId` non-null.
+  // The outer scope already returned on null, so these throws are unreachable.
+  if (friend == null) throw new Error('runBookingFlow: friend missing');
+  if (callerLineUserId == null) throw new Error('runBookingFlow: callerLineUserId missing');
 
   const event = await c.env.DB
     .prepare(

--- a/apps/worker/src/services/event-bus.ts
+++ b/apps/worker/src/services/event-bus.ts
@@ -213,7 +213,8 @@ function matchConditions(
 
   // keyword_exact（完全一致）
   if (conditions.keyword_exact) {
-    const text = (payload.eventData?.text || '').trim();
+    const rawText = payload.eventData?.text as string | undefined;
+    const text = (rawText || '').trim();
     if (text !== conditions.keyword_exact) {
       return false;
     }
@@ -383,8 +384,9 @@ async function executeAction(
           .replace(/\r/g, '\\r')
           .replace(/\t/g, '\\t')
           .replace(/[\u0000-\u001f]/g, (c) => '\\u' + c.charCodeAt(0).toString(16).padStart(4, '0'));
+      const messageText = (payload.eventData?.text as string | undefined) || '';
       const raw = (action.params.data || '{}')
-        .replace(/\{\{message\}\}/g, escapeForJsonString(payload.eventData?.text || ''));
+        .replace(/\{\{message\}\}/g, escapeForJsonString(messageText));
       const patch = JSON.parse(raw) as Record<string, unknown>;
       const merged = { ...current, ...patch };
       await db

--- a/apps/worker/src/services/incoming-image.test.ts
+++ b/apps/worker/src/services/incoming-image.test.ts
@@ -40,7 +40,7 @@ describe('fetchAndStoreIncomingImage', () => {
     expect(r2.put).toHaveBeenCalled();
     const [key, , opts] = r2.put.mock.calls[0];
     expect(key).toBe('incoming-acc-1-msg-xyz.jpg');
-    expect(opts.httpMetadata.contentType).toBe('image/jpeg');
+    expect(opts.httpMetadata?.contentType).toBe('image/jpeg');
     expect(result?.originalContentUrl).toBe('https://worker.example.com/images/incoming-acc-1-msg-xyz.jpg');
     expect(result?.previewImageUrl).toBe(result?.originalContentUrl);
   });

--- a/apps/worker/src/services/intro-message.test.ts
+++ b/apps/worker/src/services/intro-message.test.ts
@@ -109,7 +109,7 @@ describe('DEFAULT_FORM_LINK_FLEX', () => {
   it('formUrl がボタンの uri にセットされる', () => {
     const url = 'https://liff.line.me/abc?page=form&id=xyz';
     const flex = DEFAULT_FORM_LINK_FLEX(url);
-    expect(flex.type).toBe('flex');
+    if (flex.type !== 'flex') throw new Error(`expected flex, got ${flex.type}`);
     expect(flex.altText).toBe('🎁 特典を受け取る');
     const contents = flex.contents as { footer: { contents: Array<{ action: { uri: string } }> } };
     expect(contents.footer.contents[0].action.uri).toBe(url);

--- a/apps/worker/src/services/unanswered-inbox.test.ts
+++ b/apps/worker/src/services/unanswered-inbox.test.ts
@@ -43,6 +43,10 @@ function stubDB(canned: {
   // 応答ありルールの evidence-based 判定をテストするには autoReplyOutgoings を渡す。
   autoReplies?: AutoReplyRow[];
   autoReplyOutgoings?: AutoReplyOutgoing[];
+  // 旧 fixture 互換: 期待値メモとして残されている純粋データ。stubDB は使わない。
+  total?: number;
+  byAccount?: unknown[];
+  oldestWait?: unknown;
 }) {
   const incomings: RecentIncoming[] =
     canned.recentIncomings ??


### PR DESCRIPTION
## Summary
- Restore `pnpm --filter worker typecheck` on current `main` by fixing 56 TypeScript errors across worker tests and narrow runtime typing spots
- Preserve behavior: changes are limited to type narrowing, fixture signatures, and test-side union guards
- Keep runtime changes minimal in `events.ts` and `event-bus.ts`
- Make `pnpm --filter worker build` build required workspace packages first so clean worktrees no longer depend on pre-existing `@line-crm/shared` / `@line-crm/line-sdk` dist output

## Verification
- `pnpm --filter worker typecheck` (baseline 56 errors -> clean)
- `pnpm --filter worker test` (413 / 413 passing)
- `pnpm --filter worker build` after removing local `packages/shared/dist` and `packages/line-sdk/dist`
- Codex review loop: 3 rounds, no findings before the build-order follow-up

## Notes
Worker build still emits existing Vite dynamic/static import warnings. In this sandbox, Wrangler also attempted to write a debug log under `~/.wrangler/logs` and printed an EPERM warning, but the build command exited successfully.