### PR TITLE
fix(worker): sync private baseline and assets guard

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -714,7 +714,9 @@ async function buildOgForLiffPath(db: D1Database, url: URL): Promise<string> {
 }
 
 // 404 fallback — API paths return JSON 404, everything else serves from static assets (LIFF/admin)
-app.notFound(async (c) => {
+export async function notFoundHandler(
+  c: import('hono').Context<Env>,
+): Promise<Response> {
   const url = new URL(c.req.url);
   const path = url.pathname;
   if (path.startsWith('/api/') || path === '/webhook' || path === '/docs' || path === '/openapi.json') {
@@ -728,9 +730,17 @@ app.notFound(async (c) => {
     return c.html(html);
   }
 
-  // Serve static assets (admin dashboard, LIFF pages)
+  // Serve static assets (admin dashboard, LIFF pages).
+  // ASSETS binding is missing when wrangler runs without a built `dist/client`
+  // (fresh clone, vitest, or a deploy where the assets directive was stripped).
+  // Without this guard every GET / surfaces as
+  // "TypeError: Cannot read properties of undefined (reading 'fetch')".
+  if (!c.env.ASSETS || typeof c.env.ASSETS.fetch !== 'function') {
+    return c.json({ success: false, error: 'Not found' }, 404);
+  }
   return c.env.ASSETS.fetch(c.req.raw);
-});
+}
+app.notFound(notFoundHandler);
 
 // Scheduled handler for cron triggers — runs for all active LINE accounts
 async function scheduled(

--- a/apps/worker/src/not-found.test.ts
+++ b/apps/worker/src/not-found.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// The notFound handler imports DB query helpers transitively (via the
+// /r/:ref routes file isn't reached here, but `buildOgForLiffPath` reads
+// from `@line-crm/db`-shaped tables through `c.env.DB.prepare`). The bot UA
+// path is not exercised by these tests; everything else stays inside the
+// handler so no DB calls happen.
+vi.mock('@line-crm/db', () => ({
+  // index.ts pulls these eagerly at module load; provide no-op stubs so the
+  // import graph resolves under Vitest.
+  getLineAccounts: vi.fn().mockResolvedValue([]),
+  getTrafficPoolBySlug: vi.fn(),
+  getTrafficPoolById: vi.fn(),
+  getRandomPoolAccount: vi.fn(),
+  getPoolAccounts: vi.fn(),
+  getEntryRouteByRefCode: vi.fn(),
+  getStaffByApiKey: vi.fn(),
+  recoverStalledBroadcasts: vi.fn(),
+  recoverStuckDeliveries: vi.fn(),
+}));
+
+import { notFoundHandler, type Env } from './index.js';
+
+function makeApp(env: Partial<Env['Bindings']>) {
+  const app = new Hono<Env>();
+  app.notFound(notFoundHandler);
+  return (path: string, init?: RequestInit) =>
+    app.fetch(new Request(`https://worker.example.com${path}`, init), env as Env['Bindings']);
+}
+
+describe('notFoundHandler — root / request', () => {
+  it('returns 404 JSON when ASSETS binding is undefined (no TypeError)', async () => {
+    const fetchApp = makeApp({ DB: {} as D1Database });
+    const res = await fetchApp('/');
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body).toEqual({ success: false, error: 'Not found' });
+  });
+
+  it('returns 404 JSON when ASSETS exists but has no fetch method', async () => {
+    const fetchApp = makeApp({
+      DB: {} as D1Database,
+      ASSETS: {} as unknown as Fetcher,
+    });
+    const res = await fetchApp('/');
+    expect(res.status).toBe(404);
+  });
+
+  it('delegates to ASSETS.fetch when the binding is present', async () => {
+    const assets: Fetcher = {
+      fetch: vi.fn().mockResolvedValue(new Response('static', { status: 200 })),
+    } as unknown as Fetcher;
+    const fetchApp = makeApp({ DB: {} as D1Database, ASSETS: assets });
+    const res = await fetchApp('/some-spa-path');
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('static');
+    expect(assets.fetch).toHaveBeenCalledOnce();
+  });
+
+  it('returns JSON 404 (not ASSETS lookup) for /api/* unknown paths', async () => {
+    const assets: Fetcher = {
+      fetch: vi.fn().mockResolvedValue(new Response('should not be called', { status: 200 })),
+    } as unknown as Fetcher;
+    const fetchApp = makeApp({ DB: {} as D1Database, ASSETS: assets });
+    const res = await fetchApp('/api/does-not-exist');
+    expect(res.status).toBe(404);
+    expect(assets.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/routes/capabilities.test.ts
+++ b/apps/worker/src/routes/capabilities.test.ts
@@ -21,7 +21,16 @@ describe('GET /api/capabilities', () => {
     const app = setupApp('owner');
     const res = await app.request('/api/capabilities');
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = (await res.json()) as {
+      success: boolean;
+      data: {
+        harness_kind: string;
+        harness_version: string;
+        api_version: number;
+        features: string[];
+        min_app_version: unknown;
+      };
+    };
     expect(body.success).toBe(true);
     expect(body.data.harness_kind).toBe('line');
     expect(body.data.harness_version).toMatch(/^\d+\.\d+\.\d+$/);

--- a/apps/worker/src/routes/events.test.ts
+++ b/apps/worker/src/routes/events.test.ts
@@ -77,6 +77,7 @@ interface SlotRow {
   is_active: number;
   sort_order: number;
   deleted_at: string | null;
+  [k: string]: unknown;
 }
 
 interface BookingRow {
@@ -85,6 +86,7 @@ interface BookingRow {
   status: string;
   slot_id?: string;
   friend_id?: string;
+  [k: string]: unknown;
 }
 
 interface LineAccount {

--- a/apps/worker/src/routes/events.ts
+++ b/apps/worker/src/routes/events.ts
@@ -912,6 +912,11 @@ events.post('/api/liff/events/:id/bookings', async (c) => {
   }
 
   async function runBookingFlow(): Promise<Response> {
+  // Hoisted function declarations lose narrowing of outer-scope `const`
+  // captures; re-assert here to keep `friend` / `callerLineUserId` non-null.
+  // The outer scope already returned on null, so these throws are unreachable.
+  if (friend == null) throw new Error('runBookingFlow: friend missing');
+  if (callerLineUserId == null) throw new Error('runBookingFlow: callerLineUserId missing');
 
   const event = await c.env.DB
     .prepare(

--- a/apps/worker/src/services/event-bus.ts
+++ b/apps/worker/src/services/event-bus.ts
@@ -213,7 +213,8 @@ function matchConditions(
 
   // keyword_exact（完全一致）
   if (conditions.keyword_exact) {
-    const text = (payload.eventData?.text || '').trim();
+    const rawText = payload.eventData?.text as string | undefined;
+    const text = (rawText || '').trim();
     if (text !== conditions.keyword_exact) {
       return false;
     }
@@ -383,8 +384,9 @@ async function executeAction(
           .replace(/\r/g, '\\r')
           .replace(/\t/g, '\\t')
           .replace(/[\u0000-\u001f]/g, (c) => '\\u' + c.charCodeAt(0).toString(16).padStart(4, '0'));
+      const messageText = (payload.eventData?.text as string | undefined) || '';
       const raw = (action.params.data || '{}')
-        .replace(/\{\{message\}\}/g, escapeForJsonString(payload.eventData?.text || ''));
+        .replace(/\{\{message\}\}/g, escapeForJsonString(messageText));
       const patch = JSON.parse(raw) as Record<string, unknown>;
       const merged = { ...current, ...patch };
       await db

--- a/apps/worker/src/services/incoming-image.test.ts
+++ b/apps/worker/src/services/incoming-image.test.ts
@@ -40,7 +40,7 @@ describe('fetchAndStoreIncomingImage', () => {
     expect(r2.put).toHaveBeenCalled();
     const [key, , opts] = r2.put.mock.calls[0];
     expect(key).toBe('incoming-acc-1-msg-xyz.jpg');
-    expect(opts.httpMetadata.contentType).toBe('image/jpeg');
+    expect(opts.httpMetadata?.contentType).toBe('image/jpeg');
     expect(result?.originalContentUrl).toBe('https://worker.example.com/images/incoming-acc-1-msg-xyz.jpg');
     expect(result?.previewImageUrl).toBe(result?.originalContentUrl);
   });

--- a/apps/worker/src/services/intro-message.test.ts
+++ b/apps/worker/src/services/intro-message.test.ts
@@ -109,7 +109,7 @@ describe('DEFAULT_FORM_LINK_FLEX', () => {
   it('formUrl がボタンの uri にセットされる', () => {
     const url = 'https://liff.line.me/abc?page=form&id=xyz';
     const flex = DEFAULT_FORM_LINK_FLEX(url);
-    expect(flex.type).toBe('flex');
+    if (flex.type !== 'flex') throw new Error(`expected flex, got ${flex.type}`);
     expect(flex.altText).toBe('🎁 特典を受け取る');
     const contents = flex.contents as { footer: { contents: Array<{ action: { uri: string } }> } };
     expect(contents.footer.contents[0].action.uri).toBe(url);

--- a/apps/worker/src/services/unanswered-inbox.test.ts
+++ b/apps/worker/src/services/unanswered-inbox.test.ts
@@ -43,6 +43,10 @@ function stubDB(canned: {
   // 応答ありルールの evidence-based 判定をテストするには autoReplyOutgoings を渡す。
   autoReplies?: AutoReplyRow[];
   autoReplyOutgoings?: AutoReplyOutgoing[];
+  // 旧 fixture 互換: 期待値メモとして残されている純粋データ。stubDB は使わない。
+  total?: number;
+  byAccount?: unknown[];
+  oldestWait?: unknown;
 }) {
   const incomings: RecentIncoming[] =
     canned.recentIncomings ??


### PR DESCRIPTION
## Summary
- Sync the private #51 worker TypeScript baseline fixes into OSS
- Sync the private #52 ASSETS binding guard for root/not-found requests
- Keep this PR targeted to the 9 public-safe worker files only; broad private→OSS sync dry-run was intentionally not applied

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter worker typecheck
- pnpm --filter worker test -- not-found.test.ts capabilities.test.ts events.test.ts incoming-image.test.ts intro-message.test.ts unanswered-inbox.test.ts

## Notes
- Private #51/#52 were merged to private main and Deploy Worker completed successfully before this targeted OSS sync.
- No deploy workflows, secrets, env files, wrangler.toml, docs/wiki, or package files are included.