### PR TITLE
chore: add OSS community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Report something that is not working
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please remove secrets, tokens, account IDs, friend IDs, and customer data before submitting.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What happened, and what did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: List the smallest steps that reproduce the problem.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. See ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: LINE Harness version
+      placeholder: "v0.15.0"
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: "Node 22, pnpm 9, Cloudflare Workers/D1"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste only sanitized logs. Do not include secrets or customer data.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Shudesu/line-harness-oss/security
+    about: Please do not disclose vulnerabilities in public issues.
+  - name: Documentation
+    url: https://github.com/Shudesu/line-harness-oss/tree/main/docs
+    about: Check the setup guide, manual, and wiki-style docs.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an improvement
+title: "Feature: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: What workflow or user problem should this improve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the expected behavior or interface.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional context, prior art, or workarounds.

--- a/.github/ISSUE_TEMPLATE/setup_help.yml
+++ b/.github/ISSUE_TEMPLATE/setup_help.yml
@@ -1,0 +1,28 @@
+name: Setup help
+description: Ask for help with install, deploy, Cloudflare, LINE, or LIFF setup
+title: "Setup: "
+labels: ["question", "needs-info"]
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command or screen
+      description: What command did you run, or which setup step are you on?
+      render: shell
+  - type: textarea
+    id: error
+    attributes:
+      label: Error message
+      description: Remove tokens, secrets, account IDs, and customer data.
+      render: shell
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: "macOS, Node 22, pnpm 9, Wrangler 4"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Related issue
+
+<!-- Fixes #123, relates to #123, or N/A -->
+
+## Verification
+
+<!-- Commands run, screenshots checked, or reason tests were not run. -->
+
+## Safety checklist
+
+- [ ] No secrets, tokens, customer data, or private configuration are included.
+- [ ] The change is focused and does not include unrelated formatting churn.
+- [ ] Docs or tests were updated when useful.
+- [ ] Deployment impact is understood.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,32 @@
+worker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/worker/**
+          - packages/db/**
+          - packages/shared/**
+
+web:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/web/**
+
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/create-line-harness/**
+
+sdk:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/sdk/**
+          - packages/mcp-server/**
+          - packages/plugin-template/**
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - README*
+          - CONTRIBUTING.md
+          - SECURITY.md
+          - SUPPORT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to LINE Harness
+
+Thanks for helping improve LINE Harness. This repository is the public OSS intake for issues, discussions, and community pull requests.
+
+## Repository model
+
+LINE Harness is maintained with two repositories:
+
+- `Shudesu/line-harness-oss`: public OSS repository for issues and pull requests.
+- `Shudesu/line-harness`: private source-of-truth repository for production-safe development and deployment.
+
+Bug reports and pull requests should start here in the OSS repository. Maintainers may reproduce or adapt a fix in the private repository first, then sync the safe public changes back to OSS.
+
+## Before opening an issue
+
+- Search existing issues and pull requests.
+- Include the LINE Harness version, package manager, Node.js version, and deployment target when relevant.
+- Remove tokens, account IDs, channel secrets, webhook URLs, and customer data from logs.
+- For security issues, do not open a public issue. See `SECURITY.md`.
+
+## Pull request expectations
+
+Small, focused PRs are easiest to review. A good PR usually includes:
+
+- A clear problem statement.
+- The smallest practical code change.
+- Tests or a short verification note.
+- No production secrets, private configuration, or generated build output.
+
+## Local verification
+
+Use the narrowest command that proves your change. Common checks:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter worker typecheck
+pnpm --filter worker test
+pnpm --filter web build
+```
+
+Not every PR needs every command. Please mention what you ran in the PR description.
+
+## What maintainers may do
+
+Maintainers may label, retitle, split, or supersede PRs so the public queue stays understandable. If an OSS PR needs private integration first, it may be replaced by a targeted `private-sync` PR.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ MIT License. 商用利用・改変・再配布自由。
 
 Issue / PR 歓迎。OSS リポへの PR は `Shudesu/line-harness-oss` (このリポ) に投げてください。
 
+- 貢献方法: [CONTRIBUTING.md](CONTRIBUTING.md)
+- セキュリティ報告: [SECURITY.md](SECURITY.md)
+- サポート・質問: [SUPPORT.md](SUPPORT.md)
+- Private ↔ OSS 同期方針: [docs/OSS-SYNC-CHARTER.md](docs/OSS-SYNC-CHARTER.md)
+
 ---
 
 > **LINE Harness** by [@Shudesu](https://github.com/Shudesu) — AI ネイティブ時代の OSS LINE CRM

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are prioritized for the latest public release and the current `main` branch.
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities in public GitHub issues.
+
+Use GitHub private vulnerability reporting when available, or contact the maintainer privately through the GitHub profile for `Shudesu`.
+
+When reporting, include:
+
+- A short description of the impact.
+- Reproduction steps or a minimal proof of concept.
+- Affected files, endpoints, packages, or deployment settings.
+- Any logs with secrets and personal data removed.
+
+## Secrets and production data
+
+Never paste these into issues, PRs, commits, screenshots, or logs:
+
+- LINE channel secrets or access tokens.
+- Cloudflare API tokens, account IDs, D1 database IDs, or Pages credentials.
+- Webhook signing secrets.
+- Customer data, friend IDs, message contents, or production exports.
+
+If a secret was exposed, rotate it first, then notify maintainers.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,13 @@
+# Support
+
+For bugs and feature requests, use GitHub Issues in this repository.
+
+For setup questions, please include:
+
+- LINE Harness version.
+- Node.js and pnpm versions.
+- Cloudflare Workers, Pages, and D1 setup status.
+- The command you ran.
+- The exact error message with secrets removed.
+
+For security reports, use `SECURITY.md` instead of a public issue.


### PR DESCRIPTION
## Summary

This PR adds the basic public OSS maintenance files for LINE Harness:

- contribution guide
- security policy
- support guide
- issue templates for bugs, features, and setup help
- pull request template
- README links to the new community files

It also documents the public/private repository model so contributors understand that OSS issues and PRs are intake, while maintainers may land production-safe fixes through the private source-of-truth repository and sync them back.

## Verification

- Parsed all new GitHub issue template YAML files with Ruby YAML.
- Ran `git diff --cached --check` before commit.

## Deployment impact

Documentation and GitHub metadata only. No application code, worker code, deploy workflow, or production configuration changed.
