### PR TITLE
fix(api,web): sync account-scoped list behavior

### DIFF
--- a/apps/web/src/app/automations/page.tsx
+++ b/apps/web/src/app/automations/page.tsx
@@ -22,6 +22,9 @@ interface Automation {
   actions: AutomationAction[]
   isActive: boolean
   priority: number
+  // null = global automation (fires for every account); UUID = bound to that
+  // account. Surfaced so the badge + toggle/delete guards can distinguish.
+  lineAccountId: string | null
   createdAt: string
   updatedAt: string
 }
@@ -197,6 +200,15 @@ export default function AutomationsPage() {
   }
 
   const handleToggleActive = async (id: string, current: boolean) => {
+    // Globals fire for every account; flipping one from an account-scoped view
+    // would silently affect all accounts, so warn first.
+    const target = automations.find((a) => a.id === id)
+    if (target?.lineAccountId === null) {
+      const ok = confirm(
+        `「${target.name}」は全アカウント共通のオートメーションです。${current ? '無効化' : '有効化'}するとすべてのアカウントに影響します。続行しますか?`,
+      )
+      if (!ok) return
+    }
     try {
       await api.automations.update(id, { isActive: !current })
       loadAutomations()
@@ -206,7 +218,11 @@ export default function AutomationsPage() {
   }
 
   const handleDelete = async (id: string) => {
-    if (!confirm('このオートメーションを削除してもよいですか？')) return
+    const target = automations.find((a) => a.id === id)
+    const message = target?.lineAccountId === null
+      ? `「${target.name}」は全アカウント共通のオートメーションです。削除するとすべてのアカウントから消えます。本当に削除しますか?`
+      : 'このオートメーションを削除してもよいですか？'
+    if (!confirm(message)) return
     try {
       await api.automations.delete(id)
       loadAutomations()
@@ -384,6 +400,16 @@ export default function AutomationsPage() {
                 }`}>
                   {automation.isActive ? '有効' : '無効'}
                 </span>
+                {/* lineAccountId === null = global; label it so the account-scoped
+                   list cannot disguise an all-accounts rule as account-local. */}
+                {automation.lineAccountId === null && (
+                  <span
+                    className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200"
+                    title="全アカウントに適用されるオートメーションです"
+                  >
+                    全アカウント共通
+                  </span>
+                )}
               </div>
 
               {/* Meta info */}

--- a/apps/web/src/app/friend-add-settings/page.tsx
+++ b/apps/web/src/app/friend-add-settings/page.tsx
@@ -73,9 +73,14 @@ export default function FriendAddSettingsPage() {
           accountErrors.set(account.id, res.error)
           return
         }
+        // The API returns both account-bound and global (lineAccountId === null)
+        // rows for an account query (mirroring the engine match semantic in
+        // webhook.ts / liff.ts). Strip globals here so we can merge them once,
+        // labeled, after the per-account section — and so a failed per-account
+        // fetch still falls back to the independent allRes globals fetch.
         accountScopedByAccount.set(
           account.id,
-          res.data.filter(s => s.triggerType === 'friend_add'),
+          res.data.filter(s => s.triggerType === 'friend_add' && s.lineAccountId !== null),
         )
       })
 

--- a/apps/web/src/components/scenarios/scenario-list.tsx
+++ b/apps/web/src/components/scenarios/scenario-list.tsx
@@ -53,6 +53,17 @@ export default function ScenarioList({ scenarios, onToggleActive, onDelete, load
               {scenario.name}
             </Link>
             <div className="flex items-center gap-1.5">
+              {/* lineAccountId === null = global. Label it explicitly so an
+                 account-scoped view can't trick the operator into mutating a
+                 row that fires for every account. */}
+              {scenario.lineAccountId === null && (
+                <span
+                  className="shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200"
+                  title="全アカウントに適用されるシナリオです"
+                >
+                  全アカウント共通
+                </span>
+              )}
               <ModeBadge mode={scenario.deliveryMode} />
               <span
                 className={`shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
@@ -98,7 +109,19 @@ export default function ScenarioList({ scenarios, onToggleActive, onDelete, load
               編集
             </Link>
             <button
-              onClick={() => onToggleActive(scenario.id, scenario.isActive)}
+              onClick={() => {
+                // Globals fire for every account; warn before toggling from an
+                // account-scoped view so it can't be flipped by accident.
+                if (
+                  scenario.lineAccountId === null &&
+                  !confirm(
+                    `「${scenario.name}」は全アカウント共通のシナリオです。${scenario.isActive ? '無効化' : '有効化'}するとすべてのアカウントに影響します。続行しますか?`,
+                  )
+                ) {
+                  return
+                }
+                onToggleActive(scenario.id, scenario.isActive)
+              }}
               disabled={loading}
               className="flex-1 text-xs font-medium text-gray-600 hover:text-gray-900 py-1 min-h-[44px] flex items-center justify-center rounded-md hover:bg-gray-100 transition-colors disabled:opacity-40"
             >
@@ -106,7 +129,11 @@ export default function ScenarioList({ scenarios, onToggleActive, onDelete, load
             </button>
             <button
               onClick={() => {
-                if (confirm(`「${scenario.name}」を削除してもよいですか？`)) {
+                const isGlobal = scenario.lineAccountId === null
+                const message = isGlobal
+                  ? `「${scenario.name}」は全アカウント共通のシナリオです。削除するとすべてのアカウントから消えます。本当に削除しますか?`
+                  : `「${scenario.name}」を削除してもよいですか？`
+                if (confirm(message)) {
                   onDelete(scenario.id)
                 }
               }}

--- a/apps/worker/src/routes/automations.test.ts
+++ b/apps/worker/src/routes/automations.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { Hono } from 'hono';
+
+// We assert on the SQL/binds the route forwards to D1. The DB-helper path
+// (no lineAccountId query) is mocked separately on @line-crm/db.
+const dbMocks = {
+  getAutomations: vi.fn(),
+  getAutomationById: vi.fn(),
+  createAutomation: vi.fn(),
+  updateAutomation: vi.fn(),
+  deleteAutomation: vi.fn(),
+  getAutomationLogs: vi.fn(),
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+const { automations } = await import('./automations.js');
+
+interface AutomationRow {
+  id: string;
+  name: string;
+  description: string | null;
+  event_type: string;
+  conditions: string;
+  actions: string;
+  is_active: number;
+  priority: number;
+  created_at: string;
+  updated_at: string;
+  line_account_id: string | null;
+}
+
+function makeAutomationDb(rows: AutomationRow[]) {
+  const calls: { sql: string; binds: unknown[] }[] = [];
+  const db = {
+    prepare(sql: string) {
+      let bound: unknown[] = [];
+      const stmt = {
+        bind(...args: unknown[]) {
+          bound = args;
+          return stmt;
+        },
+        async all() {
+          calls.push({ sql, binds: bound });
+          // NULL-aware filter: row matches when its line_account_id is NULL
+          // (global) OR equals the bound lineAccountId.
+          if (/FROM automations\b/i.test(sql) && /line_account_id IS NULL/i.test(sql)) {
+            const [lineAccountId] = bound as [string];
+            const filtered = rows.filter(
+              (r) => r.line_account_id == null || r.line_account_id === lineAccountId,
+            );
+            return { results: filtered };
+          }
+          return { results: [] };
+        },
+      };
+      return stmt;
+    },
+  } as unknown as D1Database;
+  return { db, calls };
+}
+
+function setupApp(db: D1Database) {
+  const app = new Hono<{ Bindings: { DB: D1Database } }>();
+  app.use('*', async (c, next) => {
+    c.env = { DB: db };
+    await next();
+  });
+  app.route('/', automations);
+  return app;
+}
+
+const rowBase = {
+  description: null,
+  event_type: 'message_received',
+  conditions: '{}',
+  actions: '[]',
+  is_active: 1,
+  priority: 0,
+  created_at: '2026-05-20T00:00:00.000',
+  updated_at: '2026-05-20T00:00:00.000',
+};
+
+beforeEach(() => {
+  for (const fn of Object.values(dbMocks)) fn.mockReset();
+});
+
+describe('GET /api/automations?lineAccountId=X', () => {
+  test('includes both account-bound and global (NULL) automations', async () => {
+    const rows: AutomationRow[] = [
+      { id: 'a-global', name: 'global', line_account_id: null, ...rowBase },
+      { id: 'a-acc1', name: 'acc1', line_account_id: 'acc-1', ...rowBase },
+      { id: 'a-acc2', name: 'acc2', line_account_id: 'acc-2', ...rowBase },
+    ];
+    const { db, calls } = makeAutomationDb(rows);
+
+    const res = await setupApp(db).request('/api/automations?lineAccountId=acc-1');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { id: string; lineAccountId: string | null }[];
+    };
+    expect(body.success).toBe(true);
+    const ids = body.data.map((d) => d.id).sort();
+    // The engine (event-bus.ts:149) fires automations whose line_account_id
+    // is NULL OR equal to the active account. The list endpoint must mirror
+    // that scope, otherwise globals + freshly-created records disappear in
+    // the UI even though they will still execute.
+    expect(ids).toEqual(['a-acc1', 'a-global']);
+    // Scope must be surfaced so callers can tell globals from account-bound
+    // rows — otherwise the UI cannot safely offer per-account edit/disable.
+    const byId = new Map(body.data.map((d) => [d.id, d.lineAccountId] as const));
+    expect(byId.get('a-global')).toBeNull();
+    expect(byId.get('a-acc1')).toBe('acc-1');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sql).toMatch(/line_account_id IS NULL/);
+    expect(calls[0].sql).toMatch(/line_account_id = \?/);
+    expect(calls[0].binds).toEqual(['acc-1']);
+  });
+
+  test('falls back to getAutomations helper when no lineAccountId is provided', async () => {
+    dbMocks.getAutomations.mockResolvedValue([
+      { id: 'a-x', name: 'x', line_account_id: null, ...rowBase },
+    ]);
+    const { db } = makeAutomationDb([]);
+
+    const res = await setupApp(db).request('/api/automations');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: { id: string }[] };
+    expect(body.data.map((d) => d.id)).toEqual(['a-x']);
+    expect(dbMocks.getAutomations).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns empty array when filter matches nothing and no globals exist', async () => {
+    const rows: AutomationRow[] = [
+      { id: 'a-other', name: 'other', line_account_id: 'acc-other', ...rowBase },
+    ];
+    const { db } = makeAutomationDb(rows);
+
+    const res = await setupApp(db).request('/api/automations?lineAccountId=acc-1');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: unknown[] };
+    expect(body.data).toEqual([]);
+  });
+});

--- a/apps/worker/src/routes/automations.ts
+++ b/apps/worker/src/routes/automations.ts
@@ -18,8 +18,10 @@ automations.get('/api/automations', async (c) => {
     const lineAccountId = c.req.query('lineAccountId');
     let items;
     if (lineAccountId) {
+      // NULL line_account_id = global automation (event-bus.ts:149 fires it for every account).
+      // Include both account-bound and global rows so the UI mirrors the engine's match semantic.
       const result = await c.env.DB
-        .prepare(`SELECT * FROM automations WHERE line_account_id = ? ORDER BY priority DESC, created_at DESC`)
+        .prepare(`SELECT * FROM automations WHERE line_account_id IS NULL OR line_account_id = ? ORDER BY priority DESC, created_at DESC`)
         .bind(lineAccountId)
         .all();
       items = result.results as unknown as Awaited<ReturnType<typeof getAutomations>>;
@@ -37,6 +39,10 @@ automations.get('/api/automations', async (c) => {
         actions: JSON.parse(a.actions),
         isActive: Boolean(a.is_active),
         priority: a.priority,
+        // null line_account_id = global automation. Surfacing this lets callers
+        // distinguish globals from account-bound rows in the mixed result and
+        // avoid unintentionally editing a rule that affects every account.
+        lineAccountId: a.line_account_id ?? null,
         createdAt: a.created_at,
         updatedAt: a.updated_at,
       })),
@@ -66,6 +72,7 @@ automations.get('/api/automations/:id', async (c) => {
         actions: JSON.parse(item.actions),
         isActive: Boolean(item.is_active),
         priority: item.priority,
+        lineAccountId: item.line_account_id ?? null,
         createdAt: item.created_at,
         updatedAt: item.updated_at,
         logs: logs.map((l) => ({
@@ -98,11 +105,15 @@ automations.post('/api/automations', async (c) => {
     if (!body.name || !body.eventType || !body.actions) {
       return c.json({ success: false, error: 'name, eventType, actions are required' }, 400);
     }
-    const item = await createAutomation(c.env.DB, body);
+    let item = await createAutomation(c.env.DB, body);
     // Save line_account_id if provided
     if (body.lineAccountId) {
       await c.env.DB.prepare(`UPDATE automations SET line_account_id = ? WHERE id = ?`)
         .bind(body.lineAccountId, item.id).run();
+      // Re-read so the response reports the persisted scope; the createAutomation
+      // helper does not accept line_account_id, so item still has the pre-UPDATE value.
+      const refreshed = await getAutomationById(c.env.DB, item.id);
+      if (refreshed) item = refreshed;
     }
     return c.json({
       success: true,
@@ -113,6 +124,7 @@ automations.post('/api/automations', async (c) => {
         actions: JSON.parse(item.actions),
         isActive: Boolean(item.is_active),
         priority: item.priority,
+        lineAccountId: item.line_account_id ?? null,
         createdAt: item.created_at,
       },
     }, 201);
@@ -139,6 +151,7 @@ automations.put('/api/automations/:id', async (c) => {
         actions: JSON.parse(updated.actions),
         isActive: Boolean(updated.is_active),
         priority: updated.priority,
+        lineAccountId: updated.line_account_id ?? null,
       },
     });
   } catch (err) {

--- a/apps/worker/src/routes/scenarios.test.ts
+++ b/apps/worker/src/routes/scenarios.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const dbMocks = {
+  getScenarios: vi.fn(),
+  getScenarioById: vi.fn(),
+  createScenario: vi.fn(),
+  updateScenario: vi.fn(),
+  deleteScenario: vi.fn(),
+  createScenarioStep: vi.fn(),
+  updateScenarioStep: vi.fn(),
+  deleteScenarioStep: vi.fn(),
+  enrollFriendInScenario: vi.fn(),
+  getFriendById: vi.fn(),
+  computeNextDeliveryAt: vi.fn(),
+  resolveStepContent: vi.fn(),
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+vi.mock('../services/scenario-stats.js', () => ({
+  computeScenarioStats: vi.fn(),
+}));
+
+const { scenarios: scenariosModule } = await import('./scenarios.js');
+
+interface ScenarioRow {
+  id: string;
+  name: string;
+  description: string | null;
+  trigger_type: string;
+  trigger_tag_id: string | null;
+  is_active: number;
+  delivery_mode: string;
+  created_at: string;
+  updated_at: string;
+  line_account_id: string | null;
+  step_count: number;
+}
+
+function makeScenarioDb(rows: ScenarioRow[]) {
+  const calls: { sql: string; binds: unknown[] }[] = [];
+  const db = {
+    prepare(sql: string) {
+      let bound: unknown[] = [];
+      const stmt = {
+        bind(...args: unknown[]) {
+          bound = args;
+          return stmt;
+        },
+        async all<_T>() {
+          calls.push({ sql, binds: bound });
+          if (/FROM scenarios s\b/i.test(sql) && /line_account_id IS NULL/i.test(sql)) {
+            const [lineAccountId] = bound as [string];
+            const filtered = rows.filter(
+              (r) => r.line_account_id == null || r.line_account_id === lineAccountId,
+            );
+            return { results: filtered };
+          }
+          return { results: [] };
+        },
+      };
+      return stmt;
+    },
+  } as unknown as D1Database;
+  return { db, calls };
+}
+
+function setupApp(db: D1Database) {
+  const app = new Hono<{ Bindings: { DB: D1Database } }>();
+  app.use('*', async (c, next) => {
+    c.env = { DB: db };
+    await next();
+  });
+  app.route('/', scenariosModule);
+  return app;
+}
+
+const rowBase = {
+  description: null,
+  trigger_type: 'friend_add',
+  trigger_tag_id: null,
+  is_active: 1,
+  delivery_mode: 'relative',
+  created_at: '2026-05-20T00:00:00.000',
+  updated_at: '2026-05-20T00:00:00.000',
+  step_count: 0,
+};
+
+beforeEach(() => {
+  for (const fn of Object.values(dbMocks)) fn.mockReset();
+});
+
+describe('GET /api/scenarios?lineAccountId=X', () => {
+  test('includes both account-bound and global (NULL) scenarios', async () => {
+    const rows: ScenarioRow[] = [
+      { id: 's-global', name: 'global', line_account_id: null, ...rowBase },
+      { id: 's-acc1', name: 'acc1', line_account_id: 'acc-1', ...rowBase },
+      { id: 's-acc2', name: 'acc2', line_account_id: 'acc-2', ...rowBase },
+    ];
+    const { db, calls } = makeScenarioDb(rows);
+
+    const res = await setupApp(db).request('/api/scenarios?lineAccountId=acc-1');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: { id: string; lineAccountId: string | null }[] };
+    expect(body.success).toBe(true);
+    // webhook.ts:211 / liff.ts:878 trigger scenarios where line_account_id is
+    // NULL (global) OR matches the active account. The list endpoint must
+    // mirror that so the UI does not hide records the engine will fire.
+    const ids = body.data.map((d) => d.id).sort();
+    expect(ids).toEqual(['s-acc1', 's-global']);
+    // Serializer surfaces the binding so the UI can distinguish 全アカ共通 from
+    // an account-specific scenario.
+    const globalRow = body.data.find((d) => d.id === 's-global');
+    expect(globalRow?.lineAccountId).toBeNull();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sql).toMatch(/line_account_id IS NULL/);
+    expect(calls[0].sql).toMatch(/s\.line_account_id = \?/);
+    expect(calls[0].binds).toEqual(['acc-1']);
+  });
+
+  test('falls back to getScenarios helper when no lineAccountId is provided', async () => {
+    dbMocks.getScenarios.mockResolvedValue([
+      { id: 's-x', name: 'x', line_account_id: null, ...rowBase },
+    ]);
+    const { db } = makeScenarioDb([]);
+
+    const res = await setupApp(db).request('/api/scenarios');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: { id: string }[] };
+    expect(body.data.map((d) => d.id)).toEqual(['s-x']);
+    expect(dbMocks.getScenarios).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns empty array when filter matches nothing and no globals exist', async () => {
+    const rows: ScenarioRow[] = [
+      { id: 's-other', name: 'other', line_account_id: 'acc-other', ...rowBase },
+    ];
+    const { db } = makeScenarioDb(rows);
+
+    const res = await setupApp(db).request('/api/scenarios?lineAccountId=acc-1');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: unknown[] };
+    expect(body.data).toEqual([]);
+  });
+});

--- a/apps/worker/src/routes/scenarios.ts
+++ b/apps/worker/src/routes/scenarios.ts
@@ -136,12 +136,14 @@ scenarios.get('/api/scenarios', async (c) => {
     const lineAccountId = c.req.query('lineAccountId');
     let items: DbScenarioWithStepCount[];
     if (lineAccountId) {
+      // NULL line_account_id = global scenario (webhook.ts:211 / liff.ts:878 fire it for every
+      // account). Include both account-bound and global rows so the list mirrors the engine.
       const result = await c.env.DB
         .prepare(
           `SELECT s.*, COUNT(ss.id) as step_count
            FROM scenarios s
            LEFT JOIN scenario_steps ss ON s.id = ss.scenario_id
-           WHERE s.line_account_id = ?
+           WHERE s.line_account_id IS NULL OR s.line_account_id = ?
            GROUP BY s.id
            ORDER BY s.created_at DESC`,
         )

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -825,6 +825,10 @@ export interface Automation {
   actions: AutomationAction[];
   isActive: boolean;
   priority: number;
+  // null = global automation (fires for every account, per event-bus.ts:149).
+  // UUID = bound to that line_account_id. Surfaced so account-scoped UIs can
+  // distinguish a rule that affects every account from one they own.
+  lineAccountId: string | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

Syncs private PR #50 to OSS for issue #121.

Fixes account-scoped list endpoints so global records (`line_account_id IS NULL`) appear alongside account-bound records for:

- `GET /api/automations?lineAccountId=...`
- `GET /api/scenarios?lineAccountId=...`

Also adds UI guardrails so global automations/scenarios are labeled and require confirmation before account-scoped toggle/delete actions.

## Verification

Private main:
- `pnpm --filter worker test -- automations.test.ts scenarios.test.ts`
- `pnpm --filter worker typecheck`
- `pnpm --filter web exec tsc --noEmit`
- Private Deploy Worker succeeded.
- Private Deploy Admin Panel succeeded.

OSS sync worktree:
- Hardened `scripts/sync-oss.sh --apply` on a dedicated OSS branch.
- Known private value scan passed.
- `pnpm --filter worker test -- automations.test.ts scenarios.test.ts`
- `pnpm --filter worker typecheck`
- `pnpm --filter web exec tsc --noEmit`

Closes #121.
