### PR TITLE
fix(scenario): sync safe step condition evaluation

### DIFF
--- a/apps/worker/src/routes/scenarios.ts
+++ b/apps/worker/src/routes/scenarios.ts
@@ -13,6 +13,7 @@ import {
   computeNextDeliveryAt,
 } from '@line-crm/db';
 import { computeScenarioStats } from '../services/scenario-stats.js';
+import { SUPPORTED_CONDITION_TYPES, isSupportedConditionType } from '../services/step-delivery.js';
 import { resolveStepContent } from '@line-crm/db';
 import type {
   Scenario as DbScenario,
@@ -69,6 +70,48 @@ function serializeStep(row: DbScenarioStep) {
 
 const VALID_DELIVERY_MODES: readonly DeliveryMode[] = ['relative', 'elapsed', 'absolute_time'];
 const HHMM_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+/**
+ * Validate scenario step condition_type / condition_value pair.
+ * Rejects unknown condition_type values up-front (write-time) so users get an
+ * actionable error instead of the silent over-delivery seen in OSS issue #120.
+ */
+function validateStepCondition(
+  conditionType: unknown,
+  conditionValue: unknown,
+): { ok: true } | { ok: false; error: string } {
+  if (conditionType == null || conditionType === '') return { ok: true };
+  if (!isSupportedConditionType(conditionType)) {
+    return {
+      ok: false,
+      error: `Unsupported conditionType "${String(conditionType)}" (supported: ${SUPPORTED_CONDITION_TYPES.join(', ')})`,
+    };
+  }
+  // conditionType が「あり」のとき conditionValue は必ず非空文字列。
+  // body の TS 型は実行時には強制されないので、明示的に runtime check しないと
+  // 数値・オブジェクトが SQL バインドに乗って 0件マッチ → tag_not_exists が全友だちに当たる、
+  // のような OSS issue #120 と同じ over-delivery を再現してしまう。
+  if (typeof conditionValue !== 'string' || conditionValue === '') {
+    return { ok: false, error: 'conditionValue must be a non-empty string when conditionType is set' };
+  }
+  if (conditionType === 'metadata_equals' || conditionType === 'metadata_not_equals') {
+    try {
+      const parsed = JSON.parse(conditionValue) as unknown;
+      if (
+        !parsed ||
+        typeof parsed !== 'object' ||
+        Array.isArray(parsed) ||
+        typeof (parsed as { key?: unknown }).key !== 'string' ||
+        !('value' in (parsed as Record<string, unknown>))
+      ) {
+        return { ok: false, error: 'conditionValue for metadata_* must be JSON {"key": "...", "value": ...}' };
+      }
+    } catch {
+      return { ok: false, error: 'conditionValue for metadata_* must be valid JSON' };
+    }
+  }
+  return { ok: true };
+}
 
 interface StepScheduleBody {
   delayMinutes?: number;
@@ -323,6 +366,9 @@ scenarios.post('/api/scenarios/:id/steps', async (c) => {
     const v = validateStepSchedule(scenarioRow.delivery_mode, body);
     if (!v.ok) return c.json({ success: false, error: v.error }, 400);
 
+    const cv = validateStepCondition(body.conditionType, body.conditionValue);
+    if (!cv.ok) return c.json({ success: false, error: cv.error }, 400);
+
     // templateId / onReachTagId 参照整合性チェック
     if (body.templateId != null) {
       const tpl = await c.env.DB
@@ -381,6 +427,25 @@ scenarios.put('/api/scenarios/:id/steps/:stepId', async (c) => {
       templateId?: string | null;
       onReachTagId?: string | null;
     }>();
+
+    // conditionType / conditionValue の partial-update 検証（OSS issue #120 回帰防止）。
+    // どちらかが touched なときだけ走らせる。effective 値は、body に来た値を優先しつつ
+    // 既存行で穴埋めして組み立て、validateStepCondition で pair を検証する。
+    // これにより「type だけ flipping、value は既存」のような partial 更新を壊さずに、
+    // 未知 type や JSON 異形を確実に弾ける。
+    if (body.conditionType !== undefined || body.conditionValue !== undefined) {
+      const existingCond = await c.env.DB
+        .prepare(`SELECT condition_type, condition_value FROM scenario_steps WHERE id = ? AND scenario_id = ?`)
+        .bind(stepId, scenarioId)
+        .first<{ condition_type: string | null; condition_value: string | null }>();
+      if (!existingCond) {
+        return c.json({ success: false, error: 'Step not found' }, 404);
+      }
+      const effectiveType = body.conditionType !== undefined ? body.conditionType : existingCond.condition_type;
+      const effectiveValue = body.conditionValue !== undefined ? body.conditionValue : existingCond.condition_value;
+      const cv = validateStepCondition(effectiveType, effectiveValue);
+      if (!cv.ok) return c.json({ success: false, error: cv.error }, 400);
+    }
 
     // templateId / onReachTagId 参照整合性チェック (null は解除を意図、bypass)
     // templateId が指定された場合は内容も取得して snapshot 更新に使う。

--- a/apps/worker/src/services/step-delivery.test.ts
+++ b/apps/worker/src/services/step-delivery.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { evaluateCondition, isSupportedConditionType, SUPPORTED_CONDITION_TYPES } from './step-delivery.js';
+
+/**
+ * Regression coverage for OSS issue #120 — scenario step
+ * conditionType/conditionValue must be evaluated at delivery time, and
+ * unknown / malformed conditions must fail safe (skip step) rather than
+ * silently treat them as "always pass" (which would over-deliver).
+ */
+
+interface FakeTables {
+  friendTags?: Set<string>; // "friendId|tagId" entries
+  friendMetadata?: Record<string, Record<string, unknown>>; // friendId → metadata
+}
+
+function mockDb(tables: FakeTables): D1Database {
+  return {
+    prepare: (sql: string) => ({
+      bind: (...args: unknown[]) => ({
+        first: async <T = unknown>(): Promise<T | null> => {
+          if (sql.includes('FROM friend_tags')) {
+            const [friendId, tagId] = args as [string, string];
+            return (tables.friendTags?.has(`${friendId}|${tagId}`) ? ({ 1: 1 } as unknown as T) : null);
+          }
+          if (sql.includes('FROM friends')) {
+            const [friendId] = args as [string];
+            const meta = tables.friendMetadata?.[friendId];
+            if (meta === undefined) return null;
+            return { metadata: JSON.stringify(meta) } as unknown as T;
+          }
+          return null;
+        },
+        all: async () => ({ results: [] }),
+        run: async () => ({ meta: { changes: 0 } }),
+      }),
+    }),
+  } as unknown as D1Database;
+}
+
+describe('isSupportedConditionType', () => {
+  it('accepts each value in SUPPORTED_CONDITION_TYPES', () => {
+    for (const t of SUPPORTED_CONDITION_TYPES) {
+      expect(isSupportedConditionType(t)).toBe(true);
+    }
+  });
+
+  it.each(['tag_not_has', 'TAG_EXISTS', '', null, undefined, 42])(
+    'rejects unsupported value %j',
+    (val) => {
+      expect(isSupportedConditionType(val)).toBe(false);
+    },
+  );
+});
+
+describe('evaluateCondition', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('returns true when condition_type is null (no condition set)', async () => {
+    const db = mockDb({});
+    expect(await evaluateCondition(db, 'f1', { condition_type: null, condition_value: null })).toBe(true);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns false (skip) when condition_type is set but condition_value is empty', async () => {
+    // Fail-safe for malformed stored rows: a configured condition without a value
+    // would otherwise bind '' into SQL and produce over-delivery (OSS #120 pattern).
+    const db = mockDb({});
+    expect(await evaluateCondition(db, 'f1', { condition_type: 'tag_exists', condition_value: '' })).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('returns false (skip) when condition_type is set but condition_value is null', async () => {
+    const db = mockDb({});
+    expect(await evaluateCondition(db, 'f1', { condition_type: 'tag_not_exists', condition_value: null })).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  describe('tag_exists', () => {
+    it('returns true when the friend has the tag', async () => {
+      const db = mockDb({ friendTags: new Set(['f1|tag-A']) });
+      expect(await evaluateCondition(db, 'f1', { condition_type: 'tag_exists', condition_value: 'tag-A' })).toBe(true);
+    });
+    it('returns false when the friend does not have the tag', async () => {
+      const db = mockDb({ friendTags: new Set() });
+      expect(await evaluateCondition(db, 'f1', { condition_type: 'tag_exists', condition_value: 'tag-A' })).toBe(false);
+    });
+  });
+
+  describe('tag_not_exists', () => {
+    it('returns true when the friend does not have the tag', async () => {
+      const db = mockDb({ friendTags: new Set() });
+      expect(await evaluateCondition(db, 'f1', { condition_type: 'tag_not_exists', condition_value: 'tag-A' })).toBe(true);
+    });
+    it('returns false when the friend has the excluded tag', async () => {
+      const db = mockDb({ friendTags: new Set(['f1|tag-A']) });
+      expect(await evaluateCondition(db, 'f1', { condition_type: 'tag_not_exists', condition_value: 'tag-A' })).toBe(false);
+    });
+  });
+
+  describe('metadata_equals', () => {
+    it('returns true when the metadata matches', async () => {
+      const db = mockDb({ friendMetadata: { f1: { purchased: 'true' } } });
+      expect(
+        await evaluateCondition(db, 'f1', {
+          condition_type: 'metadata_equals',
+          condition_value: JSON.stringify({ key: 'purchased', value: 'true' }),
+        }),
+      ).toBe(true);
+    });
+    it('returns false when the metadata key is absent', async () => {
+      const db = mockDb({ friendMetadata: { f1: {} } });
+      expect(
+        await evaluateCondition(db, 'f1', {
+          condition_type: 'metadata_equals',
+          condition_value: JSON.stringify({ key: 'purchased', value: 'true' }),
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('metadata_not_equals', () => {
+    it('returns false when the metadata equals the excluded value', async () => {
+      const db = mockDb({ friendMetadata: { f1: { tier: 'gold' } } });
+      expect(
+        await evaluateCondition(db, 'f1', {
+          condition_type: 'metadata_not_equals',
+          condition_value: JSON.stringify({ key: 'tier', value: 'gold' }),
+        }),
+      ).toBe(false);
+    });
+    it('returns true when the metadata differs from the excluded value', async () => {
+      const db = mockDb({ friendMetadata: { f1: { tier: 'silver' } } });
+      expect(
+        await evaluateCondition(db, 'f1', {
+          condition_type: 'metadata_not_equals',
+          condition_value: JSON.stringify({ key: 'tier', value: 'gold' }),
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('fail-safe semantics (OSS #120 regression)', () => {
+    it('unknown condition_type → false (skip), NOT true (deliver)', async () => {
+      // OSS issue #120: user passed condition_type='tag_not_has' (typo for tag_not_exists);
+      // pre-fix behaviour was to fall through to default and return true → over-deliver to every
+      // friend regardless of the configured filter. Lock in fail-safe = skip.
+      const db = mockDb({ friendTags: new Set(['f1|tag-A']) });
+      const result = await evaluateCondition(db, 'f1', {
+        condition_type: 'tag_not_has',
+        condition_value: 'tag-A',
+      });
+      expect(result).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('malformed condition_value JSON for metadata_equals → false (skip)', async () => {
+      const db = mockDb({ friendMetadata: { f1: { tier: 'gold' } } });
+      const result = await evaluateCondition(db, 'f1', {
+        condition_type: 'metadata_equals',
+        condition_value: '{this is not json',
+      });
+      expect(result).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('condition_value missing "key" → false (skip)', async () => {
+      const db = mockDb({ friendMetadata: { f1: { tier: 'gold' } } });
+      const result = await evaluateCondition(db, 'f1', {
+        condition_type: 'metadata_equals',
+        condition_value: JSON.stringify({ value: 'gold' }),
+      });
+      expect(result).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('condition_value missing "value" key → false (skip; would otherwise match undefined keys)', async () => {
+      // Pre-existing rows could have {"key":"tier"} (no "value"). Without the explicit
+      // 'value' in parsed check, metadata_equals compares actual === undefined and would
+      // pass for every friend who lacks the key — recreating the OSS #120 over-delivery.
+      const db = mockDb({ friendMetadata: { f1: {} } });
+      const result = await evaluateCondition(db, 'f1', {
+        condition_type: 'metadata_equals',
+        condition_value: JSON.stringify({ key: 'tier' }),
+      });
+      expect(result).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it('friend metadata stored as invalid JSON → treated as empty map (does not throw)', async () => {
+      const db = {
+        prepare: () => ({
+          bind: () => ({
+            first: async () => ({ metadata: '{not json' }),
+          }),
+        }),
+      } as unknown as D1Database;
+      const result = await evaluateCondition(db, 'f1', {
+        condition_type: 'metadata_equals',
+        condition_value: JSON.stringify({ key: 'tier', value: 'gold' }),
+      });
+      // metadata defaults to {} → key is absent → not equal → returns false
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/worker/src/services/step-delivery.ts
+++ b/apps/worker/src/services/step-delivery.ts
@@ -274,12 +274,53 @@ async function processSingleDelivery(
   return true;
 }
 
-async function evaluateCondition(
+/** Supported scenario step condition_type values evaluated at delivery time. */
+export const SUPPORTED_CONDITION_TYPES = [
+  'tag_exists',
+  'tag_not_exists',
+  'metadata_equals',
+  'metadata_not_equals',
+] as const;
+export type ConditionType = (typeof SUPPORTED_CONDITION_TYPES)[number];
+
+export function isSupportedConditionType(value: unknown): value is ConditionType {
+  return typeof value === 'string' && (SUPPORTED_CONDITION_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * Evaluate a scenario step's condition_type/condition_value at delivery time.
+ *
+ * Semantics:
+ *  - condition_type null/empty (no condition configured) → `true` (deliver normally).
+ *  - condition_type set but condition_value missing/empty → `false` (skip + log).
+ *    This is the same OSS issue #120 over-delivery pattern: a configured condition with
+ *    no value would otherwise match every friend, e.g. tag_not_exists with empty value
+ *    binds '' into the SQL and returns 0 rows → "tag absent" for everyone.
+ *  - unknown condition_type or malformed condition_value JSON → `false` (skip + log).
+ *  - condition_type + condition_value valid → actually evaluate.
+ */
+export async function evaluateCondition(
   db: D1Database,
   friendId: string,
   step: { condition_type: string | null; condition_value: string | null },
 ): Promise<boolean> {
-  if (!step.condition_type || !step.condition_value) return true;
+  // No condition configured at all → deliver as usual.
+  if (!step.condition_type) return true;
+
+  if (!isSupportedConditionType(step.condition_type)) {
+    console.error(
+      `[scenario] unknown condition_type "${step.condition_type}" for friend=${friendId} — skipping step. ` +
+        `Supported types: ${SUPPORTED_CONDITION_TYPES.join(', ')}`,
+    );
+    return false;
+  }
+
+  if (!step.condition_value) {
+    console.error(
+      `[scenario] condition_type=${step.condition_type} is set but condition_value is empty for friend=${friendId} — skipping step`,
+    );
+    return false;
+  }
 
   switch (step.condition_type) {
     case 'tag_exists': {
@@ -296,26 +337,49 @@ async function evaluateCondition(
         .first();
       return !tag;
     }
-    case 'metadata_equals': {
-      const { key, value } = JSON.parse(step.condition_value) as { key: string; value: unknown };
-      const friend = await db
-        .prepare('SELECT metadata FROM friends WHERE id = ?')
-        .bind(friendId)
-        .first<{ metadata: string }>();
-      const metadata = JSON.parse(friend?.metadata || '{}') as Record<string, unknown>;
-      return metadata[key] === value;
-    }
+    case 'metadata_equals':
     case 'metadata_not_equals': {
-      const { key, value } = JSON.parse(step.condition_value) as { key: string; value: unknown };
+      let raw: unknown;
+      try {
+        raw = JSON.parse(step.condition_value);
+      } catch {
+        console.error(
+          `[scenario] malformed condition_value JSON for friend=${friendId} type=${step.condition_type} — skipping step`,
+        );
+        return false;
+      }
+      if (
+        !raw ||
+        typeof raw !== 'object' ||
+        Array.isArray(raw) ||
+        typeof (raw as { key?: unknown }).key !== 'string' ||
+        !('value' in (raw as Record<string, unknown>))
+      ) {
+        // 既存行や直接 INSERT された行で {"key":"x"} のように value が欠落しているケースは
+        // friend.metadata[x] === undefined と比較されて「key 不在の全友だち」に一致する
+        // (= 同じ OSS issue #120 の over-delivery を再現する) ので明示的にスキップする。
+        console.error(
+          `[scenario] condition_value missing key/value for friend=${friendId} type=${step.condition_type} — skipping step`,
+        );
+        return false;
+      }
+      const parsed = raw as { key: string; value: unknown };
       const friend = await db
         .prepare('SELECT metadata FROM friends WHERE id = ?')
         .bind(friendId)
         .first<{ metadata: string }>();
-      const metadata = JSON.parse(friend?.metadata || '{}') as Record<string, unknown>;
-      return metadata[key] !== value;
+      let metadata: Record<string, unknown> = {};
+      try {
+        metadata = JSON.parse(friend?.metadata || '{}') as Record<string, unknown>;
+      } catch {
+        // Friend metadata corruption shouldn't propagate; treat as empty map.
+        metadata = {};
+      }
+      const actual = metadata[parsed.key];
+      return step.condition_type === 'metadata_equals'
+        ? actual === parsed.value
+        : actual !== parsed.value;
     }
-    default:
-      return true;
   }
 }
 

--- a/packages/mcp-server/src/tools/manage-scenarios.ts
+++ b/packages/mcp-server/src/tools/manage-scenarios.ts
@@ -21,8 +21,17 @@ export function registerManageScenarios(server: McpServer): void {
       delayMinutes: z.number().optional().describe("Delay in minutes (for add_step, update_step)"),
       messageType: z.enum(["text", "image", "flex"]).optional().describe("Message type (for add_step, update_step)"),
       messageContent: z.string().optional().describe("Message content (for add_step, update_step)"),
-      conditionType: z.string().nullable().optional().describe("Condition type (for add_step, update_step)"),
-      conditionValue: z.string().nullable().optional().describe("Condition value (for add_step, update_step)"),
+      conditionType: z
+        .enum(["tag_exists", "tag_not_exists", "metadata_equals", "metadata_not_equals"])
+        .nullable()
+        .optional()
+        .describe(
+          "Condition type evaluated at delivery time. " +
+            "tag_exists / tag_not_exists: conditionValue = tag UUID. " +
+            "metadata_equals / metadata_not_equals: conditionValue = JSON {\"key\":\"...\",\"value\":...}. " +
+            "Unknown values are rejected (set to null to clear).",
+        ),
+      conditionValue: z.string().nullable().optional().describe("Condition value (for add_step, update_step). See conditionType for format."),
       nextStepOnFalse: z.number().nullable().optional().describe("Next step on false (for add_step, update_step)"),
       templateId: z.string().nullable().optional().describe("Template ID reference (for add_step, update_step; null clears)"),
       onReachTagId: z.string().nullable().optional().describe("Tag ID to attach on step reach (for add_step, update_step; null clears)"),


### PR DESCRIPTION
## Summary

Syncs private PR #53 to OSS for issue #120.

Scenario step conditions now fail closed instead of silently delivering on unsupported or malformed condition data.

## Verification

Private main:
- `pnpm --filter worker test -- step-delivery.test.ts scenarios.test.ts`
- `pnpm --filter worker typecheck`
- `pnpm --filter @line-harness/mcp-server build`
- Private Deploy Worker succeeded.

OSS sync worktree:
- Hardened `scripts/sync-oss.sh --apply` on a dedicated OSS branch.
- Known private value scan passed.
- `pnpm --filter worker test -- step-delivery.test.ts scenarios.test.ts`
- `pnpm --filter worker typecheck`
- `pnpm --filter @line-harness/mcp-server build`

Closes #120.
