### PR TITLE
docs: add fork Cloudflare operations flow

### DIFF
--- a/.github/workflows/deploy-cloudflare-admin.yml
+++ b/.github/workflows/deploy-cloudflare-admin.yml
@@ -1,0 +1,46 @@
+name: Deploy Cloudflare Admin
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/**'
+      - 'packages/shared/**'
+      - '.github/workflows/deploy-cloudflare-admin.yml'
+
+jobs:
+  deploy:
+    if: github.repository != 'Shudesu/line-harness-oss' && vars.LINE_HARNESS_CLOUDFLARE_DEPLOY == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @line-crm/shared build
+
+      - name: Build Admin Panel
+        run: pnpm --filter web build
+        env:
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          PAGES_PROJECT_NAME: ${{ vars.PAGES_PROJECT_NAME || 'line-crm-admin' }}
+        run: |
+          test -n "$CLOUDFLARE_API_TOKEN"
+          test -n "$CLOUDFLARE_ACCOUNT_ID"
+          test -n "$NEXT_PUBLIC_API_URL"
+          npx wrangler pages deploy apps/web/out \
+            --project-name="$PAGES_PROJECT_NAME" \
+            --commit-message="deploy ${GITHUB_SHA}"

--- a/.github/workflows/deploy-cloudflare-worker.yml
+++ b/.github/workflows/deploy-cloudflare-worker.yml
@@ -1,0 +1,88 @@
+name: Deploy Cloudflare Worker
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/worker/**'
+      - 'apps/liff/**'
+      - 'packages/db/**'
+      - 'packages/shared/**'
+      - 'packages/line-sdk/**'
+      - '.github/workflows/deploy-cloudflare-worker.yml'
+
+jobs:
+  deploy:
+    if: github.repository != 'Shudesu/line-harness-oss' && vars.LINE_HARNESS_CLOUDFLARE_DEPLOY == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @line-crm/shared --filter @line-crm/line-sdk --filter @line-crm/db build
+
+      - name: Run pending D1 migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          D1_DATABASE_NAME: ${{ secrets.D1_DATABASE_NAME }}
+        run: |
+          test -n "$CLOUDFLARE_API_TOKEN"
+          test -n "$CLOUDFLARE_ACCOUNT_ID"
+          test -n "$D1_DATABASE_NAME"
+
+          npx wrangler d1 execute "$D1_DATABASE_NAME" --remote --command \
+            "CREATE TABLE IF NOT EXISTS _migrations (name TEXT PRIMARY KEY, applied_at TEXT NOT NULL)"
+
+          for f in $(ls packages/db/migrations/*.sql | sort); do
+            name=$(basename "$f")
+            applied=$(npx wrangler d1 execute "$D1_DATABASE_NAME" --remote \
+              --command "SELECT name FROM _migrations WHERE name = '${name}'" --json \
+              | node -e "const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));console.log(d[0]?.results?.length||0)")
+            if [ "$applied" = "0" ]; then
+              echo "Applying: $name"
+              npx wrangler d1 execute "$D1_DATABASE_NAME" --remote --file="$f"
+              npx wrangler d1 execute "$D1_DATABASE_NAME" --remote --command \
+                "INSERT INTO _migrations (name, applied_at) VALUES ('${name}', datetime('now'))"
+            else
+              echo "Skipped: $name"
+            fi
+          done
+
+      - name: Build Worker and LIFF assets
+        run: pnpm --filter worker build
+        env:
+          VITE_LIFF_ID: ${{ vars.VITE_LIFF_ID }}
+          VITE_BOT_BASIC_ID: ${{ vars.VITE_BOT_BASIC_ID }}
+          VITE_CALENDAR_CONNECTION_ID: ${{ vars.VITE_CALENDAR_CONNECTION_ID }}
+
+      - name: Patch wrangler config
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          D1_DATABASE_NAME: ${{ secrets.D1_DATABASE_NAME }}
+          D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+          WORKER_NAME: ${{ vars.WORKER_NAME || 'line-crm-worker' }}
+        run: |
+          test -n "$D1_DATABASE_ID"
+          cd apps/worker
+          sed -i \
+            -e "s|\"account_id\":\"[^\"]*\"|\"account_id\":\"${CLOUDFLARE_ACCOUNT_ID}\"|g" \
+            -e "s|\"database_name\":\"[^\"]*\"|\"database_name\":\"${D1_DATABASE_NAME}\"|g" \
+            -e "s|\"database_id\":\"[^\"]*\"|\"database_id\":\"${D1_DATABASE_ID}\"|g" \
+            dist/line_harness/wrangler.json
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/worker
+          command: deploy --config dist/line_harness/wrangler.json --name ${{ vars.WORKER_NAME || 'line-crm-worker' }}

--- a/.github/workflows/update-from-upstream.yml
+++ b/.github/workflows/update-from-upstream.yml
@@ -1,0 +1,71 @@
+name: Update from upstream
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 19 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    if: github.repository != 'Shudesu/line-harness-oss'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch upstream
+        run: |
+          git remote add upstream https://github.com/Shudesu/line-harness-oss.git
+          git fetch upstream main
+
+      - name: Detect upstream changes
+        id: detect
+        run: |
+          if git merge-base --is-ancestor upstream/main HEAD; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create update branch
+        if: steps.detect.outputs.has_changes == 'true'
+        id: branch
+        run: |
+          branch="upstream/update-$(date -u +%Y%m%d-%H%M%S)"
+          git switch -c "$branch"
+          echo "name=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Merge upstream/main
+        if: steps.detect.outputs.has_changes == 'true'
+        run: |
+          git merge --no-edit upstream/main
+
+      - name: Push update branch
+        if: steps.detect.outputs.has_changes == 'true'
+        run: |
+          git push origin "${{ steps.branch.outputs.name }}"
+
+      - name: Open pull request
+        if: steps.detect.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "${{ steps.branch.outputs.name }}" \
+            --title "chore: update from upstream" \
+            --body "This PR imports the latest Shudesu/line-harness-oss main into this fork.\n\nMerge this PR to receive upstream fixes and features, then let the existing Cloudflare deploy workflows update your environment."
+
+      - name: No upstream changes
+        if: steps.detect.outputs.has_changes == 'false'
+        run: echo "Fork is already up to date with upstream/main."

--- a/README.md
+++ b/README.md
@@ -136,10 +136,25 @@ CLI が以下を全部やる:
 ## ドキュメント
 
 - [セットアップガイド (動画)](https://youtu.be/DiRuGaeq1sM)
+- [Fork + Cloudflare 運用ガイド](docs/FORK_CLOUDFLARE_WORKFLOW.md)
 - [LINE で無料体験する](https://shudesu.github.io/line-harness-oss/)
 - [npm: @line-harness/sdk](https://www.npmjs.com/package/@line-harness/sdk)
 - [npm: @line-harness/mcp-server](https://www.npmjs.com/package/@line-harness/mcp-server)
 - [npm: create-line-harness](https://www.npmjs.com/package/create-line-harness)
+
+---
+
+## Fork して自分の Cloudflare で運用する
+
+LINE Harness は、fork した repo を自分の本番環境として育てる運用を推奨します。
+
+1. この repo を自分の GitHub アカウントへ fork
+2. fork の GitHub Actions に Cloudflare secrets / variables を設定
+3. `main` に merge された変更を Cloudflare Workers / Pages へ自動 deploy
+4. `Update from upstream` workflow で本流アップデートを PR として取り込む
+5. 自分専用の機能は fork の feature branch で開発
+
+ローカルPCは開発・確認用です。本番は GitHub Actions と Cloudflare に寄せると、本流機能と自分の改造を両方育てやすくなります。
 
 ---
 

--- a/docs/FORK_CLOUDFLARE_WORKFLOW.md
+++ b/docs/FORK_CLOUDFLARE_WORKFLOW.md
@@ -1,0 +1,116 @@
+# Fork + Cloudflare 運用ガイド
+
+LINE Harness は、fork した repo を自分の本番環境として育てる運用を推奨します。
+
+## 全体像
+
+```text
+Shudesu/line-harness-oss
+  upstream/main  本流アップデート
+        |
+        v
+your-name/line-harness-oss
+  main           自分の本番。GitHub Actions が Cloudflare に deploy
+  feature/*      自分専用の機能開発
+  upstream/*     本流取り込み PR
+```
+
+この形にすると、本流の新機能を取り込みながら、自分専用の機能も同じ repo で育てられます。
+
+## 初回セットアップ
+
+1. GitHub で `Shudesu/line-harness-oss` を fork
+2. fork を clone
+
+```bash
+git clone https://github.com/YOUR_NAME/line-harness-oss.git
+cd line-harness-oss
+git remote add upstream https://github.com/Shudesu/line-harness-oss.git
+pnpm install
+```
+
+3. Cloudflare にログイン
+
+```bash
+npx wrangler login
+```
+
+4. セットアップ CLI を実行
+
+```bash
+npx create-line-harness@latest
+```
+
+CLI は Cloudflare Workers、D1、R2、Pages を前提にセットアップします。
+
+## GitHub Actions を有効化する
+
+fork の `Settings > Secrets and variables > Actions` に値を入れます。
+
+Secrets:
+
+| 名前 | 用途 |
+| --- | --- |
+| `CLOUDFLARE_API_TOKEN` | GitHub Actions から Cloudflare に deploy する |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare アカウント |
+| `D1_DATABASE_NAME` | 本番 D1 database 名 |
+| `D1_DATABASE_ID` | 本番 D1 database ID |
+| `NEXT_PUBLIC_API_URL` | 管理画面から叩く Worker URL |
+
+Variables:
+
+| 名前 | 用途 |
+| --- | --- |
+| `LINE_HARNESS_CLOUDFLARE_DEPLOY` | `true` にすると fork の deploy workflow が有効 |
+| `WORKER_NAME` | Worker 名。未設定なら `line-crm-worker` |
+| `PAGES_PROJECT_NAME` | Pages project 名。未設定なら `line-crm-admin` |
+| `VITE_LIFF_ID` | LIFF ID |
+| `VITE_BOT_BASIC_ID` | LINE bot basic ID |
+| `VITE_CALENDAR_CONNECTION_ID` | Google Calendar 連携を使う場合だけ設定 |
+
+Worker secrets は Cloudflare 側へ入れます。
+
+```bash
+npx wrangler secret put API_KEY
+npx wrangler secret put LINE_CHANNEL_SECRET
+npx wrangler secret put LINE_CHANNEL_ACCESS_TOKEN
+npx wrangler secret put LINE_CHANNEL_ID
+npx wrangler secret put LINE_LOGIN_CHANNEL_ID
+npx wrangler secret put LINE_LOGIN_CHANNEL_SECRET
+npx wrangler secret put LIFF_URL
+```
+
+## 日常の開発
+
+自分専用の機能は branch を切って作ります。
+
+```bash
+git switch -c feature/my-automation
+pnpm --filter worker typecheck
+pnpm --filter worker test
+git push -u origin feature/my-automation
+```
+
+GitHub で PR を作り、問題なければ fork の `main` に merge します。`main` に入ると Cloudflare deploy workflow が走ります。
+
+## 本流アップデートの取り込み
+
+fork の `Actions > Update from upstream > Run workflow` を実行します。
+
+workflow は `Shudesu/line-harness-oss/main` を fetch し、fork の `main` に取り込む PR を作ります。PR が clean なら merge してください。conflict が出た場合は、その PR 上で直します。
+
+## 事故を防ぐルール
+
+- `main` は Cloudflare 本番に deploy される branch として扱う
+- 作業は必ず feature branch / PR で行う
+- 本流取り込みも PR 経由にする
+- Cloudflare secrets や LINE tokens は GitHub に commit しない
+- `wrangler.toml` に本番 secret を書かない
+
+## ローカル開発との違い
+
+ローカル開発は「試す場所」です。本番運用は fork の `main` と Cloudflare です。
+
+```text
+local branch -> PR -> fork main -> GitHub Actions -> Cloudflare
+```


### PR DESCRIPTION
## Summary
- Add a fork-first Cloudflare operations guide for LINE Harness users
- Add opt-in Cloudflare Worker and Admin Pages deploy workflows for forks
- Add an Update from upstream workflow that creates PRs in forks
- Link the new guide from README

## Safety
- Deploy workflows do not run in Shudesu/line-harness-oss itself
- Fork deploy workflows require vars.LINE_HARNESS_CLOUDFLARE_DEPLOY == true
- Upstream update workflow only runs outside the upstream repo

## Verification
- ruby YAML parse for all .github/workflows/*.yml
- git diff --check

Private docs counterpart: Shudesu/line-harness#58