### PR TITLE
Fix setup Worker deploy for update-engine builds

### DIFF
--- a/packages/create-line-harness/src/steps/deploy-worker.ts
+++ b/packages/create-line-harness/src/steps/deploy-worker.ts
@@ -37,6 +37,7 @@ export async function deployWorker(
   const deployToml = `name = "${options.workerName}"
 main = "src/index.ts"
 compatibility_date = "2024-12-01"
+compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 account_id = "${options.accountId}"
 
@@ -68,7 +69,23 @@ crons = ["*/5 * * * *"]
   buildSpinner.start("Worker ビルド中...");
   try {
     // Build workspace dependencies that the worker needs
-    await execa("npx", ["pnpm", "-r", "--filter", "./packages/shared", "--filter", "./packages/line-sdk", "--filter", "./packages/db", "build"], { cwd: options.repoDir });
+    await execa(
+      "npx",
+      [
+        "pnpm",
+        "-r",
+        "--filter",
+        "./packages/shared",
+        "--filter",
+        "./packages/line-sdk",
+        "--filter",
+        "./packages/db",
+        "--filter",
+        "./packages/update-engine",
+        "build",
+      ],
+      { cwd: options.repoDir },
+    );
     await execa("npx", ["vite", "build"], { cwd: workerDir });
     buildSpinner.stop("Worker ビルド完了");
 

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -20,7 +20,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/preserve-node-builtins.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/update-engine/scripts/preserve-node-builtins.mjs
+++ b/packages/update-engine/scripts/preserve-node-builtins.mjs
@@ -1,0 +1,53 @@
+import { builtinModules } from 'node:module';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const builtins = builtinModules
+  .filter((name) => !name.startsWith('node:') && !name.includes('/'))
+  .sort((a, b) => b.length - a.length);
+
+const builtinPattern = builtins.map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+
+const importFromPattern = new RegExp(`\\bfrom\\s+(["'])(${builtinPattern})\\1`, 'g');
+const sideEffectImportPattern = new RegExp(`\\bimport\\s+(["'])(${builtinPattern})\\1`, 'g');
+const requirePattern = new RegExp(`\\brequire\\(\\s*(["'])(${builtinPattern})\\1\\s*\\)`, 'g');
+const dynamicImportPattern = new RegExp(`\\bimport\\(\\s*(["'])(${builtinPattern})\\1\\s*\\)`, 'g');
+
+export function preserveNodeBuiltinSpecifiers(source) {
+  return source
+    .replace(importFromPattern, 'from $1node:$2$1')
+    .replace(sideEffectImportPattern, 'import $1node:$2$1')
+    .replace(requirePattern, 'require($1node:$2$1)')
+    .replace(dynamicImportPattern, 'import($1node:$2$1)');
+}
+
+export function findBareNodeBuiltinSpecifiers(source) {
+  const matches = [
+    ...source.matchAll(importFromPattern),
+    ...source.matchAll(sideEffectImportPattern),
+    ...source.matchAll(requirePattern),
+    ...source.matchAll(dynamicImportPattern),
+  ];
+  return [...new Set(matches.map((match) => match[2]))].sort();
+}
+
+function rewriteFile(path) {
+  const original = readFileSync(path, 'utf8');
+  const rewritten = preserveNodeBuiltinSpecifiers(original);
+  if (rewritten !== original) {
+    writeFileSync(path, rewritten);
+  }
+
+  const remaining = findBareNodeBuiltinSpecifiers(rewritten);
+  if (remaining.length > 0) {
+    throw new Error(`${path} still contains bare Node built-in imports: ${remaining.join(', ')}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const packageRoot = join(here, '..');
+  rewriteFile(join(packageRoot, 'dist/index.mjs'));
+  rewriteFile(join(packageRoot, 'dist/index.cjs'));
+}

--- a/packages/update-engine/scripts/preserve-node-builtins.mjs
+++ b/packages/update-engine/scripts/preserve-node-builtins.mjs
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const builtins = builtinModules
-  .filter((name) => !name.startsWith('node:') && !name.includes('/'))
+  .filter((name) => !name.startsWith('node:'))
   .sort((a, b) => b.length - a.length);
 
 const builtinPattern = builtins.map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');

--- a/packages/update-engine/test/preserve-node-builtins.test.ts
+++ b/packages/update-engine/test/preserve-node-builtins.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findBareNodeBuiltinSpecifiers,
+  preserveNodeBuiltinSpecifiers,
+} from '../scripts/preserve-node-builtins.mjs';
+
+describe('preserveNodeBuiltinSpecifiers', () => {
+  it('rewrites bare Node built-in specifiers to node: specifiers', () => {
+    const source = [
+      'import { Readable } from "stream";',
+      "import { createHash } from 'crypto';",
+      'import "events";',
+      'const zlib = require("zlib");',
+      "const fs = await import('fs');",
+      'import pkg from "tar-stream";',
+    ].join('\n');
+
+    const rewritten = preserveNodeBuiltinSpecifiers(source);
+
+    expect(rewritten).toContain('from "node:stream"');
+    expect(rewritten).toContain("from 'node:crypto'");
+    expect(rewritten).toContain('import "node:events"');
+    expect(rewritten).toContain('require("node:zlib")');
+    expect(rewritten).toContain("import('node:fs')");
+    expect(rewritten).toContain('from "tar-stream"');
+    expect(findBareNodeBuiltinSpecifiers(rewritten)).toEqual([]);
+  });
+});

--- a/packages/update-engine/test/preserve-node-builtins.test.ts
+++ b/packages/update-engine/test/preserve-node-builtins.test.ts
@@ -12,7 +12,10 @@ describe('preserveNodeBuiltinSpecifiers', () => {
       'import "events";',
       'const zlib = require("zlib");',
       "const fs = await import('fs');",
+      'import { readFile } from "fs/promises";',
+      'const streamWeb = require("stream/web");',
       'import pkg from "tar-stream";',
+      'import local from "./stream";',
     ].join('\n');
 
     const rewritten = preserveNodeBuiltinSpecifiers(source);
@@ -22,7 +25,10 @@ describe('preserveNodeBuiltinSpecifiers', () => {
     expect(rewritten).toContain('import "node:events"');
     expect(rewritten).toContain('require("node:zlib")');
     expect(rewritten).toContain("import('node:fs')");
+    expect(rewritten).toContain('from "node:fs/promises"');
+    expect(rewritten).toContain('require("node:stream/web")');
     expect(rewritten).toContain('from "tar-stream"');
+    expect(rewritten).toContain('from "./stream"');
     expect(findBareNodeBuiltinSpecifiers(rewritten)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- build @line-harness/update-engine before the setup Worker Vite build
- preserve node: prefixes in update-engine tsup output and fail the build if bare Node built-ins remain
- keep nodejs_compat in the temporary setup wrangler.toml

## Verification
- npx pnpm --filter @line-harness/update-engine build
- npx pnpm --filter @line-harness/update-engine test
- npx pnpm --filter @line-harness/update-engine typecheck
- npx pnpm --filter create-line-harness build
- npx pnpm --filter worker build
- rg confirmed no bare stream/zlib/crypto imports remain in update-engine dist or worker dist