### PR TITLE
feat: support per-staff LINE message sender

### DIFF
--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -39,6 +39,16 @@ interface ChatDetail extends Chat {
   messages?: ChatMessage[]
 }
 
+interface StaffInfo {
+  id: string
+  name: string
+  role: string
+  iconUrl: string | null
+  isActive?: boolean
+}
+
+type SenderMode = 'official' | 'self' | string // string = staff id for owner selecting others
+
 type StatusFilter = 'all' | 'unread' | 'in_progress' | 'resolved'
 
 const statusConfig: Record<Chat['status'], { label: string; className: string }> = {
@@ -150,9 +160,11 @@ function DirectMessagePanel({ friendId, friend, onBack, onSent }: {
     sendLockRef.current = true
     setSending(true)
     try {
+      const meRes = await api.staff.me().catch(() => null)
+      const sender = meRes?.success && meRes.data.name ? { name: meRes.data.name } : undefined
       await fetchApi(`/api/friends/${friendId}/messages`, {
         method: 'POST',
-        body: JSON.stringify({ content: message, messageType: 'text' }),
+        body: JSON.stringify({ content: message, messageType: 'text', ...(sender ? { sender } : {}) }),
       })
       setMessages((prev) => [...prev, {
         id: crypto.randomUUID(),
@@ -312,6 +324,9 @@ export default function ChatsPage() {
   const isComposingRef = useRef(false)
   const messagesScrollRef = useRef<HTMLDivElement | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [currentStaff, setCurrentStaff] = useState<StaffInfo | null>(null)
+  const [staffList, setStaffList] = useState<StaffInfo[]>([])
+  const [senderMode, setSenderMode] = useState<SenderMode>('self')
 
   useEffect(() => {
     try {
@@ -335,6 +350,24 @@ export default function ChatsPage() {
       // localStorage unavailable
     }
   }, [showLoadingIndicator, loadingSeconds])
+
+  useEffect(() => {
+    const loadStaffInfo = async () => {
+      try {
+        const meRes = await api.staff.me()
+        if (meRes.success) {
+          setCurrentStaff(meRes.data as StaffInfo)
+          if (meRes.data.role === 'owner') {
+            try {
+              const listRes = await api.staff.list()
+              if (listRes.success) setStaffList(listRes.data as unknown as StaffInfo[])
+            } catch { /* staff list is optional */ }
+          }
+        }
+      } catch { /* not logged in as staff */ }
+    }
+    loadStaffInfo()
+  }, [])
 
   const loadChats = useCallback(async () => {
     setLoading(true)
@@ -524,6 +557,19 @@ export default function ChatsPage() {
     }
   }, [showLoadingIndicator, loadingSeconds])
 
+  const buildSender = useCallback((): { name: string; iconUrl?: string } | undefined => {
+    if (senderMode === 'official') return undefined
+    if (senderMode === 'self' && currentStaff) {
+      return { name: currentStaff.name, ...(currentStaff.iconUrl ? { iconUrl: currentStaff.iconUrl } : {}) }
+    }
+    // owner selecting a specific staff member
+    const selected = staffList.find((s) => s.id === senderMode)
+    if (selected) {
+      return { name: selected.name, ...(selected.iconUrl ? { iconUrl: selected.iconUrl } : {}) }
+    }
+    return undefined
+  }, [senderMode, currentStaff, staffList])
+
   const handleSendMessage = async () => {
     if (!selectedChatId || sending || sendLockRef.current) return
     if (!messageContent.trim() && !pendingImage) return
@@ -532,13 +578,14 @@ export default function ChatsPage() {
     setSending(true)
     try {
       const now = new Date().toISOString()
+      const sender = buildSender()
       // --- Image send path (runs first when image is present) ---
       if (pendingImage && pendingImage.mode === 'line-image') {
         const imgPayload = JSON.stringify({
           originalContentUrl: pendingImage.originalContentUrl,
           previewImageUrl: pendingImage.previewImageUrl,
         })
-        await api.chats.send(sendingChatId, { messageType: 'image', content: imgPayload })
+        await api.chats.send(sendingChatId, { messageType: 'image', content: imgPayload, ...(sender ? { sender } : {}) })
         setPendingImage(null)
         // Optimistic update for image
         setChatDetail((prev) => (prev && prev.id === sendingChatId) ? {
@@ -584,7 +631,7 @@ export default function ChatsPage() {
       // --- Text send path (runs independently — both paths execute when both image and text are present) ---
       if (messageContent.trim()) {
         const content = messageContent.trim()
-        await api.chats.send(sendingChatId, { content })
+        await api.chats.send(sendingChatId, { content, ...(sender ? { sender } : {}) })
         setMessageContent('')
         // Optimistic update: append message locally instead of refetching (prevents scroll jump / full reload feel)
         // Only mutate chatDetail if it still corresponds to the chat we just sent to
@@ -1000,6 +1047,33 @@ export default function ChatsPage() {
               {/* Send Message Form */}
               <div className="px-4 py-3 border-t border-gray-200">
                 <div className="mb-2 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-gray-600">
+                  {currentStaff && (
+                    <div className="inline-flex items-center gap-1.5">
+                      <span className="text-gray-500">送信者:</span>
+                      {currentStaff.role === 'owner' && staffList.length > 0 ? (
+                        <select
+                          value={senderMode}
+                          onChange={(e) => setSenderMode(e.target.value)}
+                          className="border border-gray-300 rounded-md px-2 py-1 bg-white text-xs"
+                        >
+                          <option value="official">公式アカウント</option>
+                          <option value="self">{currentStaff.name}（自分）</option>
+                          {staffList.filter((s) => s.id !== currentStaff.id && s.isActive !== false).map((s) => (
+                            <option key={s.id} value={s.id}>{s.name}</option>
+                          ))}
+                        </select>
+                      ) : (
+                        <select
+                          value={senderMode}
+                          onChange={(e) => setSenderMode(e.target.value)}
+                          className="border border-gray-300 rounded-md px-2 py-1 bg-white text-xs"
+                        >
+                          <option value="official">公式アカウント</option>
+                          <option value="self">{currentStaff.name}（自分）</option>
+                        </select>
+                      )}
+                    </div>
+                  )}
                   <label className="inline-flex items-center gap-2 cursor-pointer select-none">
                     <input
                       type="checkbox"

--- a/apps/web/src/app/staff/page.tsx
+++ b/apps/web/src/app/staff/page.tsx
@@ -41,9 +41,14 @@ export default function StaffPage() {
   const [showForm, setShowForm] = useState(false)
   const [formName, setFormName] = useState('')
   const [formEmail, setFormEmail] = useState('')
+  const [formIconUrl, setFormIconUrl] = useState('')
   const [formRole, setFormRole] = useState<'admin' | 'staff'>('staff')
   const [formLoading, setFormLoading] = useState(false)
   const [formError, setFormError] = useState('')
+
+  // Inline icon edit
+  const [editingIconId, setEditingIconId] = useState<string | null>(null)
+  const [editIconUrl, setEditIconUrl] = useState('')
 
   const loadMembers = async () => {
     setLoading(true)
@@ -71,11 +76,12 @@ export default function StaffPage() {
     setFormLoading(true)
     setFormError('')
     try {
-      const body: { name: string; role: 'admin' | 'staff'; email?: string } = {
+      const body: { name: string; role: 'admin' | 'staff'; email?: string; iconUrl?: string } = {
         name: formName,
         role: formRole,
       }
       if (formEmail) body.email = formEmail
+      if (formIconUrl) body.iconUrl = formIconUrl
 
       const res = await fetchApi<ApiResponse<StaffMember & { apiKey?: string }>>('/api/staff', {
         method: 'POST',
@@ -87,6 +93,7 @@ export default function StaffPage() {
         }
         setFormName('')
         setFormEmail('')
+        setFormIconUrl('')
         setFormRole('staff')
         setShowForm(false)
         await loadMembers()
@@ -191,7 +198,7 @@ export default function StaffPage() {
         <div className="mb-6 p-5 bg-white border border-gray-200 rounded-lg shadow-sm">
           <h2 className="text-sm font-semibold text-gray-900 mb-4">新しいスタッフを追加</h2>
           <form onSubmit={handleCreate} className="space-y-4">
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
               <div>
                 <label className="block text-xs font-medium text-gray-700 mb-1">名前 *</label>
                 <input
@@ -210,6 +217,16 @@ export default function StaffPage() {
                   value={formEmail}
                   onChange={(e) => setFormEmail(e.target.value)}
                   placeholder="taro@example.com"
+                  className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-700 mb-1">アイコン画像URL</label>
+                <input
+                  type="url"
+                  value={formIconUrl}
+                  onChange={(e) => setFormIconUrl(e.target.value)}
+                  placeholder="https://example.com/icon.png"
                   className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500"
                 />
               </div>
@@ -291,7 +308,54 @@ export default function StaffPage() {
             <tbody className="divide-y divide-gray-100">
               {members.map((member) => (
                 <tr key={member.id} className="hover:bg-gray-50 transition-colors">
-                  <td className="px-4 py-3 font-medium text-gray-900">{member.name}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      {member.iconUrl ? (
+                        <img src={member.iconUrl} alt="" className="w-7 h-7 rounded-full flex-shrink-0" />
+                      ) : (
+                        <div className="w-7 h-7 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0">
+                          <span className="text-gray-500 text-xs">{member.name.charAt(0)}</span>
+                        </div>
+                      )}
+                      <div>
+                        <span className="font-medium text-gray-900">{member.name}</span>
+                        {editingIconId === member.id ? (
+                          <div className="flex items-center gap-1 mt-1">
+                            <input
+                              type="url"
+                              value={editIconUrl}
+                              onChange={(e) => setEditIconUrl(e.target.value)}
+                              placeholder="https://..."
+                              className="w-48 px-2 py-0.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-green-500"
+                            />
+                            <button
+                              onClick={async () => {
+                                await fetchApi(`/api/staff/${member.id}`, {
+                                  method: 'PATCH',
+                                  body: JSON.stringify({ iconUrl: editIconUrl || null }),
+                                })
+                                setEditingIconId(null)
+                                await loadMembers()
+                              }}
+                              className="px-1.5 py-0.5 text-xs text-green-700 bg-green-50 rounded hover:bg-green-100"
+                            >
+                              保存
+                            </button>
+                            <button onClick={() => setEditingIconId(null)} className="px-1.5 py-0.5 text-xs text-gray-500 rounded hover:bg-gray-100">
+                              取消
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            onClick={() => { setEditingIconId(member.id); setEditIconUrl(member.iconUrl || '') }}
+                            className="block text-xs text-gray-400 hover:text-green-600"
+                          >
+                            {member.iconUrl ? 'アイコン変更' : 'アイコン設定'}
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </td>
                   <td className="px-4 py-3 text-gray-500 hidden sm:table-cell">{member.email ?? '—'}</td>
                   <td className="px-4 py-3">
                     <RoleBadge role={member.role} />

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -25,6 +25,7 @@ import type {
   AccountHealthLog,
   AccountMigration,
   StaffMember,
+  StaffProfile,
   Broadcast,
   BroadcastTargetType,
   EntryRoute,
@@ -667,7 +668,7 @@ export const api = {
         method: 'PUT',
         body: JSON.stringify(data),
       }),
-    send: (id: string, data: { content: string; messageType?: string }) =>
+    send: (id: string, data: { content: string; messageType?: string; sender?: { name: string; iconUrl?: string } }) =>
       fetchApi<ApiResponse<unknown>>(`/api/chats/${id}/send`, {
         method: 'POST',
         body: JSON.stringify(data),
@@ -805,13 +806,13 @@ export const api = {
     get: (id: string) =>
       fetchApi<ApiResponse<StaffMember>>(`/api/staff/${id}`),
     me: () =>
-      fetchApi<ApiResponse<{ id: string; name: string; role: string; email: string | null }>>('/api/staff/me'),
-    create: (data: { name: string; email?: string; role: 'admin' | 'staff' }) =>
+      fetchApi<ApiResponse<StaffProfile>>('/api/staff/me'),
+    create: (data: { name: string; email?: string; role: 'admin' | 'staff'; iconUrl?: string | null }) =>
       fetchApi<ApiResponse<StaffMember>>('/api/staff', {
         method: 'POST',
         body: JSON.stringify(data),
       }),
-    update: (id: string, data: { name?: string; email?: string | null; role?: string; isActive?: boolean }) =>
+    update: (id: string, data: { name?: string; email?: string | null; role?: string; isActive?: boolean; iconUrl?: string | null }) =>
       fetchApi<ApiResponse<StaffMember>>(`/api/staff/${id}`, {
         method: 'PATCH',
         body: JSON.stringify(data),

--- a/apps/worker/src/routes/chats.ts
+++ b/apps/worker/src/routes/chats.ts
@@ -520,7 +520,7 @@ chats.post('/api/chats/:id/send', async (c) => {
     const chat = await resolveOrCreateChat(c.env.DB, chatId);
     if (!chat) return c.json({ success: false, error: 'Chat not found' }, 404);
 
-    const body = await c.req.json<{ messageType?: string; content: string }>();
+    const body = await c.req.json<{ messageType?: string; content: string; sender?: { name: string; iconUrl?: string } }>();
     if (!body.content) return c.json({ success: false, error: 'content is required' }, 400);
 
     const { friend, accessToken } = await resolveFriendAndAccessToken(
@@ -536,10 +536,10 @@ chats.post('/api/chats/:id/send', async (c) => {
     const messageType = body.messageType ?? 'text';
 
     if (messageType === 'text') {
-      await lineClient.pushTextMessage(friend.line_user_id, body.content);
+      await lineClient.pushTextMessage(friend.line_user_id, body.content, body.sender);
     } else if (messageType === 'flex') {
       const contents = JSON.parse(body.content);
-      await lineClient.pushFlexMessage(friend.line_user_id, extractFlexAltText(contents), contents);
+      await lineClient.pushFlexMessage(friend.line_user_id, extractFlexAltText(contents), contents, body.sender);
     } else if (messageType === 'image') {
       const parsed = JSON.parse(body.content) as {
         originalContentUrl: string;
@@ -549,6 +549,7 @@ chats.post('/api/chats/:id/send', async (c) => {
         friend.line_user_id,
         parsed.originalContentUrl,
         parsed.previewImageUrl,
+        body.sender,
       );
     }
 

--- a/apps/worker/src/routes/friends.ts
+++ b/apps/worker/src/routes/friends.ts
@@ -542,6 +542,7 @@ friends.post('/api/friends/:id/messages', async (c) => {
       messageType?: string;
       content: string;
       altText?: string;
+      sender?: { name: string; iconUrl?: string };
     }>();
 
     if (!body.content) {
@@ -573,7 +574,7 @@ friends.post('/api/friends/:id/messages', async (c) => {
     );
 
     const message = buildMessage(tracked.messageType, tracked.content, body.altText);
-    await lineClient.pushMessage(friend.line_user_id, [message]);
+    await lineClient.pushMessage(friend.line_user_id, [message], body.sender);
 
     // Log outgoing message
     const logId = crypto.randomUUID();

--- a/apps/worker/src/routes/staff.ts
+++ b/apps/worker/src/routes/staff.ts
@@ -25,6 +25,7 @@ function serializeStaff(row: StaffMember, masked = true) {
     email: row.email,
     role: row.role,
     apiKey: masked ? maskApiKey(row.api_key) : row.api_key,
+    iconUrl: row.icon_url ?? null,
     isActive: Boolean(row.is_active),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -45,6 +46,7 @@ staff.get('/api/staff/me', async (c) => {
           name: 'Owner',
           role: 'owner',
           email: null,
+          iconUrl: null,
         },
       });
     }
@@ -61,6 +63,7 @@ staff.get('/api/staff/me', async (c) => {
         name: member.name,
         role: member.role,
         email: member.email,
+        iconUrl: member.icon_url ?? null,
       },
     });
   } catch (err) {
@@ -98,7 +101,7 @@ staff.get('/api/staff/:id', requireRole('owner'), async (c) => {
 // POST /api/staff — owner only. Create staff. Returns full API key (one-time visible).
 staff.post('/api/staff', requireRole('owner'), async (c) => {
   try {
-    const body = await c.req.json<{ name: string; email?: string; role: string }>();
+    const body = await c.req.json<{ name: string; email?: string; role: string; iconUrl?: string }>();
 
     if (!body.name) {
       return c.json({ success: false, error: 'name is required' }, 400);
@@ -113,6 +116,7 @@ staff.post('/api/staff', requireRole('owner'), async (c) => {
       name: body.name,
       email: body.email ?? null,
       role: body.role as 'owner' | 'admin' | 'staff',
+      icon_url: body.iconUrl ?? null,
     });
 
     // Return full (unmasked) API key one-time
@@ -132,6 +136,7 @@ staff.patch('/api/staff/:id', requireRole('owner'), async (c) => {
       email?: string | null;
       role?: string;
       isActive?: boolean;
+      iconUrl?: string | null;
     }>();
 
     const validRoles = ['owner', 'admin', 'staff'] as const;
@@ -161,6 +166,7 @@ staff.patch('/api/staff/:id', requireRole('owner'), async (c) => {
       email: body.email,
       role: body.role as 'owner' | 'admin' | 'staff' | undefined,
       is_active: body.isActive !== undefined ? (body.isActive ? 1 : 0) : undefined,
+      icon_url: body.iconUrl !== undefined ? body.iconUrl : undefined,
     });
 
     if (!updated) {

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -13,7 +13,8 @@ workers_dev = true
 # デフォルト = テスト環境 (noda@)
 # 使い方: npx wrangler deploy
 # ═══════════════════════════════════════════════════════════════
-account_id = "YOUR_DEV_ACCOUNT_ID"
+# account_id は環境変数 CLOUDFLARE_ACCOUNT_ID で設定
+# database_id は環境変数では上書きできないため wrangler.toml に記載が必要
 
 [assets]
 directory = "dist/client"

--- a/packages/db/migrations/046_staff_icon_url.sql
+++ b/packages/db/migrations/046_staff_icon_url.sql
@@ -1,0 +1,2 @@
+-- Add icon_url to staff_members for LINE sender icon
+ALTER TABLE staff_members ADD COLUMN icon_url TEXT;

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -618,6 +618,7 @@ CREATE TABLE IF NOT EXISTS staff_members (
   email      TEXT,
   role       TEXT NOT NULL CHECK (role IN ('owner', 'admin', 'staff')),
   api_key    TEXT UNIQUE NOT NULL,
+  icon_url   TEXT,
   is_active  INTEGER NOT NULL DEFAULT 1,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))

--- a/packages/db/src/staff.ts
+++ b/packages/db/src/staff.ts
@@ -6,6 +6,7 @@ export interface StaffMember {
   email: string | null;
   role: 'owner' | 'admin' | 'staff';
   api_key: string;
+  icon_url: string | null;
   is_active: number;
   created_at: string;
   updated_at: string;
@@ -15,6 +16,7 @@ export interface CreateStaffInput {
   name: string;
   email?: string | null;
   role: 'owner' | 'admin' | 'staff';
+  icon_url?: string | null;
 }
 
 export interface UpdateStaffInput {
@@ -22,6 +24,7 @@ export interface UpdateStaffInput {
   email?: string | null;
   role?: 'owner' | 'admin' | 'staff';
   is_active?: number;
+  icon_url?: string | null;
 }
 
 function generateApiKey(): string {
@@ -68,10 +71,10 @@ export async function createStaffMember(
 
   await db
     .prepare(
-      `INSERT INTO staff_members (id, name, email, role, api_key, is_active, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+      `INSERT INTO staff_members (id, name, email, role, api_key, icon_url, is_active, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)`,
     )
-    .bind(id, input.name, input.email ?? null, input.role, apiKey, now, now)
+    .bind(id, input.name, input.email ?? null, input.role, apiKey, input.icon_url ?? null, now, now)
     .run();
 
   return (await db
@@ -93,6 +96,7 @@ export async function updateStaffMember(
   if (input.email !== undefined) { sets.push('email = ?'); values.push(input.email ?? null); }
   if (input.role !== undefined) { sets.push('role = ?'); values.push(input.role); }
   if (input.is_active !== undefined) { sets.push('is_active = ?'); values.push(input.is_active); }
+  if (input.icon_url !== undefined) { sets.push('icon_url = ?'); values.push(input.icon_url ?? null); }
 
   values.push(id);
   await db

--- a/packages/line-sdk/src/client.ts
+++ b/packages/line-sdk/src/client.ts
@@ -2,6 +2,7 @@ import type {
   BroadcastRequest,
   FlexContainer,
   Message,
+  MessageSender,
   MulticastRequest,
   PushMessageRequest,
   ReplyMessageRequest,
@@ -68,8 +69,13 @@ export class LineClient {
 
   // ─── Messaging ───────────────────────────────────────────────────────────
 
-  async pushMessage(to: string, messages: Message[]): Promise<unknown> {
-    const body: PushMessageRequest = { to, messages };
+  private applyS(messages: Message[], sender?: MessageSender): Message[] {
+    if (!sender) return messages;
+    return messages.map((m) => ({ ...m, sender }));
+  }
+
+  async pushMessage(to: string, messages: Message[], sender?: MessageSender): Promise<unknown> {
+    const body: PushMessageRequest = { to, messages: this.applyS(messages, sender) };
     const { data } = await this.request('POST', '/v2/bot/message/push', body);
     return data;
   }
@@ -78,8 +84,9 @@ export class LineClient {
     to: string[],
     messages: Message[],
     customAggregationUnits?: string[],
+    sender?: MessageSender,
   ): Promise<{ data: unknown; requestId: string | null }> {
-    const body: Record<string, unknown> = { to, messages };
+    const body: Record<string, unknown> = { to, messages: this.applyS(messages, sender) };
     if (customAggregationUnits) {
       body.customAggregationUnits = customAggregationUnits;
     }
@@ -93,8 +100,9 @@ export class LineClient {
 
   async broadcast(
     messages: Message[],
+    sender?: MessageSender,
   ): Promise<{ data: unknown; requestId: string | null }> {
-    const body: BroadcastRequest = { messages };
+    const body: BroadcastRequest = { messages: this.applyS(messages, sender) };
     const { data, headers } = await this.request(
       'POST',
       '/v2/bot/message/broadcast',
@@ -106,8 +114,9 @@ export class LineClient {
   async replyMessage(
     replyToken: string,
     messages: Message[],
+    sender?: MessageSender,
   ): Promise<unknown> {
-    const body: ReplyMessageRequest = { replyToken, messages };
+    const body: ReplyMessageRequest = { replyToken, messages: this.applyS(messages, sender) };
     const { data } = await this.request('POST', '/v2/bot/message/reply', body);
     return data;
   }
@@ -187,24 +196,26 @@ export class LineClient {
 
   // ─── Helpers ──────────────────────────────────────────────────────────────
 
-  async pushTextMessage(to: string, text: string): Promise<unknown> {
-    return this.pushMessage(to, [{ type: 'text', text }]);
+  async pushTextMessage(to: string, text: string, sender?: MessageSender): Promise<unknown> {
+    return this.pushMessage(to, [{ type: 'text', text }], sender);
   }
 
   async pushFlexMessage(
     to: string,
     altText: string,
     contents: FlexContainer,
+    sender?: MessageSender,
   ): Promise<unknown> {
-    return this.pushMessage(to, [{ type: 'flex', altText, contents }]);
+    return this.pushMessage(to, [{ type: 'flex', altText, contents }], sender);
   }
 
   async pushImageMessage(
     to: string,
     originalContentUrl: string,
     previewImageUrl: string,
+    sender?: MessageSender,
   ): Promise<unknown> {
-    return this.pushMessage(to, [{ type: 'image', originalContentUrl, previewImageUrl }]);
+    return this.pushMessage(to, [{ type: 'image', originalContentUrl, previewImageUrl }], sender);
   }
 
   // ─── Rich Menu Image Upload ─────────────────────────────────────────────

--- a/packages/line-sdk/src/index.ts
+++ b/packages/line-sdk/src/index.ts
@@ -35,6 +35,7 @@ export type {
   LocationEventMessage,
   Message,
   MessageEvent,
+  MessageSender,
   MulticastRequest,
   PostbackEvent,
   PushMessageRequest,

--- a/packages/line-sdk/src/types.ts
+++ b/packages/line-sdk/src/types.ts
@@ -190,13 +190,15 @@ export interface ImageMapMessageType {
   actions: Record<string, unknown>[];
 }
 
-export type Message =
+export type BaseMessage =
   | TextMessage
   | ImageMessage
   | FlexMessage
   | VideoMessage
   | TemplateMessage
   | ImageMapMessageType;
+
+export type Message = BaseMessage & { sender?: MessageSender };
 
 // ─── Rich Menu types ──────────────────────────────────────────────────────────
 
@@ -264,6 +266,13 @@ export interface RichMenuObject {
   name: string;
   chatBarText: string;
   areas: RichMenuArea[];
+}
+
+// ─── Sender ──────────────────────────────────────────────────────────────────
+
+export interface MessageSender {
+  name: string;
+  iconUrl?: string;
 }
 
 // ─── Request types ────────────────────────────────────────────────────────────

--- a/packages/mcp-server/src/tools/manage-staff.ts
+++ b/packages/mcp-server/src/tools/manage-staff.ts
@@ -12,11 +12,12 @@ export function registerManageStaff(server: McpServer): void {
         .describe("Action to perform"),
       name: z.string().optional().describe("Staff name (for 'create' action)"),
       email: z.string().nullable().optional().describe("Staff email (optional, null to clear)"),
+      iconUrl: z.string().url().nullable().optional().describe("Staff sender icon URL (optional, null to clear)"),
       role: z.enum(["admin", "staff"]).optional().describe("Staff role (for 'create'/'update')"),
       staffId: z.string().optional().describe("Staff ID (for 'get','update','delete','regenerate_key')"),
       isActive: z.boolean().optional().describe("Activate/deactivate (for 'update')"),
     },
-    async ({ action, name, email, role, staffId, isActive }) => {
+    async ({ action, name, email, iconUrl, role, staffId, isActive }) => {
       try {
         const client = getClient();
 
@@ -37,7 +38,7 @@ export function registerManageStaff(server: McpServer): void {
         if (action === "create") {
           if (!name) throw new Error("name is required for create action");
           if (!role) throw new Error("role is required for create action");
-          const member = await client.staff.create({ name, email, role });
+          const member = await client.staff.create({ name, email, role, iconUrl });
           return {
             content: [{
               type: "text" as const,
@@ -62,6 +63,7 @@ export function registerManageStaff(server: McpServer): void {
           const updates: Record<string, unknown> = {};
           if (name !== undefined) updates.name = name;
           if (email !== undefined) updates.email = email;
+          if (iconUrl !== undefined) updates.iconUrl = iconUrl;
           if (role !== undefined) updates.role = role;
           if (isActive !== undefined) updates.isActive = isActive;
           const member = await client.staff.update(staffId, updates);

--- a/packages/mcp-server/src/tools/send-message.ts
+++ b/packages/mcp-server/src/tools/send-message.ts
@@ -32,8 +32,22 @@ export function registerSendMessage(server: McpServer): void {
         .describe(
           "Mark as test send. Prepends 【テスト配信】 to text messages, adds test banner to flex messages.",
         ),
+      senderName: z
+        .string()
+        .max(20)
+        .optional()
+        .describe(
+          "Display name shown as the message sender (max 20 chars). Use for staff-specific messages, e.g. 'スタッフ田中'.",
+        ),
+      senderIconUrl: z
+        .string()
+        .url()
+        .optional()
+        .describe(
+          "HTTPS URL of the sender's icon image (PNG recommended, max 1MB).",
+        ),
     },
-    async ({ friendId, content, messageType, altText, isTest }) => {
+    async ({ friendId, content, messageType, altText, isTest, senderName, senderIconUrl }) => {
       try {
         const client = getClient();
 
@@ -71,11 +85,13 @@ export function registerSendMessage(server: McpServer): void {
           `DM to ${friendId.slice(0, 8)}`,
         );
 
+        const sender = senderName ? { name: senderName, ...(senderIconUrl ? { iconUrl: senderIconUrl } : {}) } : undefined;
         const result = await client.friends.sendMessage(
           friendId,
           trackedContent,
           messageType,
           altText,
+          sender,
         );
         return {
           content: [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -34,6 +34,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^25.5.2",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0",
     "vitest": "^2.0.0"

--- a/packages/sdk/src/resources/friends.ts
+++ b/packages/sdk/src/resources/friends.ts
@@ -1,5 +1,5 @@
 import type { HttpClient } from '../http.js'
-import type { ApiResponse, PaginatedData, Friend, FriendListParams, MessageType } from '../types.js'
+import type { ApiResponse, PaginatedData, Friend, FriendListParams, MessageType, MessageSender } from '../types.js'
 
 export class FriendsResource {
   constructor(
@@ -44,11 +44,12 @@ export class FriendsResource {
     await this.http.delete(`/api/friends/${friendId}/tags/${tagId}`)
   }
 
-  async sendMessage(friendId: string, content: string, messageType: MessageType = 'text', altText?: string): Promise<{ messageId: string }> {
+  async sendMessage(friendId: string, content: string, messageType: MessageType = 'text', altText?: string, sender?: MessageSender): Promise<{ messageId: string }> {
     const res = await this.http.post<ApiResponse<{ messageId: string }>>(`/api/friends/${friendId}/messages`, {
       messageType,
       content,
       ...(altText ? { altText } : {}),
+      ...(sender ? { sender } : {}),
     })
     return res.data
   }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -25,6 +25,11 @@ export interface PaginatedData<T> {
 // ─── Common ─────────────────────────────────────────────
 export type ScenarioTriggerType = 'friend_add' | 'tag_added' | 'manual'
 export type MessageType = 'text' | 'image' | 'flex'
+
+export interface MessageSender {
+  name: string
+  iconUrl?: string
+}
 export type BroadcastStatus = 'draft' | 'scheduled' | 'sending' | 'sent'
 
 // ─── Friend ─────────────────────────────────────────────
@@ -486,6 +491,7 @@ export interface StaffMember {
    * The full key is only returned once — on create or regenerate-key responses.
    */
   apiKey: string
+  iconUrl: string | null
   isActive: boolean
   createdAt: string
   updatedAt: string
@@ -496,12 +502,14 @@ export interface StaffProfile {
   name: string
   role: StaffRole
   email: string | null
+  iconUrl: string | null
 }
 
 export interface CreateStaffInput {
   name: string
-  email?: string
+  email?: string | null
   role: 'admin' | 'staff'
+  iconUrl?: string | null
 }
 
 export interface UpdateStaffInput {
@@ -509,6 +517,7 @@ export interface UpdateStaffInput {
   email?: string | null
   role?: StaffRole
   isActive?: boolean
+  iconUrl?: string | null
 }
 
 // ─── High-Level ─────────────────────────────────────────

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -842,6 +842,7 @@ export interface StaffMember {
   email: string | null;
   role: 'owner' | 'admin' | 'staff';
   apiKey: string;
+  iconUrl: string | null;
   isActive: boolean;
   createdAt: string;
   updatedAt: string;
@@ -852,6 +853,7 @@ export interface StaffProfile {
   name: string;
   role: 'owner' | 'admin' | 'staff';
   email: string | null;
+  iconUrl: string | null;
 }
 
 // =============================================================================

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.0
-        version: 2.1.9(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@25.9.1)(lightningcss@1.32.0)
       wrangler:
         specifier: '4'
         version: 4.77.0(@cloudflare/workers-types@4.20260317.1)
@@ -47,7 +47,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.0
-        version: 4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 4.7.0(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.0
         version: 10.5.0(postcss@8.5.8)
@@ -62,7 +62,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+        version: 6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   apps/web:
     dependencies:
@@ -139,13 +139,13 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.0.0
-        version: 1.30.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(workerd@1.20260317.1)(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))
+        version: 1.30.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(workerd@1.20260317.1)(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))
       '@cloudflare/workers-types':
         specifier: ^4.20241205.0
         version: 4.20260317.1
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 4.2.4(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -154,7 +154,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.0
-        version: 4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 4.7.0(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.2
@@ -166,10 +166,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+        version: 6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@25.9.1)(lightningcss@1.32.0)
       wrangler:
         specifier: ^4.0.0
         version: 4.77.0(@cloudflare/workers-types@4.20260317.1)
@@ -215,7 +215,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@25.9.1)(lightningcss@1.32.0)
 
   packages/line-sdk:
     devDependencies:
@@ -269,6 +269,9 @@ importers:
 
   packages/sdk:
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.2
+        version: 25.9.1
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
@@ -277,7 +280,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@25.9.1)(lightningcss@1.32.0)
 
   packages/shared:
     devDependencies:
@@ -308,7 +311,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.0.0
-        version: 2.1.9(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@25.9.1)(lightningcss@1.32.0)
 
 packages:
 
@@ -2206,6 +2209,9 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -3545,6 +3551,9 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
@@ -3911,12 +3920,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260317.1
 
-  '@cloudflare/vite-plugin@1.30.1(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(workerd@1.20260317.1)(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))':
+  '@cloudflare/vite-plugin@1.30.1(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(workerd@1.20260317.1)(wrangler@4.77.0(@cloudflare/workers-types@4.20260317.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
       miniflare: 4.20260317.2
       unenv: 2.0.0-rc.24
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       wrangler: 4.77.0(@cloudflare/workers-types@4.20260317.1)
       ws: 8.18.0
     transitivePeerDependencies:
@@ -5357,12 +5366,12 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
-  '@tailwindcss/vite@4.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.2.4(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -5403,6 +5412,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -5415,7 +5428,7 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5423,7 +5436,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5434,13 +5447,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.9.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@25.9.1)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -6889,6 +6902,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  undici-types@7.24.6: {}
+
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
@@ -6921,13 +6936,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.1.9(@types/node@25.5.0)(lightningcss@1.32.0):
+  vite-node@2.1.9(@types/node@25.9.1)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@25.9.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6939,17 +6954,17 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0):
+  vite@5.4.21(@types/node@25.9.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.8
       rollup: 4.59.0
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+  vite@6.4.1(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6958,16 +6973,16 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  vitest@2.1.9(@types/node@25.5.0)(lightningcss@1.32.0):
+  vitest@2.1.9(@types/node@25.9.1)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.9.1)(lightningcss@1.32.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -6983,11 +6998,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@25.5.0)(lightningcss@1.32.0)
-      vite-node: 2.1.9(@types/node@25.5.0)(lightningcss@1.32.0)
+      vite: 5.4.21(@types/node@25.9.1)(lightningcss@1.32.0)
+      vite-node: 2.1.9(@types/node@25.9.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.1
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## Summary
- add staff icon URLs and use staff sender metadata when sending LINE messages
- pass LINE sender name/icon through chat, friend message, SDK, and MCP send paths
- expose staff icon URL in shared/SDK types and manage_staff MCP updates

## Verification
- pnpm --filter @line-crm/shared build
- pnpm --filter @line-crm/line-sdk build
- pnpm --filter @line-harness/sdk build
- pnpm --filter @line-harness/mcp-server build
- git diff --check