### PR TITLE
[codex] Add event list booking flow

### DIFF
--- a/apps/liff/src/App.tsx
+++ b/apps/liff/src/App.tsx
@@ -5,17 +5,29 @@ import Event from './pages/Event.js';
 import EventConfirm from './pages/EventConfirm.js';
 import EventDone from './pages/EventDone.js';
 import EventBookings from './pages/EventBookings.js';
+import EventList from './pages/EventList.js';
+
+function RootRedirect() {
+  const params = new URLSearchParams(window.location.search);
+  const page = params.get('page');
+  const id = params.get('id');
+  if (page === 'events') return <Navigate to="/events" replace />;
+  if (page === 'event' && id) return <Navigate to={`/events/${id}`} replace />;
+  if (page === 'booking') return <Navigate to="/booking" replace />;
+  return <Navigate to="/booking" replace />;
+}
 
 export default function App() {
   return (
     <Routes>
       <Route path="/booking" element={<Booking />} />
       <Route path="/booking/history" element={<BookingHistory />} />
+      <Route path="/events" element={<EventList />} />
       <Route path="/events/me" element={<EventBookings />} />
       <Route path="/events/:id/confirm" element={<EventConfirm />} />
       <Route path="/events/:id/done" element={<EventDone />} />
       <Route path="/events/:id" element={<Event />} />
-      <Route path="/" element={<Navigate to="/booking" replace />} />
+      <Route path="/" element={<RootRedirect />} />
       <Route
         path="*"
         element={

--- a/apps/liff/src/lib/api.ts
+++ b/apps/liff/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { getIdToken, getLiffId } from './liff-auth.js';
 
 const BASE = import.meta.env.VITE_API_BASE ?? '';
+const DEV_MOCK = import.meta.env.DEV && new URL(window.location.href).searchParams.get('__mock') === '1';
 
 export interface MenuItem {
   id: string;
@@ -47,6 +48,8 @@ function authHeaders(extra: Record<string, string> = {}): Record<string, string>
 }
 
 async function get<T>(path: string): Promise<T> {
+  const mocked = maybeMockGet<T>(path);
+  if (mocked) return mocked;
   const url = new URL(`${BASE}${path}`, window.location.origin);
   url.searchParams.set('liffId', getLiffId());
   const res = await fetch(url.toString(), { headers: authHeaders() });
@@ -55,6 +58,8 @@ async function get<T>(path: string): Promise<T> {
 }
 
 async function post<T>(path: string, body: unknown, headers: Record<string, string> = {}): Promise<T> {
+  const mocked = maybeMockPost<T>(path);
+  if (mocked) return mocked;
   const url = new URL(`${BASE}${path}`, window.location.origin);
   url.searchParams.set('liffId', getLiffId());
   const res = await fetch(url.toString(), {
@@ -91,6 +96,12 @@ export interface EventDetail {
   cancel_deadline_hours_before: number | null;
 }
 
+export interface EventListItem extends EventDetail {
+  next_slot_starts_at: string;
+  next_slot_ends_at: string;
+  future_slot_count: number;
+}
+
 export interface EventSlot {
   id: string;
   event_id: string;
@@ -116,6 +127,70 @@ export interface EventBookingMine {
   slot_ends_at: string;
 }
 
+const mockEvents: EventListItem[] = [
+  {
+    id: 'kazama',
+    name: '風間佑太プロダーツ交流会',
+    venue_name: '茶はいダーツバー西新宿Luu',
+    venue_url: null,
+    image_url: null,
+    description: 'プロと一緒にダーツ交流を楽しめるイベントです。',
+    description_centered: 0,
+    max_bookings_per_friend: null,
+    requires_approval: 0,
+    cancel_deadline_hours_before: null,
+    next_slot_starts_at: '2026-06-22T10:00:00.000Z',
+    next_slot_ends_at: '2026-06-22T14:00:00.000Z',
+    future_slot_count: 1,
+  },
+  {
+    id: 'kumagai-morota',
+    name: '熊谷幸花プロ＆母良田桃香プロ交流会',
+    venue_name: '茶はいダーツバー西新宿Luu',
+    venue_url: null,
+    image_url: null,
+    description: '人数と同行者名を入力して予約できます。',
+    description_centered: 0,
+    max_bookings_per_friend: null,
+    requires_approval: 0,
+    cancel_deadline_hours_before: null,
+    next_slot_starts_at: '2026-06-29T09:00:00.000Z',
+    next_slot_ends_at: '2026-06-29T13:00:00.000Z',
+    future_slot_count: 1,
+  },
+];
+
+const mockSlots: EventSlot[] = [
+  {
+    id: 'slot-1',
+    event_id: 'kazama',
+    starts_at: '2026-06-22T10:00:00.000Z',
+    ends_at: '2026-06-22T14:00:00.000Z',
+    capacity: 20,
+    is_active: 1,
+    active_count: 4,
+    remaining: 16,
+  },
+];
+
+function maybeMockGet<T>(path: string): T | null {
+  if (!DEV_MOCK) return null;
+  const [pathname] = path.split('?');
+  if (pathname === '/api/liff/events') return { items: mockEvents } as T;
+  if (pathname === '/api/liff/events/kazama') return mockEvents[0] as T;
+  if (pathname === '/api/liff/events/kazama/slots') return { items: mockSlots } as T;
+  if (pathname === '/api/liff/events/me') return { items: [] } as T;
+  return null;
+}
+
+function maybeMockPost<T>(path: string): T | null {
+  if (!DEV_MOCK) return null;
+  if (path === '/api/liff/events/kazama/bookings') {
+    return { id: 'mock-booking', status: 'confirmed' } as T;
+  }
+  return null;
+}
+
 export const api = {
   menus: () => get<{ menus: MenuItem[] }>('/api/liff/booking/menus'),
   staffOf: (menuId: string) =>
@@ -138,6 +213,7 @@ export const api = {
   me: () => get<{ upcoming: BookingHistoryItem[]; past: BookingHistoryItem[] }>('/api/liff/booking/me'),
 
   // ===== Event booking =====
+  listEvents: () => get<{ items: EventListItem[] }>('/api/liff/events'),
   getEvent: (id: string) => get<EventDetail>(`/api/liff/events/${id}`),
   getEventSlots: (id: string) => get<{ items: EventSlot[] }>(`/api/liff/events/${id}/slots`),
   createEventBooking: (

--- a/apps/liff/src/lib/liff-auth.ts
+++ b/apps/liff/src/lib/liff-auth.ts
@@ -3,6 +3,7 @@ import liff from '@line/liff';
 let _liffId: string | null = null;
 let _lineUserId: string | null = null;
 let _idToken: string | null = null;
+const DEV_MOCK = import.meta.env.DEV && new URL(window.location.href).searchParams.get('__mock') === '1';
 
 export async function initLiff(): Promise<void> {
   const url = new URL(window.location.href);
@@ -11,6 +12,11 @@ export async function initLiff(): Promise<void> {
     throw new Error('liffId not provided. Append ?liffId=... to the URL.');
   }
   _liffId = liffId;
+  if (DEV_MOCK) {
+    _lineUserId = 'Umock';
+    _idToken = 'mock-id-token';
+    return;
+  }
   await liff.init({ liffId });
   if (!liff.isLoggedIn()) {
     liff.login();

--- a/apps/liff/src/pages/Event.tsx
+++ b/apps/liff/src/pages/Event.tsx
@@ -78,16 +78,16 @@ export default function Event() {
   const overLimit = max != null && myCount >= max;
 
   return (
-    <div className="pb-16">
+    <div className="min-h-screen bg-white pb-16">
       {event.image_url ? (
         <img src={event.image_url} alt="" className="w-full h-48 object-cover bg-gray-100" />
       ) : (
         <div className="w-full h-48 bg-gradient-to-br from-blue-100 to-blue-200" />
       )}
-      <div className="p-4">
+      <div className="mx-auto max-w-xl p-4">
         <h1 className="text-xl font-bold mb-2">{event.name}</h1>
         {event.venue_name && (
-          <div className="text-sm text-gray-700 mb-1">📍 {event.venue_name}</div>
+          <div className="text-sm text-gray-700 mb-1">会場: {event.venue_name}</div>
         )}
         {event.venue_url && (
           <a
@@ -151,6 +151,15 @@ export default function Event() {
         )}
 
         <div className="mt-6 text-center">
+          <button
+            onClick={() => navigate('/events')}
+            className="text-sm text-blue-600 underline"
+          >
+            イベント一覧へ戻る
+          </button>
+        </div>
+
+        <div className="mt-3 text-center">
           <button
             onClick={() => navigate('/events/me')}
             className="text-sm text-blue-600 underline"

--- a/apps/liff/src/pages/EventConfirm.tsx
+++ b/apps/liff/src/pages/EventConfirm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { api, type EventDetail, type EventSlot } from '../lib/api.js';
 
@@ -13,6 +13,74 @@ function nanoid(): string {
   return crypto.randomUUID();
 }
 
+interface SignupForm {
+  name: string;
+  xAccount: string;
+  phone: string;
+  people: string;
+  companionCount: string;
+  companionNames: string;
+  memo: string;
+}
+
+const initialSignupForm: SignupForm = {
+  name: '',
+  xAccount: '',
+  phone: '',
+  people: '1',
+  companionCount: '0',
+  companionNames: '',
+  memo: '',
+};
+
+function toPositiveInt(value: string): number | null {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const n = Number(trimmed);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+function validateSignupForm(form: SignupForm): string | null {
+  if (!form.name.trim()) return '名前を入力してください。';
+  if (!form.phone.trim()) return '電話番号を入力してください。';
+  const people = toPositiveInt(form.people);
+  if (people == null || people < 1) return '人数は1以上の数字で入力してください。';
+  const companionCount = toPositiveInt(form.companionCount);
+  if (companionCount == null) return '同行者人数は0以上の数字で入力してください。';
+  if (companionCount > people - 1) {
+    return '同行者人数は、本人を除いた人数で入力してください。';
+  }
+  if (companionCount > 0 && !form.companionNames.trim()) {
+    return '同行者がいる場合は、同行者名を入力してください。';
+  }
+  return null;
+}
+
+function buildCustomerNote(form: SignupForm): string {
+  return [
+    `名前: ${form.name.trim()}`,
+    `Xアカウント: ${form.xAccount.trim()}`,
+    `電話番号: ${form.phone.trim()}`,
+    `人数: ${form.people.trim()}`,
+    `同行者人数: ${form.companionCount.trim()}`,
+    `同行者名: ${form.companionNames.trim()}`,
+    `備考: ${form.memo.trim()}`,
+  ].join('\n');
+}
+
+function FieldLabel({ children, required = false }: { children: ReactNode; required?: boolean }) {
+  return (
+    <label className="block text-sm font-medium text-gray-700 mb-1">
+      {children}
+      {required && (
+        <span className="ml-2 rounded bg-red-50 px-1.5 py-0.5 text-[11px] font-semibold text-red-600">
+          必須
+        </span>
+      )}
+    </label>
+  );
+}
+
 export default function EventConfirm() {
   const { id } = useParams<{ id: string }>();
   const [search] = useSearchParams();
@@ -21,9 +89,10 @@ export default function EventConfirm() {
 
   const [event, setEvent] = useState<EventDetail | null>(null);
   const [slot, setSlot] = useState<EventSlot | null>(null);
-  const [note, setNote] = useState('');
+  const [form, setForm] = useState<SignupForm>(initialSignupForm);
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [fatalError, setFatalError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
 
   // Stable Idempotency-Key — regenerate would defeat the purpose if user
   // taps twice. One key per Confirm-screen mount.
@@ -41,12 +110,12 @@ export default function EventConfirm() {
         if (!found) {
           // 枠が消えた / 満員でフィルタアウト / 開始済 → 詳細画面に戻すべき。
           // null のまま放置すると無限ローディングになる。
-          setError('選択した枠は受付終了しました。別の日時をお選びください。');
+          setFatalError('選択した枠は受付終了しました。別の日時をお選びください。');
           return;
         }
         setSlot(found);
       } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+        if (!cancelled) setFatalError(err instanceof Error ? err.message : String(err));
       }
     }
     void load();
@@ -55,14 +124,20 @@ export default function EventConfirm() {
 
   async function submit() {
     if (!id || !slotId) return;
-    if (note.length > 5000) {
-      setError('備考は5000字以内で入力してください');
+    const validation = validateSignupForm(form);
+    if (validation) {
+      setFormError(validation);
+      return;
+    }
+    const customerNote = buildCustomerNote(form);
+    if (customerNote.length > 5000) {
+      setFormError('入力内容は5000字以内で入力してください');
       return;
     }
     setSubmitting(true);
-    setError(null);
+    setFormError(null);
     try {
-      const res = await api.createEventBooking(id, { slot_id: slotId, customer_note: note || null }, idemKey);
+      const res = await api.createEventBooking(id, { slot_id: slotId, customer_note: customerNote }, idemKey);
       navigate(`/events/${id}/done?bookingId=${res.id}&status=${res.status}`);
     } catch (err) {
       const e = err as { status?: number; body?: { error?: string } };
@@ -81,16 +156,16 @@ export default function EventConfirm() {
           default: return err instanceof Error ? err.message : String(err);
         }
       })();
-      setError(msg);
+      setFormError(msg);
     } finally {
       setSubmitting(false);
     }
   }
 
-  if (error) {
+  if (fatalError) {
     return (
       <div className="p-8 text-center">
-        <div className="text-red-700 mb-4">{error}</div>
+        <div className="text-red-700 mb-4">{fatalError}</div>
         <button
           onClick={() => navigate(`/events/${id}`)}
           className="px-4 py-2 border rounded"
@@ -104,13 +179,18 @@ export default function EventConfirm() {
     return <div className="p-8 text-center text-gray-500">読み込み中...</div>;
   }
 
+  function updateField<K extends keyof SignupForm>(key: K, value: SignupForm[K]) {
+    setForm((current) => ({ ...current, [key]: value }));
+  }
+
   return (
-    <div className="p-4 pb-20">
+    <div className="min-h-screen bg-gray-50">
+      <div className="mx-auto max-w-xl p-4 pb-20">
       <h1 className="text-lg font-bold mb-3">予約内容の確認</h1>
       <div className="border rounded p-3 mb-4 space-y-1">
         <div className="text-sm font-semibold">{event.name}</div>
-        <div className="text-sm text-gray-700">📅 {formatJp(slot.starts_at)}</div>
-        {event.venue_name && <div className="text-sm text-gray-700">📍 {event.venue_name}</div>}
+        <div className="text-sm text-gray-700">日時: {formatJp(slot.starts_at)}</div>
+        {event.venue_name && <div className="text-sm text-gray-700">会場: {event.venue_name}</div>}
       </div>
 
       {event.requires_approval === 1 && (
@@ -119,18 +199,88 @@ export default function EventConfirm() {
         </div>
       )}
 
-      <label className="block text-sm font-medium mb-1">備考（任意）</label>
-      <textarea
-        value={note}
-        onChange={(e) => setNote(e.target.value)}
-        rows={4}
-        maxLength={5000}
-        className="w-full border rounded p-2 text-sm"
-        placeholder="質問や伝えたいことがあれば..."
-      />
-      <div className="text-xs text-gray-500 text-right">{note.length} / 5000</div>
+      <div className="space-y-3">
+        <div>
+          <FieldLabel required>名前</FieldLabel>
+          <input
+            value={form.name}
+            onChange={(e) => updateField('name', e.target.value)}
+            className="w-full border rounded p-2 text-sm"
+            placeholder="例: 山田 太郎"
+            autoComplete="name"
+          />
+        </div>
 
-      {error && <div className="bg-red-50 text-red-700 p-2 rounded mt-2 text-sm">{error}</div>}
+        <div>
+          <FieldLabel required>電話番号</FieldLabel>
+          <input
+            value={form.phone}
+            onChange={(e) => updateField('phone', e.target.value)}
+            className="w-full border rounded p-2 text-sm"
+            placeholder="例: 09012345678"
+            inputMode="tel"
+            autoComplete="tel"
+          />
+        </div>
+
+        <div>
+          <FieldLabel>Xアカウント</FieldLabel>
+          <input
+            value={form.xAccount}
+            onChange={(e) => updateField('xAccount', e.target.value)}
+            className="w-full border rounded p-2 text-sm"
+            placeholder="例: @example"
+            autoCapitalize="none"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <FieldLabel required>人数</FieldLabel>
+            <input
+              value={form.people}
+              onChange={(e) => updateField('people', e.target.value)}
+              className="w-full border rounded p-2 text-sm"
+              inputMode="numeric"
+              pattern="[0-9]*"
+            />
+          </div>
+          <div>
+            <FieldLabel>同行者人数</FieldLabel>
+            <input
+              value={form.companionCount}
+              onChange={(e) => updateField('companionCount', e.target.value)}
+              className="w-full border rounded p-2 text-sm"
+              inputMode="numeric"
+              pattern="[0-9]*"
+            />
+          </div>
+        </div>
+
+        <div>
+          <FieldLabel>同行者名</FieldLabel>
+          <textarea
+            value={form.companionNames}
+            onChange={(e) => updateField('companionNames', e.target.value)}
+            rows={2}
+            className="w-full border rounded p-2 text-sm"
+            placeholder="同行者がいる場合は名前を入力"
+          />
+        </div>
+
+        <div>
+          <FieldLabel>備考</FieldLabel>
+          <textarea
+            value={form.memo}
+            onChange={(e) => updateField('memo', e.target.value)}
+            rows={3}
+            className="w-full border rounded p-2 text-sm"
+            placeholder="遅れる、質問など"
+          />
+        </div>
+      </div>
+
+      {formError && <div className="bg-red-50 text-red-700 p-2 rounded mt-2 text-sm">{formError}</div>}
 
       <button
         onClick={submit}
@@ -146,6 +296,7 @@ export default function EventConfirm() {
       >
         戻る
       </button>
+      </div>
     </div>
   );
 }

--- a/apps/liff/src/pages/EventList.tsx
+++ b/apps/liff/src/pages/EventList.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api, type EventListItem } from '../lib/api.js';
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    weekday: 'short',
+  });
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('ja-JP', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function firstDescriptionLine(value: string | null): string {
+  return String(value || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean) || '';
+}
+
+export default function EventList() {
+  const navigate = useNavigate();
+  const [events, setEvents] = useState<EventListItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await api.listEvents();
+        if (!cancelled) setEvents(res.items);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) return <div className="p-8 text-center text-gray-500">読み込み中...</div>;
+  if (error) return <div className="p-4 bg-red-50 text-red-700">{error}</div>;
+
+  return (
+    <div className="min-h-screen bg-gray-50 pb-16">
+      <div className="mx-auto max-w-xl">
+        <div className="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3">
+          <h1 className="text-lg font-bold text-gray-900">イベント予約</h1>
+          <p className="text-xs text-gray-500 mt-1">参加したいイベントを選択してください</p>
+        </div>
+
+        <div className="p-4 space-y-3">
+          {events.length === 0 ? (
+            <div className="bg-white border border-gray-200 rounded-lg p-6 text-center text-sm text-gray-500">
+              現在予約可能なイベントはありません。
+            </div>
+          ) : (
+            events.map((event) => {
+              const description = firstDescriptionLine(event.description);
+              return (
+                <button
+                  key={event.id}
+                  type="button"
+                  onClick={() => navigate(`/events/${event.id}`)}
+                  className="w-full bg-white border border-gray-200 rounded-lg overflow-hidden text-left shadow-sm active:bg-gray-50"
+                >
+                  {event.image_url ? (
+                    <img src={event.image_url} alt="" className="w-full h-36 object-cover bg-gray-100" />
+                  ) : (
+                    <div className="w-full h-3 bg-[#06C755]" />
+                  )}
+                  <div className="p-4">
+                    <div className="text-xs font-semibold text-[#06C755] mb-1">
+                      {formatDate(event.next_slot_starts_at)}
+                      {' '}
+                      {formatTime(event.next_slot_starts_at)}
+                      {' - '}
+                      {formatTime(event.next_slot_ends_at)}
+                    </div>
+                    <div className="text-base font-bold text-gray-900 leading-snug">{event.name}</div>
+                    {event.venue_name && (
+                      <div className="mt-2 text-xs text-gray-600">会場: {event.venue_name}</div>
+                    )}
+                    {description && (
+                      <div className="mt-2 text-xs text-gray-500 line-clamp-2">{description}</div>
+                    )}
+                    <div className="mt-3 flex items-center justify-between">
+                      <span className="text-xs text-gray-500">
+                        {event.future_slot_count > 1 ? `${event.future_slot_count}枠` : '1枠'}
+                      </span>
+                      <span className="text-sm font-semibold text-[#06C755]">予約へ進む</span>
+                    </div>
+                  </div>
+                </button>
+              );
+            })
+          )}
+
+          <div className="pt-2 text-center">
+            <button
+              onClick={() => navigate('/events/me')}
+              className="text-sm text-[#06C755] underline"
+            >
+              予約履歴を見る
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/worker/src/client/event-booking/main.tsx
+++ b/apps/worker/src/client/event-booking/main.tsx
@@ -2,7 +2,7 @@
 // apps/worker/src/client/main.ts (?page=event&id=<eventId> or ?page=event-me).
 // Mirrors salon-booking design language (LINE 緑 + sb-card + fade animations).
 
-import { StrictMode, useEffect, useState } from 'react';
+import { StrictMode, type ReactNode, useEffect, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import './styles.css';
 
@@ -44,6 +44,12 @@ interface EventSlot {
   is_active: number;
   active_count: number;
   remaining: number | null;
+}
+
+interface EventListItem extends EventDetail {
+  next_slot_starts_at: string;
+  next_slot_ends_at: string;
+  future_slot_count: number;
 }
 
 interface MyBooking {
@@ -127,6 +133,13 @@ function uid(): string {
   return crypto.randomUUID();
 }
 
+function firstDescriptionLine(value: string | null): string {
+  return String(value || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean) || '';
+}
+
 // ─── Loading ──────────────────────────────────────────────
 
 function Spinner() {
@@ -139,15 +152,119 @@ function Spinner() {
 
 // ─── Screens ──────────────────────────────────────────────
 
+function EventListScreen({
+  ctx,
+  onSelectEvent,
+  onGoHistory,
+}: {
+  ctx: EventBookingContext;
+  onSelectEvent: (eventId: string) => void;
+  onGoHistory: () => void;
+}) {
+  const [events, setEvents] = useState<EventListItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await apiGet<{ items: EventListItem[] }>('/api/liff/events', ctx);
+        if (!cancelled) setEvents(res.items);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => { cancelled = true; };
+  }, [ctx]);
+
+  if (loading) return <Spinner />;
+  if (error) {
+    return (
+      <div className="px-4 py-6 eb-fade-in">
+        <div className="eb-card text-center text-sm text-red-700">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-4 pb-24 eb-fade-in">
+      <div className="mb-4">
+        <h1 className="text-lg font-bold text-gray-900">イベント予約</h1>
+        <p className="text-xs text-gray-500 mt-1">参加したいイベントを選択してください</p>
+      </div>
+
+      {events.length === 0 ? (
+        <div className="eb-card text-center text-sm text-gray-500">
+          現在予約可能なイベントはありません。
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {events.map((event) => {
+            const description = firstDescriptionLine(event.description);
+            return (
+              <button
+                key={event.id}
+                type="button"
+                onClick={() => onSelectEvent(event.id)}
+                className="eb-event-list-btn"
+              >
+                {event.image_url ? (
+                  <img src={event.image_url} alt="" className="w-full h-36 object-cover bg-gray-100" />
+                ) : (
+                  <div className="w-full h-2 eb-line-green" />
+                )}
+                <div className="p-4">
+                  <div className="text-xs font-semibold eb-line-green-text mb-1">
+                    {formatJpDateOnly(event.next_slot_starts_at)}
+                    {' '}
+                    {formatJpTimeOnly(event.next_slot_starts_at)}
+                    {' 〜 '}
+                    {formatJpTimeOnly(event.next_slot_ends_at)}
+                  </div>
+                  <div className="text-base font-bold text-gray-900 leading-snug">{event.name}</div>
+                  {event.venue_name && (
+                    <div className="mt-2 text-xs text-gray-600">会場: {event.venue_name}</div>
+                  )}
+                  {description && (
+                    <div className="mt-2 text-xs text-gray-500 line-clamp-2">{description}</div>
+                  )}
+                  <div className="mt-3 flex items-center justify-between">
+                    <span className="text-xs text-gray-500">
+                      {event.future_slot_count > 1 ? `${event.future_slot_count}枠` : '1枠'}
+                    </span>
+                    <span className="text-sm font-semibold eb-line-green-text">予約へ進む</span>
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="mt-6 text-center">
+        <button onClick={onGoHistory} className="text-sm eb-line-green-text underline">
+          予約履歴を見る
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function EventDetailScreen({
   ctx,
   eventId,
   onPickSlot,
+  onGoList,
   onGoHistory,
 }: {
   ctx: EventBookingContext;
   eventId: string;
   onPickSlot: (slot: EventSlot, event: EventDetail) => void;
+  onGoList: () => void;
   onGoHistory: () => void;
 }) {
   const [event, setEvent] = useState<EventDetail | null>(null);
@@ -249,7 +366,7 @@ function EventDetailScreen({
           <h1 className="text-lg font-bold text-gray-900 leading-snug">{event.name}</h1>
           {event.venue_name && (
             <div className="mt-2 text-sm text-gray-700 flex items-start gap-1.5">
-              <span>📍</span><span>{event.venue_name}</span>
+              <span>会場:</span><span>{event.venue_name}</span>
             </div>
           )}
           {event.venue_url && (
@@ -321,12 +438,80 @@ function EventDetailScreen({
         </div>
 
         <div className="mt-6 text-center">
+          <button onClick={onGoList} className="text-sm eb-line-green-text underline">
+            イベント一覧へ戻る
+          </button>
+        </div>
+
+        <div className="mt-3 text-center">
           <button onClick={onGoHistory} className="text-sm eb-line-green-text underline">
             予約履歴を見る
           </button>
         </div>
       </div>
     </div>
+  );
+}
+
+interface SignupForm {
+  name: string;
+  xAccount: string;
+  phone: string;
+  people: string;
+  companionCount: string;
+  companionNames: string;
+  memo: string;
+}
+
+const initialSignupForm: SignupForm = {
+  name: '',
+  xAccount: '',
+  phone: '',
+  people: '1',
+  companionCount: '0',
+  companionNames: '',
+  memo: '',
+};
+
+function toUnsignedInt(value: string): number | null {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const n = Number(trimmed);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+function validateSignupForm(form: SignupForm): string | null {
+  if (!form.name.trim()) return '名前を入力してください。';
+  if (!form.phone.trim()) return '電話番号を入力してください。';
+  const people = toUnsignedInt(form.people);
+  if (people == null || people < 1) return '人数は1以上の数字で入力してください。';
+  const companionCount = toUnsignedInt(form.companionCount);
+  if (companionCount == null) return '同行者人数は0以上の数字で入力してください。';
+  if (companionCount > people - 1) return '同行者人数は、本人を除いた人数で入力してください。';
+  if (companionCount > 0 && !form.companionNames.trim()) {
+    return '同行者がいる場合は、同行者名を入力してください。';
+  }
+  return null;
+}
+
+function buildCustomerNote(form: SignupForm): string {
+  return [
+    `名前: ${form.name.trim()}`,
+    `Xアカウント: ${form.xAccount.trim()}`,
+    `電話番号: ${form.phone.trim()}`,
+    `人数: ${form.people.trim()}`,
+    `同行者人数: ${form.companionCount.trim()}`,
+    `同行者名: ${form.companionNames.trim()}`,
+    `備考: ${form.memo.trim()}`,
+  ].join('\n');
+}
+
+function FieldLabel({ children, required = false }: { children: ReactNode; required?: boolean }) {
+  return (
+    <label className="block text-sm font-medium text-gray-700 mb-1.5">
+      {children}
+      {required && <span className="eb-required-badge">必須</span>}
+    </label>
   );
 }
 
@@ -343,14 +528,24 @@ function ConfirmScreen({
   onBack: () => void;
   onDone: (status: string) => void;
 }) {
-  const [note, setNote] = useState('');
+  const [form, setForm] = useState<SignupForm>(initialSignupForm);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [idemKey] = useState(uid);
 
+  function updateField<K extends keyof SignupForm>(key: K, value: SignupForm[K]) {
+    setForm((current) => ({ ...current, [key]: value }));
+  }
+
   async function submit() {
-    if (note.length > 5000) {
-      setError('備考は 5000 字以内で入力してください');
+    const validation = validateSignupForm(form);
+    if (validation) {
+      setError(validation);
+      return;
+    }
+    const customerNote = buildCustomerNote(form);
+    if (customerNote.length > 5000) {
+      setError('入力内容は5000字以内で入力してください');
       return;
     }
     setSubmitting(true);
@@ -358,7 +553,7 @@ function ConfirmScreen({
     try {
       const res = await apiPost<{ id: string; status: string }>(
         `/api/liff/events/${event.id}/bookings`,
-        { slot_id: slot.id, customer_note: note || null },
+        { slot_id: slot.id, customer_note: customerNote },
         ctx,
         { 'Idempotency-Key': idemKey },
       );
@@ -417,19 +612,85 @@ function ConfirmScreen({
         </div>
       )}
 
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1.5">
-          備考（任意）
-        </label>
-        <textarea
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-          rows={4}
-          maxLength={5000}
-          placeholder="質問や伝えたいことがあれば..."
-          className="w-full border border-gray-300 rounded-xl p-3 text-sm bg-white"
-        />
-        <div className="text-xs text-gray-500 text-right mt-1">{note.length} / 5000</div>
+      <div className="space-y-3">
+        <div>
+          <FieldLabel required>名前</FieldLabel>
+          <input
+            value={form.name}
+            onChange={(e) => updateField('name', e.target.value)}
+            className="eb-input"
+            placeholder="例: 山田 太郎"
+            autoComplete="name"
+          />
+        </div>
+
+        <div>
+          <FieldLabel required>電話番号</FieldLabel>
+          <input
+            value={form.phone}
+            onChange={(e) => updateField('phone', e.target.value)}
+            className="eb-input"
+            placeholder="例: 09012345678"
+            inputMode="tel"
+            autoComplete="tel"
+          />
+        </div>
+
+        <div>
+          <FieldLabel>Xアカウント</FieldLabel>
+          <input
+            value={form.xAccount}
+            onChange={(e) => updateField('xAccount', e.target.value)}
+            className="eb-input"
+            placeholder="例: @example"
+            autoCapitalize="none"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <FieldLabel required>人数</FieldLabel>
+            <input
+              value={form.people}
+              onChange={(e) => updateField('people', e.target.value)}
+              className="eb-input"
+              inputMode="numeric"
+              pattern="[0-9]*"
+            />
+          </div>
+          <div>
+            <FieldLabel>同行者人数</FieldLabel>
+            <input
+              value={form.companionCount}
+              onChange={(e) => updateField('companionCount', e.target.value)}
+              className="eb-input"
+              inputMode="numeric"
+              pattern="[0-9]*"
+            />
+          </div>
+        </div>
+
+        <div>
+          <FieldLabel>同行者名</FieldLabel>
+          <textarea
+            value={form.companionNames}
+            onChange={(e) => updateField('companionNames', e.target.value)}
+            rows={2}
+            className="eb-input"
+            placeholder="同行者がいる場合は名前を入力"
+          />
+        </div>
+
+        <div>
+          <FieldLabel>備考</FieldLabel>
+          <textarea
+            value={form.memo}
+            onChange={(e) => updateField('memo', e.target.value)}
+            rows={3}
+            className="eb-input"
+            placeholder="遅れる、質問など"
+          />
+        </div>
       </div>
 
       {error && (
@@ -586,7 +847,7 @@ function HistoryScreen({ ctx }: { ctx: EventBookingContext }) {
                       <span className={`eb-badge ${s.cls} shrink-0`}>{s.text}</span>
                     </div>
                     <div className="text-xs text-gray-600 mt-1">{formatJp(b.slot_starts_at)}</div>
-                    {b.venue_name && <div className="text-xs text-gray-500 truncate">📍 {b.venue_name}</div>}
+                    {b.venue_name && <div className="text-xs text-gray-500 truncate">会場: {b.venue_name}</div>}
                   </div>
                 </div>
                 {canCancel(b) && (
@@ -612,6 +873,7 @@ function HistoryScreen({ ctx }: { ctx: EventBookingContext }) {
 // ─── App ──────────────────────────────────────────────────
 
 type Screen =
+  | { kind: 'list' }
   | { kind: 'detail'; eventId: string }
   | { kind: 'confirm'; event: EventDetail; slot: EventSlot }
   | { kind: 'done'; status: string }
@@ -622,6 +884,7 @@ function App({ ctx, initial }: { ctx: EventBookingContext; initial: Screen }) {
 
   const headerLabel = (() => {
     switch (screen.kind) {
+      case 'list': return 'イベント予約';
       case 'detail': return 'イベント予約';
       case 'confirm': return 'ご予約内容の確認';
       case 'done': return '完了';
@@ -638,11 +901,19 @@ function App({ ctx, initial }: { ctx: EventBookingContext; initial: Screen }) {
         {headerLabel}
       </header>
       <main className="max-w-md mx-auto">
+        {screen.kind === 'list' && (
+          <EventListScreen
+            ctx={ctx}
+            onSelectEvent={(eventId) => setScreen({ kind: 'detail', eventId })}
+            onGoHistory={() => setScreen({ kind: 'history' })}
+          />
+        )}
         {screen.kind === 'detail' && (
           <EventDetailScreen
             ctx={ctx}
             eventId={screen.eventId}
             onPickSlot={(slot, event) => setScreen({ kind: 'confirm', event, slot })}
+            onGoList={() => setScreen({ kind: 'list' })}
             onGoHistory={() => setScreen({ kind: 'history' })}
           />
         )}

--- a/apps/worker/src/client/event-booking/styles.css
+++ b/apps/worker/src/client/event-booking/styles.css
@@ -98,6 +98,18 @@ body.eb-active #app {
 .eb-line-green { background-color: #06C755; }
 .eb-line-green-text { color: #06C755; }
 
+.eb-required-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 2px 6px;
+  border-radius: 9999px;
+  background: #fef2f2;
+  color: #dc2626;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
 /* fade-in / slide-up アニメーション */
 @keyframes eb-fade-in {
   from { opacity: 0; transform: translateY(8px); }
@@ -127,6 +139,33 @@ body.eb-active #app {
   border-radius: 14px;
   padding: 18px 16px;
   box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 1px 3px rgba(0,0,0,0.06);
+}
+
+.eb-event-list-btn {
+  width: 100%;
+  overflow: hidden;
+  text-align: left;
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04), 0 1px 3px rgba(0,0,0,0.06);
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+.eb-event-list-btn:active {
+  transform: scale(0.99);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+}
+
+.eb-input {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  background: #fff;
+  padding: 11px 12px;
+  font-size: 14px;
+}
+.eb-input:focus {
+  outline: 2px solid rgba(6,199,85,0.22);
+  border-color: #06C755;
 }
 
 /* ステータスバッジ */

--- a/apps/worker/src/client/main.ts
+++ b/apps/worker/src/client/main.ts
@@ -13,6 +13,8 @@
  *   ?redirect=x       — redirect after linking (for wrapped URLs)
  *   ?page=book        — booking page (calendar slot picker, Google Calendar)
  *   ?page=salon-book  — salon booking flow (React, dynamic-imported)
+ *   ?page=events      — event booking list (React, dynamic-imported)
+ *   ?page=event&id=xx — event booking detail (React, dynamic-imported)
  */
 
 import { initBooking } from './booking.js';
@@ -57,6 +59,7 @@ function apiCall(path: string, options?: RequestInit): Promise<Response> {
 function getPage(): string | null {
   const path = window.location.pathname.replace(/^\/+/, '');
   if (path === 'book') return 'book';
+  if (path === 'events') return 'events';
   const params = new URLSearchParams(window.location.search);
   return params.get('page');
 }
@@ -383,7 +386,7 @@ async function initSalonBooking(): Promise<void> {
 
 // ─── Event Booking (React, dynamic-imported) ─────────────
 
-async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void> {
+async function initEventBooking(initialKind: 'list' | 'detail' | 'history'): Promise<void> {
   // salon-booking と同じ初期化シーケンス: profile/idToken/friendship 取得、
   // 未友達なら friend-add gate、友達なら React mount。
   const [profile, idToken, friendship] = await Promise.all([
@@ -437,7 +440,9 @@ async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void
   }
   const { mountEventBooking } = await import('./event-booking/main.js');
   const ctx = { liffId: LIFF_ID, lineUserId: profile.userId, idToken };
-  const initial = initialKind === 'detail'
+  const initial = initialKind === 'list'
+    ? { kind: 'list' as const }
+    : initialKind === 'detail'
     ? { kind: 'detail' as const, eventId }
     : { kind: 'history' as const };
   mountEventBooking(container, ctx, initial);
@@ -470,6 +475,8 @@ async function main() {
       await initBooking();
     } else if (page === 'salon-book') {
       await initSalonBooking();
+    } else if (page === 'events') {
+      await initEventBooking('list');
     } else if (page === 'event') {
       await initEventBooking('detail');
     } else if (page === 'event-me') {

--- a/apps/worker/src/routes/booking.ts
+++ b/apps/worker/src/routes/booking.ts
@@ -45,7 +45,27 @@ async function resolveAccountIdFromLiff(c: Context<Env>): Promise<string | null>
     .prepare(`SELECT id FROM line_accounts WHERE liff_id = ? AND is_active = 1`)
     .bind(liffId)
     .first<{ id: string }>();
-  return acc?.id ?? null;
+  if (acc?.id) return acc.id;
+
+  const envLiffId = (() => {
+    const value = c.env.LIFF_URL;
+    if (!value) return null;
+    return value.match(/liff\.line\.me\/([0-9]+-[A-Za-z0-9]+)/)?.[1]
+      ?? (/^[0-9]+-[A-Za-z0-9]+$/.test(value) ? value : null);
+  })();
+  if (envLiffId !== liffId) return null;
+
+  if (c.env.LINE_CHANNEL_ACCESS_TOKEN) {
+    const envAcc = await c.env.DB
+      .prepare(`SELECT id FROM line_accounts WHERE channel_access_token = ? AND is_active = 1`)
+      .bind(c.env.LINE_CHANNEL_ACCESS_TOKEN)
+      .first<{ id: string }>();
+    if (envAcc?.id) return envAcc.id;
+  }
+  const fallback = await c.env.DB
+    .prepare(`SELECT id FROM line_accounts WHERE is_active = 1 ORDER BY display_order ASC, created_at ASC LIMIT 1`)
+    .first<{ id: string }>();
+  return fallback?.id ?? null;
 }
 
 // LIFF が送る id_token を LINE Login API で verify し、認証済み LINE userId を返す。

--- a/apps/worker/src/routes/events.test.ts
+++ b/apps/worker/src/routes/events.test.ts
@@ -89,7 +89,7 @@ interface BookingRow {
 
 interface LineAccount {
   id: string;
-  liff_id: string;
+  liff_id: string | null;
   is_active: number;
   channel_access_token?: string;
 }
@@ -123,11 +123,24 @@ function makeEventDb(state: {
         },
         async first<T>() {
           // SELECT id FROM line_accounts WHERE liff_id = ? AND is_active = 1
-          if (sql.startsWith('SELECT id FROM line_accounts')) {
+          if (sql.startsWith('SELECT id FROM line_accounts WHERE liff_id')) {
             const [liff_id] = bound as [string];
             const acc = (state.accounts ?? []).find(
               (a) => a.liff_id === liff_id && a.is_active === 1,
             );
+            return (acc ? { id: acc.id } : null) as T | null;
+          }
+          // SELECT id FROM line_accounts WHERE channel_access_token = ? AND is_active = 1
+          if (sql.startsWith('SELECT id FROM line_accounts WHERE channel_access_token')) {
+            const [token] = bound as [string];
+            const acc = (state.accounts ?? []).find(
+              (a) => a.channel_access_token === token && a.is_active === 1,
+            );
+            return (acc ? { id: acc.id } : null) as T | null;
+          }
+          // SELECT id FROM line_accounts WHERE is_active = 1 ORDER BY ...
+          if (sql.startsWith('SELECT id FROM line_accounts WHERE is_active = 1')) {
+            const acc = (state.accounts ?? []).find((a) => a.is_active === 1);
             return (acc ? { id: acc.id } : null) as T | null;
           }
           // SELECT channel_access_token FROM line_accounts WHERE id = ?
@@ -402,6 +415,66 @@ function makeEventDb(state: {
           return null;
         },
         async all<T>() {
+          // LIFF public event list: SELECT e.id, ... future_slot_count FROM events e
+          if (sql.includes('FROM events e') && sql.includes('future_slot_count')) {
+            const [account, account2] = bound as [string, string?];
+            const acct = account2 ?? account;
+            const eventMatchesAccount = (e: EventRow): boolean => {
+              if (e.target_type === 'multi-account-dedup') {
+                const ids = e.account_ids
+                  ? (() => { try { return JSON.parse(e.account_ids as string) as string[]; } catch { return [] } })()
+                  : [];
+                return ids.includes(acct);
+              }
+              return e.line_account_id === acct;
+            };
+            const nowIso = new Date().toISOString();
+            const items = state.events
+              .filter((e) => e.deleted_at == null && e.is_published === 1 && eventMatchesAccount(e))
+              .map((e) => {
+                const futureSlots = (state.slots ?? [])
+                  .filter(
+                    (s) =>
+                      s.event_id === e.id &&
+                      s.deleted_at == null &&
+                      s.is_active === 1 &&
+                      s.starts_at > nowIso,
+                  )
+                  .sort((a, b) =>
+                    a.sort_order !== b.sort_order
+                      ? a.sort_order - b.sort_order
+                      : a.starts_at.localeCompare(b.starts_at),
+                  );
+                const next = futureSlots[0];
+                if (!next) return null;
+                return {
+                  id: e.id,
+                  name: e.name,
+                  venue_name: e.venue_name,
+                  venue_url: e.venue_url,
+                  image_url: e.image_url,
+                  description: e.description,
+                  description_centered: e.description_centered,
+                  max_bookings_per_friend: e.max_bookings_per_friend,
+                  requires_approval: e.requires_approval,
+                  cancel_deadline_hours_before: e.cancel_deadline_hours_before,
+                  sort_order: e.sort_order,
+                  next_slot_starts_at: next.starts_at,
+                  next_slot_ends_at: next.ends_at,
+                  future_slot_count: futureSlots.length,
+                  created_at: e.created_at,
+                };
+              })
+              .filter((e): e is NonNullable<typeof e> => e !== null)
+              .sort((a, b) =>
+                a.next_slot_starts_at !== b.next_slot_starts_at
+                  ? a.next_slot_starts_at.localeCompare(b.next_slot_starts_at)
+                  : a.sort_order !== b.sort_order
+                    ? a.sort_order - b.sort_order
+                    : b.created_at.localeCompare(a.created_at),
+              );
+            return { results: items as unknown as T[] };
+          }
           // admin events list (must come before event_slots branch since
           // its sub-queries also reference event_slots s)
           if (sql.startsWith('SELECT\n         e.*') || (sql.includes('FROM events e') && (sql.includes('e.line_account_id') || sql.includes('e.target_type')))) {
@@ -731,12 +804,15 @@ function makeEventDb(state: {
   return db;
 }
 
-function setupApp(state: { events: EventRow[]; slots?: SlotRow[]; bookings?: BookingRow[] }) {
+function setupApp(
+  state: { events: EventRow[]; slots?: SlotRow[]; bookings?: BookingRow[]; accounts?: LineAccount[]; friends?: FriendRow[] },
+  bindings: Partial<TestEnv['Bindings'] & { LIFF_URL: string; LINE_CHANNEL_ACCESS_TOKEN: string }> = {},
+) {
   const app = new Hono<TestEnv>();
   const db = makeEventDb(state);
   app.use('*', async (c, next) => {
     c.set('staff', { id: 'staff-1', role: 'owner' });
-    c.env = { DB: db } as TestEnv['Bindings'];
+    c.env = { DB: db, ...bindings } as TestEnv['Bindings'];
     await next();
   });
   app.route('/', events);
@@ -1228,6 +1304,77 @@ describe('event_slots admin', () => {
       method: 'DELETE',
     });
     expect(res.status).toBe(204);
+  });
+});
+
+describe('LIFF event list', () => {
+  test('GET returns published future events for the LIFF account in slot order', async () => {
+    const state = {
+      events: [
+        baseEvent({ id: 'later', line_account_id: 'la1', name: 'Later', is_published: 1 }),
+        baseEvent({ id: 'first', line_account_id: 'la1', name: 'First', is_published: 1 }),
+        baseEvent({ id: 'draft', line_account_id: 'la1', name: 'Draft', is_published: 0 }),
+        baseEvent({ id: 'past', line_account_id: 'la1', name: 'Past', is_published: 1 }),
+        baseEvent({ id: 'other', line_account_id: 'la2', name: 'Other', is_published: 1 }),
+        baseEvent({
+          id: 'shared',
+          line_account_id: 'la2',
+          name: 'Shared',
+          is_published: 1,
+          target_type: 'multi-account-dedup',
+          account_ids: JSON.stringify(['la2', 'la1']),
+        }),
+      ],
+      slots: [
+        { id: 's-later', event_id: 'later', starts_at: '2099-07-01T10:00:00Z', ends_at: '2099-07-01T12:00:00Z', capacity: 10, is_active: 1, sort_order: 0, deleted_at: null },
+        { id: 's-first-2', event_id: 'first', starts_at: '2099-06-01T12:00:00Z', ends_at: '2099-06-01T14:00:00Z', capacity: 10, is_active: 1, sort_order: 1, deleted_at: null },
+        { id: 's-first-1', event_id: 'first', starts_at: '2099-06-01T10:00:00Z', ends_at: '2099-06-01T12:00:00Z', capacity: 10, is_active: 1, sort_order: 0, deleted_at: null },
+        { id: 's-draft', event_id: 'draft', starts_at: '2099-05-01T10:00:00Z', ends_at: '2099-05-01T12:00:00Z', capacity: 10, is_active: 1, sort_order: 0, deleted_at: null },
+        { id: 's-past', event_id: 'past', starts_at: '2000-05-01T10:00:00Z', ends_at: '2000-05-01T12:00:00Z', capacity: 10, is_active: 1, sort_order: 0, deleted_at: null },
+        { id: 's-other', event_id: 'other', starts_at: '2099-04-01T10:00:00Z', ends_at: '2099-04-01T12:00:00Z', capacity: 10, is_active: 1, sort_order: 0, deleted_at: null },
+        { id: 's-shared', event_id: 'shared', starts_at: '2099-08-01T10:00:00Z', ends_at: '2099-08-01T12:00:00Z', capacity: 10, is_active: 1, sort_order: 0, deleted_at: null },
+      ],
+      accounts: [{ id: 'la1', liff_id: 'L1', is_active: 1 }],
+    };
+    const app = setupApp(state);
+    const res = await app.request('/api/liff/events?liffId=L1');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      items: Array<{
+        id: string;
+        next_slot_starts_at: string;
+        next_slot_ends_at: string;
+        future_slot_count: number;
+      }>;
+    };
+    expect(body.items.map((e) => e.id)).toEqual(['first', 'later', 'shared']);
+    expect(body.items[0].next_slot_starts_at).toBe('2099-06-01T10:00:00Z');
+    expect(body.items[0].next_slot_ends_at).toBe('2099-06-01T12:00:00Z');
+    expect(body.items[0].future_slot_count).toBe(2);
+  });
+
+  test('GET 400 when liffId missing', async () => {
+    const app = setupApp({ events: [] });
+    const res = await app.request('/api/liff/events');
+    expect(res.status).toBe(400);
+  });
+
+  test('GET resolves default account from LIFF_URL when account liff_id is not stored', async () => {
+    const state = {
+      events: [baseEvent({ id: 'e1', line_account_id: 'la1', name: 'Fallback', is_published: 1 })],
+      slots: [
+        { id: 's1', event_id: 'e1', starts_at: '2099-06-01T10:00:00Z', ends_at: '2099-06-01T12:00:00Z', capacity: 10, is_active: 1, sort_order: 0, deleted_at: null },
+      ],
+      accounts: [{ id: 'la1', liff_id: null, is_active: 1, channel_access_token: 'token-1' }],
+    };
+    const app = setupApp(state, {
+      LIFF_URL: '2000000000-default',
+      LINE_CHANNEL_ACCESS_TOKEN: 'token-1',
+    });
+    const res = await app.request('/api/liff/events?liffId=2000000000-default');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: Array<{ id: string }> };
+    expect(body.items.map((e) => e.id)).toEqual(['e1']);
   });
 });
 

--- a/apps/worker/src/routes/events.ts
+++ b/apps/worker/src/routes/events.ts
@@ -53,6 +53,13 @@ function getAccountId(c: Context<Env>): string | null {
   return c.req.query('account_id') ?? null;
 }
 
+function extractLiffId(value: string | undefined): string | null {
+  if (!value) return null;
+  const fromUrl = value.match(/liff\.line\.me\/([0-9]+-[A-Za-z0-9]+)/)?.[1];
+  if (fromUrl) return fromUrl;
+  return /^[0-9]+-[A-Za-z0-9]+$/.test(value) ? value : null;
+}
+
 async function resolveAccountIdFromLiff(c: Context<Env>): Promise<string | null> {
   const liffId = c.req.query('liffId');
   if (!liffId) return null;
@@ -60,7 +67,22 @@ async function resolveAccountIdFromLiff(c: Context<Env>): Promise<string | null>
     .prepare(`SELECT id FROM line_accounts WHERE liff_id = ? AND is_active = 1`)
     .bind(liffId)
     .first<{ id: string }>();
-  return acc?.id ?? null;
+  if (acc?.id) return acc.id;
+
+  const envLiffId = extractLiffId(c.env.LIFF_URL);
+  if (envLiffId !== liffId) return null;
+
+  if (c.env.LINE_CHANNEL_ACCESS_TOKEN) {
+    const envAcc = await c.env.DB
+      .prepare(`SELECT id FROM line_accounts WHERE channel_access_token = ? AND is_active = 1`)
+      .bind(c.env.LINE_CHANNEL_ACCESS_TOKEN)
+      .first<{ id: string }>();
+    if (envAcc?.id) return envAcc.id;
+  }
+  const fallback = await c.env.DB
+    .prepare(`SELECT id FROM line_accounts WHERE is_active = 1 ORDER BY display_order ASC, created_at ASC LIMIT 1`)
+    .first<{ id: string }>();
+  return fallback?.id ?? null;
 }
 
 interface EventInput {
@@ -687,6 +709,71 @@ events.post('/api/liff/events/me/:bookingId/cancel', async (c) => {
 // ============================================================
 // LIFF: read-only event/slots
 // ============================================================
+
+events.get('/api/liff/events', async (c) => {
+  const account_id = await resolveAccountIdFromLiff(c);
+  if (!account_id) return bad(c, 'liff_account_resolution_failed', 400);
+  const { results } = await c.env.DB
+    .prepare(
+      `SELECT
+         e.id,
+         e.name,
+         e.venue_name,
+         e.venue_url,
+         e.image_url,
+         e.description,
+         e.description_centered,
+         e.max_bookings_per_friend,
+         e.requires_approval,
+         e.cancel_deadline_hours_before,
+         e.sort_order,
+         (SELECT s.starts_at
+            FROM event_slots s
+           WHERE s.event_id = e.id
+             AND s.deleted_at IS NULL
+             AND s.is_active = 1
+             AND s.starts_at > strftime('%Y-%m-%dT%H:%M:%fZ','now')
+           ORDER BY s.sort_order ASC, s.starts_at ASC
+           LIMIT 1
+         ) AS next_slot_starts_at,
+         (SELECT s.ends_at
+            FROM event_slots s
+           WHERE s.event_id = e.id
+             AND s.deleted_at IS NULL
+             AND s.is_active = 1
+             AND s.starts_at > strftime('%Y-%m-%dT%H:%M:%fZ','now')
+           ORDER BY s.sort_order ASC, s.starts_at ASC
+           LIMIT 1
+         ) AS next_slot_ends_at,
+         (SELECT COUNT(*)
+            FROM event_slots s
+           WHERE s.event_id = e.id
+             AND s.deleted_at IS NULL
+             AND s.is_active = 1
+             AND s.starts_at > strftime('%Y-%m-%dT%H:%M:%fZ','now')
+         ) AS future_slot_count
+       FROM events e
+       WHERE e.deleted_at IS NULL
+         AND e.is_published = 1
+         AND (
+           (e.target_type = 'single' AND e.line_account_id = ?)
+           OR (e.target_type = 'multi-account-dedup'
+               AND EXISTS (SELECT 1 FROM json_each(e.account_ids) WHERE value = ?))
+         )
+         AND EXISTS (
+           SELECT 1
+             FROM event_slots s
+            WHERE s.event_id = e.id
+              AND s.deleted_at IS NULL
+              AND s.is_active = 1
+              AND s.starts_at > strftime('%Y-%m-%dT%H:%M:%fZ','now')
+         )
+       ORDER BY next_slot_starts_at ASC, e.sort_order ASC, e.created_at DESC`,
+    )
+    .bind(account_id, account_id)
+    .all();
+  return c.json({ items: results ?? [] });
+});
 
 events.get('/api/liff/events/:id', async (c) => {
   const account_id = await resolveAccountIdFromLiff(c);

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -22,6 +22,7 @@ import {
 import type { EntryRoute } from '@line-crm/db';
 import { fireEvent } from '../services/event-bus.js';
 import { buildMessage, expandVariables } from '../services/step-delivery.js';
+import { renderMessageContent } from '../services/render-message.js';
 import type { Env } from '../index.js';
 
 const webhook = new Hono<Env>();
@@ -31,6 +32,28 @@ const webhook = new Hono<Env>();
 // bursty batched deliveries (~100 events × ~5 KB) while still well below the
 // 128 MB Cloudflare Workers memory ceiling.
 const MAX_WEBHOOK_BODY_SIZE = 1024 * 1024; // 1 MiB
+
+function extractLiffId(value: string | undefined): string | null {
+  if (!value) return null;
+  const fromUrl = value.match(/liff\.line\.me\/([0-9]+-[A-Za-z0-9]+)/)?.[1];
+  if (fromUrl) return fromUrl;
+  return /^[0-9]+-[A-Za-z0-9]+$/.test(value) ? value : null;
+}
+
+async function resolveLiffIdForReply(
+  db: D1Database,
+  lineAccountId: string | null,
+  fallbackLiffUrl?: string,
+): Promise<string | null> {
+  if (lineAccountId) {
+    const row = await db
+      .prepare('SELECT liff_id FROM line_accounts WHERE id = ?')
+      .bind(lineAccountId)
+      .first<{ liff_id: string | null }>();
+    if (row?.liff_id) return row.liff_id;
+  }
+  return extractLiffId(fallbackLiffUrl);
+}
 
 webhook.post('/webhook', async (c) => {
   // Pre-read size guard: reject before reading the body if Content-Length is oversized.
@@ -389,7 +412,10 @@ async function handleEvent(
             response_type: rule.response_type,
             response_content: rule.response_content,
           });
-          const expandedContent = expandVariables(resolved.content, { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1], workerUrl);
+          const expandedContent = renderMessageContent(
+            expandVariables(resolved.content, { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1], workerUrl),
+            await resolveLiffIdForReply(db, lineAccountId, liffUrl),
+          );
           const replyMsg = buildMessage(resolved.messageType, expandedContent);
           await lineClient.replyMessage(event.replyToken, [replyMsg]);
 
@@ -577,7 +603,10 @@ async function handleEvent(
             response_type: rule.response_type,
             response_content: rule.response_content,
           });
-          const expandedContent = expandVariables(resolved.content, { ...friend, metadata: resolvedMeta2 } as Parameters<typeof expandVariables>[1], workerUrl);
+          const expandedContent = renderMessageContent(
+            expandVariables(resolved.content, { ...friend, metadata: resolvedMeta2 } as Parameters<typeof expandVariables>[1], workerUrl),
+            await resolveLiffIdForReply(db, lineAccountId, liffUrl),
+          );
           const replyMsg = buildMessage(resolved.messageType, expandedContent);
           await lineClient.replyMessage(event.replyToken, [replyMsg]);
           replyTokenConsumed = true;


### PR DESCRIPTION
## Summary
- add a LIFF event list page so users can choose from available events before booking
- replace the free-text event booking note with structured fields for name, phone, X account, headcount, companion count, companion names, and memo
- make LIFF account resolution work from per-account `liff_id` and render `{{liff_id}}` in webhook auto-replies

## Validation
- `pnpm --filter worker test -- events.test.ts render-message.test.ts webhook.test.ts`
- `pnpm --filter worker typecheck`
- `pnpm --filter liff build`
