### PR TITLE
fix: LIFF state のパラメータ復元に対応

### DIFF
--- a/apps/worker/src/client/form.ts
+++ b/apps/worker/src/client/form.ts
@@ -10,6 +10,8 @@
  * URL format: https://liff.line.me/{LIFF_ID}?page=form&id={FORM_ID}
  */
 
+import { getEffectiveSearchParams } from './url-params.js';
+
 declare const liff: {
   init(config: { liffId: string }): Promise<void>;
   isLoggedIn(): boolean;
@@ -851,7 +853,7 @@ function attachXAutocomplete(): void {
 
   // Extract gateId from URL param (priority) or onSubmitWebhookUrl
   function getGateId(): string | null {
-    const urlParams = new URLSearchParams(window.location.search);
+    const urlParams = getEffectiveSearchParams();
     const gateParam = urlParams.get('gate');
     if (gateParam) return gateParam;
     const url = state.formDef?.onSubmitWebhookUrl ?? '';
@@ -1228,7 +1230,7 @@ export async function initForm(formId: string | null): Promise<void> {
     state.formDef = json.data;
 
     // Extract X Harness base URL: from URL param (priority) or webhook URL
-    const urlParams = new URLSearchParams(window.location.search);
+    const urlParams = getEffectiveSearchParams();
     const xhParam = urlParams.get('xh');
     if (xhParam) {
       state.xHarnessBaseUrl = xhParam.replace(/\/$/, '');

--- a/apps/worker/src/client/main.ts
+++ b/apps/worker/src/client/main.ts
@@ -17,6 +17,7 @@
 
 import { initBooking } from './booking.js';
 import { initForm } from './form.js';
+import { getEffectivePathname, getEffectiveQueryParam, getEffectiveSearchParams } from './url-params.js';
 
 declare const liff: {
   init(config: { liffId: string }): Promise<void>;
@@ -30,16 +31,13 @@ declare const liff: {
   closeWindow(): void;
 };
 
-// Resolve LIFF ID: ?liffId= param (from endpoint URL) > env var (fallback to ①)
+// Resolve LIFF ID: ?liffId= param (from endpoint URL) > LIFF `liff.state` wrapper > env var (fallback)
 function detectLiffId(): string {
-  const fromParam = new URLSearchParams(window.location.search).get('liffId');
+  const fromParam = getEffectiveQueryParam('liffId');
   if (fromParam) return fromParam;
   return import.meta.env?.VITE_LIFF_ID || '';
 }
 const LIFF_ID = detectLiffId();
-if (!LIFF_ID) {
-  throw new Error('LIFF ID not found. Set ?liffId= in LIFF endpoint URL or VITE_LIFF_ID env.');
-}
 const UUID_STORAGE_KEY = 'lh_uuid';
 // Bot basic ID — resolved dynamically from API after liff.init()
 let BOT_BASIC_ID = '';
@@ -55,19 +53,19 @@ function apiCall(path: string, options?: RequestInit): Promise<Response> {
 }
 
 function getPage(): string | null {
-  const path = window.location.pathname.replace(/^\/+/, '');
+  const path = getEffectivePathname().replace(/^\/+/, '');
   if (path === 'book') return 'book';
-  const params = new URLSearchParams(window.location.search);
+  const params = getEffectiveSearchParams();
   return params.get('page');
 }
 
 function getRedirectUrl(): string | null {
-  const params = new URLSearchParams(window.location.search);
+  const params = getEffectiveSearchParams();
   return params.get('redirect');
 }
 
 function getRef(): string | null {
-  const params = new URLSearchParams(window.location.search);
+  const params = getEffectiveSearchParams();
   return params.get('ref');
 }
 
@@ -126,13 +124,13 @@ function showFriendAdd(profile: { displayName: string; pictureUrl?: string }) {
       if (!friendFlag) return;
 
       // Send form link if form param exists (was lost during friend-add flow)
-      const formParam = new URLSearchParams(window.location.search).get('form');
+      const formParam = getEffectiveQueryParam('form');
       if (formParam && !formLinkSent) {
         formLinkSent = true;
         try {
           const fp = await liff.getProfile();
           const idToken = liff.getIDToken();
-          const params = new URLSearchParams(window.location.search);
+          const params = getEffectiveSearchParams();
           await apiCall('/api/liff/send-form-link', {
             method: 'POST',
             body: JSON.stringify({
@@ -213,7 +211,7 @@ async function linkAndAddFlow() {
     ]);
 
     // 1. UUID linking (always, regardless of friendship)
-    const linkParams = new URLSearchParams(window.location.search);
+    const linkParams = getEffectiveSearchParams();
     const linkPromise = apiCall('/api/liff/link', {
       method: 'POST',
       body: JSON.stringify({
@@ -268,12 +266,12 @@ async function linkAndAddFlow() {
       showFriendAdd(profile);
     } else {
       // Already a friend — check for form param
-      const formParam = new URLSearchParams(window.location.search).get('form');
+      const formParam = getEffectiveQueryParam('form');
       if (formParam) {
         // Send form link via push message, then show completion
         try {
           const idToken = liff.getIDToken();
-          const params = new URLSearchParams(window.location.search);
+          const params = getEffectiveSearchParams();
           await apiCall('/api/liff/send-form-link', {
             method: 'POST',
             body: JSON.stringify({
@@ -325,7 +323,7 @@ async function initSalonBooking(): Promise<void> {
 
   const existingUuid = getSavedUuid();
   const ref = getRef();
-  const ig = new URLSearchParams(window.location.search).get('ig');
+  const ig = getEffectiveQueryParam('ig');
 
   // ② Silent UUID linking (fire-and-forget; booking API は id_token verify で
   //    認証するので待つ必要はない)。
@@ -429,7 +427,7 @@ async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void
     showError('mount target #app が見つかりません');
     return;
   }
-  const params = new URLSearchParams(window.location.search);
+  const params = getEffectiveSearchParams();
   const eventId = params.get('id') ?? '';
   if (initialKind === 'detail' && !eventId) {
     showError('id クエリパラメータが必要です（?page=event&id=<eventId>）');
@@ -447,6 +445,11 @@ async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void
 
 async function main() {
   try {
+    if (!LIFF_ID) {
+      showError('LIFF IDが見つかりません。LIFF Endpoint URL の liffId または liff.state を確認してください。');
+      return;
+    }
+
     await liff.init({ liffId: LIFF_ID });
 
     if (!liff.isLoggedIn()) {
@@ -475,7 +478,7 @@ async function main() {
     } else if (page === 'event-me') {
       await initEventBooking('history');
     } else if (page === 'form') {
-      const params = new URLSearchParams(window.location.search);
+      const params = getEffectiveSearchParams();
       const formId = params.get('id');
       await initForm(formId);
     } else if (!page) {

--- a/apps/worker/src/client/url-params.test.ts
+++ b/apps/worker/src/client/url-params.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { getEffectiveLocationParts } from './url-params.js';
+
+const origin = 'https://example.com';
+const liffId = '1234567890-example';
+
+describe('getEffectiveLocationParts', () => {
+  it('uses direct query params when LINE does not wrap them', () => {
+    const parts = getEffectiveLocationParts({
+      origin,
+      pathname: '/',
+      search: `?liffId=${liffId}&ref=fashion-bank-lp`,
+    });
+
+    expect(parts.pathname).toBe('/');
+    expect(parts.params.get('liffId')).toBe(liffId);
+    expect(parts.params.get('ref')).toBe('fashion-bank-lp');
+  });
+
+  it('restores LIFF params from liff.state wrapper', () => {
+    const state = encodeURIComponent(`/?liffId=${liffId}&ref=fashion-bank-lp&gate=g1`);
+    const parts = getEffectiveLocationParts({
+      origin,
+      pathname: '/',
+      search: `?liff.state=${state}`,
+    });
+
+    expect(parts.pathname).toBe('/');
+    expect(parts.params.get('liffId')).toBe(liffId);
+    expect(parts.params.get('ref')).toBe('fashion-bank-lp');
+    expect(parts.params.get('gate')).toBe('g1');
+  });
+
+  it('restores path and params from a wrapped LIFF state path', () => {
+    const state = encodeURIComponent('/book?liffId=abc-def&ref=campaign');
+    const parts = getEffectiveLocationParts({
+      origin,
+      pathname: '/',
+      search: `?liff.state=${state}`,
+    });
+
+    expect(parts.pathname).toBe('/book');
+    expect(parts.params.get('liffId')).toBe('abc-def');
+    expect(parts.params.get('ref')).toBe('campaign');
+  });
+
+  it('lets explicit URL params override wrapped state params', () => {
+    const state = encodeURIComponent('/?liffId=old&ref=wrapped');
+    const parts = getEffectiveLocationParts({
+      origin,
+      pathname: '/',
+      search: `?liff.state=${state}&ref=direct`,
+    });
+
+    expect(parts.params.get('liffId')).toBe('old');
+    expect(parts.params.get('ref')).toBe('direct');
+  });
+});

--- a/apps/worker/src/client/url-params.ts
+++ b/apps/worker/src/client/url-params.ts
@@ -1,0 +1,93 @@
+export interface LocationLike {
+  search: string;
+  pathname: string;
+  origin?: string;
+}
+
+export interface EffectiveLocationParts {
+  pathname: string;
+  params: URLSearchParams;
+}
+
+const LIFF_STATE_PARAM = 'liff.state';
+
+function parseQueryString(query: string): URLSearchParams {
+  return new URLSearchParams(query.startsWith('?') ? query.slice(1) : query);
+}
+
+function candidateStateValues(rawState: string): string[] {
+  const values = [rawState];
+  if (/%[0-9a-f]{2}/i.test(rawState)) {
+    try {
+      const decoded = decodeURIComponent(rawState);
+      if (decoded && decoded !== rawState) values.push(decoded);
+    } catch {
+      // Keep the original value when percent-decoding fails.
+    }
+  }
+  return values;
+}
+
+function parseLiffState(rawState: string | null, origin: string): EffectiveLocationParts | null {
+  if (!rawState) return null;
+
+  for (const state of candidateStateValues(rawState)) {
+    const trimmed = state.trim();
+    if (!trimmed) continue;
+
+    try {
+      // LINE commonly wraps the original endpoint path/query as `/?liffId=...&ref=...`.
+      if (trimmed.startsWith('/') || /^https?:\/\//i.test(trimmed)) {
+        const url = new URL(trimmed, origin);
+        return { pathname: url.pathname || '/', params: parseQueryString(url.search) };
+      }
+
+      // Also accept a bare query string (`?liffId=...`) or path+query (`book?liffId=...`).
+      if (trimmed.startsWith('?')) {
+        return { pathname: '/', params: parseQueryString(trimmed) };
+      }
+      if (trimmed.includes('?')) {
+        const url = new URL(`/${trimmed.replace(/^\/+/, '')}`, origin);
+        return { pathname: url.pathname || '/', params: parseQueryString(url.search) };
+      }
+
+      // Last fallback: treat the state as a query-string payload.
+      return { pathname: '/', params: parseQueryString(trimmed) };
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return null;
+}
+
+export function getEffectiveLocationParts(locationLike: LocationLike): EffectiveLocationParts {
+  const origin = locationLike.origin || 'https://liff.local';
+  const directParams = parseQueryString(locationLike.search || '');
+  const stateParts = parseLiffState(directParams.get(LIFF_STATE_PARAM), origin);
+
+  const params = new URLSearchParams(stateParts?.params ?? undefined);
+  for (const [key, value] of directParams) {
+    if (key === LIFF_STATE_PARAM) continue;
+    params.set(key, value);
+  }
+
+  const directPathname = locationLike.pathname || '/';
+  const pathname = directPathname !== '/'
+    ? directPathname
+    : (stateParts?.pathname || directPathname);
+
+  return { pathname, params };
+}
+
+export function getEffectiveSearchParams(): URLSearchParams {
+  return getEffectiveLocationParts(window.location).params;
+}
+
+export function getEffectivePathname(): string {
+  return getEffectiveLocationParts(window.location).pathname;
+}
+
+export function getEffectiveQueryParam(name: string): string | null {
+  return getEffectiveSearchParams().get(name);
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -247,6 +247,10 @@ app.get('/r/:ref', async (c) => {
     }
   }
 
+  if (!liffUrl) {
+    return c.text('LIFF URL の設定が不足しています。LINE Login/LIFF 設定を確認してください。', 503);
+  }
+
   // Build LIFF URL with params (direct link for Universal Link)
   const liffIdMatch = liffUrl.match(/liff\.line\.me\/([0-9]+-[A-Za-z0-9]+)/);
   const liffParams = new URLSearchParams();

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -378,6 +378,11 @@ liffRoutes.get('/auth/line', async (c) => {
       }
     }
   }
+
+  if (!channelId || !liffUrl) {
+    return c.text('LINE Login / LIFF URL の設定が不足しています。LINE Developers の認証情報を設定してください。', 503);
+  }
+
   const callbackUrl = `${baseUrl}/auth/callback`;
 
   // xh: refs are X Harness one-time tokens — never forward to third-party URLs (liff.line.me / QR)
@@ -560,6 +565,10 @@ liffRoutes.get('/auth/oauth', async (c) => {
         }
       }
     }
+  }
+
+  if (!channelId) {
+    return c.text('LINE Login の設定が不足しています。LINE Developers の認証情報を設定してください。', 503);
   }
 
   // Build OAuth URL with full state


### PR DESCRIPTION
## 概要
- LIFF が認証後に元の path/query を `liff.state` に包んで返すケースに対応しました。
- `liffId` / `ref` / `form` / `gate` / `xh` などの参照を、direct query と `liff.state` を統合した値から読むようにしました。
- `liffId` が取れない場合に top-level throw で「読み込み中...」のまま止まらないよう、画面上にエラーを表示します。
- LIFF/Login未設定の環境では `/r/:ref` / `/auth/line` / `/auth/oauth` が500にならず、503で設定不足を返すようにしました。

## 確認したこと
- `corepack pnpm --filter worker exec vitest run src/client/url-params.test.ts`
- `corepack pnpm --filter worker typecheck`
- `corepack pnpm --filter worker build`
- `corepack pnpm --filter worker test`（473 tests passed）
- 本番Cloudflare Workerへ手動デプロイ後、`/docs` 200、LINE未設定時の `/r/:ref` 503 を確認

## リスク
- LIFF クライアントのURLパラメータ解釈に関わる変更です。
- direct query を優先し、`liff.state` はLINE認証後の復元用途として扱うため、既存の直指定URLは維持されます。
- LINE本番認証情報が入るまでは流入リンクは503で止まる想定です。