### PR TITLE
feat: 流入リンクで自動付与タグを設定できるようにする

### DIFF
--- a/apps/web/src/app/inflow-links/_components/edit-route-modal.tsx
+++ b/apps/web/src/app/inflow-links/_components/edit-route-modal.tsx
@@ -7,6 +7,7 @@ import type {
   CreateEntryRouteInput,
   TrafficPool,
   Scenario,
+  Tag,
 } from '@line-crm/shared'
 
 interface MessageTemplate {
@@ -21,6 +22,7 @@ interface Props {
   pools: TrafficPool[]
   scenarios: Scenario[]
   templates: MessageTemplate[]
+  tags: Tag[]
   /** Pre-filled ref_code for "register an unregistered inflow ref" flow. */
   initialRefCode?: string
   onClose: () => void
@@ -32,6 +34,7 @@ export default function EditRouteModal({
   pools,
   scenarios,
   templates,
+  tags,
   initialRefCode,
   onClose,
   onSaved,
@@ -64,6 +67,7 @@ export default function EditRouteModal({
   const [form, setForm] = useState<CreateEntryRouteInput>(() => ({
     refCode: route?.refCode ?? initialRefCode ?? '',
     name: route?.name ?? '',
+    tagId: route?.tagId ?? null,
     poolId: route?.poolId ?? mainPool?.id ?? null,
     scenarioId: route?.scenarioId ?? null,
     introTemplateId: route?.introTemplateId ?? null,
@@ -141,6 +145,24 @@ export default function EditRouteModal({
               既に流入があった ref を登録中のため、ref_code は変更できません。
             </p>
           )}
+        </Field>
+
+        <Field label="自動付与タグ（任意）">
+          <select
+            value={form.tagId ?? ''}
+            onChange={(e) => setForm({ ...form, tagId: e.target.value || null })}
+            className="w-full border border-gray-200 rounded px-3 py-2 text-sm"
+          >
+            <option value="">— 設定なし —</option>
+            {tags.map((tag) => (
+              <option key={tag.id} value={tag.id}>
+                {tag.name}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-500 mt-1">
+            友だち追加時にこのタグを自動付与します。タグ未作成の場合は先にタグを作成してください。
+          </p>
         </Field>
 
         <Field label="送り先 Pool">

--- a/apps/web/src/app/inflow-links/page.tsx
+++ b/apps/web/src/app/inflow-links/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import { api, fetchApi } from '@/lib/api'
 import Header from '@/components/layout/header'
 import { useAccount } from '@/contexts/account-context'
-import type { EntryRoute, TrafficPool, Scenario } from '@line-crm/shared'
+import type { EntryRoute, TrafficPool, Scenario, Tag } from '@line-crm/shared'
 import EditRouteModal from './_components/edit-route-modal'
 
 interface MessageTemplate {
@@ -52,6 +52,7 @@ export default function InflowLinksPage() {
   const [pools, setPools] = useState<TrafficPool[]>([])
   const [scenarios, setScenarios] = useState<Scenario[]>([])
   const [templates, setTemplates] = useState<MessageTemplate[]>([])
+  const [tags, setTags] = useState<Tag[]>([])
   const [summary, setSummary] = useState<RefSummaryData | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -83,11 +84,12 @@ export default function InflowLinksPage() {
     // ref_code のみ」に絞れる。pool_id NULL のリンクが多い現状ではアカ別の
     // pool 紐付け判定よりも、こちらの実流入ベースの方が運用実態に合う。
     const summaryQuery = selectedAccountId ? `?lineAccountId=${selectedAccountId}` : ''
-    const [r, p, s, t, sum] = await Promise.all([
+    const [r, p, s, t, tagRes, sum] = await Promise.all([
       api.entryRoutes.list(),
       api.pools.list(),
       api.scenarios.list(),
       api.messageTemplates.list(),
+      api.tags.list().catch(() => ({ success: false, data: [] as Tag[] })),
       fetchApi<{ success: boolean; data: RefSummaryData }>(
         `/api/analytics/ref-summary${summaryQuery}`,
       ).catch(() => ({ success: false, data: null })),
@@ -97,6 +99,7 @@ export default function InflowLinksPage() {
     if (p.success) setPools(p.data)
     if (s.success) setScenarios(s.data)
     if (t.success) setTemplates(t.data)
+    if (tagRes.success) setTags(tagRes.data)
     if ('success' in sum && sum.success && sum.data) setSummary(sum.data)
 
     // Load pool→accounts mapping after we know the pool list. Done in a 2nd
@@ -189,6 +192,7 @@ export default function InflowLinksPage() {
     refCode: string
     name: string
     poolId: string | null
+    tagId: string | null
     scenarioId: string | null
     runAccountFriendAddScenarios: boolean
     stats: RefRouteStats | undefined
@@ -201,6 +205,7 @@ export default function InflowLinksPage() {
       refCode: r.refCode,
       name: r.name,
       poolId: r.poolId,
+      tagId: r.tagId,
       scenarioId: r.scenarioId,
       runAccountFriendAddScenarios: r.runAccountFriendAddScenarios,
       stats: statsByRef.get(r.refCode),
@@ -214,6 +219,7 @@ export default function InflowLinksPage() {
       refCode: s.refCode,
       name: s.name ?? '(未登録)',
       poolId: null,
+      tagId: null,
       scenarioId: null,
       runAccountFriendAddScenarios: true,
       stats: s,
@@ -329,7 +335,7 @@ export default function InflowLinksPage() {
         </div>
       ) : (
         <div className="bg-white rounded-lg border border-gray-200 overflow-x-auto">
-          <table className="w-full min-w-[960px]">
+          <table className="w-full min-w-[1080px]">
             <thead className="bg-gray-50 border-b border-gray-200">
               <tr>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
@@ -343,6 +349,9 @@ export default function InflowLinksPage() {
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
                   起動シナリオ
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
+                  自動付与タグ
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">
                   モード
@@ -366,6 +375,7 @@ export default function InflowLinksPage() {
               {sortedRows.map((r) => {
                 const pool = pools.find((p) => p.id === r.poolId)
                 const sc = scenarios.find((s) => s.id === r.scenarioId)
+                const tag = tags.find((t) => t.id === r.tagId)
                 const editTarget = r.registered
                   ? routes.find((e) => e.id === r.entryRouteId) ?? null
                   : null
@@ -416,6 +426,21 @@ export default function InflowLinksPage() {
                       )}
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-700">{sc?.name ?? '—'}</td>
+                    <td className="px-4 py-3 text-sm text-gray-700">
+                      {tag ? (
+                        <span
+                          className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+                          style={{
+                            backgroundColor: `${tag.color}22`,
+                            color: tag.color,
+                          }}
+                        >
+                          {tag.name}
+                        </span>
+                      ) : (
+                        <span className="text-gray-400">—</span>
+                      )}
+                    </td>
                     <td className="px-4 py-3 text-sm text-gray-600">
                       {r.registered ? (r.runAccountFriendAddScenarios ? '並走' : '上書き') : '—'}
                     </td>
@@ -477,6 +502,7 @@ export default function InflowLinksPage() {
           pools={pools}
           scenarios={scenarios}
           templates={templates}
+          tags={tags}
           onClose={() => setEditing(null)}
           onSaved={() => {
             setEditing(null)
@@ -517,7 +543,7 @@ function FragmentRow({
       </tr>
       {isExpanded && (
         <tr>
-          <td colSpan={10} className="px-6 py-4 bg-gray-50 border-t border-gray-100">
+          <td colSpan={11} className="px-6 py-4 bg-gray-50 border-t border-gray-100">
             {refDetailLoading ? (
               <p className="text-sm text-gray-400">読み込み中…</p>
             ) : !friends ? (

--- a/scripts/inflow-link-tag-ui.test.ts
+++ b/scripts/inflow-link-tag-ui.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const page = readFileSync(
+  resolve(root, 'apps/web/src/app/inflow-links/page.tsx'),
+  'utf8',
+);
+const modal = readFileSync(
+  resolve(root, 'apps/web/src/app/inflow-links/_components/edit-route-modal.tsx'),
+  'utf8',
+);
+
+describe('inflow link tag auto-assignment UI wiring', () => {
+  test('inflow-links page loads tags and shows the assigned auto-tag in the route list', () => {
+    expect(page).toContain("import type { EntryRoute, TrafficPool, Scenario, Tag }");
+    expect(page).toContain('const [tags, setTags] = useState<Tag[]>([])');
+    expect(page).toContain('api.tags.list()');
+    expect(page).toContain('if (tagRes.success) setTags(tagRes.data)');
+    expect(page).toContain('tagId: r.tagId');
+    expect(page).toContain('自動付与タグ');
+    expect(page).toContain('const tag = tags.find((t) => t.id === r.tagId)');
+    expect(page).toContain('tags={tags}');
+    expect(page).toContain('colSpan={11}');
+  });
+
+  test('edit route modal lets operators select a tagId that is sent with create/update payloads', () => {
+    expect(modal).toContain("Tag,");
+    expect(modal).toContain('tags: Tag[]');
+    expect(modal).toContain('tagId: route?.tagId ?? null');
+    expect(modal).toContain('自動付与タグ（任意）');
+    expect(modal).toContain('value={form.tagId ?? \'\'}');
+    expect(modal).toContain('tagId: e.target.value || null');
+    expect(modal).toContain('友だち追加時にこのタグを自動付与します');
+    expect(modal).toContain('tags.map((tag) => (');
+  });
+});


### PR DESCRIPTION
## 概要
- `/inflow-links` の一覧で、各リファラルリンクに紐づく自動付与タグを表示します。
- 新規作成・編集モーダルに「自動付与タグ（任意）」の選択欄を追加し、`tagId` を `POST/PATCH /api/entry-routes` へ渡せるようにしました。
- UI配線の回帰を防ぐ source-level test を追加しました。

## 確認したこと
- `corepack pnpm exec vitest run --config vitest.config.ts scripts/inflow-link-tag-ui.test.ts`
- `corepack pnpm exec vitest run --config vitest.config.ts`
- `corepack pnpm --filter @line-harness/update-engine build`
- `corepack pnpm --filter @line-crm/shared build`
- `corepack pnpm --filter @line-crm/line-sdk build`
- `corepack pnpm --filter web exec tsc --noEmit`
- `NEXT_PUBLIC_API_URL=https://api.line.collection-bank.ai corepack pnpm --filter web build`
- `git diff --check`

## リスク
- 既存API/DBは `entry_routes.tag_id` と `CreateEntryRouteInput.tagId` に対応済みのため、DB migration は不要です。
- タグ自体が未作成の場合は選択肢が空になります。先にタグ作成が必要です。
