### PR TITLE
feat: 管理画面更新バナーを無効化できるようにする

### DIFF
--- a/apps/web/src/components/update/update-banner.tsx
+++ b/apps/web/src/components/update/update-banner.tsx
@@ -16,10 +16,14 @@ type Status =
   | { kind: 'fork'; reason: string; version: string }
   | { kind: 'upgrade'; current: string; target: ReleaseEntry }
 
+const updateBannerEnabled = process.env.NEXT_PUBLIC_UPDATE_BANNER_ENABLED !== 'false'
+
 export function UpdateBanner() {
   const [status, setStatus] = useState<Status>({ kind: 'loading' })
 
   useEffect(() => {
+    if (!updateBannerEnabled) return
+
     let cancelled = false
     ;(async () => {
       try {

--- a/scripts/update-banner-toggle.test.ts
+++ b/scripts/update-banner-toggle.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const updateBanner = readFileSync(
+  resolve(root, 'apps/web/src/components/update/update-banner.tsx'),
+  'utf8',
+);
+
+describe('update banner deployment toggle', () => {
+  test('custom client builds can disable the fork/update banner at build time', () => {
+    expect(updateBanner).toContain('NEXT_PUBLIC_UPDATE_BANNER_ENABLED');
+    expect(updateBanner).toContain("!== 'false'");
+    expect(updateBanner).toContain('if (!updateBannerEnabled) return');
+    expect(updateBanner).toContain('getCurrentVersion()');
+    expect(updateBanner).toContain('detectFork(current, manifest)');
+  });
+});


### PR DESCRIPTION
## Summary
- 管理画面の更新/改造検知バナーを build-time flag で無効化できるようにしました
- `NEXT_PUBLIC_UPDATE_BANNER_ENABLED=false` のときは `/admin/version` / manifest チェックを走らせず、バナーを表示しません
- デフォルトは従来通り有効なので、OSS標準挙動は維持します

## Test Plan
- `corepack pnpm exec vitest run --config vitest.config.ts scripts/update-banner-toggle.test.ts`
- `corepack pnpm exec vitest run --config vitest.config.ts`
- `corepack pnpm --filter @line-harness/update-engine build`
- `corepack pnpm --filter @line-crm/shared build`
- `corepack pnpm --filter @line-crm/line-sdk build`
- `corepack pnpm --filter web exec tsc --noEmit`
- `NEXT_PUBLIC_API_URL=https://api.line.collection-bank.ai NEXT_PUBLIC_UPDATE_BANNER_ENABLED=false corepack pnpm --filter web build`

## Notes
- Collection Bank の手動デプロイ環境で出る `改造を検知しました` 表示を消すための独立PRです。
- 流入リンクの自動付与タグUI PRとは分離しています。
