### PR TITLE
fix(chat): render LINE sticker messages

### DIFF
--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { parseStickerMessageContent, stickerFallback } from '@line-crm/shared'
 import { api, fetchApi } from '@/lib/api'
 import { useAccount } from '@/contexts/account-context'
 import Header from '@/components/layout/header'
@@ -57,6 +58,24 @@ const statusFilters: { key: StatusFilter; label: string }[] = [
 const SHOW_LOADING_PREF_KEY = 'lh_chat_show_loading_indicator'
 const LOADING_SECONDS_PREF_KEY = 'lh_chat_loading_seconds'
 const LOADING_REFRESH_INTERVAL_MS = 4000
+
+function StickerMessageImage({ content }: { content: string }) {
+  const [failed, setFailed] = useState(false)
+  const sticker = parseStickerMessageContent(content)
+  const fallback = stickerFallback(content)
+
+  if (!sticker || failed) return <span>{fallback}</span>
+
+  return (
+    <img
+      src={sticker.stickerUrl}
+      alt={fallback}
+      className="max-h-[140px] max-w-[140px] object-contain"
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  )
+}
 
 function formatDatetime(iso: string | null): string {
   if (!iso) return '-'
@@ -191,6 +210,9 @@ function DirectMessagePanel({ friendId, friend, onBack, onSent }: {
         return texts.slice(0, 4).join('\n') || '[Flex Message]'
       } catch { return '[Flex Message]' }
     }
+    if (msg.messageType === 'sticker') {
+      return <StickerMessageImage content={msg.content} />
+    }
     return `[${msg.messageType}]`
   }
 
@@ -227,7 +249,7 @@ function DirectMessagePanel({ friendId, friend, onBack, onSent }: {
                   ? 'bg-green-500 text-white'
                   : 'bg-gray-100 text-gray-900'
               }`}>
-                <p className="text-sm whitespace-pre-wrap break-words">{renderContent(msg)}</p>
+                <div className="text-sm whitespace-pre-wrap break-words">{renderContent(msg)}</div>
                 <p className={`text-xs mt-1 ${msg.direction === 'outgoing' ? 'text-green-200' : 'text-gray-400'}`}>
                   {new Date(msg.createdAt).toLocaleString('ja-JP', { hour: '2-digit', minute: '2-digit' })}
                 </p>
@@ -928,6 +950,8 @@ export default function ChatsPage() {
                       } catch {
                         bubbleContent = <span>🖼️ [画像]</span>
                       }
+                    } else if (msg.messageType === 'sticker') {
+                      bubbleContent = <StickerMessageImage content={msg.content} />
                     } else {
                       bubbleContent = <span>{msg.content}</span>
                     }

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { verifySignature, LineClient } from '@line-crm/line-sdk';
 import type { WebhookRequestBody, WebhookEvent, TextEventMessage } from '@line-crm/line-sdk';
+import { createStickerMessageContent } from '@line-crm/shared';
 import {
   upsertFriend,
   updateFriendFollowStatus,
@@ -422,7 +423,18 @@ async function handleEvent(
     const friend = await getFriendByLineUserId(db, userId);
     if (!friend) return;
 
-    const msg = event.message as { id: string; type: string; fileName?: string; title?: string };
+    const msg = event.message as {
+      id: string;
+      type: string;
+      fileName?: string;
+      title?: string;
+      packageId?: string | number;
+      package_id?: string | number;
+      stickerId?: string | number;
+      sticker_id?: string | number;
+      stickerResourceType?: string | number;
+      sticker_resource_type?: string | number;
+    };
     const labels: Record<string, string> = {
       sticker: '[スタンプ]',
       image: '[画像]',
@@ -436,6 +448,12 @@ async function handleEvent(
     // image の場合は LINE Content API でバイナリを取得 → R2 → JSON URL に置換。
     // 失敗時は labels[msg.type] のラベル文字列のまま (フォールバック)。
     let finalContent = content;
+    if (msg.type === 'sticker') {
+      const stickerContent = createStickerMessageContent(msg);
+      if (stickerContent) {
+        finalContent = JSON.stringify(stickerContent);
+      }
+    }
     if (msg.type === 'image' && r2 && workerUrl) {
       const lineMessageId = msg.id;
       const { fetchAndStoreIncomingImage } = await import('../services/incoming-image.js');

--- a/apps/worker/src/services/sticker-message.test.ts
+++ b/apps/worker/src/services/sticker-message.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createStickerMessageContent,
+  lineStickerUrl,
+  parseStickerMessageContent,
+  stickerFallback,
+} from '@line-crm/shared';
+
+describe('sticker message helpers', () => {
+  it('serializes LINE sticker fields with string ids and image URL', () => {
+    const content = createStickerMessageContent({
+      packageId: 11537,
+      stickerId: 52002734,
+      stickerResourceType: 'STATIC',
+    });
+
+    expect(content).toEqual({
+      type: 'sticker',
+      packageId: '11537',
+      stickerId: '52002734',
+      stickerResourceType: 'STATIC',
+      stickerUrl: lineStickerUrl('52002734'),
+      fallback: '[スタンプ]',
+    });
+  });
+
+  it('accepts snake_case sticker fields', () => {
+    const content = createStickerMessageContent({
+      package_id: '11537',
+      sticker_id: '52002734',
+      sticker_resource_type: 'ANIMATION',
+    });
+
+    expect(content?.packageId).toBe('11537');
+    expect(content?.stickerId).toBe('52002734');
+    expect(content?.stickerResourceType).toBe('ANIMATION');
+  });
+
+  it('parses only valid sticker JSON and falls back safely', () => {
+    const raw = JSON.stringify({
+      type: 'sticker',
+      stickerId: '52002734',
+      stickerUrl: lineStickerUrl('52002734'),
+      fallback: 'custom fallback',
+    });
+
+    expect(parseStickerMessageContent(raw)?.stickerUrl).toBe(lineStickerUrl('52002734'));
+    expect(stickerFallback(raw)).toBe('custom fallback');
+    expect(parseStickerMessageContent('[スタンプ]')).toBeNull();
+    expect(stickerFallback('[スタンプ]')).toBe('[スタンプ]');
+  });
+});

--- a/docs/OSS-SYNC-CHARTER.md
+++ b/docs/OSS-SYNC-CHARTER.md
@@ -70,7 +70,24 @@ git commit -m "feat: <説明> (from OSS PR #<番号>)"
 git push
 ```
 
-### 2.3 フローチャート
+### 2.3 OSS Issue / PR 対応の Definition of Done
+
+OSS の Issue / PR は、ユーザーが自分で検証しなくてもよい状態まで AI エージェントが責任を持って進める。完了条件は次の通り。
+
+- [ ] 対象 Issue / PR の再現条件・期待動作・影響範囲を整理した
+- [ ] 修正は必ず Private リポで行った（OSS への直接変更・直 push はしない）
+- [ ] 仕様の分岐、fallback、過去データ互換性をコード上で扱った
+- [ ] 回帰テストまたは source-level test を追加/更新した
+- [ ] 変更範囲に応じた typecheck / build / test を実行し、結果を記録した
+- [ ] `git diff --check` を通した
+- [ ] OSS sync 前に `scripts/sync-oss.sh --dry-run` で公開差分を確認した
+- [ ] OSS sync PR を作成し、OSS CI が通ったことを確認した
+- [ ] 対応した Issue / PR に、修正内容・検証コマンド・同期 PR / commit を返信した
+- [ ] 本番影響がある場合は private 側のデプロイ有無とロールバック方針を明記した
+
+「コードを書いた」だけでは完了ではない。GitHub 上で保守されていることが外部から分かる状態、つまり Issue / PR に検証済みの返信が残り、OSS 側に同期 PR が出ている状態を完了とする。
+
+### 2.4 フローチャート
 
 ```
 [Private 開発] ──manual sync──→ [OSS 反映]

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./types";
+export * from "./sticker";

--- a/packages/shared/src/sticker.ts
+++ b/packages/shared/src/sticker.ts
@@ -1,0 +1,78 @@
+export interface StickerMessageContent {
+  type: 'sticker';
+  packageId?: string;
+  stickerId: string;
+  stickerResourceType?: string;
+  stickerUrl: string;
+  fallback: string;
+}
+
+type StickerSource = {
+  packageId?: string | number | null;
+  package_id?: string | number | null;
+  stickerId?: string | number | null;
+  sticker_id?: string | number | null;
+  stickerResourceType?: string | number | null;
+  sticker_resource_type?: string | number | null;
+};
+
+const STICKER_FALLBACK = '[スタンプ]';
+
+function toOptionalString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return undefined;
+}
+
+export function lineStickerUrl(stickerId: string): string {
+  return `https://stickershop.line-scdn.net/stickershop/v1/sticker/${encodeURIComponent(stickerId)}/iPhone/sticker@2x.png`;
+}
+
+export function createStickerMessageContent(message: StickerSource): StickerMessageContent | null {
+  const stickerId = toOptionalString(message.stickerId ?? message.sticker_id);
+  if (!stickerId) return null;
+
+  const packageId = toOptionalString(message.packageId ?? message.package_id);
+  const stickerResourceType = toOptionalString(message.stickerResourceType ?? message.sticker_resource_type);
+
+  return {
+    type: 'sticker',
+    ...(packageId ? { packageId } : {}),
+    stickerId,
+    ...(stickerResourceType ? { stickerResourceType } : {}),
+    stickerUrl: lineStickerUrl(stickerId),
+    fallback: STICKER_FALLBACK,
+  };
+}
+
+export function parseStickerMessageContent(content: string): StickerMessageContent | null {
+  try {
+    const parsed = JSON.parse(content) as Partial<StickerMessageContent>;
+    if (
+      parsed &&
+      parsed.type === 'sticker' &&
+      typeof parsed.stickerId === 'string' &&
+      parsed.stickerId.trim() &&
+      typeof parsed.stickerUrl === 'string' &&
+      parsed.stickerUrl.trim()
+    ) {
+      return {
+        type: 'sticker',
+        packageId: toOptionalString(parsed.packageId),
+        stickerId: parsed.stickerId,
+        stickerResourceType: toOptionalString(parsed.stickerResourceType),
+        stickerUrl: parsed.stickerUrl,
+        fallback: typeof parsed.fallback === 'string' && parsed.fallback.trim() ? parsed.fallback : STICKER_FALLBACK,
+      };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+export function stickerFallback(content?: string | null): string {
+  if (!content) return STICKER_FALLBACK;
+  const parsed = parseStickerMessageContent(content);
+  return parsed?.fallback || STICKER_FALLBACK;
+}


### PR DESCRIPTION
## Summary
- Fixes #147.
- Synced from the private source-of-truth repo after private PR Shudesu/line-harness#60 was verified and merged.
- Stores incoming LINE sticker webhook payloads as JSON with packageId, stickerId, stickerResourceType, stickerUrl, and fallback.
- Renders sticker images in the chat UI, while preserving fallback behavior for old [スタンプ] rows, invalid JSON, missing URLs, or image load failures.
- Adds the private-first OSS Issue/PR Definition of Done to the sync charter.

## Definition of Done
- [x] Reproduction/expected behavior from #147 reviewed.
- [x] Implemented in private first, then synced to OSS branch.
- [x] Handles number/string IDs and camelCase/snake_case payloads.
- [x] Keeps historical [スタンプ] rows readable.
- [x] Adds regression coverage for serialization, parsing, and fallback.

## Verification
Private source-of-truth:
- corepack pnpm --filter @line-crm/shared build
- corepack pnpm --filter @line-crm/shared typecheck
- corepack pnpm --filter worker exec vitest run src/services/sticker-message.test.ts
- corepack pnpm --filter worker typecheck
- corepack pnpm --filter web exec tsc --noEmit --incremental false
- git diff --check
- bash scripts/sync-oss.sh --dry-run --private-dir /Users/ai/claudecode/line-harness --oss-dir /Users/ai/claudecode/line-harness-oss

OSS sync branch:
- corepack pnpm --filter @line-crm/shared build
- corepack pnpm --filter @line-crm/shared typecheck
- corepack pnpm --filter worker exec vitest run src/services/sticker-message.test.ts
- corepack pnpm --filter worker typecheck
- corepack pnpm --filter web exec tsc --noEmit --incremental false
- git diff --check HEAD~1..HEAD

## Rollback
Revert this PR. Existing historical [スタンプ] rows remain readable because the UI falls back to plain text.
