### PR TITLE
fix: move admin auth to production-safe httpOnly cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,22 @@ WORKER_URL=https://your-worker.workers.dev
 LIFF_URL=https://liff.line.me/your-liff-id
 STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-secret
 
+# --- Admin auth (cookie session) ---
+# The admin dashboard authenticates with an HttpOnly session cookie (no API key
+# in localStorage). When the admin (Pages, *.pages.dev) and API (Worker,
+# *.workers.dev) are on different sites, the cookie must be SameSite=None;
+# Secure and the admin origin must be allow-listed for credentialed CORS.
+# `create-line-harness` sets these automatically; set them manually for custom
+# deployments.
+#   ADMIN_ORIGIN: comma-separated admin origin allowlist (no trailing slash)
+ADMIN_ORIGIN=https://your-admin.pages.dev
+#   true → issue SameSite=None; Secure cookies (required for the cross-site
+#   Pages↔Workers topology). Omit/false when admin and API share a registrable
+#   domain (e.g. admin.example.com + api.example.com), where SameSite=Lax works.
+ADMIN_ALLOW_CROSS_SITE=true
+#   Optional override: Strict | Lax | None (normally derived automatically)
+# ADMIN_COOKIE_SAMESITE=None
+
 # Optional: Cross-account linking
 X_HARNESS_URL=https://your-other-harness.workers.dev
 

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -14,37 +14,49 @@ export default function LoginPage() {
     setError('')
 
     try {
-      // Validate by calling a simple endpoint
       const apiUrl = process.env.NEXT_PUBLIC_API_URL
       if (!apiUrl) {
         setError('NEXT_PUBLIC_API_URL is not set in build env')
         setLoading(false)
         return
       }
-      const res = await fetch(`${apiUrl}/api/friends/count`, {
-        headers: { Authorization: `Bearer ${apiKey}` },
+      // Exchange the API key for an HttpOnly session cookie. The key is never
+      // stored in localStorage (removes the XSS-exposed credential).
+      const res = await fetch(`${apiUrl}/api/auth/login`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey }),
       })
 
       if (res.ok) {
-        localStorage.setItem('lh_api_key', apiKey)
-        // Fetch staff profile for name/role display
+        localStorage.removeItem('lh_api_key')
         try {
-          const profileRes = await fetch(`${apiUrl}/api/staff/me`, {
-            headers: { Authorization: `Bearer ${apiKey}` },
-          })
-          if (profileRes.ok) {
-            const profileData = await profileRes.json()
-            if (profileData.success && profileData.data) {
-              localStorage.setItem('lh_staff_name', profileData.data.name)
-              localStorage.setItem('lh_staff_role', profileData.data.role)
-            }
+          const loginData = await res.json()
+          if (loginData.success && loginData.data) {
+            localStorage.setItem('lh_staff_name', loginData.data.name)
+            localStorage.setItem('lh_staff_role', loginData.data.role)
+          }
+          // Cache the CSRF token for mutating requests (double-submit).
+          if (loginData.csrfToken) {
+            localStorage.setItem('lh_csrf', loginData.csrfToken)
           }
         } catch {
-          // Profile fetch is best-effort
+          // Profile / CSRF caching is best-effort.
         }
         router.push('/')
-      } else {
+      } else if (res.status === 401) {
         setError('APIキーが正しくありません')
+      } else {
+        // Surface topology / configuration errors (e.g. cross-site cookie guard).
+        let message = 'ログインに失敗しました'
+        try {
+          const data = await res.json()
+          if (data?.error) message = data.error
+        } catch {
+          // keep default message
+        }
+        setError(message)
       }
     } catch {
       setError('接続に失敗しました')

--- a/apps/web/src/components/auth-guard.tsx
+++ b/apps/web/src/components/auth-guard.tsx
@@ -8,17 +8,34 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
   const [checked, setChecked] = useState(false)
 
   useEffect(() => {
+    let cancelled = false
+
     if (pathname === '/login') {
       setChecked(true)
-      return
+      return () => { cancelled = true }
     }
 
-    const key = localStorage.getItem('lh_api_key')
-    if (!key) {
-      router.replace('/login')
-    } else {
-      setChecked(true)
+    // Verify the session via the HttpOnly cookie. /api/auth/session returns the
+    // staff identity and refreshes the CSRF token if it was lost (e.g. reload).
+    const checkSession = async () => {
+      try {
+        localStorage.removeItem('lh_api_key')
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL
+        const res = await fetch(`${apiUrl}/api/auth/session`, { credentials: 'include' })
+        if (!res.ok) throw new Error('unauthenticated')
+        const data = await res.json()
+        if (!data?.success || !data?.data) throw new Error('unauthenticated')
+        if (data.data.name) localStorage.setItem('lh_staff_name', data.data.name)
+        if (data.data.role) localStorage.setItem('lh_staff_role', data.data.role)
+        if (data.csrfToken) localStorage.setItem('lh_csrf', data.csrfToken)
+        if (!cancelled) setChecked(true)
+      } catch {
+        if (!cancelled) router.replace('/login')
+      }
     }
+
+    checkSession()
+    return () => { cancelled = true }
   }, [pathname, router])
 
   if (!checked) {

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -311,8 +311,20 @@ export default function Sidebar() {
         <div className="px-6 py-4 space-y-3">
         <p className="text-xs text-gray-400">L Harness v{process.env.APP_VERSION || '0.0.0'}</p>
         <button
-          onClick={() => {
+          onClick={async () => {
+            try {
+              const apiUrl = process.env.NEXT_PUBLIC_API_URL
+              if (apiUrl) {
+                await fetch(`${apiUrl}/api/auth/logout`, {
+                  method: 'POST',
+                  credentials: 'include',
+                })
+              }
+            } catch {
+              // Local cleanup still logs the browser out if the network call fails.
+            }
             localStorage.removeItem('lh_api_key')
+            localStorage.removeItem('lh_csrf')
             localStorage.removeItem('lh_staff_name')
             localStorage.removeItem('lh_staff_role')
             window.location.href = '/login'

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -63,22 +63,41 @@ if (!API_URL) {
 }
 
 /**
- * Read the API key from localStorage (set during login).
- * Never embed secrets in the client bundle via NEXT_PUBLIC_* env vars.
+ * Read the CSRF token issued at login. The session credential itself lives in
+ * an HttpOnly cookie (never exposed to JS); only the CSRF token is held
+ * client-side and echoed back via the X-CSRF-Token header on mutating
+ * requests. In a cross-site topology the SPA cannot read the API's CSRF cookie
+ * directly, so the token is delivered in the login/session response body and
+ * cached here.
  */
-function getApiKey(): string {
-  if (typeof window !== 'undefined') {
-    return localStorage.getItem('lh_api_key') || ''
-  }
-  return ''
+export const CSRF_STORAGE_KEY = 'lh_csrf'
+
+export function getCsrfToken(): string {
+  if (typeof window === 'undefined') return ''
+  return localStorage.getItem(CSRF_STORAGE_KEY) || ''
 }
 
+export function setCsrfToken(token: string | undefined | null): void {
+  if (typeof window === 'undefined' || !token) return
+  localStorage.setItem(CSRF_STORAGE_KEY, token)
+}
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
 export async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
+  const method = (options?.method ?? 'GET').toUpperCase()
+  const csrfHeaders: Record<string, string> = {}
+  if (MUTATING_METHODS.has(method)) {
+    const token = getCsrfToken()
+    if (token) csrfHeaders['X-CSRF-Token'] = token
+  }
   const res = await fetch(`${API_URL}${path}`, {
     ...options,
+    // Send the HttpOnly session cookie with every request.
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${getApiKey()}`,
+      ...csrfHeaders,
       ...options?.headers,
     },
   })
@@ -1076,13 +1095,15 @@ export const api = {
 
     // 画像 upload は Content-Type を image/* で送るので fetchApi を使わず直接 fetch。
     uploadImage: async (groupId: string, pageId: string, file: File) => {
+      const csrf = getCsrfToken();
       const res = await fetch(
         `${API_URL}/api/rich-menu-groups/${groupId}/pages/${pageId}/image`,
         {
           method: 'POST',
+          credentials: 'include',
           headers: {
             'Content-Type': file.type,
-            Authorization: `Bearer ${getApiKey()}`,
+            ...(csrf ? { 'X-CSRF-Token': csrf } : {}),
           },
           body: file,
         },

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -63,6 +63,8 @@ import { images } from './routes/images.js';
 import { accountSettings } from './routes/account-settings.js';
 import { setup } from './routes/setup.js';
 import { autoReplies } from './routes/auto-replies.js';
+import { adminAuth } from './routes/admin-auth.js';
+import { resolveCorsOrigin } from './middleware/admin-auth-config.js';
 import booking from './routes/booking.js';
 import events from './routes/events.js';
 import { trafficPools } from './routes/traffic-pools.js';
@@ -88,6 +90,10 @@ export type Env = {
     LINE_LOGIN_CHANNEL_ID: string;
     LINE_LOGIN_CHANNEL_SECRET: string;
     WORKER_URL: string;
+    // Admin auth topology (see middleware/admin-auth-config.ts):
+    ADMIN_ORIGIN?: string;          // Comma-separated admin web origin allowlist for credentialed CORS
+    ADMIN_COOKIE_SAMESITE?: string; // Optional override: 'Strict' | 'Lax' | 'None'
+    ADMIN_ALLOW_CROSS_SITE?: string; // 'true' opts into SameSite=None cross-site cookies
     X_HARNESS_URL?: string;  // Optional: X Harness API URL for account linking
     IG_HARNESS_URL?: string;  // Optional: IG Harness API URL for cross-platform linking
     IG_HARNESS_LINK_SECRET?: string;  // Shared secret for IG Harness link-line webhook
@@ -115,8 +121,17 @@ export type Env = {
 
 const app = new Hono<Env>();
 
-// CORS — allow all origins for MVP
-app.use('*', cors({ origin: '*' }));
+// CORS — credentialed cookie auth cannot use a wildcard origin. Reflect only
+// same-origin requests and origins on the ADMIN_ORIGIN allowlist; everything
+// else gets no Access-Control-Allow-Origin header (browser blocks it). Bearer
+// SDK/MCP callers send no Origin header and are unaffected.
+app.use('*', cors({
+  origin: (origin, c) => resolveCorsOrigin(c.env, origin, c.req.url),
+  credentials: true,
+  allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  allowHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token'],
+  maxAge: 600,
+}));
 
 // Rate limiting — runs before auth to block abuse early
 app.use('*', rateLimitMiddleware);
@@ -161,6 +176,7 @@ app.route('/', capabilities);
 app.route('/', images);
 app.route('/', setup);
 app.route('/', autoReplies);
+app.route('/', adminAuth);
 app.route('/', trafficPools);
 app.route('/', booking);
 app.route('/', events);

--- a/apps/worker/src/middleware/admin-auth-config.test.ts
+++ b/apps/worker/src/middleware/admin-auth-config.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'vitest';
+import {
+  isCrossSite,
+  parseAllowedOrigins,
+  registrableDomain,
+  resolveAdminAuthConfig,
+  resolveCorsOrigin,
+  type AdminAuthEnv,
+} from './admin-auth-config.js';
+
+const PAGES = 'https://line-crm-admin.pages.dev';
+const WORKERS = 'https://line-crm-worker.line-crm-api.workers.dev';
+
+describe('registrableDomain', () => {
+  test('treats each *.pages.dev / *.workers.dev host as its own site', () => {
+    expect(registrableDomain('line-crm-admin.pages.dev')).toBe('line-crm-admin.pages.dev');
+    expect(registrableDomain('line-crm-worker.line-crm-api.workers.dev')).toBe(
+      'line-crm-api.workers.dev',
+    );
+  });
+
+  test('falls back to the last two labels for ordinary domains', () => {
+    expect(registrableDomain('admin.example.com')).toBe('example.com');
+    expect(registrableDomain('api.example.com')).toBe('example.com');
+  });
+});
+
+describe('isCrossSite', () => {
+  test('pages.dev ↔ workers.dev is cross-site', () => {
+    expect(isCrossSite(PAGES, WORKERS)).toBe(true);
+  });
+
+  test('subdomains of a shared custom domain are same-site', () => {
+    expect(isCrossSite('https://admin.example.com', 'https://api.example.com')).toBe(false);
+  });
+});
+
+describe('parseAllowedOrigins', () => {
+  test('splits, trims and normalizes a comma-separated allowlist', () => {
+    const env: AdminAuthEnv = {
+      ADMIN_ORIGIN: 'https://admin.example.com/ , https://staff.example.com',
+    };
+    expect(parseAllowedOrigins(env)).toEqual([
+      'https://admin.example.com',
+      'https://staff.example.com',
+    ]);
+  });
+
+  test('returns [] when unset', () => {
+    expect(parseAllowedOrigins({})).toEqual([]);
+  });
+});
+
+describe('resolveAdminAuthConfig — topology guard', () => {
+  test('cross-site without opt-in is flagged as misconfigured (the #57/#59 blocker)', () => {
+    const cfg = resolveAdminAuthConfig({ ADMIN_ORIGIN: PAGES, WORKER_URL: WORKERS });
+    expect(cfg.crossSite).toBe(true);
+    expect(cfg.sameSite).toBe('Lax'); // would be silently dropped cross-site
+    expect(cfg.misconfigured).toMatch(/cross-site/i);
+  });
+
+  test('cross-site WITH ADMIN_ALLOW_CROSS_SITE=true issues SameSite=None and is valid', () => {
+    const cfg = resolveAdminAuthConfig({
+      ADMIN_ORIGIN: PAGES,
+      WORKER_URL: WORKERS,
+      ADMIN_ALLOW_CROSS_SITE: 'true',
+    });
+    expect(cfg.sameSite).toBe('None');
+    expect(cfg.secure).toBe(true);
+    expect(cfg.misconfigured).toBeNull();
+  });
+
+  test('same-site custom domains use SameSite=Lax and are valid', () => {
+    const cfg = resolveAdminAuthConfig({
+      ADMIN_ORIGIN: 'https://admin.example.com',
+      WORKER_URL: 'https://api.example.com',
+    });
+    expect(cfg.crossSite).toBe(false);
+    expect(cfg.sameSite).toBe('Lax');
+    expect(cfg.misconfigured).toBeNull();
+  });
+
+  test('explicit SameSite=Strict on a cross-site topology is still flagged', () => {
+    const cfg = resolveAdminAuthConfig({
+      ADMIN_ORIGIN: PAGES,
+      WORKER_URL: WORKERS,
+      ADMIN_COOKIE_SAMESITE: 'Strict',
+    });
+    expect(cfg.sameSite).toBe('Strict');
+    expect(cfg.misconfigured).toMatch(/cross-site/i);
+  });
+
+  test('SameSite=None without an ADMIN_ORIGIN allowlist is flagged', () => {
+    const cfg = resolveAdminAuthConfig({
+      WORKER_URL: WORKERS,
+      ADMIN_COOKIE_SAMESITE: 'None',
+    });
+    expect(cfg.misconfigured).toMatch(/ADMIN_ORIGIN/);
+  });
+
+  test('no admin origin (worker-served same-origin) defaults to Lax and is valid', () => {
+    const cfg = resolveAdminAuthConfig({ WORKER_URL: WORKERS });
+    expect(cfg.crossSite).toBe(false);
+    expect(cfg.sameSite).toBe('Lax');
+    expect(cfg.misconfigured).toBeNull();
+  });
+
+  test('with WORKER_URL unset, the request origin is used for cross-site detection', () => {
+    // Production installer never sets WORKER_URL; the request origin is the
+    // Worker's own origin and must still flag the cross-site blocker.
+    const cfg = resolveAdminAuthConfig(
+      { ADMIN_ORIGIN: PAGES },
+      { requestOrigin: WORKERS },
+    );
+    expect(cfg.crossSite).toBe(true);
+    expect(cfg.misconfigured).toMatch(/cross-site/i);
+  });
+
+  test('opt-in cross-site with WORKER_URL unset still issues a valid SameSite=None config', () => {
+    const cfg = resolveAdminAuthConfig(
+      { ADMIN_ORIGIN: PAGES, ADMIN_ALLOW_CROSS_SITE: 'true' },
+      { requestOrigin: WORKERS },
+    );
+    expect(cfg.sameSite).toBe('None');
+    expect(cfg.misconfigured).toBeNull();
+  });
+});
+
+describe('resolveCorsOrigin — allowed / blocked', () => {
+  const env: AdminAuthEnv = {
+    ADMIN_ORIGIN: PAGES,
+    WORKER_URL: WORKERS,
+    ADMIN_ALLOW_CROSS_SITE: 'true',
+  };
+  const requestUrl = `${WORKERS}/api/friends`;
+
+  test('echoes an allowlisted admin origin', () => {
+    expect(resolveCorsOrigin(env, PAGES, requestUrl)).toBe(PAGES);
+  });
+
+  test('blocks an unknown origin (empty string → no ACAO header)', () => {
+    expect(resolveCorsOrigin(env, 'https://evil.example.com', requestUrl)).toBe('');
+  });
+
+  test('always allows same-origin requests', () => {
+    expect(resolveCorsOrigin(env, WORKERS, requestUrl)).toBe(WORKERS);
+  });
+
+  test('permits no-Origin (non-browser / SDK) callers', () => {
+    expect(resolveCorsOrigin(env, undefined, requestUrl)).toBe(WORKERS);
+  });
+});
+
+describe('resolveCorsOrigin — local development', () => {
+  test('allows a loopback admin origin when the Worker runs on loopback', () => {
+    // `pnpm dev:web` (localhost:3001) → `wrangler dev` (localhost:8787),
+    // with no ADMIN_ORIGIN configured.
+    expect(
+      resolveCorsOrigin({}, 'http://localhost:3001', 'http://localhost:8787/api/friends'),
+    ).toBe('http://localhost:3001');
+  });
+
+  test('does NOT allow loopback origins when the Worker is deployed (production)', () => {
+    expect(
+      resolveCorsOrigin({ ADMIN_ORIGIN: PAGES }, 'http://localhost:3001', `${WORKERS}/api/friends`),
+    ).toBe('');
+  });
+});

--- a/apps/worker/src/middleware/admin-auth-config.ts
+++ b/apps/worker/src/middleware/admin-auth-config.ts
@@ -1,0 +1,211 @@
+import type { Env } from '../index.js';
+
+// ---------------------------------------------------------------------------
+// Admin auth configuration & topology resolution
+//
+// The admin SPA (Cloudflare Pages) and the Worker API (workers.dev / custom
+// domain) may live on different sites. Cookie auth only works if the cookie's
+// SameSite attribute matches the topology:
+//
+//   * same-site (shared registrable domain) → SameSite=Lax is fine.
+//   * cross-site (e.g. *.pages.dev ↔ *.workers.dev) → the cookie is only sent
+//     with SameSite=None; Secure, and the operator must opt in because
+//     browsers increasingly block third-party cookies.
+//
+// This module derives the safe attributes from the environment and refuses
+// (loudly) to issue a cookie the browser would silently drop — that silent
+// drop is exactly the merge/deploy blocker found in review of #57/#59.
+// ---------------------------------------------------------------------------
+
+export type AdminSameSite = 'Strict' | 'Lax' | 'None';
+
+export interface AdminAuthConfig {
+  /** Origins permitted to make credentialed cross-origin requests. */
+  allowedOrigins: string[];
+  /** SameSite attribute applied to the session + CSRF cookies. */
+  sameSite: AdminSameSite;
+  /** Cookies are always Secure (HTTPS only) in this app. */
+  secure: boolean;
+  /** True when an admin origin is cross-site relative to the Worker API. */
+  crossSite: boolean;
+  /**
+   * Non-null when the configured topology cannot deliver the session cookie.
+   * Login refuses with this message instead of silently issuing a cookie the
+   * browser will never send back.
+   */
+  misconfigured: string | null;
+}
+
+// Bindings this module reads. Declared here (rather than only on Env) so the
+// helpers stay testable with a plain object.
+export type AdminAuthEnv = {
+  WORKER_URL?: string;
+  ADMIN_ORIGIN?: string;
+  ADMIN_COOKIE_SAMESITE?: string;
+  ADMIN_ALLOW_CROSS_SITE?: string;
+};
+
+/**
+ * Public-suffix-style multi-tenant hosts where every subdomain is its own
+ * registrable site. `line-crm-admin.pages.dev` and `x.workers.dev` are
+ * therefore cross-site to each other. Not a full PSL — just the suffixes this
+ * deployment topology actually uses.
+ */
+const MULTI_TENANT_SUFFIXES = [
+  'pages.dev',
+  'workers.dev',
+  'github.io',
+  'vercel.app',
+  'netlify.app',
+];
+
+export function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+/** True for localhost / 127.0.0.1 / ::1 origins (local development). */
+export function isLoopbackOrigin(value: string | undefined | null): boolean {
+  if (!value) return false;
+  try {
+    const host = new URL(value).hostname;
+    return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1';
+  } catch {
+    return false;
+  }
+}
+
+/** Returns the canonical `scheme://host[:port]` origin, or null if unparizable. */
+export function normalizeOrigin(value: string | undefined | null): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort registrable domain. Honours the multi-tenant suffix list so each
+ * `*.pages.dev` / `*.workers.dev` host is treated as its own site; otherwise
+ * falls back to the last two labels.
+ */
+export function registrableDomain(host: string): string {
+  const labels = host.toLowerCase().split('.').filter(Boolean);
+  if (labels.length <= 2) return labels.join('.');
+  for (const suffix of MULTI_TENANT_SUFFIXES) {
+    const suffixLabels = suffix.split('.');
+    if (labels.slice(-suffixLabels.length).join('.') === suffix) {
+      return labels.slice(-(suffixLabels.length + 1)).join('.');
+    }
+  }
+  return labels.slice(-2).join('.');
+}
+
+/** True when the two origins do not share a registrable domain. */
+export function isCrossSite(originA: string, originB: string): boolean {
+  try {
+    const a = new URL(originA);
+    const b = new URL(originB);
+    return registrableDomain(a.hostname) !== registrableDomain(b.hostname);
+  } catch {
+    // Unknown → fail safe by assuming cross-site.
+    return true;
+  }
+}
+
+function parseSameSite(value: string | undefined): AdminSameSite | null {
+  if (!value) return null;
+  switch (value.trim().toLowerCase()) {
+    case 'strict':
+      return 'Strict';
+    case 'lax':
+      return 'Lax';
+    case 'none':
+      return 'None';
+    default:
+      return null;
+  }
+}
+
+/** Parse the comma-separated ADMIN_ORIGIN allowlist into normalized origins. */
+export function parseAllowedOrigins(env: AdminAuthEnv): string[] {
+  if (!env.ADMIN_ORIGIN) return [];
+  return env.ADMIN_ORIGIN.split(',')
+    .map((value) => normalizeOrigin(value.trim()))
+    .filter((value): value is string => Boolean(value));
+}
+
+export function resolveAdminAuthConfig(
+  env: AdminAuthEnv,
+  opts: { requestOrigin?: string } = {},
+): AdminAuthConfig {
+  const allowedOrigins = parseAllowedOrigins(env);
+  // WORKER_URL is the source of truth, but the installer doesn't always set it.
+  // Fall back to the request origin (which IS the Worker's own origin when an
+  // API route is handling the request) so cross-site detection stays correct
+  // even when WORKER_URL is unset in production.
+  const workerOrigin = normalizeOrigin(env.WORKER_URL) ?? normalizeOrigin(opts.requestOrigin);
+
+  const crossSite =
+    allowedOrigins.length > 0 &&
+    workerOrigin != null &&
+    allowedOrigins.some((origin) => isCrossSite(origin, workerOrigin));
+
+  const explicit = parseSameSite(env.ADMIN_COOKIE_SAMESITE);
+  const allowCrossSite = env.ADMIN_ALLOW_CROSS_SITE === 'true';
+
+  // Opting into cross-site cookies means SameSite=None (the only value a
+  // browser sends cross-site). An explicit override always wins.
+  const sameSite: AdminSameSite =
+    explicit ?? (allowCrossSite ? 'None' : 'Lax');
+
+  let misconfigured: string | null = null;
+  if (crossSite && sameSite !== 'None') {
+    misconfigured =
+      `Admin origin (${allowedOrigins.join(', ')}) is cross-site to the Worker API ` +
+      `(${env.WORKER_URL ?? 'unset'}); a SameSite=${sameSite} session cookie will not be ` +
+      `sent and login would break. Either serve the admin under a same-site custom domain, ` +
+      `or set ADMIN_ALLOW_CROSS_SITE=true (issues SameSite=None; Secure cookies).`;
+  } else if (sameSite === 'None' && allowedOrigins.length === 0) {
+    misconfigured =
+      `SameSite=None admin cookies require an explicit ADMIN_ORIGIN allowlist for ` +
+      `credentialed CORS, but ADMIN_ORIGIN is unset.`;
+  }
+
+  return { allowedOrigins, sameSite, secure: true, crossSite, misconfigured };
+}
+
+/**
+ * CORS origin resolver for credentialed admin requests. Returns the origin to
+ * echo back, or '' when the origin is not allowed (so no ACAO header is set).
+ * Same-origin requests (and non-browser callers with no Origin header) are
+ * always permitted; this keeps SDK/MCP Bearer callers working.
+ */
+export function resolveCorsOrigin(
+  env: AdminAuthEnv,
+  origin: string | null | undefined,
+  requestUrl: string,
+): string {
+  let requestOrigin = '';
+  try {
+    requestOrigin = new URL(requestUrl).origin;
+  } catch {
+    requestOrigin = '';
+  }
+  if (!origin) return requestOrigin;
+
+  // Local development: when the Worker itself runs on loopback (e.g.
+  // `wrangler dev` on localhost:8787), allow loopback admin origins (e.g.
+  // `pnpm dev:web` on localhost:3001) so dev login works without configuring
+  // ADMIN_ORIGIN. Never enabled in production, where requestOrigin is the
+  // deployed (non-loopback) Worker origin.
+  if (isLoopbackOrigin(requestOrigin) && isLoopbackOrigin(origin)) {
+    return origin;
+  }
+
+  const { allowedOrigins } = resolveAdminAuthConfig(env);
+  const allowed = new Set(
+    [...allowedOrigins, requestOrigin].filter(Boolean).map(stripTrailingSlash),
+  );
+  return allowed.has(stripTrailingSlash(origin)) ? origin : '';
+}

--- a/apps/worker/src/middleware/auth.test.ts
+++ b/apps/worker/src/middleware/auth.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, test, vi } from 'vitest';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+import { authMiddleware } from './auth.js';
+import { resolveCorsOrigin } from './admin-auth-config.js';
+import { adminAuth } from '../routes/admin-auth.js';
+import type { Env } from '../index.js';
+
+vi.mock('@line-crm/db', () => ({
+  getStaffByApiKey: vi.fn(async (_db: unknown, token: string) => {
+    if (token !== 'staff-key') return null;
+    return { id: 'staff-1', name: 'Staff One', role: 'admin' };
+  }),
+}));
+
+const PAGES = 'https://line-crm-admin.pages.dev';
+const WORKERS = 'https://line-crm-worker.line-crm-api.workers.dev';
+
+function env(overrides: Partial<Env['Bindings']> = {}): Env['Bindings'] {
+  return {
+    DB: {} as D1Database,
+    IMAGES: {} as R2Bucket,
+    ASSETS: {} as Fetcher,
+    LINE_CHANNEL_SECRET: 'secret',
+    LINE_CHANNEL_ACCESS_TOKEN: 'line-token',
+    API_KEY: 'env-key',
+    LIFF_URL: 'https://liff.example.test',
+    LINE_CHANNEL_ID: 'line-channel',
+    LINE_LOGIN_CHANNEL_ID: 'login-channel',
+    LINE_LOGIN_CHANNEL_SECRET: 'login-secret',
+    WORKER_URL: WORKERS,
+    ...overrides,
+  };
+}
+
+// Cross-site production topology with explicit opt-in (the supported case).
+function crossSiteEnv(): Env['Bindings'] {
+  return env({ ADMIN_ORIGIN: PAGES, ADMIN_ALLOW_CROSS_SITE: 'true' });
+}
+
+function app() {
+  const a = new Hono<Env>();
+  a.use('*', cors({
+    origin: (origin, c) => resolveCorsOrigin(c.env, origin, c.req.url),
+    credentials: true,
+  }));
+  a.use('*', authMiddleware);
+  a.route('/', adminAuth);
+  a.get('/api/protected', (c) => c.json({ success: true, data: c.get('staff') }));
+  a.post('/api/protected', (c) => c.json({ success: true, data: c.get('staff') }));
+  return a;
+}
+
+function setCookies(res: Response): string[] {
+  const anyHeaders = res.headers as Headers & { getSetCookie?: () => string[] };
+  if (typeof anyHeaders.getSetCookie === 'function') return anyHeaders.getSetCookie();
+  const single = res.headers.get('Set-Cookie');
+  return single ? [single] : [];
+}
+
+function cookieFor(res: Response, name: string): string | undefined {
+  return setCookies(res).find((c) => c.startsWith(`${name}=`));
+}
+
+describe('admin login cookie attributes', () => {
+  test('cross-site login sets HttpOnly Secure SameSite=None session + readable CSRF cookie', async () => {
+    const res = await app().request('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ apiKey: 'staff-key' }),
+      headers: { 'Content-Type': 'application/json' },
+    }, crossSiteEnv());
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; data: { id: string }; csrfToken: string };
+    expect(body.data).toMatchObject({ id: 'staff-1', role: 'admin' });
+    expect(body.csrfToken).toBeTruthy();
+
+    const session = cookieFor(res, 'lh_admin_session') ?? '';
+    expect(session).toContain('lh_admin_session=staff-key');
+    expect(session).toContain('HttpOnly');
+    expect(session).toContain('Secure');
+    expect(session).toContain('SameSite=None');
+    expect(session).toContain('Max-Age=604800');
+
+    const csrf = cookieFor(res, 'lh_csrf') ?? '';
+    expect(csrf).toContain(`lh_csrf=${body.csrfToken}`);
+    expect(csrf).not.toContain('HttpOnly'); // SPA-readable (double-submit)
+    expect(csrf).toContain('SameSite=None');
+  });
+
+  test('same-site (custom domain) login uses SameSite=Lax', async () => {
+    const res = await app().request('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ apiKey: 'staff-key' }),
+      headers: { 'Content-Type': 'application/json' },
+    }, env({ ADMIN_ORIGIN: 'https://admin.example.com', WORKER_URL: 'https://api.example.com' }));
+
+    expect(res.status).toBe(200);
+    expect(cookieFor(res, 'lh_admin_session') ?? '').toContain('SameSite=Lax');
+  });
+
+  test('invalid api key is rejected without a cookie', async () => {
+    const res = await app().request('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ apiKey: 'wrong' }),
+      headers: { 'Content-Type': 'application/json' },
+    }, crossSiteEnv());
+    expect(res.status).toBe(401);
+    expect(cookieFor(res, 'lh_admin_session')).toBeUndefined();
+  });
+});
+
+describe('topology guard', () => {
+  test('cross-site WITHOUT opt-in refuses login with an actionable error', async () => {
+    const res = await app().request('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ apiKey: 'staff-key' }),
+      headers: { 'Content-Type': 'application/json' },
+    }, env({ ADMIN_ORIGIN: PAGES })); // no ADMIN_ALLOW_CROSS_SITE
+
+    expect(res.status).toBe(500);
+    const body = await res.json() as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/cross-site/i);
+    expect(cookieFor(res, 'lh_admin_session')).toBeUndefined();
+  });
+});
+
+describe('protected API access', () => {
+  test('accepts the admin session cookie (GET, no CSRF needed)', async () => {
+    const res = await app().request('/api/protected', {
+      headers: { Cookie: 'lh_admin_session=staff-key' },
+    }, crossSiteEnv());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: { id: string } };
+    expect(body.data).toMatchObject({ id: 'staff-1', role: 'admin' });
+  });
+
+  test('still accepts Bearer tokens for SDK / MCP callers', async () => {
+    const res = await app().request('/api/protected', {
+      headers: { Authorization: 'Bearer env-key' },
+    }, crossSiteEnv());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: { id: string } };
+    expect(body.data).toMatchObject({ id: 'env-owner', role: 'owner' });
+  });
+
+  test('rejects requests with no credentials', async () => {
+    const res = await app().request('/api/protected', {}, crossSiteEnv());
+    expect(res.status).toBe(401);
+  });
+
+  test('a malformed cookie value yields 401, not a 500', async () => {
+    // `%` is an invalid percent escape — decoding must not throw.
+    const res = await app().request('/api/protected', {
+      headers: { Cookie: 'lh_admin_session=%; other=%E0%A4%A' },
+    }, crossSiteEnv());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('CSRF protection', () => {
+  test('cookie-authenticated POST without an X-CSRF-Token is rejected', async () => {
+    const res = await app().request('/api/protected', {
+      method: 'POST',
+      headers: { Cookie: 'lh_admin_session=staff-key; lh_csrf=token-abc' },
+    }, crossSiteEnv());
+    expect(res.status).toBe(403);
+    expect((await res.json() as { error: string }).error).toMatch(/csrf/i);
+  });
+
+  test('cookie-authenticated POST with a mismatched token is rejected', async () => {
+    const res = await app().request('/api/protected', {
+      method: 'POST',
+      headers: {
+        Cookie: 'lh_admin_session=staff-key; lh_csrf=token-abc',
+        'X-CSRF-Token': 'token-WRONG',
+      },
+    }, crossSiteEnv());
+    expect(res.status).toBe(403);
+  });
+
+  test('cookie-authenticated POST with a matching double-submit token succeeds', async () => {
+    const res = await app().request('/api/protected', {
+      method: 'POST',
+      headers: {
+        Cookie: 'lh_admin_session=staff-key; lh_csrf=token-abc',
+        'X-CSRF-Token': 'token-abc',
+      },
+    }, crossSiteEnv());
+    expect(res.status).toBe(200);
+  });
+
+  test('Bearer POST is exempt from CSRF (not cookie-driven)', async () => {
+    const res = await app().request('/api/protected', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer env-key' },
+    }, crossSiteEnv());
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('logout', () => {
+  test('expires both the session and CSRF cookies', async () => {
+    const res = await app().request('/api/auth/logout', { method: 'POST' }, crossSiteEnv());
+    expect(res.status).toBe(200);
+    const session = cookieFor(res, 'lh_admin_session') ?? '';
+    const csrf = cookieFor(res, 'lh_csrf') ?? '';
+    expect(session).toContain('Max-Age=0');
+    expect(csrf).toContain('Max-Age=0');
+  });
+});
+
+describe('session endpoint', () => {
+  test('returns the staff identity and a CSRF token', async () => {
+    const res = await app().request('/api/auth/session', {
+      headers: { Cookie: 'lh_admin_session=staff-key; lh_csrf=token-abc' },
+    }, crossSiteEnv());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { data: { id: string }; csrfToken: string };
+    expect(body.data).toMatchObject({ id: 'staff-1' });
+    expect(body.csrfToken).toBe('token-abc');
+  });
+
+  test('mints and sets a CSRF cookie when none is present', async () => {
+    const res = await app().request('/api/auth/session', {
+      headers: { Cookie: 'lh_admin_session=staff-key' },
+    }, crossSiteEnv());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { csrfToken: string };
+    expect(body.csrfToken).toBeTruthy();
+    expect(cookieFor(res, 'lh_csrf') ?? '').toContain(`lh_csrf=${body.csrfToken}`);
+  });
+});
+
+describe('CORS allowed / blocked origins', () => {
+  test('allowlisted admin origin is echoed back', async () => {
+    const res = await app().request('/api/protected', {
+      headers: { Origin: PAGES, Cookie: 'lh_admin_session=staff-key' },
+    }, crossSiteEnv());
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(PAGES);
+    expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+  });
+
+  test('unknown origin gets no Access-Control-Allow-Origin header', async () => {
+    const res = await app().request('/api/protected', {
+      headers: { Origin: 'https://evil.example.com', Cookie: 'lh_admin_session=staff-key' },
+    }, crossSiteEnv());
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+  });
+});

--- a/apps/worker/src/middleware/auth.ts
+++ b/apps/worker/src/middleware/auth.ts
@@ -1,6 +1,132 @@
 import type { Context, Next } from 'hono';
 import { getStaffByApiKey } from '@line-crm/db';
 import type { Env } from '../index.js';
+import type { AdminSameSite } from './admin-auth-config.js';
+
+export const ADMIN_AUTH_COOKIE = 'lh_admin_session';
+export const CSRF_COOKIE = 'lh_csrf';
+export const CSRF_HEADER = 'x-csrf-token';
+
+// 7 days, matching the previous localStorage session longevity.
+const SESSION_MAX_AGE = 604800;
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+/**
+ * decodeURIComponent throws on malformed percent escapes (e.g. `%`). Cookie
+ * headers are client-controlled, so fall back to the raw value rather than
+ * letting the exception turn a request into a 500.
+ */
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function parseCookieHeader(cookieHeader: string | undefined): Record<string, string> {
+  if (!cookieHeader) return {};
+  const cookies: Record<string, string> = {};
+  for (const part of cookieHeader.split(';')) {
+    const [rawName, ...rawValue] = part.trim().split('=');
+    if (!rawName) continue;
+    cookies[rawName] = safeDecode(rawValue.join('=') || '');
+  }
+  return cookies;
+}
+
+function bearerToken(c: Context<Env>): string | null {
+  const authHeader = c.req.header('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+  return authHeader.slice('Bearer '.length);
+}
+
+function cookieToken(c: Context<Env>): string | null {
+  return parseCookieHeader(c.req.header('Cookie'))[ADMIN_AUTH_COOKIE] || null;
+}
+
+export function csrfTokenFromCookie(c: Context<Env>): string | null {
+  return parseCookieHeader(c.req.header('Cookie'))[CSRF_COOKIE] || null;
+}
+
+function buildCookie(
+  name: string,
+  value: string,
+  sameSite: AdminSameSite,
+  maxAge: number,
+  httpOnly: boolean,
+): string {
+  const parts = [`${name}=${encodeURIComponent(value)}`, 'Path=/'];
+  if (httpOnly) parts.push('HttpOnly');
+  parts.push('Secure', `SameSite=${sameSite}`, `Max-Age=${maxAge}`);
+  return parts.join('; ');
+}
+
+/** HttpOnly session cookie carrying the API token. */
+export function adminSessionCookie(token: string, sameSite: AdminSameSite): string {
+  return buildCookie(ADMIN_AUTH_COOKIE, token, sameSite, SESSION_MAX_AGE, true);
+}
+
+/**
+ * CSRF cookie. NOT HttpOnly so it can participate in double-submit, but in a
+ * cross-site topology the SPA cannot read it (different registrable domain) —
+ * the token is therefore also returned in the login/session response body and
+ * the SPA echoes it via the X-CSRF-Token header. The Worker validates that
+ * header against this cookie, which the browser does send back to the API
+ * (SameSite=None).
+ */
+export function csrfCookie(token: string, sameSite: AdminSameSite): string {
+  return buildCookie(CSRF_COOKIE, token, sameSite, SESSION_MAX_AGE, false);
+}
+
+export function expiredCookie(name: string, sameSite: AdminSameSite): string {
+  return buildCookie(name, '', sameSite, 0, name === ADMIN_AUTH_COOKIE);
+}
+
+export type AuthenticatedStaff = {
+  id: string;
+  name: string;
+  role: 'owner' | 'admin' | 'staff';
+};
+
+/**
+ * Resolve a token (from a Bearer header or the session cookie) to a staff
+ * identity. Shared by the auth middleware and the /api/auth/login endpoint so
+ * cookie and Bearer auth accept exactly the same credentials.
+ */
+export async function authenticateApiToken(
+  c: Context<Env>,
+  token: string | null,
+): Promise<AuthenticatedStaff | null> {
+  if (!token) return null;
+
+  const staff = await getStaffByApiKey(c.env.DB, token);
+  if (staff) {
+    return { id: staff.id, name: staff.name, role: staff.role };
+  }
+
+  // Fallback: env API_KEY acts as owner (current rotation slot)
+  if (token === c.env.API_KEY) {
+    return { id: 'env-owner', name: 'Owner', role: 'owner' };
+  }
+
+  // Legacy fallback: LEGACY_API_KEY accepted during rotation grace period.
+  // Same-value guard: if both env vars are set to the same secret, the primary
+  // check above already accepts it; this branch must skip to avoid false
+  // LEGACY counters. Logs accept_via=LEGACY_API_KEY so operators can confirm
+  // zero legacy usage before deleting the secret.
+  if (
+    c.env.LEGACY_API_KEY &&
+    c.env.LEGACY_API_KEY !== c.env.API_KEY &&
+    token === c.env.LEGACY_API_KEY
+  ) {
+    console.log('[auth] accept_via=LEGACY_API_KEY');
+    return { id: 'env-owner', name: 'Owner', role: 'owner' };
+  }
+
+  return null;
+}
 
 export async function authMiddleware(c: Context<Env>, next: Next): Promise<Response | void> {
   // Skip auth for the LINE webhook endpoint — it uses signature verification instead
@@ -40,6 +166,9 @@ export async function authMiddleware(c: Context<Env>, next: Next): Promise<Respo
     // LINE 上 rich menu 画像 proxy (Authorization ヘッダなしで <img src> 経由表示)
     path.match(/^\/api\/rich-menu-groups\/external\/[^/]+\/image$/) ||
     path.startsWith('/api/liff/') ||
+    // Admin login/logout — issue/clear the session cookie before auth exists.
+    path === '/api/auth/login' ||
+    path === '/api/auth/logout' ||
     path.startsWith('/auth/') ||
     path === '/setup' ||
     path === '/api/integrations/stripe/webhook' ||
@@ -54,42 +183,27 @@ export async function authMiddleware(c: Context<Env>, next: Next): Promise<Respo
     return next();
   }
 
-  const authHeader = c.req.header('Authorization');
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+  const bearer = bearerToken(c);
+  const cookie = cookieToken(c);
+  const token = bearer ?? cookie;
+
+  const staff = await authenticateApiToken(c, token);
+  if (!staff) {
     return c.json({ success: false, error: 'Unauthorized' }, 401);
   }
 
-  const token = authHeader.slice('Bearer '.length);
-
-  // Check staff_members table first
-  const staff = await getStaffByApiKey(c.env.DB, token);
-  if (staff) {
-    c.set('staff', { id: staff.id, name: staff.name, role: staff.role });
-    return next();
+  // CSRF protection applies ONLY to cookie-authenticated, state-changing
+  // requests. Bearer callers (SDK/MCP) cannot be driven cross-site by a
+  // browser (an attacker cannot set the Authorization header), so they are
+  // exempt. Safe methods (GET/HEAD/OPTIONS) never mutate, so they are exempt.
+  if (!bearer && cookie && !SAFE_METHODS.has(c.req.method.toUpperCase())) {
+    const header = c.req.header(CSRF_HEADER);
+    const expected = csrfTokenFromCookie(c);
+    if (!header || !expected || header !== expected) {
+      return c.json({ success: false, error: 'CSRF token mismatch' }, 403);
+    }
   }
 
-  // Fallback: env API_KEY acts as owner (current rotation slot)
-  if (token === c.env.API_KEY) {
-    c.set('staff', { id: 'env-owner', name: 'Owner', role: 'owner' as const });
-    return next();
-  }
-
-  // Legacy fallback: LEGACY_API_KEY accepted during rotation grace period.
-  // Uses the same staff.id as primary so /api/staff/me's special-case keeps
-  // working. Logs accept_via=LEGACY_API_KEY so operators can confirm zero
-  // legacy usage before deleting the secret to revoke the old key.
-  // Same-value guard: if both env vars are set to the same secret, the
-  // primary check above already accepts it; this branch must skip to avoid
-  // false LEGACY counters.
-  if (
-    c.env.LEGACY_API_KEY &&
-    c.env.LEGACY_API_KEY !== c.env.API_KEY &&
-    token === c.env.LEGACY_API_KEY
-  ) {
-    c.set('staff', { id: 'env-owner', name: 'Owner', role: 'owner' as const });
-    console.log('[auth] accept_via=LEGACY_API_KEY');
-    return next();
-  }
-
-  return c.json({ success: false, error: 'Unauthorized' }, 401);
+  c.set('staff', staff);
+  return next();
 }

--- a/apps/worker/src/middleware/rate-limit.test.ts
+++ b/apps/worker/src/middleware/rate-limit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest';
+import { Hono } from 'hono';
+import { rateLimitMiddleware } from './rate-limit.js';
+import type { Env } from '../index.js';
+
+function app() {
+  const a = new Hono<Env>();
+  a.use('*', rateLimitMiddleware);
+  a.get('/api/protected', (c) => c.json({ success: true }));
+  return a;
+}
+
+const env = {} as Env['Bindings'];
+
+describe('rate-limit IP ceiling (pre-auth token rotation)', () => {
+  test('rotating unvalidated session cookies from one IP cannot bypass the limiter', async () => {
+    // A unique IP isolates this test from the module-level store. Each request
+    // uses a DIFFERENT bogus cookie, so the per-token bucket never trips — only
+    // the per-IP ceiling (3000) should eventually return 429.
+    const ip = '203.0.113.77';
+    const a = app();
+    let saw429 = false;
+
+    for (let i = 0; i < 3001; i++) {
+      const res = await a.request('/api/protected', {
+        headers: {
+          'cf-connecting-ip': ip,
+          Cookie: `lh_admin_session=bogus-${i}`,
+        },
+      }, env);
+      if (res.status === 429) {
+        saw429 = true;
+        break;
+      }
+    }
+
+    expect(saw429).toBe(true);
+  });
+
+  test('a single legitimate token keeps its full allowance from one IP', async () => {
+    const ip = '198.51.100.42';
+    const a = app();
+    // Well under both AUTHENTICATED_MAX and the IP ceiling.
+    for (let i = 0; i < 50; i++) {
+      const res = await a.request('/api/protected', {
+        headers: { 'cf-connecting-ip': ip, Cookie: 'lh_admin_session=stable-token' },
+      }, env);
+      expect(res.status).toBe(200);
+    }
+  });
+});

--- a/apps/worker/src/middleware/rate-limit.ts
+++ b/apps/worker/src/middleware/rate-limit.ts
@@ -82,6 +82,25 @@ function getClientIp(c: Context): string {
   );
 }
 
+function getAdminCookieToken(c: Context): string | null {
+  const cookie = c.req.header('Cookie');
+  if (!cookie) return null;
+  for (const part of cookie.split(';')) {
+    const [rawName, ...rawValue] = part.trim().split('=');
+    if (rawName === 'lh_admin_session') {
+      const raw = rawValue.join('=') || '';
+      // Cookie values are client-controlled; a malformed percent escape must
+      // not throw (it would turn the request into a 500 before auth runs).
+      try {
+        return decodeURIComponent(raw) || null;
+      } catch {
+        return raw || null;
+      }
+    }
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Hono middleware
 // ---------------------------------------------------------------------------
@@ -91,6 +110,15 @@ const AUTHENTICATED_WINDOW = 60_000; // 1 min
 
 const UNAUTHENTICATED_MAX = 100;
 const UNAUTHENTICATED_WINDOW = 60_000; // 1 min
+
+// Per-IP ceiling applied to token/cookie-keyed requests. Rate limiting runs
+// BEFORE auth, so the token (Bearer or session cookie) is not yet validated —
+// an attacker could otherwise rotate bogus tokens/cookies to mint endless
+// fresh per-token buckets and bypass the IP limit. This ceiling bounds total
+// throughput per IP (well above a single legitimate session's allowance) so
+// rotation cannot escalate beyond it.
+const IP_CEILING_MAX = 3000;
+const IP_CEILING_WINDOW = 60_000; // 1 min
 
 export async function rateLimitMiddleware(c: Context<Env>, next: Next): Promise<Response | void> {
   const path = new URL(c.req.url).pathname;
@@ -112,12 +140,21 @@ export async function rateLimitMiddleware(c: Context<Env>, next: Next): Promise<
   } else {
     // Key by API key for authenticated endpoints
     const authHeader = c.req.header('Authorization');
-    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : getAdminCookieToken(c);
     if (token) {
       // Use first 16 chars of token as key to avoid storing full secrets
       key = `key:${token.slice(0, 16)}`;
       max = AUTHENTICATED_MAX;
       windowMs = AUTHENTICATED_WINDOW;
+      // Bound total per-IP throughput so an attacker cannot bypass the limiter
+      // by rotating unvalidated tokens/cookies (each minting a fresh bucket).
+      const ceiling = check(`ip-ceiling:${getClientIp(c)}`, IP_CEILING_MAX, IP_CEILING_WINDOW);
+      if (!ceiling.ok) {
+        return c.json(
+          { success: false, error: 'Too many requests. Please try again later.' },
+          { status: 429, headers: { 'Retry-After': String(ceiling.retryAfter) } },
+        );
+      }
     } else {
       // No auth header — key by IP with the lower limit
       key = `ip:${getClientIp(c)}`;

--- a/apps/worker/src/routes/admin-auth.ts
+++ b/apps/worker/src/routes/admin-auth.ts
@@ -1,0 +1,78 @@
+import { Hono } from 'hono';
+import type { Env } from '../index.js';
+import {
+  ADMIN_AUTH_COOKIE,
+  CSRF_COOKIE,
+  adminSessionCookie,
+  authenticateApiToken,
+  csrfCookie,
+  csrfTokenFromCookie,
+  expiredCookie,
+} from '../middleware/auth.js';
+import { resolveAdminAuthConfig } from '../middleware/admin-auth-config.js';
+
+export const adminAuth = new Hono<Env>();
+
+/**
+ * POST /api/auth/login
+ *
+ * Validates the API key, then issues:
+ *   - lh_admin_session (HttpOnly) — the credential, never exposed to JS.
+ *   - lh_csrf (readable) — the double-submit CSRF token, also returned in the
+ *     body so a cross-site SPA (which cannot read the API's cookie) can echo it
+ *     back via the X-CSRF-Token header.
+ *
+ * Refuses with a clear error when the topology cannot deliver the cookie,
+ * turning the silent "login breaks after deploy" failure into an actionable
+ * configuration error.
+ */
+adminAuth.post('/api/auth/login', async (c) => {
+  const config = resolveAdminAuthConfig(c.env, { requestOrigin: new URL(c.req.url).origin });
+  if (config.misconfigured) {
+    console.error('[admin-auth] refused login — misconfigured topology:', config.misconfigured);
+    return c.json({ success: false, error: config.misconfigured }, 500);
+  }
+
+  const body = await c.req
+    .json<{ apiKey?: string }>()
+    .catch(() => ({}) as { apiKey?: string });
+  const apiKey = body.apiKey?.trim() ?? '';
+  const staff = await authenticateApiToken(c, apiKey || null);
+
+  if (!staff) {
+    return c.json({ success: false, error: 'Unauthorized' }, 401);
+  }
+
+  const csrfToken = crypto.randomUUID();
+  c.header('Set-Cookie', adminSessionCookie(apiKey, config.sameSite), { append: true });
+  c.header('Set-Cookie', csrfCookie(csrfToken, config.sameSite), { append: true });
+  return c.json({ success: true, data: staff, csrfToken });
+});
+
+/**
+ * POST /api/auth/logout — clears both cookies. No CSRF required: clearing your
+ * own session is not a meaningful CSRF target, and this keeps logout resilient
+ * even if the CSRF token was lost client-side.
+ */
+adminAuth.post('/api/auth/logout', async (c) => {
+  const { sameSite } = resolveAdminAuthConfig(c.env, { requestOrigin: new URL(c.req.url).origin });
+  c.header('Set-Cookie', expiredCookie(ADMIN_AUTH_COOKIE, sameSite), { append: true });
+  c.header('Set-Cookie', expiredCookie(CSRF_COOKIE, sameSite), { append: true });
+  return c.json({ success: true, data: null });
+});
+
+/**
+ * GET /api/auth/session — returns the authenticated staff (set by the auth
+ * middleware) plus the current CSRF token, refreshing the CSRF cookie if it is
+ * missing (e.g. after a reload that dropped the in-memory token). This lets the
+ * SPA recover the CSRF token without forcing a re-login.
+ */
+adminAuth.get('/api/auth/session', async (c) => {
+  const config = resolveAdminAuthConfig(c.env, { requestOrigin: new URL(c.req.url).origin });
+  let csrfToken = csrfTokenFromCookie(c);
+  if (!csrfToken) {
+    csrfToken = crypto.randomUUID();
+    c.header('Set-Cookie', csrfCookie(csrfToken, config.sameSite), { append: true });
+  }
+  return c.json({ success: true, data: c.get('staff'), csrfToken });
+});

--- a/docs/ADMIN-AUTH.md
+++ b/docs/ADMIN-AUTH.md
@@ -1,0 +1,76 @@
+# Admin Authentication (cookie session + CSRF)
+
+The admin dashboard authenticates against the Worker API with an **HttpOnly
+session cookie** instead of an API key stored in `localStorage`. This removes
+the XSS-exposed credential (OSS security issue #102) while keeping SDK/MCP
+Bearer-token access unchanged.
+
+## How it works
+
+1. **Login** — `POST /api/auth/login { apiKey }`. The Worker validates the key
+   (staff table, `API_KEY`, or `LEGACY_API_KEY`) and sets two cookies:
+   - `lh_admin_session` — the credential. **HttpOnly**, `Secure`, `Path=/`,
+     `Max-Age=604800`. JavaScript can never read it.
+   - `lh_csrf` — a random CSRF token. Readable, `Secure`. Also returned in the
+     response body.
+2. **Authenticated requests** — the browser sends `lh_admin_session`
+   automatically (`credentials: 'include'`). For state-changing requests
+   (`POST/PUT/PATCH/DELETE`) the SPA also sends the CSRF token in the
+   `X-CSRF-Token` header; the Worker rejects the request (`403`) unless that
+   header matches the `lh_csrf` cookie (double-submit).
+3. **Session check** — `GET /api/auth/session` returns the staff identity and
+   the current CSRF token (minting one if missing), letting the SPA recover the
+   token after a reload without re-login.
+4. **Logout** — `POST /api/auth/logout` expires both cookies.
+
+### Why the CSRF token is also returned in the body
+
+In the default cross-site topology the admin (`*.pages.dev`) and the API
+(`*.workers.dev`) are on different registrable domains. The `lh_csrf` cookie
+belongs to the API's domain, so the SPA's JavaScript on the admin domain
+**cannot read it**. The token is therefore delivered in the login/session
+response body and cached client-side; the Worker still validates it against its
+own cookie, which the browser does send back (`SameSite=None`).
+
+### Bearer tokens are unaffected
+
+SDK and MCP callers continue to send `Authorization: Bearer <key>`. They are not
+cookie-driven, so CSRF enforcement does not apply to them, and CORS does not
+affect non-browser (no `Origin`) callers.
+
+## Topology & configuration
+
+Cookies only reach the API if `SameSite` matches the topology. The Worker reads
+three environment variables (see
+`apps/worker/src/middleware/admin-auth-config.ts`):
+
+| Variable | Purpose |
+|----------|---------|
+| `ADMIN_ORIGIN` | Comma-separated allowlist of admin origins for credentialed CORS. No trailing slash. |
+| `ADMIN_ALLOW_CROSS_SITE` | `true` → issue `SameSite=None; Secure` cookies (required when admin and API are cross-site). |
+| `ADMIN_COOKIE_SAMESITE` | Optional explicit override: `Strict` \| `Lax` \| `None`. |
+
+### Two supported deployments
+
+**(a) Cross-site Pages ↔ Workers (default).** Set
+`ADMIN_ORIGIN=https://<admin>.pages.dev` and `ADMIN_ALLOW_CROSS_SITE=true`.
+`create-line-harness` does this automatically after deploying the admin.
+Cookies are `SameSite=None; Secure`; CSRF protects mutations; CORS is locked to
+the allowlist.
+
+> ⚠️ Browsers are phasing out third-party cookies (Safari ITP blocks them
+> outright). For long-term robustness prefer option (b).
+
+**(b) Same-site custom domains (recommended).** Serve the admin and API under
+one registrable domain — e.g. `admin.example.com` (Pages custom domain) and
+`api.example.com` (Worker route). Set `ADMIN_ORIGIN=https://admin.example.com`
+and leave `ADMIN_ALLOW_CROSS_SITE` unset; cookies use `SameSite=Lax` and no
+third-party-cookie restrictions apply.
+
+### Topology guard
+
+If the admin is cross-site to the API but `SameSite` is not `None` (e.g. the old
+`SameSite=Strict`, or a custom domain misconfiguration), `POST /api/auth/login`
+**refuses with a 500 and an actionable error** rather than silently issuing a
+cookie the browser will drop. This converts the "login breaks after deploy"
+failure mode into a clear configuration error.

--- a/packages/create-line-harness/src/commands/setup.ts
+++ b/packages/create-line-harness/src/commands/setup.ts
@@ -11,6 +11,7 @@ import { createDatabase } from "../steps/database.js";
 import { deployWorker, syncInstalledWorkerConfig } from "../steps/deploy-worker.js";
 import { deployAdmin } from "../steps/deploy-admin.js";
 import { setSecrets } from "../steps/secrets.js";
+import { configureAdminAuth } from "../steps/admin-auth.js";
 import { generateMcpConfig } from "../steps/mcp-config.js";
 import { generateApiKey } from "../lib/crypto.js";
 import {
@@ -57,6 +58,7 @@ const ACCOUNT_DEPENDENT_STEPS = [
   "lineAccount",
   "admin",
   "workerConfig",
+  "adminAuth",
 ];
 
 function getStatePath(repoDir: string): string {
@@ -704,6 +706,20 @@ ON CONFLICT(channel_id) DO UPDATE SET
     saveState(repoDir, state);
   } else {
     p.log.success(`Admin UI: デプロイ済み（${state.adminUrl}）`);
+  }
+
+  // Step 13b: Configure cookie-based admin auth for the cross-site
+  // Pages↔Workers topology (SameSite=None cookie + CORS allowlist).
+  if (!isDone(state, "adminAuth")) {
+    await configureAdminAuth({
+      workerName: state.workerName,
+      workerUrl: state.workerUrl!,
+      adminUrl: state.adminUrl!,
+    });
+    markDone(state, "adminAuth");
+    saveState(repoDir, state);
+  } else {
+    p.log.success("管理画面の認証設定: 設定済み");
   }
 
   if (!isDone(state, "workerConfig")) {

--- a/packages/create-line-harness/src/commands/update.ts
+++ b/packages/create-line-harness/src/commands/update.ts
@@ -17,6 +17,7 @@ import {
   deployPagesProject,
   type CurrentVersion,
 } from "@line-harness/update-engine";
+import { configureAdminAuth } from "../steps/admin-auth.js";
 
 /**
  * Shape of `.line-harness-config.json` written by `setup.ts` after
@@ -610,7 +611,16 @@ export async function runUpdate(repoDir: string): Promise<void> {
     process.exit(1);
   }
 
-  // 12) Health check (non-fatal)
+  // 12) Ensure cookie-based admin auth is configured. Installs created before
+  // this version never set ADMIN_ORIGIN / ADMIN_ALLOW_CROSS_SITE, so the new
+  // cross-site cookie auth would otherwise break their admin login on upgrade.
+  await configureAdminAuth({
+    workerName: cfg.workerName,
+    workerUrl: cfg.workerPublicUrl,
+    adminUrl: cfg.adminPublicUrl,
+  });
+
+  // 13) Health check (non-fatal)
   s.start("Health チェック中");
   try {
     const hRes = await fetch(

--- a/packages/create-line-harness/src/steps/admin-auth.ts
+++ b/packages/create-line-harness/src/steps/admin-auth.ts
@@ -1,0 +1,51 @@
+import * as p from "@clack/prompts";
+import { wrangler } from "../lib/wrangler.js";
+
+interface AdminAuthOptions {
+  workerName: string;
+  /** Optional: the Worker can fall back to the request origin if unset. */
+  workerUrl?: string;
+  adminUrl: string;
+}
+
+/**
+ * Configure the Worker for cookie-based admin auth.
+ *
+ * The default topology puts the admin on `*.pages.dev` and the API on
+ * `*.workers.dev` — these are cross-site, so the session cookie must be
+ * SameSite=None; Secure and the admin origin must be on the CORS allowlist.
+ * This sets the env the Worker reads (see apps/worker/src/middleware/
+ * admin-auth-config.ts):
+ *
+ *   - ADMIN_ORIGIN          = the admin Pages URL (credentialed CORS allowlist)
+ *   - ADMIN_ALLOW_CROSS_SITE= true (opt into SameSite=None cookies)
+ *   - WORKER_URL            = the Worker URL (used for cross-site detection)
+ */
+export async function configureAdminAuth(options: AdminAuthOptions): Promise<void> {
+  const s = p.spinner();
+  s.start("管理画面の認証設定中...");
+
+  const secrets: Record<string, string> = {
+    ADMIN_ORIGIN: options.adminUrl,
+    ADMIN_ALLOW_CROSS_SITE: "true",
+  };
+  if (options.workerUrl) {
+    secrets.WORKER_URL = options.workerUrl;
+  }
+
+  const jsonPayload = JSON.stringify(secrets);
+  try {
+    await wrangler(["secret", "bulk", "--name", options.workerName], {
+      input: jsonPayload,
+    });
+  } catch {
+    for (const [name, value] of Object.entries(secrets)) {
+      await wrangler(["versions", "secret", "put", name, "--name", options.workerName], {
+        input: value,
+      });
+    }
+    await wrangler(["versions", "deploy", "--name", options.workerName, "--yes"]);
+  }
+
+  s.stop("管理画面の認証設定完了");
+}


### PR DESCRIPTION
## Summary
- Fixes #102 by moving admin API-key auth out of browser localStorage and into an HttpOnly session cookie.
- Adds double-submit CSRF protection for cookie-authenticated mutating requests.
- Handles the real Cloudflare Pages + Workers topology by requiring explicit cross-site cookie opt-in and an ADMIN_ORIGIN allowlist.
- Keeps Bearer token auth working for SDK/MCP/backward-compatible callers.
- Updates setup/update flows and adds operator documentation.

## Private-first source
This was fixed and verified in the private production source repo first, then synced here:

- private PR: Shudesu/line-harness#61
- private merge commit: 5a4d6ac

## Definition of Done
- [x] API key is no longer stored or read from localStorage
- [x] session credential is stored in an HttpOnly cookie
- [x] CSRF is required for cookie-authenticated POST/PUT/PATCH/DELETE requests
- [x] Bearer auth remains accepted for SDK/MCP callers
- [x] credentialed CORS only echoes allowed origins, plus loopback dev origins
- [x] cross-site Pages/Workers deployments require explicit opt-in
- [x] setup/update flows configure ADMIN_ORIGIN / ADMIN_ALLOW_CROSS_SITE
- [x] docs added in docs/ADMIN-AUTH.md

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter worker exec vitest run src/middleware/admin-auth-config.test.ts src/middleware/auth.test.ts src/middleware/rate-limit.test.ts`
- `corepack pnpm --filter worker typecheck`
- `corepack pnpm --filter web exec tsc --noEmit --incremental false`
- `corepack pnpm --filter worker test`
- `corepack pnpm --filter create-line-harness build`
- `NEXT_PUBLIC_API_URL=http://127.0.0.1:8787 corepack pnpm build`
- `git diff --check`
- `rg` audit confirmed no remaining `lh_api_key` localStorage get/set usage, only cleanup removals

## Rollout notes
- Same-site custom-domain deployments can use the default SameSite=Lax cookie.
- Cross-site Pages/Workers deployments must set ADMIN_ORIGIN and opt in with ADMIN_ALLOW_CROSS_SITE=true, which issues SameSite=None; Secure cookies.
- If third-party cookies are blocked by the browser, use a same-site custom domain for the admin and API.
