### PR TITLE
fix(update): proxy manifest fetch through worker

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",
+    "test": "vitest run --config vitest.config.ts",
     "build": "next build",
     "start": "next start"
   },

--- a/apps/web/src/components/update/update-banner.tsx
+++ b/apps/web/src/components/update/update-banner.tsx
@@ -49,7 +49,7 @@ export function UpdateBanner() {
         }
       } catch (e) {
         // Banner is best-effort: do not break the dashboard if /admin/version
-        // or the GitHub-hosted manifest is unreachable. Phase 9 will add a
+        // or the Worker-hosted manifest proxy is unreachable. Phase 9 will add a
         // visible error chip; for Phase 6 we just stay in `loading` (null).
         console.error('update banner failed', e)
       }

--- a/apps/web/src/lib/update-client.test.ts
+++ b/apps/web/src/lib/update-client.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function loadUpdateClient() {
+  vi.resetModules()
+  return import('./update-client')
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('update-client manifest URL', () => {
+  it('always uses the Worker manifest proxy even when a public GitHub URL is configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://example-worker.workers.dev')
+    vi.stubEnv(
+      'NEXT_PUBLIC_MANIFEST_URL',
+      'https://github.com/Shudesu/line-harness-oss/releases/latest/download/release-manifest.json',
+    )
+
+    const { getManifestUrl } = await loadUpdateClient()
+
+    expect(getManifestUrl()).toBe('https://example-worker.workers.dev/admin/manifest')
+  })
+
+  it('fetches the manifest from the Worker proxy', async () => {
+    vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://example-worker.workers.dev')
+    const manifest = { schema_version: 1, latest: '0.14.1', releases: [] }
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify(manifest)))
+
+    const { getManifest } = await loadUpdateClient()
+
+    await expect(getManifest()).resolves.toEqual(manifest)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example-worker.workers.dev/admin/manifest',
+      { cache: 'no-store' },
+    )
+  })
+})

--- a/apps/web/src/lib/update-client.ts
+++ b/apps/web/src/lib/update-client.ts
@@ -27,8 +27,17 @@ if (!API_URL) {
   )
 }
 
-const MANIFEST_URL =
-  process.env.NEXT_PUBLIC_MANIFEST_URL ?? `${API_URL}/admin/manifest`
+/**
+ * Always fetch the manifest through the Worker proxy.
+ *
+ * GitHub release assets do not reliably include browser CORS headers, so a
+ * public `NEXT_PUBLIC_MANIFEST_URL` pointing at GitHub breaks the dashboard.
+ * Operators can still change the upstream source by setting the Worker's
+ * server-side `MANIFEST_URL`; the browser should only talk to `/admin/manifest`.
+ */
+export function getManifestUrl(): string {
+  return `${API_URL}/admin/manifest`
+}
 
 function adminKey(): string {
   const v = process.env.NEXT_PUBLIC_ADMIN_API_KEY
@@ -54,7 +63,7 @@ export async function getCurrentVersion(): Promise<CurrentVersion> {
 }
 
 export async function getManifest(): Promise<Manifest> {
-  const r = await fetch(MANIFEST_URL, { cache: 'no-store' })
+  const r = await fetch(getManifestUrl(), { cache: 'no-store' })
   if (!r.ok) throw new Error(`manifest fetch failed ${r.status}`)
   return r.json() as Promise<Manifest>
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+})


### PR DESCRIPTION
## Summary
- Fixes #143 by making the admin update client always fetch the release manifest through the Worker proxy at `/admin/manifest`.
- Ignores `NEXT_PUBLIC_MANIFEST_URL` in browser code so a GitHub release asset URL cannot be baked into the static admin bundle and fail on CORS.
- Keeps the trusted upstream manifest override on the server side via the Worker's `MANIFEST_URL`.
- Adds a Web Vitest config/script and a regression test that proves a public GitHub manifest URL still resolves to the Worker proxy.

## Route note
This is an OSS-only exception to the usual private-first sync flow. The private production source repo does not contain the OSS self-update UI/API (`apps/web/src/app/updates`, `apps/web/src/lib/update-client`, `apps/worker/src/routes/admin-update`, or `packages/update-engine`). Importing the OSS updater into private production just to stage this fix would add unrelated production surface area, so this PR keeps the change scoped to the OSS-only feature.

## Definition of Done
- [x] Reproduced root cause from the issue: browser code can fetch the GitHub release manifest directly when `NEXT_PUBLIC_MANIFEST_URL` is set.
- [x] Browser manifest fetch now always goes through `${NEXT_PUBLIC_API_URL}/admin/manifest`.
- [x] Operators can still change the manifest upstream with the Worker-side `MANIFEST_URL`.
- [x] Regression test covers the GitHub URL override case.
- [x] Full build passes even when `NEXT_PUBLIC_MANIFEST_URL` is set to the GitHub release asset URL.

## Verification
- `corepack pnpm --filter web test`
- `corepack pnpm --filter worker exec vitest run src/routes/admin-version.test.ts`
- `corepack pnpm --filter web exec tsc --noEmit --incremental false`
- `corepack pnpm --filter worker typecheck`
- `NEXT_PUBLIC_API_URL=http://127.0.0.1:8787 NEXT_PUBLIC_MANIFEST_URL=https://github.com/Shudesu/line-harness-oss/releases/latest/download/release-manifest.json corepack pnpm build`
- `git diff --check`
- built admin assets do not contain the GitHub `release-manifest.json` URL
