### PR TITLE
chore: prepare 0.15.0 release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "line-oss-crm",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "description": "Open-source LINE Official Account CRM/marketing automation",
   "scripts": {

--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Set up LINE Harness \u2014 AI-operated LINE CRM \u2014 with one command",
   "type": "module",
   "bin": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/mcp-server",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "type": "module",
   "bin": {
     "line-harness-mcp": "./dist/index.js"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/sdk",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "AI-native SDK for LINE Harness — programmatic LINE official account automation",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- bump OSS umbrella packages to 0.15.0 for the next public release
- bump create-line-harness to 0.1.25 for the matching npx installer/update package
- keep SDK and MCP server aligned with the release version expected for npm publication

## Definition of Done
- [x] Root, web, worker, SDK, and MCP package versions are aligned at 0.15.0
- [x] create-line-harness is prepared as 0.1.25
- [x] Release script tests pass
- [x] Admin, Worker, LIFF, SDK, MCP, and CLI builds pass
- [x] npm publish dry-runs pass for SDK, MCP, and create-line-harness

## Verification
- `corepack pnpm test:scripts`
- `corepack pnpm --filter web test`
- `corepack pnpm --filter web exec tsc --noEmit --incremental false`
- `NEXT_PUBLIC_API_URL=http://127.0.0.1:8787 corepack pnpm --filter web build`
- `corepack pnpm --filter worker build`
- `corepack pnpm --filter liff build`
- `corepack pnpm --filter @line-harness/sdk build`
- `corepack pnpm --filter @line-harness/mcp-server build`
- `corepack pnpm --filter create-line-harness build`
- `corepack pnpm publish --dry-run --access public --no-git-checks` in packages/sdk, packages/mcp-server, packages/create-line-harness