### PR TITLE
fix: show admin build fingerprint

### DIFF
--- a/.github/workflows/deploy-cloudflare-admin.yml
+++ b/.github/workflows/deploy-cloudflare-admin.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'apps/web/**'
       - 'packages/shared/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-cloudflare-admin.yml'
 
 jobs:
@@ -26,10 +28,15 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @line-crm/shared build
 
+      - name: Capture build metadata
+        id: build-meta
+        run: echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: Build Admin Panel
         run: pnpm --filter web build
         env:
           NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          APP_BUILD_TIME: ${{ steps.build-meta.outputs.build_time }}
 
       - name: Deploy to Cloudflare Pages
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,11 +75,16 @@ jobs:
       - name: Build shared workspace packages
         run: pnpm --filter @line-crm/shared --filter @line-crm/line-sdk --filter @line-crm/db --filter @line-harness/update-engine build
 
+      - name: Capture build metadata
+        id: build-meta
+        run: echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: Build Admin (Next.js static export)
         # Placeholder URL gets baked into the bundle. End users replace it at
         # install time (Phase 2 will introduce runtime config to avoid this).
         env:
           NEXT_PUBLIC_API_URL: "https://__LH_WORKER_URL__"
+          APP_BUILD_TIME: ${{ steps.build-meta.outputs.build_time }}
         run: pnpm --filter web build
 
       - name: Build LIFF

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,14 +1,32 @@
 import type { NextConfig } from 'next'
+import { execSync } from 'child_process'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 
 const pkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8'))
+const repoRoot = resolve(__dirname, '../..')
+
+function readGitSha(): string | null {
+  try {
+    return execSync('git rev-parse HEAD', { cwd: repoRoot, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim()
+  } catch {
+    return null
+  }
+}
+
+const buildSha =
+  process.env.APP_COMMIT_SHA || process.env.GITHUB_SHA || process.env.CF_PAGES_COMMIT_SHA || readGitSha() || 'local'
+const buildTime = process.env.APP_BUILD_TIME || new Date().toISOString()
 
 const nextConfig: NextConfig = {
   output: 'export',
   transpilePackages: ['@line-crm/shared'],
   env: {
     APP_VERSION: pkg.version,
+    APP_COMMIT_SHA: buildSha.slice(0, 12),
+    APP_BUILD_TIME: buildTime,
   },
 }
 export default nextConfig

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -7,6 +7,11 @@ import { useAccount } from '@/contexts/account-context'
 import type { AccountWithStats } from '@/contexts/account-context'
 import { countryFlag } from '@/lib/country-flag'
 
+const appVersion = process.env.APP_VERSION || '0.0.0'
+const appCommitSha = process.env.APP_COMMIT_SHA || 'local'
+const appBuildTime = process.env.APP_BUILD_TIME || ''
+const appBuildDate = appBuildTime ? appBuildTime.replace('T', ' ').replace(/\.\d{3}Z$/, 'Z') : ''
+
 // ─── メニュー定義（ユーザー目線のカテゴリ） ───
 
 const menuSections = [
@@ -309,7 +314,12 @@ export default function Sidebar() {
           </div>
         )}
         <div className="px-6 py-4 space-y-3">
-        <p className="text-xs text-gray-400">L Harness v{process.env.APP_VERSION || '0.0.0'}</p>
+        <div className="space-y-0.5">
+          <p className="text-xs text-gray-400">L Harness v{appVersion}</p>
+          <p className="text-[10px] text-gray-400 font-mono break-all">
+            build {appCommitSha}{appBuildDate ? ` · ${appBuildDate}` : ''}
+          </p>
+        </div>
         <button
           onClick={async () => {
             try {

--- a/docs/OSS-SYNC-CHARTER.md
+++ b/docs/OSS-SYNC-CHARTER.md
@@ -253,6 +253,10 @@ gh release create v0.13.0 --repo Shudesu/line-harness-oss --title "v0.13.0" --no
 
 `apps/web/next.config.ts` がビルド時に root `package.json` を読み、`APP_VERSION` env として注入する。サイドバーの `LINE Harness v{APP_VERSION}` 表示はこの値を使う。手動の env 上書き不要。
 
+Admin UI はスクリーンショットだけでデプロイ元を判別できるよう、`APP_COMMIT_SHA` (GitHub Actions の `GITHUB_SHA`、またはローカル git SHA) と `APP_BUILD_TIME` もビルド時に埋め込み、サイドバーに `build <sha> · <UTC time>` として表示する。
+
+root version だけを変更した場合にも Admin deploy が走るよう、Admin deploy workflow の path filter には root `package.json` を含める。通常リリースでは version sync で `apps/web/package.json` も更新されるが、path filter 側でも root version を明示的に監視して二重に守る。
+
 ### 7.5 バージョン同期チェック
 
 - `bash scripts/sync-versions.sh` — root → umbrella packages へ伝播 (apply mode)


### PR DESCRIPTION
## Summary
- show the Admin UI build commit and UTC build time in the sidebar below the release version
- inject APP_COMMIT_SHA and APP_BUILD_TIME at Next.js build time
- pass APP_BUILD_TIME through both Cloudflare Admin deploy and release bundle workflows
- include root package.json / pnpm-lock.yaml in the Admin deploy path filter
- document the screenshot fingerprint requirement in the OSS sync charter

## Why
Semver identifies the release, but it does not identify the deployed Admin UI build. Screenshots need a build-level fingerprint so maintainers can tell exactly which commit generated the screen.

## Definition of Done
- [x] Sidebar shows semver plus build SHA/time
- [x] Release workflow bundles receive the same build metadata
- [x] Root version-only changes can trigger Admin deploy workflows
- [x] Charter documents the requirement

## Verification
- `corepack pnpm --filter web exec tsc --noEmit --incremental false`
- `GITHUB_SHA=abcdef1234567890abcdef1234567890abcdef12 APP_BUILD_TIME=2026-06-07T05:45:00Z NEXT_PUBLIC_API_URL=http://127.0.0.1:8787 corepack pnpm --filter web build`
- Verified generated bundle contains `L Harness v0.15.0`, `build abcdef123456`, and `2026-06-07 05:45:00Z`
- `git diff --check`