### PR TITLE
fix(create-line-harness): make setup deploy robust from existing checkouts & non-default branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ apps/web/out/
 apps/worker/dist/
 .worktrees/
 .claude/worktrees/
+
+# LINE Harness setup/state files — contain real channel tokens & API keys
+.line-harness-setup.json
+.line-harness-config.json

--- a/packages/create-line-harness/src/steps/clone-repo.ts
+++ b/packages/create-line-harness/src/steps/clone-repo.ts
@@ -16,17 +16,44 @@ const REPO_URL =
   "https://github.com/Shudesu/line-harness-oss.git";
 
 /**
+ * Make sure workspace dependencies are installed.
+ *
+ * The build step (`deployWorker`) relies on workspace binaries such as `tsc`
+ * and `tsup`, which only exist once `pnpm install` has populated
+ * `node_modules`. Resolving the repo from an existing checkout (`--repo-dir`,
+ * cwd, or `~/.line-harness`) used to skip the install entirely, so a checkout
+ * without `node_modules` would fail the build with "tsc: command not found".
+ */
+async function ensureDependencies(repoDir: string): Promise<void> {
+  if (existsSync(join(repoDir, "node_modules"))) {
+    return;
+  }
+
+  const s = p.spinner();
+  s.start("依存関係インストール中...");
+  try {
+    await repoPnpm(repoDir, ["install", "--frozen-lockfile"], { cwd: repoDir });
+  } catch {
+    // Lockfile may be out of sync — fall back to a normal install.
+    await repoPnpm(repoDir, ["install"], { cwd: repoDir });
+  }
+  s.stop("依存関係インストール完了");
+}
+
+/**
  * Clone the LINE Harness repo and install dependencies.
  * Returns the path to the cloned repo.
  */
 export async function ensureRepo(repoDir: string | null): Promise<string> {
   // If --repo-dir was given and has the repo, use it
   if (repoDir && existsSync(join(repoDir, "pnpm-workspace.yaml"))) {
+    await ensureDependencies(repoDir);
     return repoDir;
   }
 
   // Check if cwd is the repo
   if (existsSync(join(process.cwd(), "pnpm-workspace.yaml"))) {
+    await ensureDependencies(process.cwd());
     return process.cwd();
   }
 
@@ -84,6 +111,7 @@ export async function ensureRepo(repoDir: string | null): Promise<string> {
         // Non-critical — the next setup run will regenerate it again.
       }
     }
+    await ensureDependencies(homeDir);
     return homeDir;
   }
 
@@ -102,16 +130,7 @@ export async function ensureRepo(repoDir: string | null): Promise<string> {
   s.stop("ダウンロード完了");
 
   // Install dependencies
-  s.start("依存関係インストール中...");
-  try {
-    await repoPnpm(homeDir, ["install", "--frozen-lockfile"], {
-      cwd: homeDir,
-    });
-  } catch {
-    // Try without frozen lockfile
-    await repoPnpm(homeDir, ["install"], { cwd: homeDir });
-  }
-  s.stop("依存関係インストール完了");
+  await ensureDependencies(homeDir);
 
   return homeDir;
 }

--- a/packages/create-line-harness/src/steps/deploy-admin.ts
+++ b/packages/create-line-harness/src/steps/deploy-admin.ts
@@ -61,11 +61,26 @@ export async function deployAdmin(
   }
   projectSpinner.stop("Pages プロジェクト準備完了");
 
-  // Deploy to CF Pages — hand TTY over to wrangler
+  // Deploy to CF Pages — hand TTY over to wrangler.
+  //
+  // Pin `--branch main` to match the project's production branch (set above).
+  // Without it, wrangler infers the branch from git; deploying from any other
+  // branch (e.g. a `feat/*` worktree) creates a *preview* deployment that maps
+  // to `<branch>.<project>.pages.dev`, leaving the canonical
+  // `<project>.pages.dev` showing "Nothing is here yet".
   p.log.info("Admin UI をデプロイしています（wrangler の出力が表示されます）...");
   try {
     await wrangler(
-      ["pages", "deploy", "out", "--project-name", options.projectName, "--commit-dirty=true"],
+      [
+        "pages",
+        "deploy",
+        "out",
+        "--project-name",
+        options.projectName,
+        "--branch",
+        "main",
+        "--commit-dirty=true",
+      ],
       { cwd: webDir, tty: true },
     );
 


### PR DESCRIPTION
## Summary

Three small robustness fixes to the `create-line-harness` setup/deploy flow, found while running `setup` from an existing checkout on a non-default git branch (a git worktree). Each failure happened *after* dependencies/credentials were already configured, so they were easy to hit late in a deploy.

### 1. Install workspace deps when resolving an existing checkout (`clone-repo.ts`)
`ensureRepo()` only ran `pnpm install` on the fresh-clone path. When the repo was resolved from an existing checkout (`--repo-dir`, cwd, or `~/.line-harness`), the install was skipped, so a checkout without `node_modules` failed the Worker build with:

```
sh: tsc: command not found
sh: tsup: command not found
WARN Local package.json exists, but node_modules missing
```

Added `ensureDependencies()` (install-if-missing) and call it on every `ensureRepo()` return path, honoring the function's "…and install dependencies" contract.

### 2. Deploy admin to the production branch (`deploy-admin.ts`)
`wrangler pages deploy` was called without `--branch`, so wrangler inferred the branch from git. Deploying from any non-production branch (e.g. a `feat/*` worktree) produced a **preview** deployment mapped to `<branch>.<project>.pages.dev`, leaving the canonical `<project>.pages.dev` showing "Nothing is here yet".

Pinned `--branch main` to match the project's `--production-branch main` so the admin always lands on the canonical domain regardless of local git branch.

### 3. gitignore setup/state files (`.gitignore`)
`.line-harness-setup.json` / `.line-harness-config.json` are written by the setup CLI to resume runs and hold **real channel access tokens, channel secrets, and the worker API key**. Since setup commonly runs from a clone of this repo, these land in the working tree — ignore them so they can never be committed.

## Verification
- `pnpm --filter ./packages/create-line-harness exec tsc --noEmit` passes
- Re-ran the previously-failing build command end-to-end; build succeeds
- Confirmed admin now serves on the canonical `*.pages.dev` after the `--branch main` fix (HTTP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)