### PR TITLE
CORS/cookieの設定修正と、ローカルソースからsandboxでデプロイするdeploy-local-sandboxスクリプト追加

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { setCsrfToken, setSessionApiKey } from '@/lib/api'
 
 export default function LoginPage() {
   const [apiKey, setApiKey] = useState('')
@@ -31,6 +32,7 @@ export default function LoginPage() {
 
       if (res.ok) {
         localStorage.removeItem('lh_api_key')
+        setSessionApiKey(apiKey)
         try {
           const loginData = await res.json()
           if (loginData.success && loginData.data) {
@@ -39,7 +41,7 @@ export default function LoginPage() {
           }
           // Cache the CSRF token for mutating requests (double-submit).
           if (loginData.csrfToken) {
-            localStorage.setItem('lh_csrf', loginData.csrfToken)
+            setCsrfToken(loginData.csrfToken)
           }
         } catch {
           // Profile / CSRF caching is best-effort.

--- a/apps/web/src/components/auth-guard.tsx
+++ b/apps/web/src/components/auth-guard.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
+import { getSessionApiKey, setCsrfToken } from '@/lib/api'
 
 export default function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter()
@@ -21,13 +22,20 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
       try {
         localStorage.removeItem('lh_api_key')
         const apiUrl = process.env.NEXT_PUBLIC_API_URL
-        const res = await fetch(`${apiUrl}/api/auth/session`, { credentials: 'include' })
+        let res = await fetch(`${apiUrl}/api/auth/session`, { credentials: 'include' })
+        const apiKey = getSessionApiKey()
+        if (!res.ok && apiKey) {
+          res = await fetch(`${apiUrl}/api/auth/session`, {
+            credentials: 'include',
+            headers: { Authorization: `Bearer ${apiKey}` },
+          })
+        }
         if (!res.ok) throw new Error('unauthenticated')
         const data = await res.json()
         if (!data?.success || !data?.data) throw new Error('unauthenticated')
         if (data.data.name) localStorage.setItem('lh_staff_name', data.data.name)
         if (data.data.role) localStorage.setItem('lh_staff_role', data.data.role)
-        if (data.csrfToken) localStorage.setItem('lh_csrf', data.csrfToken)
+        if (data.csrfToken) setCsrfToken(data.csrfToken)
         if (!cancelled) setChecked(true)
       } catch {
         if (!cancelled) router.replace('/login')

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation'
 import { useAccount } from '@/contexts/account-context'
 import type { AccountWithStats } from '@/contexts/account-context'
 import { countryFlag } from '@/lib/country-flag'
+import { clearSessionApiKey } from '@/lib/api'
 
 const appVersion = process.env.APP_VERSION || '0.0.0'
 const appCommitSha = process.env.APP_COMMIT_SHA || 'local'
@@ -337,6 +338,7 @@ export default function Sidebar() {
             localStorage.removeItem('lh_csrf')
             localStorage.removeItem('lh_staff_name')
             localStorage.removeItem('lh_staff_role')
+            clearSessionApiKey()
             window.location.href = '/login'
           }}
           className="flex items-center gap-2 text-xs text-gray-400 hover:text-red-500 transition-colors"

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -71,6 +71,7 @@ if (!API_URL) {
  * cached here.
  */
 export const CSRF_STORAGE_KEY = 'lh_csrf'
+export const SESSION_API_KEY_STORAGE_KEY = 'lh_session_api_key'
 
 export function getCsrfToken(): string {
   if (typeof window === 'undefined') return ''
@@ -82,6 +83,21 @@ export function setCsrfToken(token: string | undefined | null): void {
   localStorage.setItem(CSRF_STORAGE_KEY, token)
 }
 
+export function getSessionApiKey(): string {
+  if (typeof window === 'undefined') return ''
+  return sessionStorage.getItem(SESSION_API_KEY_STORAGE_KEY) || ''
+}
+
+export function setSessionApiKey(token: string | undefined | null): void {
+  if (typeof window === 'undefined' || !token) return
+  sessionStorage.setItem(SESSION_API_KEY_STORAGE_KEY, token)
+}
+
+export function clearSessionApiKey(): void {
+  if (typeof window === 'undefined') return
+  sessionStorage.removeItem(SESSION_API_KEY_STORAGE_KEY)
+}
+
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
 export async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
@@ -91,12 +107,17 @@ export async function fetchApi<T>(path: string, options?: RequestInit): Promise<
     const token = getCsrfToken()
     if (token) csrfHeaders['X-CSRF-Token'] = token
   }
+  const apiKey = getSessionApiKey()
+  const authHeaders: Record<string, string> = apiKey
+    ? { Authorization: `Bearer ${apiKey}` }
+    : {}
   const res = await fetch(`${API_URL}${path}`, {
     ...options,
     // Send the HttpOnly session cookie with every request.
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
+      ...authHeaders,
       ...csrfHeaders,
       ...options?.headers,
     },

--- a/packages/create-line-harness/src/lib/installed-wrangler.ts
+++ b/packages/create-line-harness/src/lib/installed-wrangler.ts
@@ -134,5 +134,8 @@ WORKER_PUBLIC_URL = "${config.workerPublicUrl}"
 ADMIN_PUBLIC_URL = "${config.adminPublicUrl}"
 LIFF_PUBLIC_URL = "${config.liffPublicUrl}"
 CF_ACCOUNT_ID = "${config.accountId}"
+WORKER_URL = "${config.workerPublicUrl}"
+ADMIN_ORIGIN = "${config.adminPublicUrl}"
+ADMIN_ALLOW_CROSS_SITE = "true"
 `;
 }

--- a/scripts/deploy-local-sandbox
+++ b/scripts/deploy-local-sandbox
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/deploy-local-sandbox [options] [-- create-line-harness args...]
+
+Options:
+  --name NAME              Sandbox name (default: local)
+  --root PATH              Persistent sandbox root (default: ./.sandboxes/local)
+  --reset                  Delete the sandbox root before copying local source
+  --no-reuse-wrangler-auth Do not copy the current user's wrangler auth
+  -h, --help               Show this help
+
+Examples:
+  scripts/deploy-local-sandbox \
+    --name aitenposhukyaku-local \
+    --root /Users/taroken/client-harnesses/client-settings/aitenposhukyaku/line-harness-local
+
+What this does:
+  1. Copies the current checkout, including uncommitted source edits, into
+     <root>/local-source.
+  2. Runs inside the LINE Harness sandbox environment.
+  3. Installs dependencies in the copied source.
+  4. Builds local workspace packages required by create-line-harness.
+  5. Runs the built local CLI with --repo-dir <root>/local-source.
+
+This avoids npm's create-line-harness@latest and deploys from local source.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SANDBOX_NAME="local"
+SANDBOX_ROOT="$REPO_ROOT/.sandboxes/local"
+RESET_SANDBOX=0
+REUSE_WRANGLER_AUTH=1
+CLI_ARGS=()
+HAS_CLI_ARGS=0
+
+while (($# > 0)); do
+  case "$1" in
+    --name)
+      shift
+      (($# > 0)) || die "--name requires a value"
+      SANDBOX_NAME="$1"
+      ;;
+    --root)
+      shift
+      (($# > 0)) || die "--root requires a value"
+      SANDBOX_ROOT="$1"
+      ;;
+    --reset)
+      RESET_SANDBOX=1
+      ;;
+    --no-reuse-wrangler-auth)
+      REUSE_WRANGLER_AUTH=0
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      CLI_ARGS=("$@")
+      HAS_CLI_ARGS=1
+      break
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+  shift
+done
+
+SANDBOX_ROOT="${SANDBOX_ROOT%/}"
+LOCAL_SOURCE="$SANDBOX_ROOT/local-source"
+
+if (( RESET_SANDBOX )); then
+  echo "Resetting sandbox root: $SANDBOX_ROOT"
+  rm -rf "$SANDBOX_ROOT"
+fi
+
+mkdir -p "$LOCAL_SOURCE"
+
+echo "Copying local source to: $LOCAL_SOURCE"
+rsync -a --delete \
+  --exclude ".git" \
+  --exclude ".line-harness-config.json" \
+  --exclude ".line-harness-setup.json" \
+  --exclude "node_modules" \
+  --exclude ".sandboxes" \
+  --exclude "apps/web/out" \
+  --exclude "apps/worker/dist" \
+  --exclude "packages/*/dist" \
+  --exclude ".next" \
+  --exclude ".wrangler" \
+  "$REPO_ROOT/" \
+  "$LOCAL_SOURCE/"
+
+SANDBOX_ARGS=(
+  "--name" "$SANDBOX_NAME"
+  "--root" "$SANDBOX_ROOT"
+)
+
+if (( REUSE_WRANGLER_AUTH )); then
+  SANDBOX_ARGS+=("--reuse-wrangler-auth")
+fi
+
+echo "Starting local-source create-line-harness inside sandbox."
+echo "  sandbox root: $SANDBOX_ROOT"
+echo "  local source : $LOCAL_SOURCE"
+
+run_local_cli() {
+  "$SCRIPT_DIR/run-create-line-harness-sandbox.sh" \
+    "${SANDBOX_ARGS[@]}" \
+    -- bash -lc '
+    set -euo pipefail
+
+    SRC="$LINE_HARNESS_SANDBOX_ROOT/local-source"
+
+    echo "Installing dependencies in $SRC"
+    npx -y pnpm@9.15.4 --dir "$SRC" install --frozen-lockfile
+
+    echo "Building local workspace packages"
+    npx -y pnpm@9.15.4 --dir "$SRC" \
+      --filter @line-crm/shared \
+      --filter @line-crm/line-sdk \
+      --filter @line-harness/update-engine \
+      build
+
+    echo "Building local create-line-harness CLI"
+    npx -y pnpm@9.15.4 --dir "$SRC" --filter create-line-harness build
+
+    echo "Running local create-line-harness CLI"
+    node "$SRC/packages/create-line-harness/dist/index.js" --repo-dir "$SRC" "$@"
+  ' bash "$@"
+}
+
+if (( HAS_CLI_ARGS )); then
+  run_local_cli "${CLI_ARGS[@]}"
+else
+  run_local_cli
+fi

--- a/scripts/installed-wrangler.test.ts
+++ b/scripts/installed-wrangler.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+import { renderInstalledWranglerToml } from '../packages/create-line-harness/src/lib/installed-wrangler';
+
+describe('renderInstalledWranglerToml', () => {
+  test('persists admin CORS and cookie topology vars', () => {
+    const toml = renderInstalledWranglerToml({
+      workerName: 'line-harness-2',
+      accountId: 'account-id',
+      d1DatabaseName: 'line-harness-2',
+      d1DatabaseId: 'database-id',
+      r2BucketName: 'line-harness-2-images',
+      workerPublicUrl: 'https://line-harness-2.example.workers.dev',
+      adminPagesProject: 'line-harness-2-admin',
+      adminPublicUrl: 'https://line-harness-2-admin.pages.dev',
+      liffPagesProject: 'line-harness-2-liff',
+      liffPublicUrl: 'https://line-harness-2.example.workers.dev',
+      manifestUrl: 'https://example.com/release-manifest.json',
+    });
+
+    expect(toml).toContain('WORKER_URL = "https://line-harness-2.example.workers.dev"');
+    expect(toml).toContain('ADMIN_ORIGIN = "https://line-harness-2-admin.pages.dev"');
+    expect(toml).toContain('ADMIN_ALLOW_CROSS_SITE = "true"');
+  });
+});


### PR DESCRIPTION
変更は大きく3つです。create-line-harness が生成する Worker 設定に CORS/
  cookie 用 vars を残す修正、pages.dev と workers.dev 間で cookie が効かない場合の管理画面 fallback、npm
  publish なしでローカル修正版 CLI を sandbox 実行するスクリプト追加です。

  1. Worker 設定に CORS/cookie vars を永続化

  packages/create-line-harness/src/lib/installed-wrangler.ts:137

  WORKER_URL = "${config.workerPublicUrl}"
  ADMIN_ORIGIN = "${config.adminPublicUrl}"
  ADMIN_ALLOW_CROSS_SITE = "true"

  目的: wrangler.toml の [vars] に管理画面 origin と Worker URL を残し、再デプロイ後も Access-Control-Allow-
  Origin が出るようにするためです。

  回帰テスト:
  scripts/installed-wrangler.test.ts:1

  expect(toml).toContain('WORKER_URL = "https://line-harness-2.example.workers.dev"');
  expect(toml).toContain('ADMIN_ORIGIN = "https://line-harness-2-admin.pages.dev"');
  expect(toml).toContain('ADMIN_ALLOW_CROSS_SITE = "true"');

  2. 管理画面の Bearer fallback（要判断）

  apps/web/src/lib/api.ts:71

  export const SESSION_API_KEY_STORAGE_KEY = 'lh_session_api_key'

  同ファイルで sessionStorage の API key を読み、API 呼び出しに Bearer を付けます。

  const apiKey = getSessionApiKey()
  const authHeaders: Record<string, string> = apiKey
    ? { Authorization: `Bearer ${apiKey}` }
    : {}

  apps/web/src/app/login/page.tsx:32

  setSessionApiKey(apiKey)

  目的: pages.dev から workers.dev への cross-site cookie がブラウザで保存・送信されない場合でも、同じタブ内
  ではログイン状態を確認できるようにするためです。

  apps/web/src/components/auth-guard.tsx:22

  let res = await fetch(`${apiUrl}/api/auth/session`, { credentials: 'include' })
  const apiKey = getSessionApiKey()
  if (!res.ok && apiKey) {
    res = await fetch(`${apiUrl}/api/auth/session`, {
      credentials: 'include',
      headers: { Authorization: `Bearer ${apiKey}` },
    })
  }

  apps/web/src/components/layout/sidebar.tsx:338

  clearSessionApiKey()

sessionStorageとはいえ、API Keyを保存すべきかどうかはセキュリティに関わるので判断すべきかと思います。
fallbackが不要なら、削除ください。

  3. ローカル修正版 CLI を sandbox で使うスクリプト

  scripts/deploy-local-sandbox:1

  主な処理:

  rsync -a --delete \
    --exclude ".git" \
    --exclude ".line-harness-config.json" \
    --exclude ".line-harness-setup.json" \
    ...
    "$REPO_ROOT/" \
    "$LOCAL_SOURCE/"

  ローカル checkout を sandbox root の local-source にコピーします。

  npx -y pnpm@9.15.4 --dir "$SRC" install --frozen-lockfile
  npx -y pnpm@9.15.4 --dir "$SRC" \
    --filter @line-crm/shared \
    --filter @line-crm/line-sdk \
    --filter @line-harness/update-engine \
    build
  npx -y pnpm@9.15.4 --dir "$SRC" --filter create-line-harness build
  node "$SRC/packages/create-line-harness/dist/index.js" --repo-dir "$SRC" "$@"
  
  よろしくお願いいたします。