### PR TITLE
fix(liff): open-redirect guard on /auth/line ?redirect=

### DIFF
--- a/apps/worker/src/client/main.ts
+++ b/apps/worker/src/client/main.ts
@@ -17,6 +17,7 @@
 
 import { initBooking } from './booking.js';
 import { initForm } from './form.js';
+import { safeRedirectTarget } from '../lib/safe-redirect.js';
 
 declare const liff: {
   init(config: { liffId: string }): Promise<void>;
@@ -63,7 +64,11 @@ function getPage(): string | null {
 
 function getRedirectUrl(): string | null {
   const params = new URLSearchParams(window.location.search);
-  return params.get('redirect');
+  // Guard the client-side navigation sink (window.location.href below) against
+  // open-redirect / javascript: abuse, mirroring the server-side /auth/callback
+  // guard. A directly-crafted LIFF URL never reaches the server route, so the
+  // client must validate too.
+  return safeRedirectTarget(params.get('redirect'));
 }
 
 function getRef(): string | null {

--- a/apps/worker/src/lib/safe-redirect.test.ts
+++ b/apps/worker/src/lib/safe-redirect.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { safeRedirectTarget } from './safe-redirect';
+
+describe('safeRedirectTarget', () => {
+  it('allows http(s) absolute URLs (tracked-link / marketing destinations are intentional)', () => {
+    expect(safeRedirectTarget('https://example.com/lp')).toBe('https://example.com/lp');
+    expect(safeRedirectTarget('http://example.com')).toBe('http://example.com');
+  });
+
+  it('allows root-relative paths', () => {
+    expect(safeRedirectTarget('/thanks')).toBe('/thanks');
+    expect(safeRedirectTarget('/r/abc?x=1')).toBe('/r/abc?x=1');
+  });
+
+  it('allows non-dangerous app/deep-link schemes (funnels must not break)', () => {
+    expect(safeRedirectTarget('line://ti/p/@abc')).toBe('line://ti/p/@abc');
+    expect(safeRedirectTarget('tel:08012345678')).toBe('tel:08012345678');
+    expect(safeRedirectTarget('mailto:hi@example.com')).toBe('mailto:hi@example.com');
+    expect(safeRedirectTarget('myapp://open/path')).toBe('myapp://open/path');
+  });
+
+  it('rejects dangerous schemes', () => {
+    expect(safeRedirectTarget('javascript:alert(1)')).toBeNull();
+    expect(safeRedirectTarget('data:text/html,<script>alert(1)</script>')).toBeNull();
+    expect(safeRedirectTarget('vbscript:msgbox(1)')).toBeNull();
+    expect(safeRedirectTarget('file:///etc/passwd')).toBeNull();
+  });
+
+  it('rejects protocol-relative URLs (ambiguous scheme)', () => {
+    expect(safeRedirectTarget('//evil.com')).toBeNull();
+    expect(safeRedirectTarget('//evil.com/path')).toBeNull();
+  });
+
+  it('rejects backslash protocol-relative bypass (browsers normalize \\ to /)', () => {
+    expect(safeRedirectTarget('/\\evil.com')).toBeNull();
+    expect(safeRedirectTarget('/\\/evil.com')).toBeNull();
+    expect(safeRedirectTarget('\\\\evil.com')).toBeNull();
+  });
+
+  it('rejects targets containing control characters', () => {
+    expect(safeRedirectTarget('/path\nSet-Cookie: x')).toBeNull();
+    expect(safeRedirectTarget('/foo\tbar')).toBeNull();
+    expect(safeRedirectTarget('https://example.com/\r\nevil')).toBeNull();
+  });
+
+  it('rejects empty / malformed input', () => {
+    expect(safeRedirectTarget('')).toBeNull();
+    expect(safeRedirectTarget('not a url')).toBeNull();
+    expect(safeRedirectTarget('   ')).toBeNull();
+  });
+
+  it('tolerates leading/trailing whitespace around an otherwise valid target', () => {
+    expect(safeRedirectTarget('  https://example.com  ')).toBe('https://example.com');
+  });
+});

--- a/apps/worker/src/lib/safe-redirect.ts
+++ b/apps/worker/src/lib/safe-redirect.ts
@@ -1,0 +1,60 @@
+/**
+ * URL schemes that can execute script / load attacker content when handed to
+ * `c.redirect()` (Location) or `window.location.href`. These are the only
+ * schemes this guard blocks.
+ */
+const DANGEROUS_SCHEMES = new Set(['javascript:', 'data:', 'vbscript:', 'file:']);
+
+/**
+ * Validate a user-supplied post-OAuth redirect target.
+ *
+ * The `?redirect=` param on /auth/line (and the /api/links/wrap proxy) is an
+ * intentional feature: businesses send users to their own marketing/LP
+ * destinations — and app/deep-link schemes like `line://`, `tel:`, `mailto:` —
+ * after the friend-add funnel. To avoid breaking those funnels this guard is a
+ * *denylist*, not an allowlist: it accepts http(s), root-relative paths, and
+ * any non-dangerous scheme, and only rejects the things that are never a
+ * legitimate redirect target:
+ *   - script/content schemes (javascript:, data:, vbscript:, file:) — XSS,
+ *   - protocol-relative `//host` (incl. the `/\host` / `\\host` backslash
+ *     variants browsers normalize to `//`) — scheme confusion,
+ *   - control characters — header-splitting / bypass tricks,
+ *   - and anything that is neither an absolute URL nor a root-relative path.
+ *
+ * Used on both redirect sinks: the server-side /auth/callback redirect and the
+ * client-side LIFF navigation (apps/worker/src/client/main.ts).
+ *
+ * @returns the trimmed redirect string when safe, or null when the caller
+ *          should fall back to the default completion screen.
+ */
+export function safeRedirectTarget(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const value = raw.trim();
+  if (!value) return null;
+
+  // Control characters (incl. CR/LF/TAB, code point < 0x20 or DEL 0x7f) enable
+  // header-splitting / bypass tricks — never legitimate in a redirect target.
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x20 || code === 0x7f) return null;
+  }
+
+  // Protocol-relative forms (`//host`, and the `/\`, `\\`, `\/` backslash
+  // variants browsers normalize to `//`) — reject before the relative-path
+  // branch below.
+  if (/^[/\\][/\\]/.test(value)) return null;
+
+  // Root-relative path (single leading slash) — same-origin, always safe.
+  if (value.startsWith('/')) return value;
+
+  // Absolute URL: accept any scheme except the dangerous ones. A value that is
+  // neither root-relative nor a parseable absolute URL (e.g. "not a url",
+  // bare "evil.com") is rejected rather than guessed.
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  return DANGEROUS_SCHEMES.has(url.protocol.toLowerCase()) ? null : value;
+}

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -20,6 +20,7 @@ import {
   jstNow,
 } from '@line-crm/db';
 import { buildIntroMessage } from '../services/intro-message.js';
+import { safeRedirectTarget } from '../lib/safe-redirect.js';
 import type { Env } from '../index.js';
 
 const liffRoutes = new Hono<Env>();
@@ -941,9 +942,12 @@ liffRoutes.get('/auth/callback', async (c) => {
       console.error('OAuth scenario enrollment error:', err);
     }
 
-    // Redirect or show completion
-    if (redirect) {
-      return c.redirect(redirect);
+    // Redirect or show completion. Guard against open-redirect abuse: external
+    // marketing/LP and app/deep-link redirects stay allowed (intentional
+    // feature); javascript:/data:/protocol-relative targets are rejected.
+    const safeRedirect = safeRedirectTarget(redirect);
+    if (safeRedirect) {
+      return c.redirect(safeRedirect);
     }
 
     // Send form link as LINE message if form param was passed


### PR DESCRIPTION
## Summary

The `?redirect=` param on `/auth/line` (and the `/api/links/wrap` proxy) was passed to `c.redirect()` and the client-side `window.location.href` without validation. A crafted Worker URL could carry `javascript:` / `data:` / protocol-relative targets — an XSS / scheme-confusion vector inherited by every fork.

Redirecting to external marketing/LP and app/deep-link destinations after the friend-add funnel is an **intentional feature**, so this uses a **denylist**, not an allowlist:

- ✅ allow: `http(s)`, root-relative paths, and any non-dangerous scheme (`line://`, `tel:`, `mailto:`, custom app schemes)
- ❌ reject: `javascript:` / `data:` / `vbscript:` / `file:`, protocol-relative `//host` (incl. `/\host`, `\\host` backslash variants browsers normalize to `//`), and control characters

When a target is rejected the flow falls back to the completion screen (graceful — the user is still added as a friend).

## Changes

- `apps/worker/src/lib/safe-redirect.ts` — new `safeRedirectTarget()` + 9 unit tests
- `apps/worker/src/routes/liff.ts` — guard the server `/auth/callback` redirect sink
- `apps/worker/src/client/main.ts` — guard the client LIFF navigation sink (a directly-crafted LIFF URL never reaches the server route)

## Verification

- `safe-redirect.test.ts`: 9/9 pass (external-URL/deep-link allowed, dangerous schemes + protocol-relative + control chars rejected)
- Touched files typecheck clean
- Reviewed with 3 rounds of independent review; equivalent change is already deployed in the upstream private repo

## Note on unrelated CI failures

This branch's Vite build error (`@line-harness/update-engine` resolution) and the `src/routes/admin-update.test.ts` / `src/not-found.test.ts` failures are **pre-existing on `main`** (verified by stashing this change), not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)