### PR TITLE
fix(ci): build update-engine before worker in deploy workflow

### DIFF
--- a/.github/workflows/deploy-cloudflare-worker.yml
+++ b/.github/workflows/deploy-cloudflare-worker.yml
@@ -27,7 +27,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @line-crm/shared --filter @line-crm/line-sdk --filter @line-crm/db build
+      - run: pnpm --filter @line-crm/shared --filter @line-crm/line-sdk --filter @line-crm/db --filter @line-harness/update-engine build
 
       - name: Run pending D1 migrations
         env:


### PR DESCRIPTION
## Problem

`deploy-cloudflare-worker.yml` builds only `@line-crm/shared`, `@line-crm/line-sdk`, `@line-crm/db` before running `pnpm --filter worker build`. But the worker imports `@line-harness/update-engine` (`apps/worker/src/routes/admin-update.ts`).

`pnpm --filter worker build` does **not** build the package's workspace dependencies, so `@line-harness/update-engine`'s `dist/` is never produced and the worker's Vite build fails:

```
[commonjs--resolver] Failed to resolve entry for package "@line-harness/update-engine".
```

This breaks the deploy.

## Fix

Add `--filter @line-harness/update-engine` to the dependency-build step, matching what `worker-ci.yml` and `release.yml` already do.

## Notes

- The standard `pnpm install && pnpm -r build` is unaffected (pnpm builds workspace deps in topological order because the worker declares `@line-harness/update-engine: workspace:*`). Only the deploy workflow's explicit-filter build was missing it.
- Verified locally: after `pnpm --filter @line-harness/update-engine build`, the worker typecheck, `vite build`, and full test suite (45 files / 511 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)