### PR TITLE
feat(ci): bake admin CORS vars into deploy config (survive redeploys)

### DIFF
--- a/.github/workflows/deploy-cloudflare-worker.yml
+++ b/.github/workflows/deploy-cloudflare-worker.yml
@@ -70,6 +70,14 @@ jobs:
           D1_DATABASE_NAME: ${{ secrets.D1_DATABASE_NAME }}
           D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
           WORKER_NAME: ${{ vars.WORKER_NAME || 'your-worker-name' }}
+          # Admin CORS config — set these as repo Variables when the admin panel
+          # and the Worker API are on different origins (e.g. *.pages.dev admin
+          # + *.workers.dev API). Baking them into the deployed config (vars)
+          # means every deploy carries them, so they can't be silently dropped
+          # the way a manually-set dashboard variable is on redeploy.
+          ADMIN_ORIGIN: ${{ vars.ADMIN_ORIGIN }}
+          ADMIN_ALLOW_CROSS_SITE: ${{ vars.ADMIN_ALLOW_CROSS_SITE }}
+          WORKER_URL: ${{ vars.WORKER_URL }}
         run: |
           test -n "$D1_DATABASE_ID"
           cd apps/worker
@@ -78,6 +86,18 @@ jobs:
             -e "s|\"database_name\":\"[^\"]*\"|\"database_name\":\"${D1_DATABASE_NAME}\"|g" \
             -e "s|\"database_id\":\"[^\"]*\"|\"database_id\":\"${D1_DATABASE_ID}\"|g" \
             dist/line_harness/wrangler.json
+          # Inject admin CORS vars into the deployed config when ADMIN_ORIGIN is
+          # set. ADMIN_ALLOW_CROSS_SITE defaults to "true" (SameSite=None; Secure
+          # cookies) since cross-origin admin/API is the case that needs it.
+          if [ -n "$ADMIN_ORIGIN" ]; then
+            tmp="$(mktemp)"
+            jq --arg o "$ADMIN_ORIGIN" --arg x "$ADMIN_ALLOW_CROSS_SITE" --arg w "$WORKER_URL" '
+              .vars.ADMIN_ORIGIN = $o
+              | .vars.ADMIN_ALLOW_CROSS_SITE = (if $x == "" then "true" else $x end)
+              | (if $w != "" then .vars.WORKER_URL = $w else . end)
+            ' dist/line_harness/wrangler.json > "$tmp" && mv "$tmp" dist/line_harness/wrangler.json
+            echo "Patched admin CORS vars: ADMIN_ORIGIN=$ADMIN_ORIGIN ADMIN_ALLOW_CROSS_SITE=${ADMIN_ALLOW_CROSS_SITE:-true}"
+          fi
 
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3

--- a/docs/ADMIN-AUTH.md
+++ b/docs/ADMIN-AUTH.md
@@ -67,6 +67,27 @@ one registrable domain — e.g. `admin.example.com` (Pages custom domain) and
 and leave `ADMIN_ALLOW_CROSS_SITE` unset; cookies use `SameSite=Lax` and no
 third-party-cookie restrictions apply.
 
+### Setting these in the fork + GitHub Actions flow
+
+Set them as **repository Variables** (Settings → Secrets and variables →
+Actions → Variables), the same place you set `WORKER_NAME` / `VITE_LIFF_ID`:
+
+| Variable | Value |
+|----------|-------|
+| `ADMIN_ORIGIN` | `https://<admin>.pages.dev` (or your admin custom domain) |
+| `ADMIN_ALLOW_CROSS_SITE` | `true` for the cross-site Pages↔Workers default; omit for same-site |
+| `WORKER_URL` | `https://<worker>.workers.dev` (your Worker's public URL) |
+
+`deploy-cloudflare-worker.yml` bakes these into the deployed Worker config on
+every deploy, so they survive redeploys.
+
+> 🚫 **Do not** add these by hand as plain Worker variables in the Cloudflare
+> dashboard. A `wrangler deploy` from config that doesn't include them will
+> drop them, and the admin login breaks with a CORS error
+> (`No 'Access-Control-Allow-Origin' header`). Use repo Variables (above) so
+> they are part of the deployed config — or, for an existing install, set them
+> as Worker **secrets** (`wrangler secret bulk`), which persist across deploys.
+
 ### Topology guard
 
 If the admin is cross-site to the API but `SameSite` is not `None` (e.g. the old


### PR DESCRIPTION
## Why

Fork users who deploy via GitHub Actions never run the interactive `create-line-harness` admin-auth step, so the Worker ends up without `ADMIN_ORIGIN` / `ADMIN_ALLOW_CROSS_SITE` / `WORKER_URL`. Setting them by hand as Cloudflare **dashboard variables** is fragile — a `wrangler deploy` from config that doesn't include them silently drops them, and admin login breaks with:

```
Access to fetch ... blocked by CORS policy: No 'Access-Control-Allow-Origin' header
```

This is the exact failure mode reported in #161, and we hit it in production.

## What

- `deploy-cloudflare-worker.yml`: in the *Patch wrangler config* step, inject `ADMIN_ORIGIN` / `ADMIN_ALLOW_CROSS_SITE` / `WORKER_URL` (from repo **Variables**) into the deployed `wrangler.json` `vars` via `jq`, on every deploy. Config-as-code → can't be silently dropped.
  - Gated on `ADMIN_ORIGIN` being set — **no-op for same-site setups**, so existing deployments are unaffected.
  - `ADMIN_ALLOW_CROSS_SITE` defaults to `"true"` (the cross-site Pages↔Workers case that needs it).
- `docs/ADMIN-AUTH.md`: document the repo-Variables setup and a ⚠️ warning against hand-setting dashboard vars.

## Verification

- `jq` transform validated against a real built `wrangler.json` (sets the three keys, preserves existing vars, defaults cross-site to `true`).
- YAML validated.
- No-op confirmed when `ADMIN_ORIGIN` is unset (existing behavior preserved).

Addresses the durable-fix half of #161 (item 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)