### PR TITLE
fix(worker): accept SDK rich menu imageData uploads

### DIFF
--- a/apps/worker/src/routes/rich-menus.test.ts
+++ b/apps/worker/src/routes/rich-menus.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { Hono } from 'hono';
+import { richMenus } from './rich-menus.js';
+
+const uploadRichMenuImage = vi.fn();
+
+vi.mock('@line-crm/line-sdk', () => ({
+  LineClient: vi.fn().mockImplementation(() => ({
+    uploadRichMenuImage,
+  })),
+}));
+
+describe('POST /api/rich-menus/:id/image', () => {
+  function setupApp() {
+    const app = new Hono<{
+      Bindings: {
+        DB: D1Database;
+        LINE_CHANNEL_ACCESS_TOKEN: string;
+      };
+    }>();
+    app.route('/', richMenus);
+    return app;
+  }
+
+  beforeEach(() => {
+    uploadRichMenuImage.mockReset();
+    uploadRichMenuImage.mockResolvedValue(undefined);
+  });
+
+  test('accepts SDK imageData JSON field for base64 uploads', async () => {
+    const app = setupApp();
+    const res = await app.request('/api/rich-menus/richmenu-1/image', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        imageData: 'aGVsbG8=',
+        contentType: 'image/png',
+      }),
+    }, {
+      LINE_CHANNEL_ACCESS_TOKEN: 'token',
+      DB: {} as D1Database,
+    });
+
+    expect(res.status).toBe(200);
+    expect(uploadRichMenuImage).toHaveBeenCalledTimes(1);
+    const [richMenuId, imageData, contentType] = uploadRichMenuImage.mock.calls[0];
+    expect(richMenuId).toBe('richmenu-1');
+    expect(contentType).toBe('image/png');
+    expect(new TextDecoder().decode(imageData as ArrayBuffer)).toBe('hello');
+  });
+
+  test('keeps accepting legacy image JSON field', async () => {
+    const app = setupApp();
+    const res = await app.request('/api/rich-menus/richmenu-2/image', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        image: 'data:image/jpeg;base64,aGVsbG8=',
+        contentType: 'image/jpeg',
+      }),
+    }, {
+      LINE_CHANNEL_ACCESS_TOKEN: 'token',
+      DB: {} as D1Database,
+    });
+
+    expect(res.status).toBe(200);
+    expect(uploadRichMenuImage).toHaveBeenCalledTimes(1);
+    const [richMenuId, imageData, contentType] = uploadRichMenuImage.mock.calls[0];
+    expect(richMenuId).toBe('richmenu-2');
+    expect(contentType).toBe('image/jpeg');
+    expect(new TextDecoder().decode(imageData as ArrayBuffer)).toBe('hello');
+  });
+});

--- a/apps/worker/src/routes/rich-menus.ts
+++ b/apps/worker/src/routes/rich-menus.ts
@@ -211,12 +211,13 @@ richMenus.post('/api/rich-menus/:id/image', async (c) => {
 
     if (contentType.includes('application/json')) {
       // Accept base64 encoded image in JSON body
-      const body = await c.req.json<{ image: string; contentType?: string }>();
-      if (!body.image) {
+      const body = await c.req.json<{ image?: string; imageData?: string; contentType?: string }>();
+      const imageBase64 = body.image ?? body.imageData;
+      if (!imageBase64) {
         return c.json({ success: false, error: 'image (base64) is required' }, 400);
       }
       // Strip data URI prefix if present
-      const base64 = body.image.replace(/^data:image\/\w+;base64,/, '');
+      const base64 = imageBase64.replace(/^data:image\/\w+;base64,/, '');
       const binaryString = atob(base64);
       const bytes = new Uint8Array(binaryString.length);
       for (let i = 0; i < binaryString.length; i++) {


### PR DESCRIPTION
## Summary
- fix rich menu image uploads sent by the SDK
- accept both JSON fields: legacy `image` and SDK `imageData`
- add worker route coverage for both fields

Closes #171

## Verification
- pnpm --filter worker test -- routes/rich-menus.test.ts
- pnpm --filter worker typecheck
- git diff --check

## Sandbox / safety
- no deploy
- no remote D1 migration
- no LINE message send path changed