### PR TITLE
fix(mcp): compare account summary with LINE followers

### DIFF
--- a/apps/worker/src/routes/line-accounts.test.ts
+++ b/apps/worker/src/routes/line-accounts.test.ts
@@ -16,6 +16,13 @@ const dbMocks = {
 };
 vi.mock('@line-crm/db', () => dbMocks);
 
+const lineClientMocks = {
+  getFollowersInsight: vi.fn(),
+};
+vi.mock('@line-crm/line-sdk', () => ({
+  LineClient: vi.fn().mockImplementation(() => lineClientMocks),
+}));
+
 // Re-import after mock so the module picks up mocked deps.
 const { lineAccounts } = await import('./line-accounts.js');
 
@@ -71,6 +78,56 @@ const fakeAccount = {
 
 beforeEach(() => {
   for (const fn of Object.values(dbMocks)) fn.mockReset();
+  lineClientMocks.getFollowersInsight.mockReset();
+});
+
+describe('GET /api/line-accounts/:id/follower-insight', () => {
+  test('returns LINE follower insight without exposing account token', async () => {
+    dbMocks.getLineAccountById.mockResolvedValue(fakeAccount);
+    lineClientMocks.getFollowersInsight.mockResolvedValue({
+      status: 'ready',
+      followers: 123,
+      targetedReaches: 111,
+      blocks: 4,
+    });
+
+    const app = setupApp('owner');
+    const res = await app.request('/api/line-accounts/acc-1/follower-insight?date=20260616');
+
+    expect(res.status).toBe(200);
+    expect(dbMocks.getLineAccountById).toHaveBeenCalledWith(expect.anything(), 'acc-1');
+    expect(lineClientMocks.getFollowersInsight).toHaveBeenCalledWith('20260616');
+    const body = (await res.json()) as {
+      success: boolean;
+      data: {
+        lineAccountId: string;
+        date: string;
+        status: string;
+        followers: number;
+        targetedReaches: number;
+        blocks: number;
+        channelAccessToken?: string;
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data).toMatchObject({
+      lineAccountId: 'acc-1',
+      date: '20260616',
+      status: 'ready',
+      followers: 123,
+      targetedReaches: 111,
+      blocks: 4,
+    });
+    expect(body.data.channelAccessToken).toBeUndefined();
+  });
+
+  test('rejects missing insight date', async () => {
+    const app = setupApp('owner');
+    const res = await app.request('/api/line-accounts/acc-1/follower-insight');
+
+    expect(res.status).toBe(400);
+    expect(lineClientMocks.getFollowersInsight).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /api/line-accounts', () => {

--- a/apps/worker/src/routes/line-accounts.ts
+++ b/apps/worker/src/routes/line-accounts.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { LineClient } from '@line-crm/line-sdk';
 import {
   getLineAccounts,
   getLineAccountById,
@@ -122,6 +123,39 @@ lineAccounts.get('/api/line-accounts/:id', async (c) => {
   } catch (err) {
     console.error('GET /api/line-accounts/:id error:', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
+// GET /api/line-accounts/:id/follower-insight - compare DB state with LINE official follower stats
+lineAccounts.get('/api/line-accounts/:id/follower-insight', async (c) => {
+  try {
+    const date = c.req.query('date');
+    if (!date || !/^\d{8}$/.test(date)) {
+      return c.json({ success: false, error: 'date query is required in yyyyMMdd format' }, 400);
+    }
+
+    const account = await getLineAccountById(c.env.DB, c.req.param('id'));
+    if (!account) {
+      return c.json({ success: false, error: 'LINE account not found' }, 404);
+    }
+
+    const client = new LineClient(account.channel_access_token);
+    const insight = await client.getFollowersInsight(date);
+    return c.json({
+      success: true,
+      data: {
+        lineAccountId: account.id,
+        date,
+        status: insight.status,
+        followers: typeof insight.followers === 'number' ? insight.followers : null,
+        targetedReaches: typeof insight.targetedReaches === 'number' ? insight.targetedReaches : null,
+        blocks: typeof insight.blocks === 'number' ? insight.blocks : null,
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('GET /api/line-accounts/:id/follower-insight error:', message);
+    return c.json({ success: false, error: 'Failed to fetch LINE follower insight' }, 502);
   }
 });
 

--- a/packages/line-sdk/src/client.ts
+++ b/packages/line-sdk/src/client.ts
@@ -11,6 +11,13 @@ import type {
 
 const LINE_API_BASE = 'https://api.line.me';
 
+export interface FollowersInsight {
+  status: string;
+  followers?: number;
+  targetedReaches?: number;
+  blocks?: number;
+}
+
 export class LineClient {
   constructor(private readonly channelAccessToken: string) {}
 
@@ -262,5 +269,17 @@ export class LineClient {
       `/v2/bot/insight/message/event/aggregation?${params.toString()}`,
     );
     return data;
+  }
+
+  /**
+   * Get the number of followers for a LINE Official Account on a given date.
+   * GET only — no messages are sent.
+   */
+  async getFollowersInsight(date: string): Promise<FollowersInsight> {
+    const { data } = await this.request(
+      'GET',
+      `/v2/bot/insight/followers?date=${encodeURIComponent(date)}`,
+    );
+    return data as FollowersInsight;
   }
 }

--- a/packages/mcp-server/src/tools/account-summary.ts
+++ b/packages/mcp-server/src/tools/account-summary.ts
@@ -12,8 +12,72 @@ interface AccountStat {
   id: string;
   name: string;
   channelId: string;
-  friendsInDb: number;
+  friendsInDb: number | null;
+  friendsFromLine: number | null;
+  lineFollowersDate: string;
+  lineFollowersStatus: string | null;
+  dbCountStatus: "ready" | "error";
+  lineCountStatus: "ready" | "unready" | "error";
+  syncDifference: number | null;
+  syncRiskLevel: "ok" | "warning" | "unknown";
   riskLevel?: string;
+  targetedReaches?: number | null;
+  blocks?: number | null;
+  warnings: string[];
+}
+
+interface ApiEnvelope<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+function yyyymmddInJst(date: Date): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}${get("month")}${get("day")}`;
+}
+
+function previousJstDate(): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 1);
+  return yyyymmddInJst(d);
+}
+
+async function fetchHarnessJson<T>(
+  apiUrl: string,
+  apiKey: string,
+  path: string,
+): Promise<ApiEnvelope<T>> {
+  try {
+    const res = await fetch(`${apiUrl}${path}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const json = (await res.json().catch(() => null)) as ApiEnvelope<T> | null;
+    if (!res.ok) {
+      return {
+        success: false,
+        error: json?.error ?? `HTTP ${res.status}`,
+      };
+    }
+    if (!json?.success) {
+      return {
+        success: false,
+        error: json?.error ?? "API returned success=false",
+      };
+    }
+    return json;
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
 }
 
 export function registerAccountSummary(server: McpServer): void {
@@ -31,56 +95,106 @@ export function registerAccountSummary(server: McpServer): void {
         const client = getClient();
         const apiUrl = process.env.LINE_HARNESS_API_URL;
         const apiKey = process.env.LINE_HARNESS_API_KEY;
+        if (!apiUrl || !apiKey) {
+          throw new Error("LINE_HARNESS_API_URL and LINE_HARNESS_API_KEY are required");
+        }
+        const lineFollowersDate = previousJstDate();
 
         // Fetch all LINE accounts
-        const accountsRes = await fetch(`${apiUrl}/api/line-accounts`, {
-          headers: { Authorization: `Bearer ${apiKey}` },
-        });
-        const accountsData = (await accountsRes.json()) as {
-          success: boolean;
-          data: AccountInfo[];
-        };
+        const accountsData = await fetchHarnessJson<AccountInfo[]>(
+          apiUrl,
+          apiKey,
+          "/api/line-accounts",
+        );
         const accounts: AccountInfo[] = accountsData.success
-          ? accountsData.data
+          ? accountsData.data ?? []
           : [];
 
         // Get per-account friend counts
         const accountStats: AccountStat[] = [];
         for (const acc of accounts) {
           // Use direct API call for per-account count (SDK count() has no params)
-          const countRes = await fetch(
-            `${apiUrl}/api/friends/count?lineAccountId=${encodeURIComponent(acc.id)}`,
-            { headers: { Authorization: `Bearer ${apiKey}` } },
+          const countData = await fetchHarnessJson<{ count: number }>(
+            apiUrl,
+            apiKey,
+            `/api/friends/count?lineAccountId=${encodeURIComponent(acc.id)}`,
           );
-          const countData = (await countRes.json()) as {
-            success: boolean;
-            data: { count: number };
-          };
-          const count = countData.success ? countData.data.count : 0;
+          const lineData = await fetchHarnessJson<{
+            date: string;
+            status: string;
+            followers: number | null;
+            targetedReaches: number | null;
+            blocks: number | null;
+          }>(
+            apiUrl,
+            apiKey,
+            `/api/line-accounts/${encodeURIComponent(acc.id)}/follower-insight?date=${lineFollowersDate}`,
+          );
+          const friendsInDb = countData.success ? countData.data?.count ?? null : null;
+          const friendsFromLine = lineData.success && lineData.data?.status === "ready"
+            ? lineData.data.followers
+            : null;
+          const warnings: string[] = [];
+          if (!countData.success) {
+            warnings.push(`DB friend count unavailable: ${countData.error ?? "unknown error"}`);
+          }
+          if (!lineData.success) {
+            warnings.push(`LINE follower insight unavailable: ${lineData.error ?? "unknown error"}`);
+          } else if (lineData.data?.status !== "ready") {
+            warnings.push(`LINE follower insight is not ready for ${lineFollowersDate}`);
+          }
+          const syncDifference =
+            friendsInDb !== null && friendsFromLine !== null
+              ? friendsInDb - friendsFromLine
+              : null;
+          if (syncDifference !== null && syncDifference !== 0) {
+            warnings.push(
+              `DB friends (${friendsInDb}) differ from LINE followers (${friendsFromLine}) by ${syncDifference}. Check webhook sync and channel tokens.`,
+            );
+          }
           accountStats.push({
             id: acc.id,
             name: acc.name,
             channelId: acc.channelId,
-            friendsInDb: count,
+            friendsInDb,
+            friendsFromLine,
+            lineFollowersDate,
+            lineFollowersStatus: lineData.success ? lineData.data?.status ?? null : null,
+            dbCountStatus: countData.success ? "ready" : "error",
+            lineCountStatus: !lineData.success
+              ? "error"
+              : lineData.data?.status === "ready"
+                ? "ready"
+                : "unready",
+            syncDifference,
+            syncRiskLevel: syncDifference === null
+              ? "unknown"
+              : syncDifference === 0
+                ? "ok"
+                : "warning",
+            targetedReaches: lineData.success ? lineData.data?.targetedReaches ?? null : null,
+            blocks: lineData.success ? lineData.data?.blocks ?? null : null,
+            warnings,
           });
         }
 
         // Get health/risk level for each account
         for (const acc of accountStats) {
           try {
-            const healthRes = await fetch(
-              `${apiUrl}/api/accounts/${acc.id}/health`,
-              { headers: { Authorization: `Bearer ${apiKey}` } },
+            const healthData = await fetchHarnessJson<{ riskLevel: string }>(
+              apiUrl,
+              apiKey,
+              `/api/accounts/${encodeURIComponent(acc.id)}/health`,
             );
-            const healthData = (await healthRes.json()) as {
-              success: boolean;
-              data: { riskLevel: string };
-            };
             if (healthData.success) {
-              acc.riskLevel = healthData.data.riskLevel;
+              acc.riskLevel = healthData.data?.riskLevel;
+            } else {
+              acc.warnings.push(`Health risk level unavailable: ${healthData.error ?? "unknown error"}`);
             }
-          } catch {
-            // Health endpoint may not exist yet
+          } catch (err) {
+            acc.warnings.push(
+              `Health risk level unavailable: ${err instanceof Error ? err.message : String(err)}`,
+            );
           }
         }
 
@@ -101,7 +215,8 @@ export function registerAccountSummary(server: McpServer): void {
         const summary = {
           friends: {
             totalDbRecords: totalFriends,
-            note: "totalDbRecords includes both Account \u2460 and \u2461 records. Same user on different accounts = separate records. Use per-account counts below for accurate numbers.",
+            note: "totalDbRecords is the DB count. perAccount[].friendsFromLine is the LINE official follower insight for the previous JST date. If these differ, webhook sync or channel token health may be broken.",
+            warningCount: accountStats.reduce((sum, acc) => sum + acc.warnings.length, 0),
             perAccount: accountStats,
           },
           scenarios: {


### PR DESCRIPTION
## Summary
- add a Worker read-only endpoint for LINE follower insight per account
- add a LINE SDK helper for `GET /v2/bot/insight/followers?date=...`
- update MCP `account_summary` to show DB friends, LINE official followers, sync difference, and warnings
- stop silently converting failed DB count checks to `0`

Closes #172

## Verification
- pnpm --filter @line-crm/line-sdk build
- pnpm --filter @line-crm/line-sdk typecheck
- pnpm --filter worker test -- routes/line-accounts.test.ts
- pnpm --filter worker typecheck
- WRANGLER_LOG_PATH=/tmp/line-harness-wrangler-build.log pnpm --filter worker build
- pnpm --filter @line-harness/mcp-server typecheck
- pnpm --filter @line-harness/mcp-server build
- git diff --check

## Sandbox / safety
- read-only LINE Insights API call only
- no deploy
- no remote D1 migration
- no LINE message send path changed
- channel access tokens stay inside the Worker; MCP reads through the authenticated Harness API