### PR TITLE
chore(create): publish CLI build with nodejs compat deploy fix

### DIFF
--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.1.25",
+  "version": "0.1.27",
   "description": "Set up LINE Harness \u2014 AI-operated LINE CRM \u2014 with one command",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump create-line-harness to 0.1.27 so npm can publish a fresh CLI build
- The current source already includes nodejs_compat in the generated deploy wrangler.toml
- This addresses the npm package mismatch reported in #177, where create-line-harness@0.1.26 deploys a Worker with compatibility_flags=[] and Cloudflare rejects node:stream

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @line-harness/update-engine build
- pnpm --filter create-line-harness build
- pnpm --filter create-line-harness exec tsc --noEmit
- pnpm --filter @line-crm/shared build
- pnpm --filter @line-crm/line-sdk build
- WRANGLER_LOG_PATH=/tmp/line-harness-oss-fix-177-wrangler.log pnpm --filter worker build
- node check: apps/worker/dist/line_harness/wrangler.json includes compatibility_flags=["nodejs_compat"]
- node check: packages/create-line-harness/dist/index.js includes nodejs_compat
- git diff --check

## Release note
After merge, npm publish is still required. Recommended flow:

pnpm --filter @line-harness/update-engine build
pnpm --filter create-line-harness build
pnpm --filter create-line-harness publish --access public --no-git-checks

Closes #177