### PR TITLE
fix(create-line-harness): set LINE_HARNESS_ACCOUNT_ID for single-account installs

### DIFF
--- a/packages/create-line-harness/src/commands/setup.ts
+++ b/packages/create-line-harness/src/commands/setup.ts
@@ -749,7 +749,7 @@ ON CONFLICT(channel_id) DO UPDATE SET
     message: "MCP 設定を .mcp.json に追加しますか？（Claude Code / Cursor 用）",
   });
   if (addMcp && !p.isCancel(addMcp)) {
-    generateMcpConfig({ workerUrl: state.workerUrl!, apiKey: state.apiKey! });
+    await generateMcpConfig({ workerUrl: state.workerUrl!, apiKey: state.apiKey! });
   }
 
   // Step 15: Show completion screen

--- a/packages/create-line-harness/src/steps/mcp-config.ts
+++ b/packages/create-line-harness/src/steps/mcp-config.ts
@@ -7,16 +7,65 @@ interface McpConfigOptions {
   apiKey: string;
 }
 
-export function generateMcpConfig(options: McpConfigOptions): void {
+interface LineAccount {
+  id: string;
+  name?: string;
+}
+
+/**
+ * Resolve the single LINE account id for a fresh install so the MCP server can
+ * be configured with a default account.
+ *
+ * Why this matters: the MCP server passes its `LINE_HARNESS_ACCOUNT_ID` to the
+ * SDK as `defaultAccountId`. The SDK only auto-fills `lineAccountId` on
+ * broadcast create/list/send when that default is present. Without it, every
+ * broadcast created via the MCP server is written with `line_account_id = NULL`
+ * and is therefore invisible in the account-scoped admin UI list (which filters
+ * on `line_account_id`). Single-account installs are the common case, so we set
+ * the default automatically. Multi-account setups are left unset on purpose —
+ * the operator should pick a default per server entry themselves.
+ *
+ * Best-effort: any failure (network, multi-account, unexpected shape) just
+ * skips the field and never breaks the install.
+ */
+async function resolveDefaultAccountId(
+  options: McpConfigOptions,
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(`${options.workerUrl}/api/line-accounts`, {
+      headers: { Authorization: `Bearer ${options.apiKey}` },
+    });
+    if (!res.ok) return undefined;
+    const json = (await res.json().catch(() => null)) as
+      | { success?: boolean; data?: LineAccount[] }
+      | null;
+    if (!json?.success || !Array.isArray(json.data)) return undefined;
+    if (json.data.length === 1) return json.data[0]?.id;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function generateMcpConfig(options: McpConfigOptions): Promise<void> {
   const mcpJsonPath = join(process.cwd(), ".mcp.json");
+
+  const env: Record<string, string> = {
+    LINE_HARNESS_API_URL: options.workerUrl,
+    LINE_HARNESS_API_KEY: options.apiKey,
+  };
+
+  // Set a default account for single-account installs so MCP-created
+  // broadcasts are tagged with line_account_id and show up in the admin UI.
+  const defaultAccountId = await resolveDefaultAccountId(options);
+  if (defaultAccountId) {
+    env.LINE_HARNESS_ACCOUNT_ID = defaultAccountId;
+  }
 
   const newServerConfig = {
     command: "npx",
     args: ["-y", "@line-harness/mcp-server@latest"],
-    env: {
-      LINE_HARNESS_API_URL: options.workerUrl,
-      LINE_HARNESS_API_KEY: options.apiKey,
-    },
+    env,
   };
 
   let mcpConfig: Record<string, any> = {};


### PR DESCRIPTION
## Problem

Broadcasts created through the **MCP server** (`manage_broadcasts create_draft`, `broadcast`, …) are persisted with `line_account_id = NULL` and never show up in the admin UI's broadcast list.

### Root cause

The chain is wired correctly **only when a default account is configured**:

- `packages/mcp-server/src/client.ts` builds the SDK client with `lineAccountId: process.env.LINE_HARNESS_ACCOUNT_ID`.
- The SDK (`packages/sdk/src/client.ts`) stores that as `defaultAccountId`, and `BroadcastsResource.create()` only auto-fills `lineAccountId` when `this.defaultAccountId` is set:
  ```ts
  if (!body.lineAccountId && this.defaultAccountId) {
    body.lineAccountId = this.defaultAccountId
  }
  ```
- `BroadcastsResource.list()` likewise filters by `params?.accountId ?? this.defaultAccountId`.

But the installer's `generateMcpConfig` only ever writes `LINE_HARNESS_API_URL` and `LINE_HARNESS_API_KEY` to `.mcp.json` — never `LINE_HARNESS_ACCOUNT_ID`. So on a typical single-account install, `defaultAccountId` is `undefined`, MCP-created broadcasts get `line_account_id = NULL`, and the account-scoped UI list (which filters on `line_account_id`) hides them. The operator sees "no broadcasts" even though the row exists in D1.

(Encountered this in production: a draft created via the MCP server was missing from the UI list; the row was present in D1 with `line_account_id` NULL.)

## Fix

In `generateMcpConfig` (Step 14, which runs after the LINE account is registered in Step 12 and the worker is deployed), resolve the account id from `GET /api/line-accounts`. When exactly one account exists, write `LINE_HARNESS_ACCOUNT_ID` into the MCP server env.

- Multi-account installs are intentionally left unset — the operator should choose a default per server entry.
- Fully best-effort: any failure (network, unexpected shape, >1 account) just skips the field and never breaks the install.
- `generateMcpConfig` becomes `async`; the single call site is updated to `await`.

## Verification

- `tsc --noEmit` passes for `create-line-harness`.
- `pnpm build` (tsup) succeeds.