### PR TITLE
fix(inbox): 解決済チャットを未対応カウントから除外

### DIFF
--- a/apps/worker/src/services/unanswered-inbox.test.ts
+++ b/apps/worker/src/services/unanswered-inbox.test.ts
@@ -11,6 +11,9 @@ interface InboxRow {
   last_incoming: string;
   last_manual: string | null;
   last_machine: string | null;
+  // 最新 chat 行の status (CANDIDATES_SQL が COALESCE で surface する)。
+  // 未指定 = chat 行なし扱い (= unread 相当でカウント対象)。
+  chat_status?: string;
   // 旧 schema 互換 (テストヘルパーで preview として recentIncomings に展開する)
   last_incoming_type?: string;
   last_incoming_content?: string;
@@ -585,6 +588,58 @@ describe('auto_reply マッチ除外', () => {
 
     const result = await computeUnansweredInbox(db);
     expect(result.rows.map((r) => r.friendId)).toEqual(['f_new', 'f_mid', 'f_old']);
+  });
+
+  test('chat status=resolved の friend は未対応から除外される', async () => {
+    const db = stubDB({
+      rows: [
+        baseRow({ friend_id: 'f_unread', chat_status: 'unread' }),
+        baseRow({ friend_id: 'f_inprog', chat_status: 'in_progress' }),
+        baseRow({ friend_id: 'f_resolved', chat_status: 'resolved' }),
+      ],
+    });
+
+    const result = await computeUnansweredInbox(db);
+    expect(result.total).toBe(2);
+    expect(result.rows.map((r) => r.friendId).sort()).toEqual(['f_inprog', 'f_unread']);
+  });
+
+  test('chat 行が無い (status 未設定) friend は未対応に残る', async () => {
+    const db = stubDB({
+      rows: [baseRow({ friend_id: 'f_nochat' })],
+    });
+
+    const result = await computeUnansweredInbox(db);
+    expect(result.total).toBe(1);
+    expect(result.rows[0].friendId).toBe('f_nochat');
+  });
+
+  test('countUnanswered も resolved を除外する', async () => {
+    const db = stubDB({
+      rows: [
+        baseRow({ friend_id: 'f1', chat_status: 'unread' }),
+        baseRow({ friend_id: 'f2', chat_status: 'resolved' }),
+      ],
+    });
+
+    const c = await countUnanswered(db);
+    expect(c.total).toBe(1);
+    expect(c.byAccount).toEqual([{ accountId: 'a1', accountName: 'L ①', count: 1 }]);
+  });
+
+  test('getUnansweredFriendIds は resolved を除外する', async () => {
+    const db = stubDB({
+      rows: [
+        baseRow({ friend_id: 'f_keep', chat_status: 'in_progress' }),
+        baseRow({ friend_id: 'f_drop', chat_status: 'resolved' }),
+      ],
+    });
+
+    const { getUnansweredFriendIds } = await import('./unanswered-inbox.js');
+    const ids = await getUnansweredFriendIds(db);
+    expect(ids.has('f_keep')).toBe(true);
+    expect(ids.has('f_drop')).toBe(false);
+    expect(ids.size).toBe(1);
   });
 
   test('getUnansweredFriendIds は未対応 friend の Set を返す', async () => {

--- a/apps/worker/src/services/unanswered-inbox.ts
+++ b/apps/worker/src/services/unanswered-inbox.ts
@@ -74,6 +74,12 @@ function consumeAutoReplyEvidence(
 // 候補 friend のメタデータ + 集約タイムスタンプ。
 // プレビュー/タイプは別クエリで last_manual 以降の incoming 群から JS で決める
 // (auto_reply マッチを除いた「最新の非マッチ incoming」が triage 対象)。
+//
+// chat_status: 最新 chat 行の status を surface する。getChatByFriendId と同じ
+// 「最新 chat (created_at DESC LIMIT 1)」セマンティクスを相関サブクエリで再現
+// (friend ↔ chats は 1:多 になりうるため JOIN すると候補行が重複する)。
+// chat 行が無い friend は COALESCE で 'unread' 扱い (= カウント対象)。
+// resolved の除外判定は getAllUnansweredRows の JS 側で行う (単体テスト可能に保つ)。
 const CANDIDATES_SQL = `
   WITH agg AS (
     SELECT
@@ -94,7 +100,13 @@ const CANDIDATES_SQL = `
     COALESCE(la.name, '(未分類)') AS account_name,
     agg.last_incoming,
     agg.last_manual,
-    agg.last_machine
+    agg.last_machine,
+    COALESCE((
+      SELECT c.status FROM chats c
+      WHERE c.friend_id = f.id
+      ORDER BY c.created_at DESC
+      LIMIT 1
+    ), 'unread') AS chat_status
   FROM friends f
   LEFT JOIN line_accounts la ON la.id = f.line_account_id
   JOIN agg ON agg.friend_id = f.id
@@ -192,6 +204,7 @@ interface RawCandidateRow {
   last_incoming: string;
   last_manual: string | null;
   last_machine: string | null;
+  chat_status: string;
 }
 
 interface RawIncomingRow {
@@ -266,6 +279,11 @@ async function getAllUnansweredRows(db: D1Database): Promise<UnansweredRow[]> {
 
   const rows: UnansweredRow[] = [];
   for (const c of candidates) {
+    // 解決済 (resolved) にしたチャットは未対応から除外する。
+    // 新着メッセージが来れば upsertChatOnMessage が resolved → unread に戻すので、
+    // 再オープン時は自動的にここを通過する (webhook.ts)。
+    if (c.chat_status === 'resolved') continue;
+
     const incomings = incomingsByFriend.get(c.friend_id) ?? [];
     // outgoings は consume するのでコピーを作る (元 Map の他参照を破壊しない)。
     // incomings は新しい順に処理し、各 outgoing を 1 incoming にしか割り当てない。


### PR DESCRIPTION
## 問題

左メニューの「未対応」バッジが、チャットを**解決済にしても消えない**。

## 根本原因

未対応バッジ／インボックス（`countUnanswered`）は `messages_log` の証拠ベース＝**最後の incoming メッセージに手動返信が付いたか**だけで判定しており、`chats.status`（unread / in_progress / resolved）を一切見ていなかった。そのため「解決済にする」を押しても、手動で返信を送らない限りカウントが減らなかった。

## 修正

未対応判定の単一の真実源 `getAllUnansweredRows`（`apps/worker/src/services/unanswered-inbox.ts`）に status による除外を追加:

- `CANDIDATES_SQL` で**最新 chat 行の status** を相関サブクエリで surface
  - friend ↔ chats は 1:多 になりうるため、JOIN だと候補行が重複する → サブクエリで回避
  - `getChatByFriendId` と同じ「最新 chat = `created_at DESC LIMIT 1`」セマンティクス
  - chat 行が無い friend は `COALESCE` で `unread` 扱い（カウント対象）
- JS 側で `chat_status === 'resolved'` の候補をスキップ
- **既存のメッセージ証拠ロジックはそのまま温存**（上乗せの絞り込み）

### 仕様判断

**解決済（resolved）のみ除外**。`unread`・`in_progress`（対応中）はバッジに残す。

### 再オープンは自動

お客さんから新着メッセージが届くと `upsertChatOnMessage`（`webhook.ts`）が `resolved → unread` に戻すため、解決済にした会話も新着で自動的に未対応へ復帰する。

## 波及範囲

同じ `getAllUnansweredRows` を使う3経路すべてに一貫適用:
- サイドバーの未対応バッジ（`countUnanswered`）
- 未対応インボックス一覧（`computeUnansweredInbox`）
- チャット画面の「未対応のみ」絞り込み（`getUnansweredFriendIds`）

## 検証

- 新規テスト4件（resolved 除外 / chat 行なしは残る / count も除外 / friendIds も除外）を TDD で追加（赤を確認してから実装）
- worker 全テスト **515 件 pass（45 ファイル全 green）**
- \`tsc --noEmit\` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)