### PR TITLE
Fix Luu event approval flow

### DIFF
--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -39,6 +39,14 @@ interface ChatDetail extends Chat {
   messages?: ChatMessage[]
 }
 
+interface MessageTemplate {
+  id: string
+  name: string
+  category: string
+  messageType: string
+  messageContent: string
+}
+
 type StatusFilter = 'all' | 'unread' | 'in_progress' | 'resolved'
 
 const statusConfig: Record<Chat['status'], { label: string; className: string }> = {
@@ -300,6 +308,8 @@ export default function ChatsPage() {
   const [detailLoading, setDetailLoading] = useState(false)
   const [error, setError] = useState('')
   const [messageContent, setMessageContent] = useState('')
+  const [templates, setTemplates] = useState<MessageTemplate[]>([])
+  const [selectedTemplateId, setSelectedTemplateId] = useState('')
   const [pendingImage, setPendingImage] = useState<ImageUploaderValue | null>(null)
   const [sending, setSending] = useState(false)
   const sendLockRef = useRef(false)
@@ -367,6 +377,20 @@ export default function ChatsPage() {
   }, [selectedAccountId])
 
   useEffect(() => { void loadAllFriends() }, [loadAllFriends])
+
+  useEffect(() => {
+    const loadTemplates = async () => {
+      try {
+        const res = await api.templates.list('manual')
+        if (res.success) {
+          setTemplates((res.data as unknown as MessageTemplate[]).filter((t) => t.messageType === 'text'))
+        }
+      } catch {
+        // 定型文は補助機能なので、チャット本体の利用は止めない
+      }
+    }
+    void loadTemplates()
+  }, [])
 
   // Keep refs in sync so setChats updater can read the latest filter without stale closure
   useEffect(() => { statusFilterRef.current = statusFilter }, [statusFilter])
@@ -502,7 +526,18 @@ export default function ChatsPage() {
   const handleSelectChat = (chatId: string) => {
     setSelectedChatId(chatId)
     setMessageContent('')
+    setSelectedTemplateId('')
     setPendingImage(null)
+  }
+
+  const handleInsertTemplate = () => {
+    const template = templates.find((t) => t.id === selectedTemplateId)
+    if (!template) return
+    setMessageContent((prev) => {
+      const current = prev.trimEnd()
+      return current ? `${current}\n\n${template.messageContent}` : template.messageContent
+    })
+    textareaRef.current?.focus()
   }
 
   const triggerLoadingAnimation = useCallback(async (chatId: string) => {
@@ -1047,6 +1082,31 @@ export default function ChatsPage() {
                     label="画像を送る (任意)"
                   />
                 </div>
+                {templates.length > 0 && (
+                  <div className="mb-2 flex flex-wrap items-center gap-2">
+                    <select
+                      value={selectedTemplateId}
+                      onChange={(e) => setSelectedTemplateId(e.target.value)}
+                      className="min-h-[40px] flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
+                      aria-label="定型文を選択"
+                    >
+                      <option value="">定型文を選択</option>
+                      {templates.map((template) => (
+                        <option key={template.id} value={template.id}>
+                          {template.name}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={handleInsertTemplate}
+                      disabled={!selectedTemplateId}
+                      className="min-h-[40px] rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      入力欄へ入れる
+                    </button>
+                  </div>
+                )}
                 <div className="flex items-end gap-2">
                   <textarea
                     ref={textareaRef}

--- a/apps/worker/src/client/event-booking/main.tsx
+++ b/apps/worker/src/client/event-booking/main.tsx
@@ -2,7 +2,7 @@
 // apps/worker/src/client/main.ts (?page=event&id=<eventId> or ?page=event-me).
 // Mirrors salon-booking design language (LINE 緑 + sb-card + fade animations).
 
-import { StrictMode, useEffect, useState } from 'react';
+import { StrictMode, useEffect, useState, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import './styles.css';
 
@@ -42,8 +42,7 @@ interface EventSlot {
   ends_at: string;
   capacity: number | null;
   is_active: number;
-  active_count: number;
-  remaining: number | null;
+  is_full?: boolean;
 }
 
 interface MyBooking {
@@ -60,25 +59,58 @@ interface MyBooking {
   slot_ends_at: string;
 }
 
+interface EventListItem {
+  id: string;
+  name: string;
+  venue_name: string | null;
+  venue_url: string | null;
+  image_url: string | null;
+  description: string | null;
+  description_centered: number;
+  max_bookings_per_friend: number | null;
+  requires_approval: number;
+  next_slot_starts_at: string;
+  next_slot_ends_at: string;
+  future_slot_count: number;
+}
+
 function buildAuthHeaders(ctx: EventBookingContext, extra: Record<string, string> = {}): Record<string, string> {
   return { Authorization: `Bearer ${ctx.idToken}`, ...extra };
 }
 
-function apiGet<T>(path: string, ctx: EventBookingContext): Promise<T> {
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+async function apiGetOnce<T>(path: string, ctx: EventBookingContext): Promise<T> {
   const url = new URL(path, window.location.origin);
   url.searchParams.set('liffId', ctx.liffId);
-  return fetch(url.toString(), { headers: buildAuthHeaders(ctx) }).then(async (r) => {
-    if (!r.ok) {
-      const text = await r.text();
-      let parsed: unknown = null;
-      try { parsed = JSON.parse(text); } catch { /* ignore */ }
-      const err = new Error(`API ${r.status}`) as Error & { status: number; body: unknown };
-      err.status = r.status;
-      err.body = parsed ?? text;
-      throw err;
+  const r = await fetch(url.toString(), { headers: buildAuthHeaders(ctx) });
+  if (!r.ok) {
+    const text = await r.text();
+    let parsed: unknown = null;
+    try { parsed = JSON.parse(text); } catch { /* ignore */ }
+    const err = new Error(`API ${r.status}`) as Error & { status: number; body: unknown };
+    err.status = r.status;
+    err.body = parsed ?? text;
+    throw err;
+  }
+  return r.json() as Promise<T>;
+}
+
+async function apiGet<T>(path: string, ctx: EventBookingContext): Promise<T> {
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      return await apiGetOnce<T>(path, ctx);
+    } catch (err) {
+      lastError = err;
+      const status = (err as { status?: number }).status;
+      if (status != null && status < 500) break;
+      await sleep(450);
     }
-    return r.json() as Promise<T>;
-  });
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 async function apiPost<T>(
@@ -144,11 +176,13 @@ function EventDetailScreen({
   eventId,
   onPickSlot,
   onGoHistory,
+  onGoList,
 }: {
   ctx: EventBookingContext;
   eventId: string;
   onPickSlot: (slot: EventSlot, event: EventDetail) => void;
   onGoHistory: () => void;
+  onGoList: () => void;
 }) {
   const [event, setEvent] = useState<EventDetail | null>(null);
   const [slots, setSlots] = useState<EventSlot[]>([]);
@@ -247,20 +281,13 @@ function EventDetailScreen({
       <div className="px-4 -mt-6">
         <div className="eb-card">
           <h1 className="text-lg font-bold text-gray-900 leading-snug">{event.name}</h1>
+          <button onClick={onGoList} className="eb-list-back-btn mt-3">
+            予約一覧に戻る
+          </button>
           {event.venue_name && (
             <div className="mt-2 text-sm text-gray-700 flex items-start gap-1.5">
               <span>📍</span><span>{event.venue_name}</span>
             </div>
-          )}
-          {event.venue_url && (
-            <a
-              href={event.venue_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-1 inline-block text-xs eb-line-green-text underline break-all"
-            >
-              {event.venue_url}
-            </a>
           )}
           {max != null && (
             <div className="mt-3 inline-flex items-center gap-1 eb-badge bg-gray-100 text-gray-700">
@@ -291,7 +318,7 @@ function EventDetailScreen({
           ) : (
             <ul className="space-y-2">
               {slots.map((s) => {
-                const full = s.remaining != null && s.remaining <= 0;
+                const full = s.is_full === true;
                 const disabled = full || overLimit;
                 return (
                   <li key={s.id}>
@@ -305,7 +332,7 @@ function EventDetailScreen({
                         <span className="text-base">{formatJpTimeOnly(s.starts_at)} 〜 {formatJpTimeOnly(s.ends_at)}</span>
                       </span>
                       <span className="text-xs font-medium">
-                        {full ? '満員' : s.capacity == null ? '定員なし' : `残 ${s.remaining}`}
+                        {full ? '満員' : s.capacity == null ? '原則MAX16名' : '受付中'}
                       </span>
                     </button>
                   </li>
@@ -320,8 +347,8 @@ function EventDetailScreen({
           )}
         </div>
 
-        <div className="mt-6 text-center">
-          <button onClick={onGoHistory} className="text-sm eb-line-green-text underline">
+        <div className="mt-5">
+          <button onClick={onGoHistory} className="eb-history-btn">
             予約履歴を見る
           </button>
         </div>
@@ -343,14 +370,55 @@ function ConfirmScreen({
   onBack: () => void;
   onDone: (status: string) => void;
 }) {
+  const [customerName, setCustomerName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [xAccount, setXAccount] = useState('');
+  const [partySize, setPartySize] = useState('1');
+  const [companionCount, setCompanionCount] = useState('0');
+  const [companionNames, setCompanionNames] = useState('');
   const [note, setNote] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [idemKey] = useState(uid);
 
+  function buildCustomerNote(): string {
+    return [
+      `名前: ${customerName.trim()}`,
+      `電話番号: ${phone.trim()}`,
+      `Xアカウント: ${xAccount.trim()}`,
+      `人数: ${partySize.trim()}`,
+      `同行者人数: ${companionCount.trim()}`,
+      `同行者名: ${companionNames.trim()}`,
+      `備考: ${note.trim()}`,
+    ].join('\n');
+  }
+
   async function submit() {
-    if (note.length > 5000) {
-      setError('備考は 5000 字以内で入力してください');
+    const normalizedPartySize = Number(partySize);
+    const normalizedCompanionCount = Number(companionCount);
+    if (!customerName.trim()) {
+      setError('名前を入力してください');
+      return;
+    }
+    if (!phone.trim()) {
+      setError('電話番号を入力してください');
+      return;
+    }
+    if (!Number.isInteger(normalizedPartySize) || normalizedPartySize < 1) {
+      setError('人数は1以上で入力してください');
+      return;
+    }
+    if (!Number.isInteger(normalizedCompanionCount) || normalizedCompanionCount < 0) {
+      setError('同行者人数は0以上で入力してください');
+      return;
+    }
+    if (normalizedCompanionCount > 0 && !companionNames.trim()) {
+      setError('同行者がいる場合は同行者名を入力してください');
+      return;
+    }
+    const customerNote = buildCustomerNote();
+    if (customerNote.length > 5000) {
+      setError('入力内容は 5000 字以内で入力してください');
       return;
     }
     setSubmitting(true);
@@ -358,7 +426,7 @@ function ConfirmScreen({
     try {
       const res = await apiPost<{ id: string; status: string }>(
         `/api/liff/events/${event.id}/bookings`,
-        { slot_id: slot.id, customer_note: note || null },
+        { slot_id: slot.id, customer_note: customerNote },
         ctx,
         { 'Idempotency-Key': idemKey },
       );
@@ -417,19 +485,73 @@ function ConfirmScreen({
         </div>
       )}
 
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1.5">
-          備考（任意）
-        </label>
-        <textarea
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-          rows={4}
-          maxLength={5000}
-          placeholder="質問や伝えたいことがあれば..."
-          className="w-full border border-gray-300 rounded-xl p-3 text-sm bg-white"
-        />
-        <div className="text-xs text-gray-500 text-right mt-1">{note.length} / 5000</div>
+      <div className="space-y-3">
+        <Field label="名前" required>
+          <input
+            value={customerName}
+            onChange={(e) => setCustomerName(e.target.value)}
+            placeholder="例: 山田 太郎"
+            className="eb-input"
+          />
+        </Field>
+        <Field label="電話番号" required>
+          <input
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            inputMode="tel"
+            placeholder="例: 09012345678"
+            className="eb-input"
+          />
+        </Field>
+        <Field label="Xアカウント">
+          <input
+            value={xAccount}
+            onChange={(e) => setXAccount(e.target.value)}
+            placeholder="例: @example"
+            className="eb-input"
+          />
+        </Field>
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="人数" required>
+            <input
+              value={partySize}
+              onChange={(e) => setPartySize(e.target.value)}
+              type="number"
+              inputMode="numeric"
+              min={1}
+              className="eb-input"
+            />
+          </Field>
+          <Field label="同行者人数">
+            <input
+              value={companionCount}
+              onChange={(e) => setCompanionCount(e.target.value)}
+              type="number"
+              inputMode="numeric"
+              min={0}
+              className="eb-input"
+            />
+          </Field>
+        </div>
+        <Field label="同行者名">
+          <textarea
+            value={companionNames}
+            onChange={(e) => setCompanionNames(e.target.value)}
+            rows={2}
+            placeholder="同行者がいる場合は名前を入力"
+            className="eb-input"
+          />
+        </Field>
+        <Field label="備考">
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            rows={3}
+            maxLength={2000}
+            placeholder="遅れる、質問など"
+            className="eb-input"
+          />
+        </Field>
       </div>
 
       {error && (
@@ -457,7 +579,27 @@ function Row({ label, value, valueClassName }: { label: string; value: string; v
   );
 }
 
-function DoneScreen({ status, onGoHistory }: { status: string; onGoHistory: () => void }) {
+function Field({ label, required, children }: { label: string; required?: boolean; children: ReactNode }) {
+  return (
+    <label className="block">
+      <span className="block text-sm font-medium text-gray-700 mb-1.5">
+        {label}
+        {required && <span className="text-red-500 text-xs ml-1">必須</span>}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function DoneScreen({
+  status,
+  onGoHistory,
+  onGoList,
+}: {
+  status: string;
+  onGoHistory: () => void;
+  onGoList: () => void;
+}) {
   const isPending = status === 'requested';
   return (
     <div className="px-4 py-10 text-center eb-slide-up">
@@ -474,6 +616,109 @@ function DoneScreen({ status, onGoHistory }: { status: string; onGoHistory: () =
         <button onClick={onGoHistory} className="eb-primary-btn">
           予約履歴を見る
         </button>
+        <button onClick={onGoList} className="eb-secondary-btn mt-3">
+          イベント一覧へ
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function EventListScreen({
+  ctx,
+  onOpenEvent,
+  onGoHistory,
+}: {
+  ctx: EventBookingContext;
+  onOpenEvent: (eventId: string) => void;
+  onGoHistory: () => void;
+}) {
+  const [items, setItems] = useState<EventListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await apiGet<{ items: EventListItem[] }>('/api/liff/events', ctx);
+        if (!cancelled) setItems(res.items);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => { cancelled = true; };
+  }, [ctx]);
+
+  return (
+    <div className="pb-24 eb-fade-in">
+      <div className="px-4 py-4">
+        <div className="mb-3">
+          <div>
+            <h1 className="text-base font-bold text-gray-900">イベント一覧</h1>
+            <p className="text-xs text-gray-500 mt-1">参加したい交流会を選択してください</p>
+          </div>
+        </div>
+
+        <div className="eb-card mb-4">
+          <p className="text-sm text-gray-700 leading-relaxed">
+            予約内容の確認・キャンセルは予約履歴からできます。
+          </p>
+          <button onClick={onGoHistory} className="eb-history-btn mt-3">
+            予約履歴を見る
+          </button>
+        </div>
+
+        {error && <div className="bg-red-50 border border-red-200 text-red-700 p-3 rounded-xl text-sm">{error}</div>}
+        {loading ? (
+          <Spinner />
+        ) : items.length === 0 ? (
+          <div className="eb-card text-center text-sm text-gray-500 py-8">
+            現在受付中のイベントはありません。
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {items.map((event) => (
+              <button
+                key={event.id}
+                onClick={() => onOpenEvent(event.id)}
+                className="eb-card !p-0 w-full text-left overflow-hidden"
+              >
+                {event.image_url ? (
+                  <img src={event.image_url} alt="" className="w-full h-36 object-cover bg-gray-100" />
+                ) : (
+                  <div className="w-full h-7 bg-gradient-to-br from-green-100 to-green-200" />
+                )}
+                <div className="p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <h2 className="text-sm font-bold text-gray-900 leading-snug">{event.name}</h2>
+                    {event.requires_approval === 1 && (
+                      <span className="eb-badge bg-amber-100 text-amber-800 shrink-0">承認制</span>
+                    )}
+                  </div>
+                  <div className="mt-2 text-sm font-semibold text-gray-800">
+                    {formatJpDateOnly(event.next_slot_starts_at)}
+                  </div>
+                  <div className="text-sm text-gray-700">
+                    {formatJpTimeOnly(event.next_slot_starts_at)} 〜 {formatJpTimeOnly(event.next_slot_ends_at)}
+                  </div>
+                  {event.venue_name && (
+                    <div className="mt-1 text-xs text-gray-500 truncate">📍 {event.venue_name}</div>
+                  )}
+                  <div className="mt-3 text-xs text-gray-500">
+                    <span>{event.future_slot_count > 1 ? `日時 ${event.future_slot_count}件` : '受付中'}</span>
+                    <span className="eb-card-cta">詳細・予約へ</span>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -496,7 +741,7 @@ function canCancel(b: MyBooking): boolean {
   return deadlineMs > Date.now();
 }
 
-function HistoryScreen({ ctx }: { ctx: EventBookingContext }) {
+function HistoryScreen({ ctx, onGoList }: { ctx: EventBookingContext; onGoList: () => void }) {
   const [tab, setTab] = useState<'upcoming' | 'past'>('upcoming');
   const [items, setItems] = useState<MyBooking[]>([]);
   const [loading, setLoading] = useState(true);
@@ -546,6 +791,11 @@ function HistoryScreen({ ctx }: { ctx: EventBookingContext }) {
 
   return (
     <div className="pb-20 eb-fade-in">
+      <div className="px-4 pt-4">
+        <button onClick={onGoList} className="eb-list-back-primary-btn">
+          予約一覧に戻る
+        </button>
+      </div>
       <div className="sticky top-12 z-10 bg-white border-b border-gray-200">
         <div className="flex">
           {(['upcoming', 'past'] as const).map((t) => (
@@ -612,6 +862,7 @@ function HistoryScreen({ ctx }: { ctx: EventBookingContext }) {
 // ─── App ──────────────────────────────────────────────────
 
 type Screen =
+  | { kind: 'list' }
   | { kind: 'detail'; eventId: string }
   | { kind: 'confirm'; event: EventDetail; slot: EventSlot }
   | { kind: 'done'; status: string }
@@ -622,6 +873,7 @@ function App({ ctx, initial }: { ctx: EventBookingContext; initial: Screen }) {
 
   const headerLabel = (() => {
     switch (screen.kind) {
+      case 'list': return '茶はいダーツバー西新宿Luuイベント予約';
       case 'detail': return 'イベント予約';
       case 'confirm': return 'ご予約内容の確認';
       case 'done': return '完了';
@@ -638,12 +890,20 @@ function App({ ctx, initial }: { ctx: EventBookingContext; initial: Screen }) {
         {headerLabel}
       </header>
       <main className="max-w-md mx-auto">
+        {screen.kind === 'list' && (
+          <EventListScreen
+            ctx={ctx}
+            onOpenEvent={(eventId) => setScreen({ kind: 'detail', eventId })}
+            onGoHistory={() => setScreen({ kind: 'history' })}
+          />
+        )}
         {screen.kind === 'detail' && (
           <EventDetailScreen
             ctx={ctx}
             eventId={screen.eventId}
             onPickSlot={(slot, event) => setScreen({ kind: 'confirm', event, slot })}
             onGoHistory={() => setScreen({ kind: 'history' })}
+            onGoList={() => setScreen({ kind: 'list' })}
           />
         )}
         {screen.kind === 'confirm' && (
@@ -656,9 +916,18 @@ function App({ ctx, initial }: { ctx: EventBookingContext; initial: Screen }) {
           />
         )}
         {screen.kind === 'done' && (
-          <DoneScreen status={screen.status} onGoHistory={() => setScreen({ kind: 'history' })} />
+          <DoneScreen
+            status={screen.status}
+            onGoHistory={() => setScreen({ kind: 'history' })}
+            onGoList={() => setScreen({ kind: 'list' })}
+          />
         )}
-        {screen.kind === 'history' && <HistoryScreen ctx={ctx} />}
+        {screen.kind === 'history' && (
+          <HistoryScreen
+            ctx={ctx}
+            onGoList={() => setScreen({ kind: 'list' })}
+          />
+        )}
       </main>
     </div>
   );

--- a/apps/worker/src/client/event-booking/styles.css
+++ b/apps/worker/src/client/event-booking/styles.css
@@ -182,6 +182,83 @@ body.eb-active #app {
   cursor: not-allowed;
 }
 
+.eb-history-btn {
+  width: 100%;
+  padding: 13px 16px;
+  border-radius: 12px;
+  background: #fff;
+  color: #06C755;
+  border: 1.5px solid #06C755;
+  font-weight: 700;
+  font-size: 14px;
+  box-shadow: 0 1px 2px rgba(6,199,85,0.08);
+  transition: transform 0.15s, background-color 0.15s;
+}
+.eb-history-btn:active {
+  transform: scale(0.98);
+  background: #ecfdf5;
+}
+
+.eb-list-back-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 9px 14px;
+  border-radius: 9999px;
+  background: #ecfdf5;
+  color: #06C755;
+  border: 1.5px solid #06C755;
+  font-weight: 700;
+  font-size: 13px;
+}
+.eb-list-back-btn:active {
+  background: #dcfce7;
+  transform: scale(0.98);
+}
+
+.eb-list-back-primary-btn {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: #06C755;
+  color: #fff;
+  font-weight: 800;
+  font-size: 15px;
+  box-shadow: 0 2px 4px rgba(6,199,85,0.18);
+}
+.eb-list-back-primary-btn:active {
+  transform: scale(0.98);
+}
+
+.eb-card-cta {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  padding: 11px 14px;
+  border-radius: 10px;
+  background: #06C755;
+  color: #fff;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 800;
+  box-shadow: 0 2px 4px rgba(6,199,85,0.16);
+}
+
+.eb-input {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 12px 13px;
+  font-size: 15px;
+  line-height: 1.5;
+  background: #fff;
+}
+.eb-input:focus {
+  outline: 2px solid rgba(6,199,85,0.22);
+  border-color: #06C755;
+}
+
 /* primary action (LINE 緑塗り) */
 .eb-primary-btn {
   width: 100%;

--- a/apps/worker/src/client/main.ts
+++ b/apps/worker/src/client/main.ts
@@ -31,8 +31,29 @@ declare const liff: {
 };
 
 // Resolve LIFF ID: ?liffId= param (from endpoint URL) > env var (fallback to ①)
+function getEffectiveUrl(): URL {
+  const current = new URL(window.location.href);
+  const liffState = current.searchParams.get('liff.state');
+  if (!liffState) return current;
+  try {
+    return new URL(liffState, window.location.origin);
+  } catch {
+    try {
+      return new URL(decodeURIComponent(liffState), window.location.origin);
+    } catch {
+      return current;
+    }
+  }
+}
+
+function getParam(name: string): string | null {
+  const current = new URL(window.location.href);
+  const effective = getEffectiveUrl();
+  return effective.searchParams.get(name) ?? current.searchParams.get(name);
+}
+
 function detectLiffId(): string {
-  const fromParam = new URLSearchParams(window.location.search).get('liffId');
+  const fromParam = getParam('liffId');
   if (fromParam) return fromParam;
   return import.meta.env?.VITE_LIFF_ID || '';
 }
@@ -55,20 +76,18 @@ function apiCall(path: string, options?: RequestInit): Promise<Response> {
 }
 
 function getPage(): string | null {
-  const path = window.location.pathname.replace(/^\/+/, '');
+  const effective = getEffectiveUrl();
+  const path = effective.pathname.replace(/^\/+/, '');
   if (path === 'book') return 'book';
-  const params = new URLSearchParams(window.location.search);
-  return params.get('page');
+  return getParam('page');
 }
 
 function getRedirectUrl(): string | null {
-  const params = new URLSearchParams(window.location.search);
-  return params.get('redirect');
+  return getParam('redirect');
 }
 
 function getRef(): string | null {
-  const params = new URLSearchParams(window.location.search);
-  return params.get('ref');
+  return getParam('ref');
 }
 
 function getSavedUuid(): string | null {
@@ -126,23 +145,22 @@ function showFriendAdd(profile: { displayName: string; pictureUrl?: string }) {
       if (!friendFlag) return;
 
       // Send form link if form param exists (was lost during friend-add flow)
-      const formParam = new URLSearchParams(window.location.search).get('form');
+      const formParam = getParam('form');
       if (formParam && !formLinkSent) {
         formLinkSent = true;
         try {
           const fp = await liff.getProfile();
           const idToken = liff.getIDToken();
-          const params = new URLSearchParams(window.location.search);
           await apiCall('/api/liff/send-form-link', {
             method: 'POST',
             body: JSON.stringify({
               lineUserId: fp.userId,
               formId: formParam,
               idToken: idToken || '',
-              ref: params.get('ref') || '',
-              gate: params.get('gate') || '',
-              xh: params.get('xh') || '',
-              ig: params.get('ig') || '',
+              ref: getParam('ref') || '',
+              gate: getParam('gate') || '',
+              xh: getParam('xh') || '',
+              ig: getParam('ig') || '',
             }),
           });
         } catch { /* best-effort */ }
@@ -196,6 +214,15 @@ function showError(message: string) {
   `;
 }
 
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      window.setTimeout(() => reject(new Error(`${label} がタイムアウトしました`)), ms);
+    }),
+  ]);
+}
+
 // ─── Core Flow ──────────────────────────────────────────
 
 async function linkAndAddFlow() {
@@ -213,7 +240,6 @@ async function linkAndAddFlow() {
     ]);
 
     // 1. UUID linking (always, regardless of friendship)
-    const linkParams = new URLSearchParams(window.location.search);
     const linkPromise = apiCall('/api/liff/link', {
       method: 'POST',
       body: JSON.stringify({
@@ -221,7 +247,7 @@ async function linkAndAddFlow() {
         displayName: profile.displayName,
         existingUuid: existingUuid,
         ref: ref,
-        ig: linkParams.get('ig') || '',
+        ig: getParam('ig') || '',
       }),
     }).then(async (res) => {
       if (res.ok) {
@@ -268,12 +294,11 @@ async function linkAndAddFlow() {
       showFriendAdd(profile);
     } else {
       // Already a friend — check for form param
-      const formParam = new URLSearchParams(window.location.search).get('form');
+      const formParam = getParam('form');
       if (formParam) {
         // Send form link via push message, then show completion
         try {
           const idToken = liff.getIDToken();
-          const params = new URLSearchParams(window.location.search);
           await apiCall('/api/liff/send-form-link', {
             method: 'POST',
             body: JSON.stringify({
@@ -281,9 +306,9 @@ async function linkAndAddFlow() {
               formId: formParam,
               idToken: idToken || '',
               ref: ref || '',
-              gate: params.get('gate') || '',
-              xh: params.get('xh') || '',
-              ig: params.get('ig') || '',
+              gate: getParam('gate') || '',
+              xh: getParam('xh') || '',
+              ig: getParam('ig') || '',
             }),
           });
         } catch { /* best-effort */ }
@@ -325,7 +350,7 @@ async function initSalonBooking(): Promise<void> {
 
   const existingUuid = getSavedUuid();
   const ref = getRef();
-  const ig = new URLSearchParams(window.location.search).get('ig');
+  const ig = getParam('ig');
 
   // ② Silent UUID linking (fire-and-forget; booking API は id_token verify で
   //    認証するので待つ必要はない)。
@@ -383,13 +408,13 @@ async function initSalonBooking(): Promise<void> {
 
 // ─── Event Booking (React, dynamic-imported) ─────────────
 
-async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void> {
-  // salon-booking と同じ初期化シーケンス: profile/idToken/friendship 取得、
-  // 未友達なら friend-add gate、友達なら React mount。
-  const [profile, idToken, friendship] = await Promise.all([
-    liff.getProfile(),
+async function initEventBooking(initialKind: 'list' | 'detail' | 'history'): Promise<void> {
+  // 予約履歴は本人の idToken で取得できるため、getFriendship() を待たない。
+  // LINE外ブラウザや一部端末で friendship が返らず、履歴画面が spinner のまま
+  // 止まることがある。
+  const [profile, idToken] = await Promise.all([
+    withTimeout(liff.getProfile(), 10000, 'プロフィール取得'),
     Promise.resolve(liff.getIDToken()),
-    liff.getFriendship(),
   ]);
   if (!idToken) {
     showError('LINE 認証情報の取得に失敗しました。LINE アプリ内で再度開いてください。');
@@ -419,9 +444,12 @@ async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void
       /* silent */
     });
 
-  if (!friendship.friendFlag) {
-    showFriendAdd(profile);
-    return;
+  if (initialKind !== 'history') {
+    const friendship = await withTimeout(liff.getFriendship(), 10000, '友だち状態確認');
+    if (!friendship.friendFlag) {
+      showFriendAdd(profile);
+      return;
+    }
   }
 
   const container = document.getElementById('app');
@@ -429,8 +457,7 @@ async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void
     showError('mount target #app が見つかりません');
     return;
   }
-  const params = new URLSearchParams(window.location.search);
-  const eventId = params.get('id') ?? '';
+  const eventId = getParam('id') ?? '';
   if (initialKind === 'detail' && !eventId) {
     showError('id クエリパラメータが必要です（?page=event&id=<eventId>）');
     return;
@@ -439,6 +466,8 @@ async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void
   const ctx = { liffId: LIFF_ID, lineUserId: profile.userId, idToken };
   const initial = initialKind === 'detail'
     ? { kind: 'detail' as const, eventId }
+    : initialKind === 'list'
+      ? { kind: 'list' as const }
     : { kind: 'history' as const };
   mountEventBooking(container, ctx, initial);
 }
@@ -447,7 +476,7 @@ async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void
 
 async function main() {
   try {
-    await liff.init({ liffId: LIFF_ID });
+    await withTimeout(liff.init({ liffId: LIFF_ID }), 12000, 'LIFF初期化');
 
     if (!liff.isLoggedIn()) {
       liff.login({ redirectUri: window.location.href });
@@ -472,11 +501,12 @@ async function main() {
       await initSalonBooking();
     } else if (page === 'event') {
       await initEventBooking('detail');
+    } else if (page === 'events') {
+      await initEventBooking('list');
     } else if (page === 'event-me') {
       await initEventBooking('history');
     } else if (page === 'form') {
-      const params = new URLSearchParams(window.location.search);
-      const formId = params.get('id');
+      const formId = getParam('id');
       await initForm(formId);
     } else if (!page) {
       await linkAndAddFlow();

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -91,6 +91,9 @@ export type Env = {
     X_HARNESS_URL?: string;  // Optional: X Harness API URL for account linking
     IG_HARNESS_URL?: string;  // Optional: IG Harness API URL for cross-platform linking
     IG_HARNESS_LINK_SECRET?: string;  // Shared secret for IG Harness link-line webhook
+    TELEGRAM_BOT_TOKEN?: string;
+    TELEGRAM_CHAT_ID?: string;
+    TELEGRAM_ACTION_SECRET?: string;
     // Phase 5 self-update — consumed by /admin/update/*. Defaults live in
     // wrangler.toml [vars]; secrets (CF_API_TOKEN, ADMIN_API_KEY) come from
     // `wrangler secret put`. All are optional at the type level so the rest
@@ -522,6 +525,368 @@ ${longPressBlock}
 
 // Convenience redirect for /book path
 app.get('/book', (c) => c.redirect('/?page=book'));
+app.get('/event-list', async (c) => {
+  const liffId = c.req.query('liffId');
+  if (!liffId) return c.text('liffId is required', 400);
+  c.header('Cache-Control', 'no-store');
+
+  const account = await c.env.DB
+    .prepare(`SELECT id FROM line_accounts WHERE liff_id = ? AND is_active = 1`)
+    .bind(liffId)
+    .first<{ id: string }>();
+  if (!account) return c.text('LINE account not found', 404);
+
+  const nowIso = new Date().toISOString();
+  const { results } = await c.env.DB
+    .prepare(
+      `SELECT
+         e.id,
+         e.name,
+         e.venue_name,
+         e.image_url,
+         e.requires_approval,
+         (
+           SELECT s.starts_at
+             FROM event_slots s
+            WHERE s.event_id = e.id
+              AND s.deleted_at IS NULL
+              AND s.is_active = 1
+              AND s.starts_at >= ?
+            ORDER BY s.starts_at ASC
+            LIMIT 1
+         ) AS starts_at,
+         (
+           SELECT s.ends_at
+             FROM event_slots s
+            WHERE s.event_id = e.id
+              AND s.deleted_at IS NULL
+              AND s.is_active = 1
+              AND s.starts_at >= ?
+            ORDER BY s.starts_at ASC
+            LIMIT 1
+         ) AS ends_at,
+         (
+           SELECT COUNT(*)
+             FROM event_bookings b
+            WHERE b.event_id = e.id
+              AND b.status IN ('requested','confirmed')
+         ) AS total_active
+       FROM events e
+       WHERE e.deleted_at IS NULL
+         AND e.is_published = 1
+         AND (
+           (e.target_type = 'single' AND e.line_account_id = ?)
+           OR (e.target_type = 'multi-account-dedup'
+               AND EXISTS (SELECT 1 FROM json_each(e.account_ids) WHERE value = ?))
+         )
+         AND EXISTS (
+           SELECT 1
+             FROM event_slots s
+            WHERE s.event_id = e.id
+              AND s.deleted_at IS NULL
+              AND s.is_active = 1
+              AND s.starts_at >= ?
+         )
+       ORDER BY starts_at ASC, e.sort_order ASC, e.created_at DESC`,
+    )
+    .bind(nowIso, nowIso, account.id, account.id, nowIso)
+    .all<{
+      id: string;
+      name: string;
+      venue_name: string | null;
+      image_url: string | null;
+      requires_approval: number;
+      starts_at: string;
+      ends_at: string;
+      total_active: number;
+    }>();
+
+  const esc = (value: unknown): string =>
+    String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  const fmtDate = (iso: string): string =>
+    new Intl.DateTimeFormat('ja-JP', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      weekday: 'short',
+    }).format(new Date(iso));
+  const fmtTime = (iso: string): string =>
+    new Intl.DateTimeFormat('ja-JP', {
+      timeZone: 'Asia/Tokyo',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(new Date(iso));
+  const eventUrl = (id: string): string =>
+    `https://liff.line.me/${encodeURIComponent(liffId)}?page=event&id=${encodeURIComponent(id)}&liffId=${encodeURIComponent(liffId)}`;
+  const historyUrl = (): string =>
+    `https://liff.line.me/${encodeURIComponent(liffId)}?page=event-me&liffId=${encodeURIComponent(liffId)}`;
+  const items = (results ?? [])
+    .map((event) => {
+      const image = event.image_url
+        ? `<img class="event-image" src="${esc(event.image_url)}" alt="">`
+        : `<div class="event-image placeholder"></div>`;
+      return `<article class="event-card">
+        ${image}
+        <div class="event-body">
+          <div class="event-title-row">
+            <h2>${esc(event.name)}</h2>
+            ${event.requires_approval === 1 ? '<span class="badge">承認制</span>' : ''}
+          </div>
+          <p class="date">${esc(fmtDate(event.starts_at))}</p>
+          <p class="time">${esc(fmtTime(event.starts_at))} - ${esc(fmtTime(event.ends_at))}</p>
+          ${event.venue_name ? `<p class="venue">${esc(event.venue_name)}</p>` : ''}
+          <p class="capacity">原則MAX16名</p>
+          <a class="button" href="${esc(eventUrl(event.id))}">詳細・予約へ</a>
+        </div>
+      </article>`;
+    })
+    .join('');
+
+  return c.html(`<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>茶はいダーツバー西新宿Luuイベント予約</title>
+  <style>
+    :root { color-scheme: light; --green: #06c755; --ink: #111827; --muted: #6b7280; --line: #e5e7eb; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f7f8fa; color: var(--ink); }
+    header { position: sticky; top: 0; z-index: 2; background: var(--green); color: #fff; padding: 16px 18px; box-shadow: 0 1px 8px rgba(0,0,0,.08); }
+    header h1 { margin: 0; font-size: 18px; line-height: 1.35; }
+    header p { margin: 4px 0 0; font-size: 13px; opacity: .92; }
+    main { width: min(720px, 100%); margin: 0 auto; padding: 16px; }
+    .event-list { display: grid; gap: 14px; }
+    .event-card { background: #fff; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; box-shadow: 0 1px 4px rgba(15,23,42,.05); }
+    .event-image { display: block; width: 100%; height: 132px; object-fit: cover; background: #dcfce7; }
+    .event-image.placeholder { display: block; height: 28px; }
+    .event-body { padding: 14px; }
+    .event-title-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
+    h2 { margin: 0; font-size: 16px; line-height: 1.45; }
+    .badge { flex: 0 0 auto; background: #fef3c7; color: #92400e; border-radius: 999px; padding: 4px 8px; font-size: 11px; font-weight: 700; }
+    p { margin: 0; }
+    .date { margin-top: 10px; font-size: 15px; font-weight: 700; }
+    .time { margin-top: 3px; font-size: 15px; }
+    .venue, .capacity { margin-top: 8px; font-size: 13px; color: var(--muted); }
+    .button { display: block; margin-top: 14px; width: 100%; border-radius: 8px; background: var(--green); color: #fff; text-align: center; text-decoration: none; font-weight: 800; padding: 13px 14px; }
+    .guide-box { background: #fff; border: 1px solid var(--line); border-radius: 8px; padding: 14px; margin-bottom: 14px; box-shadow: 0 1px 4px rgba(15,23,42,.05); }
+    .guide-box p { color: var(--muted); font-size: 13px; line-height: 1.65; }
+    .history-link { display: block; margin-top: 10px; width: 100%; border-radius: 8px; background: #fff; color: var(--green); border: 1.5px solid var(--green); text-align: center; text-decoration: none; font-weight: 800; padding: 12px 14px; }
+    .history-box { background: #fff; border: 1px solid var(--line); border-radius: 8px; padding: 14px; margin-bottom: 14px; box-shadow: 0 1px 4px rgba(15,23,42,.05); }
+    .history-box p { color: var(--muted); font-size: 13px; line-height: 1.6; }
+    .history-button { display: block; width: 100%; border: 0; margin-top: 10px; border-radius: 8px; background: #dc2626; color: #fff; text-align: center; text-decoration: none; font-weight: 800; padding: 12px 14px; font-size: 15px; }
+    .history-status { margin-top: 10px; color: var(--muted); font-size: 13px; line-height: 1.6; }
+    .booking-list { display: grid; gap: 10px; margin-top: 12px; }
+    .booking-card { border: 1px solid var(--line); border-radius: 8px; padding: 12px; background: #fafafa; }
+    .booking-card h3 { margin: 0; font-size: 14px; line-height: 1.4; }
+    .booking-card .meta { margin-top: 6px; color: var(--muted); font-size: 12px; line-height: 1.5; }
+    .cancel-button { margin-top: 10px; width: 100%; border: 1px solid #fecaca; border-radius: 8px; background: #fff1f2; color: #dc2626; font-weight: 800; padding: 10px 12px; }
+    .empty { background: #fff; border: 1px solid var(--line); border-radius: 8px; padding: 32px 16px; text-align: center; color: var(--muted); }
+  </style>
+  <script charset="utf-8" src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>
+</head>
+<body>
+  <header>
+    <h1>茶はいダーツバー西新宿Luuイベント予約</h1>
+    <p>参加したい交流会を選択してください</p>
+  </header>
+  <main>
+    <section class="guide-box">
+      <p>予約内容の確認・キャンセルは予約履歴からできます。</p>
+      <a class="history-link" href="${esc(historyUrl())}">予約履歴を見る</a>
+    </section>
+    <section class="event-list">
+      ${items || '<div class="empty">現在受付中のイベントはありません。</div>'}
+    </section>
+  </main>
+  <script>
+(function(){
+  var LIFF_ID = ${JSON.stringify(liffId)};
+  var button = document.getElementById('loadHistoryButton');
+  var status = document.getElementById('historyStatus');
+  var list = document.getElementById('bookingList');
+  var liffReady = false;
+  var activeRun = 0;
+  if (!button || !status || !list) return;
+
+  function setStatus(text) {
+    status.textContent = text || '';
+  }
+  function escapeHtml(value) {
+    return String(value == null ? '' : value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+  function formatJp(iso) {
+    try {
+      return new Intl.DateTimeFormat('ja-JP', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        weekday: 'short',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      }).format(new Date(iso));
+    } catch (e) {
+      return iso || '';
+    }
+  }
+  function timeoutError(label) {
+    var err = new Error(label + '_timeout');
+    err.code = label + '_timeout';
+    return err;
+  }
+  function withTimeout(promise, ms, label) {
+    return Promise.race([
+      promise,
+      new Promise(function(_, reject){
+        setTimeout(function(){ reject(timeoutError(label)); }, ms);
+      })
+    ]);
+  }
+  async function fetchJsonWithTimeout(url, options, ms, label) {
+    var controller = new AbortController();
+    var timer = setTimeout(function(){ controller.abort(); }, ms);
+    try {
+      return await fetch(url, Object.assign({}, options || {}, { signal: controller.signal }));
+    } catch (e) {
+      if (e && e.name === 'AbortError') throw timeoutError(label);
+      throw e;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  function canCancel(booking) {
+    if (booking.status !== 'requested' && booking.status !== 'confirmed') return false;
+    if (booking.cancel_deadline_hours_before == null) return false;
+    var deadline = new Date(booking.slot_starts_at).getTime() - Number(booking.cancel_deadline_hours_before) * 3600000;
+    return deadline > Date.now();
+  }
+  async function ensureIdToken() {
+    if (!window.liff) throw new Error('LIFF SDKを読み込めませんでした。LINEアプリ内で開き直してください。');
+    if (!liffReady) {
+      setStatus('LINE認証を準備しています...');
+      await withTimeout(window.liff.init({ liffId: LIFF_ID, withLoginOnExternalBrowser: true }), 12000, 'liff_init');
+      liffReady = true;
+    }
+    setStatus('LINEログイン状態を確認しています...');
+    if (!window.liff.isLoggedIn()) {
+      try { sessionStorage.setItem('lh_event_history_after_login', '1'); } catch (e) {}
+      setStatus('LINEログインへ移動します。移動しない場合はLINEアプリ内で開き直してください。');
+      window.liff.login({ redirectUri: window.location.href });
+      return null;
+    }
+    var idToken = window.liff.getIDToken();
+    if (!idToken) throw new Error('LINE認証情報を取得できませんでした。LINEアプリ内で開き直してください。');
+    return idToken;
+  }
+  async function apiGet(path, idToken) {
+    var url = new URL(path, window.location.origin);
+    url.searchParams.set('liffId', LIFF_ID);
+    var res = await fetchJsonWithTimeout(url.toString(), { headers: { Authorization: 'Bearer ' + idToken } }, 12000, 'history_fetch');
+    if (!res.ok) throw new Error('予約履歴の取得に失敗しました');
+    return res.json();
+  }
+  async function apiPost(path, idToken) {
+    var url = new URL(path, window.location.origin);
+    url.searchParams.set('liffId', LIFF_ID);
+    var res = await fetchJsonWithTimeout(url.toString(), {
+      method: 'POST',
+      headers: { Authorization: 'Bearer ' + idToken, 'Content-Type': 'application/json' },
+      body: '{}'
+    }, 12000, 'cancel_fetch');
+    if (!res.ok) {
+      var text = await res.text().catch(function(){ return ''; });
+      throw new Error(text || 'キャンセルに失敗しました');
+    }
+    return res.json();
+  }
+  function renderBookings(items, idToken) {
+    if (!items.length) {
+      list.innerHTML = '<div class="empty">これからの予約はありません。</div>';
+      return;
+    }
+    list.innerHTML = items.map(function(booking){
+      var cancel = canCancel(booking)
+        ? '<button class="cancel-button" data-booking-id="' + escapeHtml(booking.id) + '" data-event-name="' + escapeHtml(booking.event_name) + '">キャンセルする</button>'
+        : '';
+      return '<article class="booking-card">' +
+        '<h3>' + escapeHtml(booking.event_name) + '</h3>' +
+        '<div class="meta">' + escapeHtml(formatJp(booking.slot_starts_at)) + '<br>' + escapeHtml(booking.venue_name || '') + '</div>' +
+        cancel +
+      '</article>';
+    }).join('');
+    Array.prototype.forEach.call(list.querySelectorAll('[data-booking-id]'), function(cancelButton){
+      cancelButton.addEventListener('click', async function(){
+        var eventName = cancelButton.getAttribute('data-event-name') || 'この予約';
+        if (!confirm('「' + eventName + '」をキャンセルしますか？')) return;
+        cancelButton.disabled = true;
+        setStatus('キャンセル処理中です...');
+        try {
+          await apiPost('/api/liff/events/me/' + encodeURIComponent(cancelButton.getAttribute('data-booking-id')) + '/cancel', idToken);
+          setStatus('キャンセルしました。');
+          await loadHistory();
+        } catch (e) {
+          setStatus(e instanceof Error ? e.message : String(e));
+          cancelButton.disabled = false;
+        }
+      });
+    });
+  }
+  async function loadHistory() {
+    var runId = ++activeRun;
+    list.innerHTML = '';
+    setStatus('予約履歴を読み込んでいます...');
+    button.disabled = true;
+    var watchdog = setTimeout(function(){
+      if (runId !== activeRun) return;
+      setStatus('読み込みに時間がかかっています。LINEアプリ内で開き直すか、イベント名とお名前をこのLINEに送ってください。');
+      button.disabled = false;
+    }, 15000);
+    try {
+      var idToken = await ensureIdToken();
+      if (!idToken) return;
+      setStatus('予約履歴を取得しています...');
+      var data = await apiGet('/api/liff/events/me?tab=upcoming', idToken);
+      if (runId !== activeRun) return;
+      renderBookings(data.items || [], idToken);
+      setStatus('');
+    } catch (e) {
+      if (runId !== activeRun) return;
+      if (e && (e.code === 'liff_init_timeout' || e.code === 'history_fetch_timeout')) {
+        setStatus('読み込みに時間がかかっています。LINEアプリ内で開き直すか、イベント名とお名前をこのLINEに送ってください。');
+      } else {
+        setStatus(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      clearTimeout(watchdog);
+      if (runId === activeRun) button.disabled = false;
+    }
+  }
+  button.addEventListener('click', function(){ void loadHistory(); });
+  try {
+    if (sessionStorage.getItem('lh_event_history_after_login') === '1') {
+      sessionStorage.removeItem('lh_event_history_after_login');
+      setTimeout(function(){ void loadHistory(); }, 300);
+    }
+  } catch (e) {}
+})();
+  </script>
+</body>
+</html>`);
+});
 
 // 404 fallback — API paths return JSON 404, everything else serves from static assets (LIFF/admin)
 export const notFoundHandler = async (c: Parameters<typeof app.notFound>[0] extends (ctx: infer C) => unknown ? C : never) => {

--- a/apps/worker/src/routes/events.ts
+++ b/apps/worker/src/routes/events.ts
@@ -49,6 +49,171 @@ function bad(c: Context<Env>, code: string, status = 422): Response {
   return c.json({ error: code }, status as 400 | 401 | 403 | 404 | 409 | 410 | 422 | 429);
 }
 
+function jsonB64(value: unknown): string {
+  const json = JSON.stringify(value);
+  const bytes = new TextEncoder().encode(json);
+  let bin = '';
+  for (const byte of bytes) bin += String.fromCharCode(byte);
+  return btoa(bin).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+function fromJsonB64<T>(value: string): T | null {
+  try {
+    const normalized = value.replaceAll('-', '+').replaceAll('_', '/');
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+    const bin = atob(padded);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
+    return JSON.parse(new TextDecoder().decode(bytes)) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function hmacSha256Hex(secret: string, value: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(sig)).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let out = 0;
+  for (let i = 0; i < a.length; i += 1) out |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return out === 0;
+}
+
+function telegramActionSecret(c: Context<Env>): string | null {
+  return c.env.TELEGRAM_ACTION_SECRET || c.env.API_KEY || null;
+}
+
+async function signTelegramAction(c: Context<Env>, payload: Record<string, unknown>): Promise<string | null> {
+  const secret = telegramActionSecret(c);
+  if (!secret) return null;
+  const p = jsonB64(payload);
+  const s = await hmacSha256Hex(secret, p);
+  return `${p}.${s}`;
+}
+
+async function verifyTelegramActionToken<T extends Record<string, unknown>>(
+  c: Context<Env>,
+  token: string | undefined,
+): Promise<T | null> {
+  if (!token) return null;
+  const secret = telegramActionSecret(c);
+  if (!secret) return null;
+  const [p, s] = token.split('.');
+  if (!p || !s) return null;
+  const expected = await hmacSha256Hex(secret, p);
+  if (!timingSafeEqual(expected, s)) return null;
+  return fromJsonB64<T>(p);
+}
+
+function parseCustomerNote(note: string | null | undefined): Record<string, string> {
+  const data: Record<string, string> = {};
+  for (const line of String(note || '').replaceAll('\\n', '\n').split(/\r?\n/)) {
+    const m = line.match(/^([^:：]+)[:：]\s*(.*)$/);
+    if (m) data[m[1].trim()] = m[2].trim();
+  }
+  return data;
+}
+
+function adminTelegramText(args: {
+  eventName: string;
+  startsAt: string;
+  venueName: string | null;
+  friendDisplayName: string | null;
+  customerNote: string | null;
+  bookingId: string;
+}): string {
+  const note = parseCustomerNote(args.customerNote);
+  return [
+    '新しいイベント予約リクエストが届きました。',
+    '',
+    `イベント: ${args.eventName}`,
+    `日時: ${startsAtJst(args.startsAt)}`,
+    `会場: ${args.venueName || ''}`,
+    `表示名: ${args.friendDisplayName || '未取得'}`,
+    `名前: ${note['名前'] || note['お名前'] || ''}`,
+    `電話番号: ${note['電話番号'] || ''}`,
+    `人数: ${note['人数'] || ''}`,
+    `同行者人数: ${note['同行者人数'] || ''}`,
+    `同行者名: ${note['同行者名'] || ''}`,
+    `X/SNS: ${note['Xアカウント'] || note['SNSアカウント'] || ''}`,
+    `備考: ${note['備考'] || ''}`,
+    '',
+    `bookingId: ${args.bookingId}`,
+  ].join('\n');
+}
+
+async function sendTelegramMessage(c: Context<Env>, payload: Record<string, unknown>): Promise<void> {
+  if (!c.env.TELEGRAM_BOT_TOKEN || !c.env.TELEGRAM_CHAT_ID) return;
+  const res = await fetch(`https://api.telegram.org/bot${c.env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id: c.env.TELEGRAM_CHAT_ID,
+      ...payload,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Telegram sendMessage failed: ${res.status} ${text}`);
+  }
+}
+
+async function notifyEventBookingTelegramAdmin(c: Context<Env>, args: {
+  accountId: string;
+  eventId: string;
+  bookingId: string;
+  eventName: string;
+  startsAt: string;
+  venueName: string | null;
+  friendDisplayName: string | null;
+  customerNote: string | null;
+}): Promise<void> {
+  if (!c.env.TELEGRAM_BOT_TOKEN || !c.env.TELEGRAM_CHAT_ID) return;
+  const origin = new URL(c.req.url).origin;
+  const exp = Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 14;
+  const approveToken = await signTelegramAction(c, {
+    accountId: args.accountId,
+    eventId: args.eventId,
+    bookingId: args.bookingId,
+    action: 'confirm',
+    exp,
+  });
+  const rejectToken = await signTelegramAction(c, {
+    accountId: args.accountId,
+    eventId: args.eventId,
+    bookingId: args.bookingId,
+    action: 'reject',
+    exp,
+  });
+  if (!approveToken || !rejectToken) return;
+  await sendTelegramMessage(c, {
+    text: adminTelegramText({
+      eventName: args.eventName,
+      startsAt: args.startsAt,
+      venueName: args.venueName,
+      friendDisplayName: args.friendDisplayName,
+      customerNote: args.customerNote,
+      bookingId: args.bookingId,
+    }),
+    reply_markup: {
+      inline_keyboard: [[
+        { text: '承認する', url: `${origin}/telegram/event-booking-action?t=${encodeURIComponent(approveToken)}` },
+        { text: '拒否する', url: `${origin}/telegram/event-booking-action?t=${encodeURIComponent(rejectToken)}` },
+      ]],
+    },
+  });
+}
+
 function getAccountId(c: Context<Env>): string | null {
   return c.req.query('account_id') ?? null;
 }
@@ -598,6 +763,75 @@ events.put('/api/events/admin/events/:id/slots/:slotId', async (c) => {
 // MUST be registered before /:id paths so "me" is not consumed as :id.
 // ============================================================
 
+events.get('/api/liff/events', async (c) => {
+  const account_id = await resolveAccountIdFromLiff(c);
+  if (!account_id) return bad(c, 'liff_account_resolution_failed', 400);
+  const nowIso = new Date().toISOString();
+
+  const { results } = await c.env.DB
+    .prepare(
+      `SELECT
+         e.id,
+         e.name,
+         e.venue_name,
+         e.venue_url,
+         e.image_url,
+         e.description,
+         e.description_centered,
+         e.max_bookings_per_friend,
+         e.requires_approval,
+         (
+           SELECT s.starts_at
+             FROM event_slots s
+            WHERE s.event_id = e.id
+              AND s.deleted_at IS NULL
+              AND s.is_active = 1
+              AND s.starts_at >= ?
+            ORDER BY s.starts_at ASC
+            LIMIT 1
+         ) AS next_slot_starts_at,
+         (
+           SELECT s.ends_at
+             FROM event_slots s
+            WHERE s.event_id = e.id
+              AND s.deleted_at IS NULL
+              AND s.is_active = 1
+              AND s.starts_at >= ?
+            ORDER BY s.starts_at ASC
+            LIMIT 1
+         ) AS next_slot_ends_at,
+         (
+           SELECT COUNT(*)
+             FROM event_slots s
+            WHERE s.event_id = e.id
+              AND s.deleted_at IS NULL
+              AND s.is_active = 1
+              AND s.starts_at >= ?
+         ) AS future_slot_count
+       FROM events e
+       WHERE e.deleted_at IS NULL
+         AND e.is_published = 1
+         AND (
+           (e.target_type = 'single' AND e.line_account_id = ?)
+           OR (e.target_type = 'multi-account-dedup'
+               AND EXISTS (SELECT 1 FROM json_each(e.account_ids) WHERE value = ?))
+         )
+         AND EXISTS (
+           SELECT 1
+             FROM event_slots s
+            WHERE s.event_id = e.id
+              AND s.deleted_at IS NULL
+              AND s.is_active = 1
+              AND s.starts_at >= ?
+         )
+       ORDER BY next_slot_starts_at ASC, e.sort_order ASC, e.created_at DESC`,
+    )
+    .bind(nowIso, nowIso, nowIso, account_id, account_id, nowIso)
+    .all();
+
+  return c.json({ items: results ?? [] });
+});
+
 events.get('/api/liff/events/me', async (c) => {
   const account_id = await resolveAccountIdFromLiff(c);
   if (!account_id) return bad(c, 'liff_account_resolution_failed', 400);
@@ -764,7 +998,18 @@ events.get('/api/liff/events/:id/slots', async (c) => {
     only_active: true,
     only_future: true,
   });
-  return c.json({ items });
+  return c.json({
+    items: items.map((slot) => ({
+      id: slot.id,
+      event_id: slot.event_id,
+      starts_at: slot.starts_at,
+      ends_at: slot.ends_at,
+      capacity: slot.capacity,
+      is_active: slot.is_active,
+      sort_order: slot.sort_order,
+      is_full: slot.remaining != null && slot.remaining <= 0,
+    })),
+  });
 });
 
 // ----------------------------------------------------------------
@@ -800,6 +1045,7 @@ function startsAtJst(utcIso: string): string {
 events.post('/api/liff/events/:id/bookings', async (c) => {
   const account_id = await resolveAccountIdFromLiff(c);
   if (!account_id) return bad(c, 'liff_account_resolution_failed', 400);
+  const resolvedAccountId = account_id;
   const idemKey = c.req.header('Idempotency-Key');
   if (!idemKey) return bad(c, 'idempotency_key_required', 400);
   const callerLineUserId = await verifyCallerLineUserId(c.req.header('Authorization'), c.env);
@@ -1049,9 +1295,9 @@ events.post('/api/liff/events/:id/bookings', async (c) => {
   // best-effort notification: do not fail the booking if push fails.
   try {
     const acc = await c.env.DB
-      .prepare(`SELECT channel_access_token FROM line_accounts WHERE id = ?`)
+      .prepare(`SELECT channel_access_token, liff_id FROM line_accounts WHERE id = ?`)
       .bind(account_id)
-      .first<{ channel_access_token: string }>();
+      .first<{ channel_access_token: string; liff_id: string | null }>();
     if (acc?.channel_access_token) {
       const kind: EventNotificationKind =
         status === 'requested' ? 'received_pending' : 'received_confirmed';
@@ -1064,11 +1310,29 @@ events.post('/api/liff/events/:id/bookings', async (c) => {
           startsAtJst: startsAtJst(slot.starts_at),
           venueName: event.venue_name,
           venueUrl: event.venue_url,
+          liffId: acc.liff_id,
         },
       });
     }
   } catch (e) {
     console.error('[event-booking] notify failed', e);
+  }
+
+  if (status === 'requested') {
+    try {
+      await notifyEventBookingTelegramAdmin(c, {
+        accountId: resolvedAccountId,
+        eventId: event.id,
+        bookingId: id,
+        eventName: event.name,
+        startsAt: slot.starts_at,
+        venueName: event.venue_name,
+        friendDisplayName: null,
+        customerNote: body.customer_note ?? null,
+      });
+    } catch (e) {
+      console.error('[event-booking] telegram admin notify failed', e);
+    }
   }
 
   return finalize(201, { id, status });
@@ -1118,6 +1382,149 @@ events.get('/api/events/admin/events/notifications/pending', async (c) => {
   return c.json({ count: row?.c ?? 0 });
 });
 
+function buildManualEventCustomerNote(body: {
+  name: string;
+  phone?: string | null;
+  x_account?: string | null;
+  participant_count?: number;
+  companion_count?: number;
+  companion_names?: string | null;
+  note?: string | null;
+  source?: string | null;
+}): string {
+  const rows = [
+    ['受付区分', body.source || '管理者追加'],
+    ['名前', body.name],
+    ['Xアカウント', body.x_account || ''],
+    ['電話番号', body.phone || ''],
+    ['人数', String(body.participant_count ?? 1)],
+    ['同行者人数', String(body.companion_count ?? 0)],
+    ['同行者名', body.companion_names || ''],
+    ['備考', body.note || ''],
+  ];
+  return rows.map(([k, v]) => `${k}: ${v}`).join('\n');
+}
+
+events.post('/api/events/admin/events/:id/bookings', async (c) => {
+  const account_id = getAccountId(c);
+  if (!account_id) return bad(c, 'account_id_required', 400);
+  const event_id = c.req.param('id');
+  if (!(await ownsEvent(c.env.DB, event_id, account_id))) return bad(c, 'not_found', 404);
+
+  const body = (await c.req.json().catch(() => ({}))) as {
+    slot_id?: string;
+    name?: string;
+    phone?: string;
+    x_account?: string | null;
+    participant_count?: number;
+    companion_count?: number;
+    companion_names?: string | null;
+    note?: string | null;
+    source?: string | null;
+  };
+  const name = body.name?.trim();
+  const phone = body.phone?.trim() || '';
+  if (!body.slot_id) return bad(c, 'invalid_slot_id', 422);
+  if (!name) return bad(c, 'name_required', 422);
+  const participantCount = Number.isFinite(body.participant_count)
+    ? Math.max(1, Math.floor(body.participant_count ?? 1))
+    : 1;
+  const companionCount = Number.isFinite(body.companion_count)
+    ? Math.max(0, Math.floor(body.companion_count ?? 0))
+    : 0;
+  if (participantCount > 30 || companionCount > 29) return bad(c, 'invalid_party_size', 422);
+
+  const slot = await c.env.DB
+    .prepare(
+      `SELECT id, starts_at, capacity, is_active, deleted_at
+         FROM event_slots WHERE id = ? AND event_id = ? AND deleted_at IS NULL`,
+    )
+    .bind(body.slot_id, event_id)
+    .first<{ id: string; starts_at: string; capacity: number | null; is_active: number; deleted_at: string | null }>();
+  if (!slot || slot.is_active !== 1) return bad(c, 'slot_inactive', 409);
+
+  if (slot.capacity != null) {
+    const cnt = await c.env.DB
+      .prepare(
+        `SELECT COUNT(*) AS c FROM event_bookings
+          WHERE slot_id = ? AND status IN ('requested','confirmed')`,
+      )
+      .bind(slot.id)
+      .first<{ c: number }>();
+    if ((cnt?.c ?? 0) >= slot.capacity) return bad(c, 'slot_full', 409);
+  }
+
+  const nowIso = new Date().toISOString();
+  const friendId = crypto.randomUUID();
+  const bookingId = crypto.randomUUID();
+  const manualLineUserId = `manual:${account_id}:${bookingId}`;
+  const staff = c.get('staff');
+  await c.env.DB
+    .prepare(
+      `INSERT INTO friends
+         (id, line_account_id, line_user_id, display_name, is_following, user_id, metadata, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?)`,
+    )
+    .bind(
+      friendId,
+      account_id,
+      manualLineUserId,
+      name,
+      crypto.randomUUID(),
+      JSON.stringify({ source: 'event_admin_manual' }),
+      nowIso,
+      nowIso,
+    )
+    .run();
+
+  const source = body.source?.trim() || '管理者追加';
+  const customerNote = buildManualEventCustomerNote({
+    ...body,
+    name,
+    phone,
+    participant_count: participantCount,
+    companion_count: companionCount,
+    source,
+  });
+  if (customerNote.length > CUSTOMER_NOTE_MAX) return bad(c, 'invalid_customer_note', 422);
+
+  await c.env.DB
+    .prepare(
+      `INSERT INTO event_bookings
+         (id, line_account_id, event_id, slot_id, friend_id, status, customer_note, internal_note,
+          requested_at, decided_at, decided_by_staff_id, identity_key)
+       VALUES (?, ?, ?, ?, ?, 'confirmed', ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      bookingId,
+      account_id,
+      event_id,
+      slot.id,
+      friendId,
+      customerNote,
+      `受付区分: ${source}`,
+      nowIso,
+      nowIso,
+      staff?.id ?? null,
+      `manual:${bookingId}`,
+    )
+    .run();
+
+  const row = await c.env.DB
+    .prepare(
+      `SELECT b.*,
+              s.starts_at AS slot_starts_at, s.ends_at AS slot_ends_at,
+              f.display_name AS friend_display_name, f.line_user_id AS friend_line_user_id
+         FROM event_bookings b
+         JOIN event_slots s ON s.id = b.slot_id
+         LEFT JOIN friends f ON f.id = b.friend_id
+        WHERE b.id = ?`,
+    )
+    .bind(bookingId)
+    .first();
+  return c.json(row, 201);
+});
+
 events.get('/api/events/admin/events/:id/bookings', async (c) => {
   const account_id = getAccountId(c);
   if (!account_id) return bad(c, 'account_id_required', 400);
@@ -1127,7 +1534,7 @@ events.get('/api/events/admin/events/:id/bookings', async (c) => {
   const slot_id = c.req.query('slot_id');
   const conditions = ['b.event_id = ?'];
   const params: unknown[] = [event_id];
-  if (status) {
+  if (status && status !== 'all') {
     conditions.push('b.status = ?');
     params.push(status);
   }
@@ -1194,6 +1601,7 @@ async function notifyBookingFriend(
         `SELECT e.name AS event_name, e.venue_name, e.venue_url,
                 s.starts_at AS slot_starts_at,
                 la.channel_access_token,
+                la.liff_id,
                 f.line_user_id
            FROM event_bookings b
            JOIN events e ON e.id = b.event_id
@@ -1209,6 +1617,7 @@ async function notifyBookingFriend(
         venue_url: string | null;
         slot_starts_at: string;
         channel_access_token: string;
+        liff_id: string | null;
         line_user_id: string;
       }>();
     if (!row || !row.channel_access_token) return;
@@ -1221,6 +1630,7 @@ async function notifyBookingFriend(
         startsAtJst: startsAtJst(row.slot_starts_at),
         venueName: row.venue_name,
         venueUrl: row.venue_url,
+        liffId: row.liff_id,
       },
     });
   } catch (e) {
@@ -1228,22 +1638,22 @@ async function notifyBookingFriend(
   }
 }
 
-events.post('/api/events/admin/events/:id/bookings/:bookingId/decide', async (c) => {
-  const account_id = getAccountId(c);
-  if (!account_id) return bad(c, 'account_id_required', 400);
-  const event_id = c.req.param('id');
-  if (!(await ownsEvent(c.env.DB, event_id, account_id))) return bad(c, 'not_found', 404);
-  const booking = await loadBookingForAction(c.env.DB, account_id, event_id, c.req.param('bookingId'));
+async function decideEventBooking(
+  c: Context<Env>,
+  args: {
+    account_id: string;
+    event_id: string;
+    booking_id: string;
+    action: EventBookingAction;
+    reason?: string;
+  },
+): Promise<Response> {
+  if (!(await ownsEvent(c.env.DB, args.event_id, args.account_id))) return bad(c, 'not_found', 404);
+  const booking = await loadBookingForAction(c.env.DB, args.account_id, args.event_id, args.booking_id);
   if (!booking) return bad(c, 'not_found', 404);
   if (booking.decided_at != null) return bad(c, 'already_decided', 409);
-
-  const body = (await c.req.json().catch(() => ({}))) as { action?: string; reason?: string };
-  if (body.action !== 'confirm' && body.action !== 'reject') {
-    return bad(c, 'invalid_action', 422);
-  }
-  const action: EventBookingAction = body.action;
-  if (!canTransition(booking.status as never, action)) return bad(c, 'invalid_state', 409);
-  const next = nextStatus(booking.status as never, action);
+  if (!canTransition(booking.status as never, args.action)) return bad(c, 'invalid_state', 409);
+  const next = nextStatus(booking.status as never, args.action);
 
   const nowIso = new Date().toISOString();
   const staff = c.get('staff');
@@ -1260,7 +1670,7 @@ events.post('/api/events/admin/events/:id/bookings/:bookingId/decide', async (c)
     .run();
   if ((upd.meta?.changes ?? 0) === 0) return bad(c, 'already_decided', 409);
 
-  if (action === 'reject' && body.reason) {
+  if (args.action === 'reject' && args.reason) {
     await c.env.DB
       .prepare(
         `UPDATE event_bookings
@@ -1268,11 +1678,11 @@ events.post('/api/events/admin/events/:id/bookings/:bookingId/decide', async (c)
                 updated_at = ?
           WHERE id = ?`,
       )
-      .bind(`[reject reason] ${body.reason}`, nowIso, booking.id)
+      .bind(`[reject reason] ${args.reason}`, nowIso, booking.id)
       .run();
   }
 
-  if (action === 'confirm') {
+  if (args.action === 'confirm') {
     const slot = await c.env.DB
       .prepare(`SELECT starts_at FROM event_slots WHERE id = ?`)
       .bind(booking.slot_id)
@@ -1293,12 +1703,87 @@ events.post('/api/events/admin/events/:id/bookings/:bookingId/decide', async (c)
     }
   }
 
-  await notifyBookingFriend(c.env.DB, booking.id, action === 'confirm' ? 'confirmed' : 'rejected');
+  await notifyBookingFriend(c.env.DB, booking.id, args.action === 'confirm' ? 'confirmed' : 'rejected');
   const updated = await c.env.DB
     .prepare(`SELECT * FROM event_bookings WHERE id = ?`)
     .bind(booking.id)
     .first();
   return c.json(updated);
+}
+
+events.get('/telegram/event-booking-action', async (c) => {
+  const payload = await verifyTelegramActionToken<{
+    accountId?: string;
+    eventId?: string;
+    bookingId?: string;
+    action?: string;
+    exp?: number;
+  }>(c, c.req.query('t'));
+  if (
+    !payload ||
+    typeof payload.accountId !== 'string' ||
+    typeof payload.eventId !== 'string' ||
+    typeof payload.bookingId !== 'string' ||
+    (payload.action !== 'confirm' && payload.action !== 'reject') ||
+    typeof payload.exp !== 'number' ||
+    payload.exp < Math.floor(Date.now() / 1000)
+  ) {
+    return c.html(
+      '<!doctype html><meta name="viewport" content="width=device-width,initial-scale=1"><body style="font-family:sans-serif;padding:24px"><h2>リンクが無効です</h2><p>期限切れ、または不正なリンクです。管理画面から確認してください。</p></body>',
+      400,
+    );
+  }
+
+  const res = await decideEventBooking(c, {
+    account_id: payload.accountId,
+    event_id: payload.eventId,
+    booking_id: payload.bookingId,
+    action: payload.action,
+  });
+  if (res.status === 409) {
+    return c.html(
+      '<!doctype html><meta name="viewport" content="width=device-width,initial-scale=1"><body style="font-family:sans-serif;padding:24px"><h2>処理済みです</h2><p>この予約はすでに承認または拒否されています。</p></body>',
+    );
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    console.error('[event-booking] telegram action failed', res.status, text);
+    return c.html(
+      '<!doctype html><meta name="viewport" content="width=device-width,initial-scale=1"><body style="font-family:sans-serif;padding:24px"><h2>処理に失敗しました</h2><p>管理画面から確認してください。</p></body>',
+      500,
+    );
+  }
+  const label = payload.action === 'confirm' ? '承認しました' : '拒否しました';
+  try {
+    await sendTelegramMessage(c, {
+      text: payload.action === 'confirm'
+        ? `イベント予約を承認しました。\nbookingId: ${payload.bookingId}`
+        : `イベント予約を拒否しました。\nbookingId: ${payload.bookingId}`,
+    });
+  } catch (e) {
+    console.error('[event-booking] telegram action result notify failed', e);
+  }
+  return c.html(
+    `<!doctype html><meta name="viewport" content="width=device-width,initial-scale=1"><body style="font-family:sans-serif;padding:24px"><h2>${label}</h2><p>LINE Harnessへ反映しました。この画面は閉じて大丈夫です。</p></body>`,
+  );
+});
+
+events.post('/api/events/admin/events/:id/bookings/:bookingId/decide', async (c) => {
+  const account_id = getAccountId(c);
+  if (!account_id) return bad(c, 'account_id_required', 400);
+  const event_id = c.req.param('id');
+
+  const body = (await c.req.json().catch(() => ({}))) as { action?: string; reason?: string };
+  if (body.action !== 'confirm' && body.action !== 'reject') {
+    return bad(c, 'invalid_action', 422);
+  }
+  return decideEventBooking(c, {
+    account_id,
+    event_id,
+    booking_id: c.req.param('bookingId'),
+    action: body.action,
+    reason: body.reason,
+  });
 });
 
 events.post('/api/events/admin/events/:id/bookings/:bookingId/cancel', async (c) => {

--- a/apps/worker/src/routes/webhook.test.ts
+++ b/apps/worker/src/routes/webhook.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 
+const lineClientMock = vi.hoisted(() => ({
+  getProfile: vi.fn(),
+  replyMessage: vi.fn(),
+}));
+
 // Stub the DB graph — these tests only exercise the size guard and
 // signature-verify-before-parse path; webhook event handling is out of scope.
 vi.mock('@line-crm/db', () => ({
@@ -20,6 +25,7 @@ vi.mock('@line-crm/db', () => ({
   addTagToFriend: vi.fn(),
   getEntryRouteByRefCode: vi.fn(),
   getMessageTemplateById: vi.fn(),
+  getTemplateById: vi.fn(),
 }));
 
 vi.mock('@line-crm/line-sdk', async () => {
@@ -27,7 +33,7 @@ vi.mock('@line-crm/line-sdk', async () => {
   return {
     ...actual,
     verifySignature: vi.fn(),
-    LineClient: vi.fn().mockImplementation(() => ({})),
+    LineClient: vi.fn().mockImplementation(() => lineClientMock),
   };
 });
 
@@ -38,9 +44,23 @@ vi.mock('../services/event-bus.js', () => ({
 vi.mock('../services/step-delivery.js', () => ({
   buildMessage: vi.fn(),
   expandVariables: vi.fn(),
+  resolveMetadata: vi.fn(),
+  messageToLogPayload: vi.fn(),
 }));
 
 import { verifySignature } from '@line-crm/line-sdk';
+import {
+  getFriendByLineUserId,
+  getLineAccounts,
+  jstNow,
+  upsertFriend,
+} from '@line-crm/db';
+import {
+  buildMessage,
+  expandVariables,
+  messageToLogPayload,
+  resolveMetadata,
+} from '../services/step-delivery.js';
 import { webhook } from './webhook.js';
 
 function setupApp() {
@@ -63,6 +83,24 @@ const baseExecutionCtx = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  lineClientMock.getProfile.mockResolvedValue({
+    userId: 'Uunknown',
+    displayName: '未登録ユーザー',
+    pictureUrl: 'https://example.com/p.png',
+    statusMessage: null,
+  });
+  lineClientMock.replyMessage.mockResolvedValue(undefined);
+  vi.mocked(jstNow).mockReturnValue('2026-06-03T18:00:00.000+09:00');
+  vi.mocked(buildMessage).mockImplementation((messageType: string, content: string) => ({
+    type: messageType,
+    text: content,
+  }));
+  vi.mocked(expandVariables).mockImplementation((content: string) => content);
+  vi.mocked(resolveMetadata).mockResolvedValue({});
+  vi.mocked(messageToLogPayload).mockImplementation((message: unknown) => {
+    const msg = message as { type?: string; text?: string };
+    return { messageType: msg.type ?? 'text', content: msg.text ?? '' };
+  });
 });
 
 describe('POST /webhook — DoS defenses (#104)', () => {
@@ -154,5 +192,123 @@ describe('POST /webhook — DoS defenses (#104)', () => {
     expect(res.status).toBe(200);
     // Fast-rejected before any crypto / DB work.
     expect(verifySignature).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /webhook — unknown friend auto registration', () => {
+  test('auto-registers an unknown message sender and continues to auto-reply', async () => {
+    vi.mocked(verifySignature).mockResolvedValue(true);
+    vi.mocked(getLineAccounts).mockResolvedValue([
+      {
+        id: 'account-luu',
+        name: 'Darts＆Bar Luu',
+        channel_id: '2009755907',
+        channel_secret: 'env-default-secret',
+        channel_access_token: 'account-token',
+        liff_id: null,
+        is_active: 1,
+        created_at: '2026-06-03T18:00:00.000+09:00',
+        updated_at: '2026-06-03T18:00:00.000+09:00',
+      } as never,
+    ]);
+    vi.mocked(getFriendByLineUserId).mockResolvedValue(null);
+    vi.mocked(upsertFriend).mockResolvedValue({
+      id: 'friend-new',
+      line_user_id: 'Uunknown',
+      display_name: '未登録ユーザー',
+      picture_url: 'https://example.com/p.png',
+      status_message: null,
+      is_following: 1,
+      user_id: null,
+      line_account_id: null,
+      metadata: '{}',
+      first_tracked_link_id: null,
+      created_at: '2026-06-03T18:00:00.000+09:00',
+      updated_at: '2026-06-03T18:00:00.000+09:00',
+    });
+
+    const writes: Array<{ sql: string; args: unknown[] }> = [];
+    const db = {
+      prepare: vi.fn((sql: string) => ({
+        bind: (...args: unknown[]) => ({
+          first: vi.fn(async () => {
+            if (sql.includes('SELECT liff_id FROM line_accounts')) return { liff_id: null };
+            return null;
+          }),
+          all: vi.fn(async () => {
+            if (sql.includes('FROM auto_replies')) {
+              return {
+                results: [
+                  {
+                    id: 'reply-event',
+                    keyword: 'イベント',
+                    match_type: 'exact',
+                    response_type: 'text',
+                    response_content: 'イベント予約はこちら',
+                    template_id: null,
+                    is_active: 1,
+                    created_at: '2026-06-03T18:00:00.000+09:00',
+                  },
+                ],
+              };
+            }
+            return { results: [] };
+          }),
+          run: vi.fn(async () => {
+            writes.push({ sql, args });
+            return { success: true };
+          }),
+        }),
+      })),
+    } as unknown as D1Database;
+
+    const pending: Promise<unknown>[] = [];
+    const executionCtx = {
+      waitUntil: vi.fn((promise: Promise<unknown>) => {
+        pending.push(promise);
+      }),
+      passThroughOnException: vi.fn(),
+      props: {},
+    } as unknown as ExecutionContext;
+
+    const app = setupApp();
+    const res = await app.request(
+      '/webhook',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Line-Signature': 'A'.repeat(43) + '=',
+        },
+        body: JSON.stringify({
+          events: [
+            {
+              type: 'message',
+              replyToken: 'reply-token',
+              source: { type: 'user', userId: 'Uunknown' },
+              message: { id: 'msg-1', type: 'text', text: 'イベント' },
+            },
+          ],
+        }),
+      },
+      { ...baseEnv, DB: db },
+      executionCtx,
+    );
+    await Promise.all(pending);
+
+    expect(res.status).toBe(200);
+    expect(lineClientMock.getProfile).toHaveBeenCalledWith('Uunknown');
+    expect(upsertFriend).toHaveBeenCalledWith(db, {
+      lineUserId: 'Uunknown',
+      displayName: '未登録ユーザー',
+      pictureUrl: 'https://example.com/p.png',
+      statusMessage: null,
+    });
+    expect(lineClientMock.replyMessage).toHaveBeenCalledWith('reply-token', [
+      { type: 'text', text: 'イベント予約はこちら' },
+    ]);
+    expect(writes.some((w) => w.sql.includes('UPDATE friends SET line_account_id'))).toBe(true);
+    expect(writes.some((w) => w.sql.includes('INSERT INTO messages_log') && w.sql.includes("'incoming'"))).toBe(true);
+    expect(writes.some((w) => w.sql.includes('INSERT INTO messages_log') && w.sql.includes("'auto_reply'"))).toBe(true);
   });
 });

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -19,9 +19,10 @@ import {
   getEntryRouteByRefCode,
   getMessageTemplateById,
 } from '@line-crm/db';
-import type { EntryRoute } from '@line-crm/db';
+import type { EntryRoute, Friend } from '@line-crm/db';
 import { fireEvent } from '../services/event-bus.js';
 import { buildMessage, expandVariables } from '../services/step-delivery.js';
+import { renderMessageContent } from '../services/render-message.js';
 import type { Env } from '../index.js';
 
 const webhook = new Hono<Env>();
@@ -31,6 +32,164 @@ const webhook = new Hono<Env>();
 // bursty batched deliveries (~100 events × ~5 KB) while still well below the
 // 128 MB Cloudflare Workers memory ceiling.
 const MAX_WEBHOOK_BODY_SIZE = 1024 * 1024; // 1 MiB
+const UNMATCHED_ACK_WINDOW_HOURS = 6;
+
+function extractLiffId(value: string | undefined): string | null {
+  if (!value) return null;
+  const fromUrl = value.match(/liff\.line\.me\/([0-9]+-[A-Za-z0-9]+)/)?.[1];
+  if (fromUrl) return fromUrl;
+  return /^[0-9]+-[A-Za-z0-9]+$/.test(value) ? value : null;
+}
+
+async function resolveLiffIdForReply(
+  db: D1Database,
+  lineAccountId: string | null,
+  fallbackLiffUrl?: string,
+): Promise<string | null> {
+  if (lineAccountId) {
+    const row = await db
+      .prepare('SELECT liff_id FROM line_accounts WHERE id = ?')
+      .bind(lineAccountId)
+      .first<{ liff_id: string | null }>();
+    if (row?.liff_id) return row.liff_id;
+  }
+  return extractLiffId(fallbackLiffUrl);
+}
+
+function buildUnmatchedMessageAckFlex(): unknown {
+  return {
+    type: 'bubble',
+    size: 'mega',
+    header: {
+      type: 'box',
+      layout: 'vertical',
+      paddingAll: '16px',
+      backgroundColor: '#111827',
+      contents: [
+        { type: 'text', text: 'メッセージを受け付けました', color: '#FFFFFF', weight: 'bold', size: 'lg', wrap: true },
+        { type: 'text', text: 'スタッフが確認後、順次返信いたします', color: '#D1D5DB', size: 'sm', margin: 'xs', wrap: true },
+      ],
+    },
+    body: {
+      type: 'box',
+      layout: 'vertical',
+      spacing: 'md',
+      contents: [
+        {
+          type: 'text',
+          text: 'お急ぎの場合や追加情報がある場合は、このまま続けてお送りください。',
+          size: 'sm',
+          color: '#374151',
+          wrap: true,
+        },
+        {
+          type: 'text',
+          text: 'イベント予約・キャンセルは下のボタンから操作できます。',
+          size: 'sm',
+          color: '#111827',
+          weight: 'bold',
+          wrap: true,
+        },
+      ],
+    },
+    footer: {
+      type: 'box',
+      layout: 'vertical',
+      spacing: 'sm',
+      contents: [
+        {
+          type: 'button',
+          style: 'primary',
+          color: '#06C755',
+          action: { type: 'message', label: 'イベント予約はこちら', text: 'イベント' },
+        },
+        {
+          type: 'button',
+          style: 'secondary',
+          action: { type: 'message', label: 'キャンセルはこちら', text: 'キャンセル' },
+        },
+      ],
+    },
+  };
+}
+
+async function shouldSendUnmatchedAck(db: D1Database, friendId: string): Promise<boolean> {
+  const row = await db
+    .prepare(
+      `SELECT created_at
+         FROM messages_log
+        WHERE friend_id = ?
+          AND direction = 'outgoing'
+          AND source = 'unmatched_ack'
+        ORDER BY created_at DESC
+        LIMIT 1`,
+    )
+    .bind(friendId)
+    .first<{ created_at: string }>();
+  if (!row?.created_at) return true;
+  const last = new Date(row.created_at).getTime();
+  if (!Number.isFinite(last)) return true;
+  return Date.now() - last >= UNMATCHED_ACK_WINDOW_HOURS * 3600_000;
+}
+
+async function sendUnmatchedMessageAck(
+  db: D1Database,
+  lineClient: LineClient,
+  friendId: string,
+  replyToken: string,
+  lineAccountId: string | null,
+): Promise<boolean> {
+  if (!(await shouldSendUnmatchedAck(db, friendId))) return false;
+  const contents = buildUnmatchedMessageAckFlex();
+  const replyMsg = buildMessage('flex', JSON.stringify(contents), 'メッセージを受け付けました');
+  await lineClient.replyMessage(replyToken, [replyMsg]);
+  const { messageToLogPayload } = await import('../services/step-delivery.js');
+  const payload = messageToLogPayload(replyMsg);
+  await db
+    .prepare(
+      `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, delivery_type, source, line_account_id, created_at)
+       VALUES (?, ?, 'outgoing', ?, ?, NULL, NULL, 'reply', 'unmatched_ack', ?, ?)`,
+    )
+    .bind(crypto.randomUUID(), friendId, payload.messageType, payload.content, lineAccountId, jstNow())
+    .run();
+  return true;
+}
+
+async function resolveWebhookFriend(
+  db: D1Database,
+  lineClient: LineClient,
+  userId: string,
+  lineAccountId: string | null,
+): Promise<Friend | null> {
+  let friend = await getFriendByLineUserId(db, userId);
+
+  if (!friend) {
+    let profile: Awaited<ReturnType<LineClient['getProfile']>> | null = null;
+    try {
+      profile = await lineClient.getProfile(userId);
+    } catch (err) {
+      console.error('Failed to get profile for message sender', userId, err);
+    }
+
+    friend = await upsertFriend(db, {
+      lineUserId: userId,
+      displayName: profile?.displayName ?? null,
+      pictureUrl: profile?.pictureUrl ?? null,
+      statusMessage: profile?.statusMessage ?? null,
+    });
+    console.log(`[webhook] auto-registered message sender friend=${friend.id} userId=${userId}`);
+  }
+
+  if (lineAccountId && friend.line_account_id !== lineAccountId) {
+    await db
+      .prepare('UPDATE friends SET line_account_id = ?, is_following = 1, updated_at = ? WHERE id = ?')
+      .bind(lineAccountId, jstNow(), friend.id)
+      .run();
+    friend = { ...friend, line_account_id: lineAccountId, is_following: 1 };
+  }
+
+  return friend;
+}
 
 webhook.post('/webhook', async (c) => {
   // Pre-read size guard: reject before reading the body if Content-Length is oversized.
@@ -339,7 +498,7 @@ async function handleEvent(
     const userId = event.source.type === 'user' ? event.source.userId : undefined;
     if (!userId) return;
 
-    const friend = await getFriendByLineUserId(db, userId);
+    const friend = await resolveWebhookFriend(db, lineClient, userId, lineAccountId);
     if (!friend) return;
 
     const postbackData = (event as unknown as { postback: { data: string } }).postback.data;
@@ -389,7 +548,10 @@ async function handleEvent(
             response_type: rule.response_type,
             response_content: rule.response_content,
           });
-          const expandedContent = expandVariables(resolved.content, { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1], workerUrl);
+          const expandedContent = renderMessageContent(
+            expandVariables(resolved.content, { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1], workerUrl),
+            await resolveLiffIdForReply(db, lineAccountId, liffUrl),
+          );
           const replyMsg = buildMessage(resolved.messageType, expandedContent);
           await lineClient.replyMessage(event.replyToken, [replyMsg]);
 
@@ -419,7 +581,7 @@ async function handleEvent(
   if (event.type === 'message' && event.message.type !== 'text') {
     const userId = event.source.type === 'user' ? event.source.userId : undefined;
     if (!userId) return;
-    const friend = await getFriendByLineUserId(db, userId);
+    const friend = await resolveWebhookFriend(db, lineClient, userId, lineAccountId);
     if (!friend) return;
 
     const msg = event.message as { id: string; type: string; fileName?: string; title?: string };
@@ -453,10 +615,10 @@ async function handleEvent(
 
     await db
       .prepare(
-        `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, created_at)
-         VALUES (?, ?, 'incoming', ?, ?, NULL, NULL, 'user', ?)`,
+        `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, line_account_id, created_at)
+         VALUES (?, ?, 'incoming', ?, ?, NULL, NULL, 'user', ?, ?)`,
       )
-      .bind(crypto.randomUUID(), friend.id, msg.type, finalContent, jstNow())
+      .bind(crypto.randomUUID(), friend.id, msg.type, finalContent, lineAccountId, jstNow())
       .run();
     return;
   }
@@ -467,7 +629,7 @@ async function handleEvent(
       event.source.type === 'user' ? event.source.userId : undefined;
     if (!userId) return;
 
-    const friend = await getFriendByLineUserId(db, userId);
+    const friend = await resolveWebhookFriend(db, lineClient, userId, lineAccountId);
     if (!friend) return;
 
     const incomingText = textMessage.text;
@@ -477,10 +639,10 @@ async function handleEvent(
     // 受信メッセージをログに記録
     await db
       .prepare(
-        `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, created_at)
-         VALUES (?, ?, 'incoming', 'text', ?, NULL, NULL, 'user', ?)`,
+        `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, line_account_id, created_at)
+         VALUES (?, ?, 'incoming', 'text', ?, NULL, NULL, 'user', ?, ?)`,
       )
-      .bind(logId, friend.id, incomingText, now)
+      .bind(logId, friend.id, incomingText, lineAccountId, now)
       .run();
 
     // Cross-account trigger: send message from another account via UUID
@@ -577,7 +739,10 @@ async function handleEvent(
             response_type: rule.response_type,
             response_content: rule.response_content,
           });
-          const expandedContent = expandVariables(resolved.content, { ...friend, metadata: resolvedMeta2 } as Parameters<typeof expandVariables>[1], workerUrl);
+          const expandedContent = renderMessageContent(
+            expandVariables(resolved.content, { ...friend, metadata: resolvedMeta2 } as Parameters<typeof expandVariables>[1], workerUrl),
+            await resolveLiffIdForReply(db, lineAccountId, liffUrl),
+          );
           const replyMsg = buildMessage(resolved.messageType, expandedContent);
           await lineClient.replyMessage(event.replyToken, [replyMsg]);
           replyTokenConsumed = true;
@@ -590,10 +755,10 @@ async function handleEvent(
           const wbAutoReplyPayload = logPayload2(replyMsg);
           await db
             .prepare(
-              `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, delivery_type, source, created_at)
-               VALUES (?, ?, 'outgoing', ?, ?, NULL, NULL, 'reply', 'auto_reply', ?)`,
+              `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, delivery_type, source, line_account_id, created_at)
+               VALUES (?, ?, 'outgoing', ?, ?, NULL, NULL, 'reply', 'auto_reply', ?, ?)`,
             )
-            .bind(outLogId, friend.id, wbAutoReplyPayload.messageType, wbAutoReplyPayload.content, jstNow())
+            .bind(outLogId, friend.id, wbAutoReplyPayload.messageType, wbAutoReplyPayload.content, lineAccountId, jstNow())
             .run();
         } catch (err) {
           console.error('Failed to send auto-reply', err);
@@ -607,6 +772,11 @@ async function handleEvent(
     // auto_replies にマッチしなかった = 自発メッセージ → unread にする
     if (!matched) {
       await upsertChatOnMessage(db, friend.id);
+      try {
+        replyTokenConsumed = await sendUnmatchedMessageAck(db, lineClient, friend.id, event.replyToken, lineAccountId);
+      } catch (err) {
+        console.error('Failed to send unmatched message ack', err);
+      }
     }
 
     // イベントバス発火: message_received

--- a/apps/worker/src/services/event-booking-notifier.test.ts
+++ b/apps/worker/src/services/event-booking-notifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { renderEventNotificationText } from './event-booking-notifier.js';
+import { renderEventNotificationMessage, renderEventNotificationText } from './event-booking-notifier.js';
 
 const baseCtx = {
   eventName: 'AAA説明会',
@@ -11,11 +11,12 @@ const baseCtx = {
 describe('renderEventNotificationText', () => {
   test('受付（承認待ち）', () => {
     const text = renderEventNotificationText('received_pending', baseCtx);
-    expect(text).toContain('イベント申込みを受け付けました');
+    expect(text).toContain('イベント申し込み予約を受け付けました');
     expect(text).toContain('AAA説明会');
     expect(text).toContain('2026-06-01 10:00');
     expect(text).toContain('運営の承認をお待ちください');
     expect(text).toContain('渋谷ベース');
+    expect(text).not.toContain('https://');
   });
 
   test('受付（即時確定）', () => {
@@ -31,6 +32,7 @@ describe('renderEventNotificationText', () => {
 
   test('拒否は固定文面（reason は含まない）', () => {
     const text = renderEventNotificationText('rejected', baseCtx);
+    expect(text).toContain('既に定員に達してしまっていますので');
     expect(text).toContain('お受けできませんでした');
     expect(text).not.toContain('reason');
   });
@@ -64,13 +66,52 @@ describe('renderEventNotificationText', () => {
     expect(text).not.toContain('会場:');
   });
 
-  test('venue_url のみ無ければ URL 行が出ない', () => {
+  test('venue_url があっても URL 行は出ない', () => {
     const text = renderEventNotificationText('confirmed', {
       eventName: 'X',
       startsAtJst: '2026-06-01 10:00',
       venueName: '渋谷',
+      venueUrl: 'https://maps.example/x',
     });
     expect(text).toContain('会場: 渋谷');
     expect(text).not.toContain('https://');
+  });
+
+  test('受付と確定は liffId があれば Flex ボタン付きになる', () => {
+    const msg = renderEventNotificationMessage('received_pending', {
+      ...baseCtx,
+      liffId: '2009763432-eexiWWGf',
+    });
+    expect(msg.type).toBe('flex');
+    if (msg.type !== 'flex') throw new Error('expected flex');
+    expect(msg.altText).toBe('イベント申し込み予約を受け付けました');
+    const json = JSON.stringify(msg.contents);
+    expect(json).toContain('イベント一覧を開く');
+    expect(json).toContain('予約履歴を見る');
+    expect(json).toContain('page=events');
+    expect(json).toContain('page=event-me');
+    expect(json).not.toContain('https://maps.example/x');
+  });
+
+  test('確定 Flex は青テーマになる', () => {
+    const msg = renderEventNotificationMessage('confirmed', {
+      ...baseCtx,
+      liffId: '2009763432-eexiWWGf',
+    });
+    expect(msg.type).toBe('flex');
+    if (msg.type !== 'flex') throw new Error('expected flex');
+    const json = JSON.stringify(msg.contents);
+    expect(json).toContain('#2563EB');
+    expect(json).toContain('#FFFFFF');
+    expect(json).toContain('イベント予約が確定しました');
+    expect(json).toContain('イベント一覧を開く');
+    expect(json).toContain('予約履歴を見る');
+  });
+
+  test('liffId がなければ従来のテキスト通知にフォールバックする', () => {
+    const msg = renderEventNotificationMessage('received_pending', baseCtx);
+    expect(msg.type).toBe('text');
+    if (msg.type !== 'text') throw new Error('expected text');
+    expect(msg.text).toContain('イベント申し込み予約を受け付けました');
   });
 });

--- a/apps/worker/src/services/event-booking-notifier.ts
+++ b/apps/worker/src/services/event-booking-notifier.ts
@@ -1,4 +1,4 @@
-import { LineClient } from '@line-crm/line-sdk';
+import { LineClient, type Message } from '@line-crm/line-sdk';
 
 export type EventNotificationKind =
   | 'received_pending'      // 受付（承認制ON、未承認段階）
@@ -14,6 +14,7 @@ export interface EventNotificationContext {
   startsAtJst: string; // 例: "2026-06-01 10:00"
   venueName?: string | null;
   venueUrl?: string | null;
+  liffId?: string | null;
   hoursBefore?: number;
 }
 
@@ -22,17 +23,16 @@ export function renderEventNotificationText(
   ctx: EventNotificationContext,
 ): string {
   const venueLine = ctx.venueName ? `\n会場: ${ctx.venueName}` : '';
-  const venueUrlLine = ctx.venueUrl ? `\n${ctx.venueUrl}` : '';
-  const detail = `\nイベント: ${ctx.eventName}\n日時: ${ctx.startsAtJst}${venueLine}${venueUrlLine}`;
+  const detail = `\nイベント: ${ctx.eventName}\n日時: ${ctx.startsAtJst}${venueLine}`;
   switch (kind) {
     case 'received_pending':
-      return `イベント申込みを受け付けました。${detail}\n\n運営の承認をお待ちください。`;
+      return `イベント申し込み予約を受け付けました。${detail}\n\n運営の承認をお待ちください。`;
     case 'received_confirmed':
       return `イベント予約が確定しました。${detail}\n\n変更・キャンセルは予約履歴画面からお願いします。`;
     case 'confirmed':
       return `イベント予約が確定しました。${detail}\n\n変更・キャンセルは予約履歴画面からお願いします。`;
     case 'rejected':
-      return `申し訳ございません、今回のイベント予約はお受けできませんでした。${detail}`;
+      return `申し訳ございません。既に定員に達してしまっていますので、今回のイベント予約はお受けできませんでした。${detail}`;
     case 'cancelled_by_admin':
       return `運営側でイベント予約をキャンセルさせていただきました。${detail}\n\n詳細は LINE にてご連絡ください。`;
     case 'reminder_day_before':
@@ -42,6 +42,121 @@ export function renderEventNotificationText(
       return `【リマインド】まもなくイベント開始です（あと ${hours} 時間）。${detail}`;
     }
   }
+}
+
+function isActionableNotification(kind: EventNotificationKind): boolean {
+  return kind === 'received_pending' || kind === 'received_confirmed' || kind === 'confirmed';
+}
+
+function buildLiffUrl(liffId: string, page: 'events' | 'event-me'): string {
+  const encoded = encodeURIComponent(liffId);
+  return `https://liff.line.me/${encoded}?page=${page}&liffId=${encoded}`;
+}
+
+export function renderEventNotificationMessage(
+  kind: EventNotificationKind,
+  ctx: EventNotificationContext,
+): Message {
+  const text = renderEventNotificationText(kind, ctx);
+  const liffId = ctx.liffId?.trim();
+  if (!liffId || !isActionableNotification(kind)) {
+    return { type: 'text', text };
+  }
+
+  const title = kind === 'received_pending'
+    ? 'イベント申し込み予約を受け付けました'
+    : 'イベント予約が確定しました';
+  const lead = kind === 'received_pending'
+    ? '運営の承認をお待ちください。'
+    : '変更・キャンセルは予約履歴画面からお願いします。';
+  const isConfirmed = kind === 'received_confirmed' || kind === 'confirmed';
+  const themeColor = isConfirmed ? '#2563EB' : '#06C755';
+  const themeLight = isConfirmed ? '#EFF6FF' : '#ECFDF5';
+  const themeText = isConfirmed ? '#1D4ED8' : '#047857';
+
+  return {
+    type: 'flex',
+    altText: title,
+    contents: {
+      type: 'bubble',
+      body: {
+        type: 'box',
+        layout: 'vertical',
+        spacing: 'md',
+        paddingAll: '18px',
+        contents: [
+          {
+            type: 'box',
+            layout: 'vertical',
+            backgroundColor: isConfirmed ? themeColor : themeLight,
+            cornerRadius: 'md',
+            paddingAll: '14px',
+            contents: [
+              {
+                type: 'text',
+                text: title,
+                weight: 'bold',
+                size: 'lg',
+                color: isConfirmed ? '#FFFFFF' : themeText,
+                wrap: true,
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: lead,
+            size: 'sm',
+            color: '#4b5563',
+            wrap: true,
+          },
+          {
+            type: 'separator',
+            margin: 'md',
+          },
+          {
+            type: 'box',
+            layout: 'vertical',
+            spacing: 'sm',
+            margin: 'md',
+            contents: [
+              { type: 'text', text: `イベント: ${ctx.eventName}`, size: 'sm', color: '#111827', wrap: true },
+              { type: 'text', text: `日時: ${ctx.startsAtJst}`, size: 'sm', color: '#111827', wrap: true },
+              ...(ctx.venueName ? [{ type: 'text', text: `会場: ${ctx.venueName}`, size: 'sm', color: '#111827', wrap: true }] : []),
+            ],
+          },
+        ],
+      },
+      footer: {
+        type: 'box',
+        layout: 'vertical',
+        spacing: 'sm',
+        paddingAll: '16px',
+        contents: [
+          {
+            type: 'button',
+            style: 'primary',
+            color: themeColor,
+            height: 'md',
+            action: {
+              type: 'uri',
+              label: 'イベント一覧を開く',
+              uri: buildLiffUrl(liffId, 'events'),
+            },
+          },
+          {
+            type: 'button',
+            style: 'secondary',
+            height: 'md',
+            action: {
+              type: 'uri',
+              label: '予約履歴を見る',
+              uri: buildLiffUrl(liffId, 'event-me'),
+            },
+          },
+        ],
+      },
+    },
+  };
 }
 
 export interface SendEventNotificationParams {
@@ -54,9 +169,9 @@ export interface SendEventNotificationParams {
 export async function sendEventBookingNotification(
   params: SendEventNotificationParams,
 ): Promise<void> {
-  const text = renderEventNotificationText(params.kind, params.ctx);
+  const message = renderEventNotificationMessage(params.kind, params.ctx);
   const client = new LineClient(params.channelAccessToken);
-  await client.pushMessage(params.toLineUserId, [{ type: 'text', text }]);
+  await client.pushMessage(params.toLineUserId, [message]);
 }
 
 export type EventBookingNotificationSender = (


### PR DESCRIPTION
## Summary\n- stabilize Luu event booking approval/rejection flow from Telegram action links\n- keep admin event booking decide logic shared with Telegram actions\n- include current Luu event booking UI/notification updates already deployed\n\n## Verification\n- ./node_modules/.bin/tsc --noEmit\n- ./node_modules/.bin/vite build\n\nNote: existing LIFF event tests still have unrelated failures in events.test.ts.