### PR TITLE
fix(create): verify admin-auth secrets landed after setup (#179)

### DIFF
--- a/packages/create-line-harness/src/steps/admin-auth.ts
+++ b/packages/create-line-harness/src/steps/admin-auth.ts
@@ -47,5 +47,79 @@ export async function configureAdminAuth(options: AdminAuthOptions): Promise<voi
     await wrangler(["versions", "deploy", "--name", options.workerName, "--yes"]);
   }
 
+  // Verify the secrets actually landed on the deployed Worker. The bulk /
+  // versions path can silently no-op in some auth states, and a setup that
+  // aborted earlier (e.g. the Worker-deploy failure fixed in
+  // create-line-harness@0.1.27, issue #177) never reaches this step at all — in
+  // both cases the Worker is left without ADMIN_ORIGIN and admin login then
+  // fails with an opaque CORS error (issue #179). Surface it now, at setup time,
+  // instead of leaving the operator to debug a browser CORS block.
+  const missing = await findMissingAdminAuthSecrets(options.workerName);
+
   s.stop("管理画面の認証設定完了");
+
+  if (missing.length > 0) {
+    p.log.warn(
+      `管理画面の認証用シークレット (${missing.join(", ")}) が Worker "${options.workerName}" に見つかりませんでした。\n` +
+        `このままでは管理画面ログインが CORS エラーで失敗します (issue #179)。以下で設定してください:\n` +
+        missing
+          .map((name) => {
+            const value = name === "ADMIN_ORIGIN" ? options.adminUrl : "true";
+            return `  printf '%s' '${value}' | npx wrangler secret put ${name} --name ${options.workerName}`;
+          })
+          .join("\n") +
+        `\n※ 複数の Cloudflare アカウントを使っている場合は npx wrangler whoami で対象アカウントを確認してください。` +
+        `\n詳細: docs/ADMIN-AUTH.md`,
+    );
+  }
+}
+
+export const REQUIRED_ADMIN_AUTH_SECRETS = ["ADMIN_ORIGIN", "ADMIN_ALLOW_CROSS_SITE"];
+
+/**
+ * Parse `wrangler secret list --format json` output and return which required
+ * admin-auth secrets are absent. Pure and exported so it can be unit-tested.
+ *
+ * Tolerant of leading noise (a banner or npx chatter before the JSON array) and
+ * of any unparsable input: returns `[]` ("assume fine") on failure so a garbled
+ * secret list never produces a false "missing" report.
+ */
+export function findMissingRequiredSecrets(rawSecretListJson: string): string[] {
+  // Extract from the first '[' so a stray banner line before the JSON array
+  // does not defeat the parse.
+  const start = rawSecretListJson.indexOf("[");
+  if (start === -1) return [];
+
+  let names: Set<string>;
+  try {
+    const parsed = JSON.parse(rawSecretListJson.slice(start)) as Array<{ name?: string }>;
+    if (!Array.isArray(parsed)) return [];
+    names = new Set(
+      parsed.map((entry) => entry?.name).filter((name): name is string => Boolean(name)),
+    );
+  } catch {
+    return [];
+  }
+
+  return REQUIRED_ADMIN_AUTH_SECRETS.filter((name) => !names.has(name));
+}
+
+/**
+ * Return which required admin-auth secrets are absent from the deployed Worker.
+ *
+ * Best-effort by design: returns `[]` ("assume fine") whenever the secret list
+ * cannot be read, so a transient verification failure never blocks setup with a
+ * false negative. We only report a secret as missing when the list was read
+ * successfully and the name is genuinely absent.
+ */
+async function findMissingAdminAuthSecrets(workerName: string): Promise<string[]> {
+  let raw: string;
+  try {
+    // `--format json` is the default on current wrangler but is passed
+    // explicitly so the parse stays stable across versions.
+    raw = await wrangler(["secret", "list", "--name", workerName, "--format", "json"]);
+  } catch {
+    return [];
+  }
+  return findMissingRequiredSecrets(raw);
 }


### PR DESCRIPTION
## What & why

Follow-up to #179 (see also the Worker-side diagnostic in #186). When
`ADMIN_ORIGIN` is missing from the Worker, admin login fails with an opaque
CORS error and the operator gets no signal. `configureAdminAuth` sets the
secrets, but:

- the `secret bulk` / `versions secret put` path can silently no-op in some
  auth states, and
- a setup that aborted earlier (e.g. the Worker-deploy failure fixed in
  `create-line-harness@0.1.27`, #177) never reaches this step,

so the Worker can end up without `ADMIN_ORIGIN` / `ADMIN_ALLOW_CROSS_SITE`
while setup still reports success.

## Change

`packages/create-line-harness/src/steps/admin-auth.ts`: after setting the
secrets, verify they actually landed via
`wrangler secret list --name <worker> --format json`. If a required secret is
**confirmed missing**, print an actionable `p.log.warn` with the exact
`wrangler secret put` remediation and a pointer to `docs/ADMIN-AUTH.md`.

- **Best-effort / no false blocks**: any unreadable or unparsable list is
  treated as "assume fine" (`[]`), so a transient verification failure never
  blocks setup with a false negative. It only warns when a secret is genuinely
  absent from a successfully-read list.
- **Robust parse**: the JSON is extracted from the first `[`, tolerating a
  banner/chatter line before the array.
- The parse is factored into a pure, exported `findMissingRequiredSecrets()` so
  it can be unit-tested once the package gains a test setup.

## Notes / scope

- This package currently has no test scaffold, so no unit test is included. The
  pure parser was validated manually across: both present → `[]`, none → both,
  one → the missing one, banner-prefixed JSON → correct, non-JSON → `[]`. Happy
  to add a vitest setup + table test for `findMissingRequiredSecrets` if you'd
  like.
- Follow-up idea (kept out to stay small): setup marks the `adminAuth` step done
  unconditionally, so the warning only shows on the first run. Re-running while
  secrets are missing would re-surface it — can file as an issue if useful.

## Testing

`create-line-harness` builds (tsup) and `tsc --noEmit` passes; `pnpm test:scripts`
stays green (37 passing).

Refs #179
