### PR TITLE
fix: honor next_step_on_false jump target + scope comma cleanup to flex

### DIFF
--- a/apps/worker/src/routes/forms.ts
+++ b/apps/worker/src/routes/forms.ts
@@ -572,7 +572,7 @@ forms.post('/api/forms/:id/submit', async (c) => {
             messages.push(rewardFromTrackedLink as ReturnType<typeof buildMessage>);
           } else if (form.on_submit_message_type && form.on_submit_message_content) {
             // Custom form message replaces default diagnostic result
-            const expanded = expandVariables(form.on_submit_message_content, friendData, apiOrigin);
+            const expanded = expandVariables(form.on_submit_message_content, friendData, apiOrigin, form.on_submit_message_type);
             messages.push(buildMessage(form.on_submit_message_type, expanded));
           } else {
             // Default: send diagnostic result Flex

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -213,6 +213,7 @@ async function applyRefAttribution(
         resolved.messageContent,
         { ...fresh, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1],
         c.env.WORKER_URL,
+        resolved.messageType,
       );
       const pushedMessage = buildMessage(resolved.messageType, expanded);
       await lineClient.pushMessage(lineUserId, [pushedMessage]);
@@ -900,6 +901,7 @@ liffRoutes.get('/auth/callback', async (c) => {
                   resolved.messageContent,
                   { ...friend, metadata: resolvedMetaLiff } as Parameters<typeof expandVariables>[1],
                   c.env.WORKER_URL,
+                  resolved.messageType,
                 );
                 const pushedMessage = buildMessage(resolved.messageType, expandedContent);
                 await lineClient.pushMessage(lineUserId, [pushedMessage]);

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -283,7 +283,7 @@ async function handleEvent(
                 const resolved = await resolveStepContent(db, firstStep);
                 const { resolveMetadata } = await import('../services/step-delivery.js');
                 const resolvedMeta = await resolveMetadata(db, { user_id: (friend as unknown as Record<string, string | null>).user_id, metadata: (friend as unknown as Record<string, string | null>).metadata });
-                const expandedContent = expandVariables(resolved.messageContent, { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1]);
+                const expandedContent = expandVariables(resolved.messageContent, { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1], undefined, resolved.messageType);
                 const message = buildMessage(resolved.messageType, expandedContent);
                 await lineClient.replyMessage(event.replyToken, [message]);
                 console.log(`Immediate delivery: sent step ${firstStep.id} to ${userId}`);
@@ -430,7 +430,7 @@ async function handleEvent(
             response_type: rule.response_type,
             response_content: rule.response_content,
           });
-          const expandedContent = expandVariables(resolved.content, { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1], workerUrl);
+          const expandedContent = expandVariables(resolved.content, { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1], workerUrl, resolved.messageType);
           const replyMsg = buildMessage(resolved.messageType, expandedContent);
           await lineClient.replyMessage(event.replyToken, [replyMsg]);
 
@@ -635,7 +635,7 @@ async function handleEvent(
             response_type: rule.response_type,
             response_content: rule.response_content,
           });
-          const expandedContent = expandVariables(resolved.content, { ...friend, metadata: resolvedMeta2 } as Parameters<typeof expandVariables>[1], workerUrl);
+          const expandedContent = expandVariables(resolved.content, { ...friend, metadata: resolvedMeta2 } as Parameters<typeof expandVariables>[1], workerUrl, resolved.messageType);
           const replyMsg = buildMessage(resolved.messageType, expandedContent);
           await lineClient.replyMessage(event.replyToken, [replyMsg]);
           replyTokenConsumed = true;

--- a/apps/worker/src/services/step-delivery.test.ts
+++ b/apps/worker/src/services/step-delivery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { evaluateCondition, isSupportedConditionType, SUPPORTED_CONDITION_TYPES, processStepDeliveries } from './step-delivery.js';
+import { evaluateCondition, isSupportedConditionType, SUPPORTED_CONDITION_TYPES, processStepDeliveries, expandVariables } from './step-delivery.js';
 import type { LineClient } from '@line-crm/line-sdk';
 
 /**
@@ -380,5 +380,57 @@ describe('condition-false jump (next_step_on_false)', () => {
 
     expect(advances).toHaveLength(1);
     expect(advances[0].nextStepOrder).toBe(2); // no step 99 → sequential path
+  });
+});
+
+/**
+ * Regression coverage for the comma-cleanup scope bug.
+ *
+ * The ",," / "[," / ",]" cleanup in expandVariables exists to repair Flex
+ * JSON broken by conditional-block removal ({{#if_ref}} / {{#if_metadata.KEY}}
+ * inside arrays). Pre-fix it ran on EVERY message type, silently rewriting
+ * plain-text bodies that legitimately contain those sequences.
+ */
+describe('expandVariables comma cleanup scope', () => {
+  const friend = { id: 'f1', display_name: 'Test', user_id: null };
+
+  describe('text messages are never rewritten', () => {
+    it('preserves ",," in a text body', () => {
+      const body = '価格は 1,, 2,, 3 のように表記します';
+      expect(expandVariables(body, friend, undefined, 'text')).toBe(body);
+    });
+
+    it('preserves "[," and ",]" in a text body', () => {
+      const body = '記法メモ: [, は開き、 ,] は閉じ';
+      expect(expandVariables(body, friend, undefined, 'text')).toBe(body);
+    });
+
+    it('preserves ",," when messageType is omitted (safe default)', () => {
+      const body = 'A,, B';
+      expect(expandVariables(body, friend)).toBe(body);
+    });
+
+    it('still expands {{name}} in text without touching commas', () => {
+      const out = expandVariables('{{name}}様, , こんにちは', friend, undefined, 'text');
+      expect(out).toBe('Test様, , こんにちは');
+    });
+  });
+
+  describe('flex messages keep the JSON repair (existing behaviour)', () => {
+    it('repairs "[," left by a removed {{#if_ref}} block so the JSON parses', () => {
+      // Simulates a Flex contents array whose first element was a conditional
+      // block removed for a friend without ref_code: [{{#if_ref}}{...}{{/if_ref}},{...}]
+      const template = '{"contents":[{{#if_ref}}{"type":"text","text":"ref: {{ref}}"}{{/if_ref}},{"type":"text","text":"hello"}]}';
+      const out = expandVariables(template, { ...friend, ref_code: null }, undefined, 'flex');
+      expect(out).toBe('{"contents":[{"type":"text","text":"hello"}]}');
+      expect(() => JSON.parse(out)).not.toThrow();
+    });
+
+    it('repairs ",]" when the removed block was the last array element', () => {
+      const template = '{"contents":[{"type":"text","text":"hello"},{{#if_metadata.plan}}{"type":"text","text":"{{metadata.plan}}"}{{/if_metadata.plan}}]}';
+      const out = expandVariables(template, { ...friend, metadata: {} }, undefined, 'flex');
+      expect(out).toBe('{"contents":[{"type":"text","text":"hello"}]}');
+      expect(() => JSON.parse(out)).not.toThrow();
+    });
   });
 });

--- a/apps/worker/src/services/step-delivery.test.ts
+++ b/apps/worker/src/services/step-delivery.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { evaluateCondition, isSupportedConditionType, SUPPORTED_CONDITION_TYPES } from './step-delivery.js';
+import { evaluateCondition, isSupportedConditionType, SUPPORTED_CONDITION_TYPES, processStepDeliveries } from './step-delivery.js';
+import type { LineClient } from '@line-crm/line-sdk';
 
 /**
  * Regression coverage for OSS issue #120 — scenario step
@@ -207,5 +208,177 @@ describe('evaluateCondition', () => {
       // metadata defaults to {} → key is absent → not equal → returns false
       expect(result).toBe(false);
     });
+  });
+});
+
+/**
+ * Regression coverage for the condition-false jump path.
+ *
+ * Pre-fix, a failed condition with next_step_on_false set advanced
+ * current_step_order to currentStep.step_order — so the next tick's
+ * `find(step_order > current)` delivered the sequentially-next step and the
+ * configured jump target was silently ignored (only its timing was used).
+ * The bug is invisible when the jump target happens to BE the next step,
+ * which is why it survived since the initial release.
+ */
+describe('condition-false jump (next_step_on_false)', () => {
+  interface AdvanceCall {
+    nextStepOrder: number;
+    nextDeliveryAt: string | null;
+    id: string;
+  }
+
+  /**
+   * Fake D1 driving processStepDeliveries through the condition-false path:
+   * one due friend_scenario at current_step_order=1, whose next step (order 2)
+   * has a tag_exists condition the friend does NOT satisfy.
+   */
+  function deliveryMockDb(opts: { nextStepOnFalse: number | null; steps?: number[] }): {
+    db: D1Database;
+    advances: AdvanceCall[];
+    completes: string[];
+  } {
+    const advances: AdvanceCall[] = [];
+    const completes: string[] = [];
+    const stepOrders = opts.steps ?? [1, 2, 3, 4];
+    const stepRows = stepOrders.map((order) => ({
+      id: `step-${order}`,
+      scenario_id: 'sc1',
+      step_order: order,
+      message_type: 'text',
+      message_content: `msg ${order}`,
+      template_id: null,
+      delay_minutes: 10,
+      offset_days: null,
+      offset_minutes: null,
+      delivery_time: null,
+      condition_type: order === 2 ? 'tag_exists' : null,
+      condition_value: order === 2 ? 'tag-X' : null,
+      next_step_on_false: order === 2 ? opts.nextStepOnFalse : null,
+      on_reach_tag_id: null,
+    }));
+
+    const db = {
+      prepare: (sql: string) => {
+        const stmt = (args: unknown[]) => ({
+          first: async () => {
+            if (sql.includes('FROM friends')) {
+              return {
+                id: 'f1',
+                line_user_id: 'U1',
+                display_name: 'Test',
+                is_following: 1,
+                user_id: null,
+                metadata: null,
+                line_account_id: null,
+              };
+            }
+            if (sql.includes('delivery_mode FROM scenarios')) {
+              return { delivery_mode: 'relative' };
+            }
+            if (sql.includes('FROM friend_tags')) {
+              return null; // friend does NOT have tag-X → condition fails
+            }
+            return null;
+          },
+          all: async () => {
+            if (sql.includes('FROM friend_scenarios')) {
+              return {
+                results: [
+                  {
+                    id: 'fs1',
+                    friend_id: 'f1',
+                    scenario_id: 'sc1',
+                    current_step_order: 1,
+                    status: 'active',
+                    next_delivery_at: '2026-01-01T00:00:00+09:00',
+                    started_at: '2026-01-01T00:00:00+09:00',
+                  },
+                ],
+              };
+            }
+            if (sql.includes('FROM scenario_steps')) {
+              return { results: stepRows };
+            }
+            return { results: [] };
+          },
+          run: async () => {
+            if (sql.includes("SET status = 'delivering'")) {
+              return { meta: { changes: 1 } }; // claim succeeds
+            }
+            if (sql.includes('SET current_step_order')) {
+              advances.push({
+                nextStepOrder: args[0] as number,
+                nextDeliveryAt: args[1] as string | null,
+                id: args[3] as string,
+              });
+              return { meta: { changes: 1 } };
+            }
+            if (sql.includes("SET status = 'completed'")) {
+              completes.push(args[1] as string);
+              return { meta: { changes: 1 } };
+            }
+            return { meta: { changes: 1 } };
+          },
+        });
+        return {
+          bind: (...args: unknown[]) => stmt(args),
+          ...stmt([]),
+        };
+      },
+    } as unknown as D1Database;
+
+    return { db, advances, completes };
+  }
+
+  function mockLineClient(): { client: LineClient; push: ReturnType<typeof vi.fn> } {
+    const push = vi.fn(async () => ({}));
+    return { client: { pushMessage: push } as unknown as LineClient, push };
+  }
+
+  it('failed condition with next_step_on_false=4 advances so the JUMP TARGET (4) is delivered next, not step 3', async () => {
+    const { db, advances } = deliveryMockDb({ nextStepOnFalse: 4 });
+    const { client, push } = mockLineClient();
+
+    await processStepDeliveries(db, client);
+
+    expect(push).not.toHaveBeenCalled(); // condition failed → nothing pushed
+    expect(advances).toHaveLength(1);
+    expect(advances[0].id).toBe('fs1');
+    // find(step_order > current) must select step 4 next → current must be 3.
+    // Pre-fix this was 2 (currentStep.step_order) → step 3 was wrongly delivered.
+    expect(advances[0].nextStepOrder).toBe(3);
+  });
+
+  it('jump target works with non-contiguous step orders (1,2,5,9 → jump to 9)', async () => {
+    const { db, advances } = deliveryMockDb({ nextStepOnFalse: 9, steps: [1, 2, 5, 9] });
+    const { client } = mockLineClient();
+
+    await processStepDeliveries(db, client);
+
+    expect(advances).toHaveLength(1);
+    // current=8 → first step_order > 8 is 9 (the jump target); 5 is skipped.
+    expect(advances[0].nextStepOrder).toBe(8);
+  });
+
+  it('failed condition WITHOUT jump target keeps sequential advance (next tick delivers step 3)', async () => {
+    const { db, advances } = deliveryMockDb({ nextStepOnFalse: null });
+    const { client } = mockLineClient();
+
+    await processStepDeliveries(db, client);
+
+    expect(advances).toHaveLength(1);
+    // Unchanged behaviour: advance to currentStep.step_order (2) → next is 3.
+    expect(advances[0].nextStepOrder).toBe(2);
+  });
+
+  it('jump target pointing at a missing step_order falls back to sequential advance', async () => {
+    const { db, advances } = deliveryMockDb({ nextStepOnFalse: 99 });
+    const { client } = mockLineClient();
+
+    await processStepDeliveries(db, client);
+
+    expect(advances).toHaveLength(1);
+    expect(advances[0].nextStepOrder).toBe(2); // no step 99 → sequential path
   });
 });

--- a/apps/worker/src/services/step-delivery.ts
+++ b/apps/worker/src/services/step-delivery.ts
@@ -191,7 +191,11 @@ async function processSingleDelivery(
         const jumpStep = steps.find((s) => s.step_order === currentStep.next_step_on_false);
         if (jumpStep) {
           const jitteredDate = jitterDeliveryTime(nextDeliveryFor(jumpStep));
-          await advanceFriendScenario(db, fs.id, currentStep.step_order, jitteredDate.toISOString().slice(0, -1) + '+09:00');
+          // Advance to just before the jump target so the next tick's
+          // `find(step_order > current_step_order)` selects jumpStep itself.
+          // Passing currentStep.step_order here (pre-fix) delivered the
+          // sequentially-next step and silently ignored next_step_on_false.
+          await advanceFriendScenario(db, fs.id, jumpStep.step_order - 1, jitteredDate.toISOString().slice(0, -1) + '+09:00');
           return false;
         }
       }

--- a/apps/worker/src/services/step-delivery.ts
+++ b/apps/worker/src/services/step-delivery.ts
@@ -30,6 +30,7 @@ export function expandVariables(
   content: string,
   friend: { id: string; display_name: string | null; user_id: string | null; ref_code?: string | null; metadata?: Record<string, unknown> | string | null },
   apiOrigin?: string,
+  messageType?: string,
 ): string {
   let result = content;
   result = result.replace(/\{\{name\}\}/g, friend.display_name || '');
@@ -53,10 +54,14 @@ export function expandVariables(
     if (val == null || val === '') return '';
     return inner;
   });
-  // Clean up broken JSON commas from removed conditional blocks (e.g. ",," or "[," or ",]")
-  result = result.replace(/,\s*,/g, ',');
-  result = result.replace(/\[\s*,/g, '[');
-  result = result.replace(/,\s*\]/g, ']');
+  // Clean up broken JSON commas from removed conditional blocks (e.g. ",," or "[," or ",]").
+  // Flex only: this is JSON repair — running it on plain text silently rewrote
+  // user-authored bodies containing ",," / "[," / ",]" (bug present since initial release).
+  if (messageType === 'flex') {
+    result = result.replace(/,\s*,/g, ',');
+    result = result.replace(/\[\s*,/g, '[');
+    result = result.replace(/,\s*\]/g, ']');
+  }
   result = result.replace(/\{\{metadata\.([^}]+)\}\}/g, (_match, key) => {
     const val = meta[key];
     if (val == null) return '';
@@ -217,7 +222,7 @@ async function processSingleDelivery(
   // Expand template variables ({{name}}, {{uid}}, {{auth_url:CHANNEL_ID}}, {{metadata.KEY}}, etc.)
   const resolvedMeta = await resolveMetadata(db, { user_id: (friend as unknown as Record<string, string | null>).user_id, metadata: (friend as unknown as Record<string, string | null>).metadata });
   const friendWithMeta = { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1];
-  const expandedContent = expandVariables(resolved.messageContent, friendWithMeta, workerUrl);
+  const expandedContent = expandVariables(resolved.messageContent, friendWithMeta, workerUrl, resolved.messageType);
   // Auto-wrap URLs with tracking links (text with URLs → Flex with button)
   let trackedType: string = resolved.messageType;
   let trackedContent = expandedContent;


### PR DESCRIPTION
## 概要
初回リリース（8345b5b）から存在する配信系のバグを2件修正します。

### 1. シナリオの条件分岐ジャンプが無視される
`step-delivery.ts` で条件不成立時に `next_step_on_false` へジャンプするはずが、
`advanceFriendScenario` に `currentStep.step_order` を渡していたため、次の tick では
ジャンプ先ではなく単に次のステップが配信されていました（ジャンプ先は配信時刻の計算
にしか使われていない）。`jumpStep.step_order - 1` を渡すことで、非連続なステップ番号
（1,3,5…）でもジャンプ先が正しく選ばれます。

ジャンプ先が「直後のステップ」と一致する場合は偶然正しく動くため、発見が遅れたようです。

### 2. テキスト配信の本文が勝手に書き換えられる
`expandVariables` のカンマ掃除（`,,` `[,` `,]` の除去）は条件ブロック除去で壊れた
Flex JSON の修復が目的ですが、メッセージ種別を見ずに全テキストへ適用されていたため、
これらの並びを含むテキスト本文が無断で改変されていました。`messageType` 引数を追加し、
`'flex'` のときだけ掃除を実行します（全8呼び出し箇所を更新、Flex の挙動は不変）。

## テスト
- 回帰テスト10件を追加（計535件パス、`tsc --noEmit` クリーン）
- 両修正とも red/green 検証済み: 修正前のコードでは新テストが失敗することを確認
- Flex の修復挙動は修正前後の両方でパスするテストによりロックイン

🤖 Generated with [Claude Code](https://claude.com/claude-code)