### PR TITLE
feat(plugin): add restaurant plugin — stamp card, reservations, takeout with phone-call alerts

### DIFF
--- a/.github/workflows/plugin-restaurant-ci.yml
+++ b/.github/workflows/plugin-restaurant-ci.yml
@@ -1,0 +1,39 @@
+name: Plugin Restaurant CI
+
+on:
+  pull_request:
+    paths:
+      - 'packages/plugin-restaurant/**'
+      - 'packages/sdk/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/plugin-restaurant-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/plugin-restaurant/**'
+      - 'packages/sdk/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/plugin-restaurant-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-restaurant-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @line-harness/sdk build
+      - run: pnpm --filter @line-harness/plugin-restaurant typecheck
+      - run: pnpm --filter @line-harness/plugin-restaurant test
+      - run: pnpm --filter @line-harness/plugin-restaurant build

--- a/packages/plugin-restaurant/.gitignore
+++ b/packages/plugin-restaurant/.gitignore
@@ -1,0 +1,2 @@
+.dev.vars
+tools/out/

--- a/packages/plugin-restaurant/README.md
+++ b/packages/plugin-restaurant/README.md
@@ -1,0 +1,173 @@
+# LINE Harness Plugin: Restaurant（飲食店特化拡張）
+
+LINE Harness を飲食店向けに拡張するプラグイン。1店舗 = 1デプロイの汎用プロダクトとして設計。
+
+| 機能 | 内容 |
+|---|---|
+| デジタル会員証・スタンプカード | LIFF会員証（会員番号自動発行）、店内掲示の「本日の来店コード」入力 or スタッフ操作でスタンプ、満了で特典クーポン自動発行＋LINE通知 |
+| 再来店促進 | 誕生日クーポン（年1回）、離反防止の呼び戻しクーポン（最終来店からN日、60日クールダウン、「離反リスク」タグ自動付与） |
+| 予約受付＋リマインド | LIFF予約フォーム→LINE確認メッセージ→前日18時＋2時間前リマインド。無断キャンセル抑止 |
+| スタッフページ | 来店コード表示・スタンプ押印・特典消込・予約台帳（来店/無断/取消） |
+| 配信自動生成 | `tools/campaign.mjs` — 概要1行から Claude が配信文面、Codex image_gen がリッチメッセージ画像・クーポン画像を自動生成し、テキスト→リッチの2連配信を Harness に作成 |
+| キャンペーンクーポン | 全員向け共通コード（CP-XXXXXX・複数回消込・使用回数カウント・期限つき） |
+| Googleレビュー誘導 | クーポン消込・スタンプ取得＝来店と判定し、**2時間後**に口コミ依頼を自動送信（90日に1回まで） |
+| テイクアウト注文 | LIFFでメニュー注文→スタッフに ntfy プッシュ→調理中/準備完了をLINE通知。支払いは店頭 |
+| MCPサーバー | Claude Code から予約確認・会員検索・統計・特典発行・クーポン作成・テイクアウトメニュー管理 |
+
+メッセージ送信はすべて LINE Harness API 経由（このWorkerはLINE Messaging APIを直接呼ばない）。
+
+## アーキテクチャ
+
+```
+お客様のLINE ── LIFF (/liff/card, /liff/reserve)
+                     │ LIFFアクセストークン（サーバー側でLINE検証）
+                     ▼
+   [ このWorker (Hono + 専用D1) ] ──── LINE Harness API ──── LINEへ配信
+                     ▲                    (SDK @line-harness/sdk)
+   スタッフ (/staff, PIN認証)
+   Claude Code (MCP → /api/admin, APIキー認証)
+   Cron */10分（予約リマインド／日次: 誕生日・呼び戻し）
+```
+
+## セットアップ（店舗ごと）
+
+前提: LINE Harness 本体がデプロイ済み（`npx create-line-harness`）。
+
+```bash
+cd packages/plugin-restaurant
+
+# 1. D1作成 → 出力された database_id を wrangler.toml に反映
+wrangler d1 create restaurant-plugin
+pnpm db:apply
+
+# 2. wrangler.toml の [vars] を店舗に合わせて編集
+#    LINE_HARNESS_API_URL / STORE_NAME / STAMP_GOAL / REWARD_NAME / WINBACK_DAYS
+
+# 3. シークレット設定
+wrangler secret put LINE_HARNESS_API_KEY   # Harness の API キー
+wrangler secret put STAFF_PIN              # スタッフページ用PIN（4〜8桁推奨）
+wrangler secret put PLUGIN_API_KEY         # MCP用（openssl rand -hex 24 など）
+
+# 4. デプロイ → URLを控える
+pnpm deploy
+```
+
+### LIFF アプリの作成
+
+1. [LINE Developers](https://developers.line.biz/) で LINE Login チャネルに LIFF アプリを追加
+   - エンドポイントURL: `https://<worker-url>/liff/card`
+   - サイズ: Full / スコープ: `profile`
+2. 発行された LIFF ID を `wrangler.toml` の `LIFF_ID` に設定して再デプロイ
+   - トークンのなりすまし対策を厳格にする場合は `LIFF_CHANNEL_ID`（LINE LoginチャネルID）も設定
+3. リッチメニューやあいさつメッセージ（Harness側で設定）から `https://liff.line.me/<LIFF_ID>` へ誘導
+
+### 来店判定とGoogleレビュー誘導
+
+`wrangler.toml` に `GOOGLE_REVIEW_URL`（Googleビジネスプロフィール > 「クチコミを増やす」のURL）を設定すると有効になる。
+
+- **来店判定のトリガー（5系統）**: ①来店QRスキャン/来店コード/スタッフ押印でのスタンプ ②個人特典（RW-）の消込 ③共通クーポン（CP-）の消込＋会員番号入力 ④予約を「来店」にした時 ⑤テイクアウトの受け取り完了（お客様のスライド操作 or スタッフ操作）
+- **来店QR**: スタッフページに毎日自動更新されるQRを表示。お客様はスキャンするだけで自動スタンプ（手入力ゼロ）。レジ横掲示が最も低摩擦な来店把握手段
+- 判定から**2時間後**（滞在中に届かないように）に口コミ依頼をLINEで自動送信。同じ会員には**90日に1回まで**
+- CP-クーポンは匿名でも消込できるが、スタッフページで会員番号を添えると来店記録・レビュー依頼・離反防止（last_visit_at）まで効く
+
+### テイクアウト注文
+
+- メニューの追加・編集・公開/非公開は**スタッフページ**（/staff）から直接行える（admin API / MCP `upsert_takeout_menu_item` でも可）
+- お客様は `/liff/takeout` で数量選択→受取時間（本日・15分後以降・15分刻み）→注文。**支払いは店頭**（決済連携なし）
+- **新規注文の店側通知は5系統**（すべて任意・併用可）。**標準構成は「① ntfy ＋ ③ CallMeBot電話」**:
+  1. `NTFY_TOPIC` — ntfy.sh プッシュ（無料）。urgent優先度で送るので、ntfyアプリ側で「最大優先度＝アラーム音を鳴らし続ける・サイレント貫通」に設定すればレジ端末が**着信のように鳴り続ける**（常時併用推奨・完全無料）
+  2. `CALLMEBOT_TELEGRAM_USER` — 無料の音声通話（店長のTelegramに着信・日本語TTS読み上げ。@CallMeBot_txtbot へ /start で認可）
+  3. `CALLMEBOT_PHONE_NUMBER` / `CALLMEBOT_PHONE_APIKEY` — **実電話への架電（導入時の標準）**。審査なし・WhatsAppで5分で開通。下記「CallMeBot電話のセットアップ」参照
+  4. `CLICKSEND_USERNAME` / `CLICKSEND_API_KEY` — **実電話への架電・回数無制限（繁盛店の移行先）**。メール登録のみで審査なし・番号購入不要・従量課金。宛先は `STORE_PHONE_NUMBER` に設定。**注文が月30件を超えたらこちらへ切り替え**（CallMeBotの環境変数を消してこの2つを設定するだけ）
+  5. `TWILIO_*` / `STORE_PHONE_NUMBER` — 最後の手段（発信元番号を自前で持ちたい場合のみ。要アカウント審査）
+
+### CallMeBot電話のセットアップ（5分・審査なし）
+
+1. スマホの連絡先に **+34 611 01 16 37** を追加し、WhatsApp で「**I allow callmebot to call me**」と送信 → 2分以内にAPIキーが返ってくる
+2. プランを選ぶ: **Medium $2/月（15回・日本語対応）** か **Big $3/月（30回・日本語対応）**。※Lite $1/月は英語のみなので不可
+3. `wrangler.toml` に `CALLMEBOT_PHONE_NUMBER`、`wrangler secret put CALLMEBOT_PHONE_APIKEY` でキー設定 → デプロイ
+
+**重要な制約**:
+- **架電先はAPIキーを取得したWhatsApp登録番号**（=手順1で送信した番号）に限られる。**店の固定電話で受けたい場合は、固定電話番号で WhatsApp Business を登録**（認証を「電話で受ける」にすれば固定電話でも登録可能）してから手順1を行う。店長の携帯で受けるならそのまま携帯でOK
+- **月の回数上限（15回/30回）を超えた分は鳴らない**。ntfy併用が前提。注文が月30件を超えるようになったらClickSendへ移行（上記④）
+- スタッフページで「調理開始→準備完了」を進めると、準備完了時にお客様へLINE通知が飛ぶ
+- **受け取り完了はお客様のスライド操作**（注文カードの「スライドして受け取り完了」をスタッフの面前で操作）— スタッフ側のボタンでも可。どちらでも来店判定→レビュー依頼につながる
+- 注文キャンセルはお客様側からは調理開始前のみ
+
+### 店舗オペレーション
+
+- **スタッフページ**: `https://<worker-url>/staff` をレジ端末でブックマーク（PIN認証）
+- **来店コード**: スタッフページに毎日自動発行される4桁コードを店内掲示（レジ横・卓上）。お客様が会員証に入力するとスタンプが押される（1日1回・10回試行制限）
+- **特典消込**: お客様提示の `RW-XXXXXX` をスタッフページで消込
+
+## 配信自動生成（Claude Code + Codex）
+
+キャンペーン概要ひとつから「テキスト配信 → リッチメッセージ（Flex）→ クーポン」を全自動生成する。
+運営者のMac上で実行するローカルツール（要: `claude` CLI / Codex CLIログイン済み / macOS）。
+
+```bash
+cd packages/plugin-restaurant
+
+# .env に接続情報（または環境変数）
+#   LINE_HARNESS_API_URL / LINE_HARNESS_API_KEY
+#   RESTAURANT_PLUGIN_URL / RESTAURANT_PLUGIN_API_KEY   ← --coupon 時のみ
+
+# ドラフト作成（既定・Harness管理画面で確認して送信）
+node tools/campaign.mjs --brief "雨の日限定10%オフ。雨の日に来店したら全品10%引き" \
+  --coupon --discount "10%OFF" --expires 2026-07-31
+
+# 確認済みならそのまま送信（テキスト→リッチの順に自動送信）
+node tools/campaign.mjs --brief "..." --coupon --send now
+
+# 画像を使い回す / 画像なし
+node tools/campaign.mjs --brief "..." --banner-url https://... 
+node tools/campaign.mjs --brief "..." --skip-images
+```
+
+パイプライン: ① `claude -p`（sonnet）が配信文・見出し・画像プロンプトをJSON生成 → ② Codex `image_gen` がバナー（1:1）とクーポン背景（横長）を生成（**画像内に文字は入れない**方針。文字はFlexの実テキストで載せるため崩れない）→ ③ `--coupon` 時はプラグインAPIで共通コード CP-XXXXXX を発行 → ④ Harness に画像アップロード → ⑤ テキスト配信＋Flexリッチ配信（バナー+クーポンのカルーセル、CTAは会員証LIFF）を作成。
+
+生成物（copy.json / flex.json / 画像 / summary.json）は `tools/out/<日時>/` に残る。**既定はドラフト**なので、送る前に必ず Harness 管理画面か `flex.json` で内容を確認すること。
+
+## MCP サーバー（Claude Code 連携）
+
+```bash
+pnpm build:mcp
+```
+
+`.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "restaurant": {
+      "command": "node",
+      "args": ["packages/plugin-restaurant/dist-mcp/index.js"],
+      "env": {
+        "RESTAURANT_PLUGIN_URL": "https://<worker-url>",
+        "RESTAURANT_PLUGIN_API_KEY": "<PLUGIN_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+ツール: `list_reservations` / `lookup_member` / `get_restaurant_stats` / `issue_reward` / `create_campaign_coupon` / `list_campaign_coupons` / `list_takeout_menu` / `upsert_takeout_menu_item`
+
+## 開発
+
+```bash
+pnpm db:apply:local   # ローカルD1にスキーマ適用
+pnpm dev              # wrangler dev
+pnpm test             # ユニットテスト（純ロジック20件）
+pnpm typecheck
+```
+
+ローカル用シークレットは `.dev.vars`（gitignore済み）に置く。
+
+## 設計メモ
+
+- 時刻はすべて **UTCで保存**（D1の `datetime('now')` 形式に統一）、表示・判定はJST換算。予約リマインドは「前日18:00 JST」「2時間前」の2本で、送信済みフラグにより重複送信しない
+- 日次ジョブ（誕生日・呼び戻し）は10分毎cronの中で `daily_jobs:<date>` キーの INSERT-once により**JSTの日に1回だけ**実行（10:00 JST以降の最初の発火）
+- 誕生日・呼び戻しの重複防止は `message_log.dedupe_key`（UNIQUE）で保証
+- LIFFのユーザー識別はクライアント申告を信用せず、アクセストークンを LINE の verify + profile API でサーバー検証
+- Harness の friend 解決は friends 一覧のページングで `lineUserId` を突合し、`members.friend_id` にキャッシュ（未解決でも動作し、次回アクセスで再試行）

--- a/packages/plugin-restaurant/db/schema.sql
+++ b/packages/plugin-restaurant/db/schema.sql
@@ -1,0 +1,154 @@
+-- LINE Harness plugin-restaurant — D1 schema
+-- Apply: pnpm db:apply (remote) / pnpm db:apply:local
+
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- 会員（LINE友だち1人 = 1会員）
+CREATE TABLE IF NOT EXISTS members (
+  id TEXT PRIMARY KEY,                       -- UUID
+  line_user_id TEXT NOT NULL UNIQUE,         -- LINE userId (LIFFで取得)
+  friend_id TEXT,                            -- LINE Harness friends.id（解決後キャッシュ）
+  member_no TEXT NOT NULL UNIQUE,            -- 会員番号（表示用: R-000123）
+  display_name TEXT,
+  birthday TEXT,                             -- 'MM-DD' or 'YYYY-MM-DD'
+  stamp_count INTEGER NOT NULL DEFAULT 0,    -- 現在のカードのスタンプ数
+  total_visits INTEGER NOT NULL DEFAULT 0,
+  last_visit_at TEXT,                        -- ISO 8601 (UTC)
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_members_last_visit ON members (last_visit_at);
+CREATE INDEX IF NOT EXISTS idx_members_birthday ON members (birthday);
+
+-- 来店（スタンプ）履歴
+CREATE TABLE IF NOT EXISTS visits (
+  id TEXT PRIMARY KEY,
+  member_id TEXT NOT NULL REFERENCES members (id) ON DELETE CASCADE,
+  visited_at TEXT NOT NULL DEFAULT (datetime('now')),
+  source TEXT NOT NULL CHECK (source IN ('store_code', 'staff', 'reservation')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_visits_member ON visits (member_id);
+CREATE INDEX IF NOT EXISTS idx_visits_visited_at ON visits (visited_at);
+
+-- 特典（スタンプ満了・誕生日などで発行されるクーポン）
+CREATE TABLE IF NOT EXISTS rewards (
+  id TEXT PRIMARY KEY,
+  member_id TEXT NOT NULL REFERENCES members (id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  code TEXT NOT NULL UNIQUE,                 -- 消込用コード（例: RW-8F3K2A）
+  kind TEXT NOT NULL DEFAULT 'stamp' CHECK (kind IN ('stamp', 'birthday', 'winback', 'manual')),
+  status TEXT NOT NULL DEFAULT 'issued' CHECK (status IN ('issued', 'redeemed', 'expired')),
+  issued_at TEXT NOT NULL DEFAULT (datetime('now')),
+  redeemed_at TEXT,
+  expires_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_rewards_member ON rewards (member_id);
+CREATE INDEX IF NOT EXISTS idx_rewards_status ON rewards (status);
+
+-- 予約
+CREATE TABLE IF NOT EXISTS reservations (
+  id TEXT PRIMARY KEY,
+  member_id TEXT NOT NULL REFERENCES members (id) ON DELETE CASCADE,
+  name TEXT NOT NULL,                        -- 予約名（代表者）
+  phone TEXT,
+  party_size INTEGER NOT NULL,
+  reserved_at TEXT NOT NULL,                 -- 来店日時 ISO 8601 (UTC)
+  note TEXT,
+  status TEXT NOT NULL DEFAULT 'confirmed'
+    CHECK (status IN ('confirmed', 'cancelled', 'seated', 'no_show')),
+  remind_day_before_sent INTEGER NOT NULL DEFAULT 0,
+  remind_same_day_sent INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_reservations_member ON reservations (member_id);
+CREATE INDEX IF NOT EXISTS idx_reservations_reserved_at ON reservations (reserved_at);
+CREATE INDEX IF NOT EXISTS idx_reservations_status ON reservations (status);
+
+-- キャンペーンクーポン（全員向け共通コード・複数回消込可）
+CREATE TABLE IF NOT EXISTS campaign_coupons (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,                        -- 例: 雨の日限定10%OFF
+  code TEXT NOT NULL UNIQUE,                 -- 共通コード（例: CP-AB3K2M）
+  discount_text TEXT,                        -- 例: 10%OFF
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'ended')),
+  used_count INTEGER NOT NULL DEFAULT 0,
+  expires_at TEXT,                           -- 'YYYY-MM-DD HH:MM:SS' (UTC)
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_campaign_coupons_status ON campaign_coupons (status);
+
+-- 共通クーポンの消込記録（誰が使ったか＝来店判定に使う。member_idは任意）
+CREATE TABLE IF NOT EXISTS campaign_redemptions (
+  id TEXT PRIMARY KEY,
+  coupon_id TEXT NOT NULL REFERENCES campaign_coupons (id) ON DELETE CASCADE,
+  member_id TEXT REFERENCES members (id) ON DELETE SET NULL,
+  redeemed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_campaign_redemptions_coupon ON campaign_redemptions (coupon_id);
+CREATE INDEX IF NOT EXISTS idx_campaign_redemptions_member ON campaign_redemptions (member_id);
+
+-- 遅延送信キュー（来店2時間後のGoogleレビュー依頼など）
+CREATE TABLE IF NOT EXISTS pending_notifications (
+  id TEXT PRIMARY KEY,
+  member_id TEXT NOT NULL REFERENCES members (id) ON DELETE CASCADE,
+  kind TEXT NOT NULL,                        -- 'review_ask'
+  send_at TEXT NOT NULL,                     -- 'YYYY-MM-DD HH:MM:SS' (UTC)
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'sent', 'cancelled')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_notifications_due ON pending_notifications (status, send_at);
+
+-- テイクアウトメニュー
+CREATE TABLE IF NOT EXISTS takeout_menu_items (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  price INTEGER NOT NULL,                    -- 税込・円
+  description TEXT,
+  is_available INTEGER NOT NULL DEFAULT 1,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- テイクアウト注文
+CREATE TABLE IF NOT EXISTS takeout_orders (
+  id TEXT PRIMARY KEY,
+  member_id TEXT NOT NULL REFERENCES members (id) ON DELETE CASCADE,
+  order_no TEXT NOT NULL UNIQUE,             -- 表示用（例: T-012）当日連番
+  items TEXT NOT NULL,                       -- JSON: [{id,name,price,qty}]
+  total INTEGER NOT NULL,                    -- 円
+  pickup_at TEXT NOT NULL,                   -- 受取日時 'YYYY-MM-DD HH:MM:SS' (UTC)
+  note TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'accepted', 'ready', 'completed', 'cancelled')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_takeout_orders_member ON takeout_orders (member_id);
+CREATE INDEX IF NOT EXISTS idx_takeout_orders_pickup ON takeout_orders (pickup_at);
+CREATE INDEX IF NOT EXISTS idx_takeout_orders_status ON takeout_orders (status);
+
+-- 自動配信の重複防止ログ（誕生日は年1回・呼び戻しは期間1回など）
+CREATE TABLE IF NOT EXISTS message_log (
+  id TEXT PRIMARY KEY,
+  member_id TEXT NOT NULL REFERENCES members (id) ON DELETE CASCADE,
+  kind TEXT NOT NULL,                        -- 'birthday' | 'winback' | 'reward' | 'reservation_*'
+  dedupe_key TEXT NOT NULL UNIQUE,           -- 例: 'birthday:2026:<member_id>'
+  sent_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_log_member ON message_log (member_id);

--- a/packages/plugin-restaurant/mcp-server/index.ts
+++ b/packages/plugin-restaurant/mcp-server/index.ts
@@ -1,0 +1,170 @@
+/**
+ * MCP Server for the restaurant plugin.
+ *
+ * Lets AI agents (Claude Code など) inspect reservations, members and stamp
+ * stats, and issue rewards — via the plugin worker's admin API.
+ *
+ * .mcp.json example:
+ *   {
+ *     "mcpServers": {
+ *       "restaurant": {
+ *         "command": "node",
+ *         "args": ["packages/plugin-restaurant/dist-mcp/index.js"],
+ *         "env": {
+ *           "RESTAURANT_PLUGIN_URL": "https://line-harness-plugin-restaurant.<you>.workers.dev",
+ *           "RESTAURANT_PLUGIN_API_KEY": "..."
+ *         }
+ *       }
+ *     }
+ *   }
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+import { clientFromEnv } from './plugin-api.js'
+
+const server = new McpServer({
+  name: 'line-harness-plugin-restaurant',
+  version: '0.1.0',
+})
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] }
+}
+
+function errorResult(error: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+    isError: true,
+  }
+}
+
+server.tool(
+  'list_reservations',
+  '指定日（省略時は本日・JST）の予約一覧を取得する',
+  { date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().describe('YYYY-MM-DD (JST)') },
+  async ({ date }) => {
+    try {
+      return jsonResult(await clientFromEnv().listReservations(date))
+    } catch (e) {
+      return errorResult(e)
+    }
+  },
+)
+
+server.tool(
+  'lookup_member',
+  '会員番号で会員情報（スタンプ数・来店回数・最終来店日）を取得する',
+  { memberNo: z.string().describe('会員番号 (例: R-000123)') },
+  async ({ memberNo }) => {
+    try {
+      return jsonResult(await clientFromEnv().getMember(memberNo))
+    } catch (e) {
+      return errorResult(e)
+    }
+  },
+)
+
+server.tool(
+  'get_restaurant_stats',
+  '会員数・直近30日来店数・特典発行/消込数・今後の予約数を取得する',
+  {},
+  async () => {
+    try {
+      return jsonResult(await clientFromEnv().getStats())
+    } catch (e) {
+      return errorResult(e)
+    }
+  },
+)
+
+server.tool(
+  'issue_reward',
+  '会員に特典クーポンを発行しLINEで通知する（実行前にユーザーの確認を取ること）',
+  {
+    memberNo: z.string().describe('会員番号 (例: R-000123)'),
+    name: z.string().optional().describe('特典名（省略時は店舗デフォルト特典）'),
+  },
+  async ({ memberNo, name }) => {
+    try {
+      return jsonResult(await clientFromEnv().issueReward(memberNo, name))
+    } catch (e) {
+      return errorResult(e)
+    }
+  },
+)
+
+server.tool(
+  'create_campaign_coupon',
+  '全員向けの共通クーポン（CP-コード）を作成する。配信は別途ブロードキャストで行う',
+  {
+    name: z.string().describe('キャンペーン名（例: 雨の日限定10%OFF）'),
+    discountText: z.string().optional().describe('割引表記（例: 10%OFF）'),
+    expiresAt: z.string().optional().describe('有効期限 YYYY-MM-DD（JST終日）'),
+  },
+  async ({ name, discountText, expiresAt }) => {
+    try {
+      return jsonResult(await clientFromEnv().createCampaign(name, discountText, expiresAt))
+    } catch (e) {
+      return errorResult(e)
+    }
+  },
+)
+
+server.tool(
+  'list_campaign_coupons',
+  'キャンペーンクーポン一覧（使用回数・期限つき）を取得する',
+  {},
+  async () => {
+    try {
+      return jsonResult(await clientFromEnv().listCampaigns())
+    } catch (e) {
+      return errorResult(e)
+    }
+  },
+)
+
+server.tool(
+  'list_takeout_menu',
+  'テイクアウトメニュー一覧（非公開含む）を取得する',
+  {},
+  async () => {
+    try {
+      return jsonResult(await clientFromEnv().listTakeoutMenu())
+    } catch (e) {
+      return errorResult(e)
+    }
+  },
+)
+
+server.tool(
+  'upsert_takeout_menu_item',
+  'テイクアウトメニューを追加・更新する（idを渡すと更新）',
+  {
+    id: z.string().optional().describe('更新時のみ指定'),
+    name: z.string().describe('商品名'),
+    price: z.number().int().min(0).describe('税込価格（円）'),
+    description: z.string().optional(),
+    isAvailable: z.boolean().optional().describe('false で非公開'),
+    sortOrder: z.number().int().optional(),
+  },
+  async (input) => {
+    try {
+      return jsonResult(await clientFromEnv().upsertTakeoutMenuItem(input))
+    } catch (e) {
+      return errorResult(e)
+    }
+  },
+)
+
+async function main() {
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+  console.error('Restaurant Plugin MCP Server running on stdio')
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})

--- a/packages/plugin-restaurant/mcp-server/plugin-api.ts
+++ b/packages/plugin-restaurant/mcp-server/plugin-api.ts
@@ -1,0 +1,75 @@
+/**
+ * Thin client for the restaurant plugin worker's /api/admin endpoints.
+ * Runs in Node (MCP server process), authenticated with PLUGIN_API_KEY.
+ */
+
+export interface PluginApiConfig {
+  baseUrl: string
+  apiKey: string
+}
+
+export class RestaurantPluginClient {
+  constructor(private readonly config: PluginApiConfig) {}
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await fetch(`${this.config.baseUrl.replace(/\/$/, '')}/api/admin${path}`, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.config.apiKey}`,
+        ...(init?.headers ?? {}),
+      },
+    })
+    const body = (await res.json()) as { success: boolean; data?: T; error?: string }
+    if (!res.ok || !body.success) throw new Error(body.error ?? `HTTP ${res.status}`)
+    return body.data as T
+  }
+
+  listReservations(date?: string): Promise<unknown[]> {
+    return this.request(`/reservations${date ? `?date=${date}` : ''}`)
+  }
+
+  getMember(memberNo: string): Promise<unknown> {
+    return this.request(`/members/${encodeURIComponent(memberNo)}`)
+  }
+
+  getStats(): Promise<unknown> {
+    return this.request('/stats')
+  }
+
+  issueReward(memberNo: string, name?: string): Promise<unknown> {
+    return this.request('/rewards', { method: 'POST', body: JSON.stringify({ memberNo, name }) })
+  }
+
+  createCampaign(name: string, discountText?: string, expiresAt?: string): Promise<unknown> {
+    return this.request('/campaigns', { method: 'POST', body: JSON.stringify({ name, discountText, expiresAt }) })
+  }
+
+  listCampaigns(): Promise<unknown[]> {
+    return this.request('/campaigns')
+  }
+
+  listTakeoutMenu(): Promise<unknown[]> {
+    return this.request('/takeout/menu')
+  }
+
+  upsertTakeoutMenuItem(input: {
+    id?: string
+    name: string
+    price: number
+    description?: string
+    isAvailable?: boolean
+    sortOrder?: number
+  }): Promise<unknown> {
+    return this.request('/takeout/menu', { method: 'POST', body: JSON.stringify(input) })
+  }
+}
+
+export function clientFromEnv(): RestaurantPluginClient {
+  const baseUrl = process.env.RESTAURANT_PLUGIN_URL
+  const apiKey = process.env.RESTAURANT_PLUGIN_API_KEY
+  if (!baseUrl || !apiKey) {
+    throw new Error('Missing env vars: RESTAURANT_PLUGIN_URL / RESTAURANT_PLUGIN_API_KEY')
+  }
+  return new RestaurantPluginClient({ baseUrl, apiKey })
+}

--- a/packages/plugin-restaurant/package.json
+++ b/packages/plugin-restaurant/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@line-harness/plugin-restaurant",
+  "version": "0.1.0",
+  "description": "LINE Harness plugin for restaurants — digital stamp card, revisit automation, reservations with reminders",
+  "type": "module",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "build:mcp": "tsup mcp-server/index.ts --format esm --out-dir dist-mcp",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "db:apply": "wrangler d1 execute restaurant-plugin --file=db/schema.sql --remote",
+    "db:apply:local": "wrangler d1 execute restaurant-plugin --file=db/schema.sql --local",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@line-harness/sdk": "workspace:*",
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240620.0",
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "tsup": "^8.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0",
+    "wrangler": "^3.60.0",
+    "zod": "^3.24.4"
+  }
+}

--- a/packages/plugin-restaurant/src/env.ts
+++ b/packages/plugin-restaurant/src/env.ts
@@ -1,0 +1,100 @@
+export interface Env {
+  DB: D1Database
+
+  // LINE Harness connection
+  LINE_HARNESS_API_URL: string
+  LINE_HARNESS_API_KEY: string
+  LINE_ACCOUNT_ID?: string
+
+  // LIFF
+  LIFF_ID: string
+  /** Optional: LINE Login channel ID backing the LIFF app. When set, LIFF access tokens are checked against it. */
+  LIFF_CHANNEL_ID?: string
+
+  // Store profile / behavior
+  STORE_NAME: string
+  STAMP_GOAL: string
+  REWARD_NAME: string
+  WINBACK_DAYS: string
+  /** Googleマップの口コミ投稿URL（未設定ならレビュー誘導は動かない） */
+  GOOGLE_REVIEW_URL?: string
+  /** 新規テイクアウト注文をスタッフに即時プッシュする ntfy.sh トピック（任意） */
+  NTFY_TOPIC?: string
+
+  /** 無料の自動音声通話（Telegram着信・CallMeBot）。店長のTelegramユーザー名（@付き）。要事前認可 */
+  CALLMEBOT_TELEGRAM_USER?: string
+  /** CallMeBot有料プランでの実電話架電（+81…）。月5〜30回上限プランなので低頻度店向け */
+  CALLMEBOT_PHONE_NUMBER?: string
+  /** secret: wrangler secret put CALLMEBOT_PHONE_APIKEY */
+  CALLMEBOT_PHONE_APIKEY?: string
+
+  // ClickSend実電話架電（審査なし・従量課金・回数無制限。宛先は STORE_PHONE_NUMBER）
+  CLICKSEND_USERNAME?: string
+  /** secret: wrangler secret put CLICKSEND_API_KEY */
+  CLICKSEND_API_KEY?: string
+
+  // 新規テイクアウト注文の自動架電（すべて設定されたときのみ有効・任意）
+  TWILIO_ACCOUNT_SID?: string
+  /** secret: wrangler secret put TWILIO_AUTH_TOKEN */
+  TWILIO_AUTH_TOKEN?: string
+  /** Twilioで購入した発信元番号（+81…） */
+  TWILIO_FROM_NUMBER?: string
+  /** 架電先＝お店の電話番号（+81…） */
+  STORE_PHONE_NUMBER?: string
+
+  // Secrets
+  STAFF_PIN: string
+  PLUGIN_API_KEY: string
+}
+
+export interface StoreConfig {
+  storeName: string
+  stampGoal: number
+  rewardName: string
+  winbackDays: number
+  googleReviewUrl: string | null
+  ntfyTopic: string | null
+  callmebotUser: string | null
+  callmebotPhone: { number: string; apiKey: string } | null
+  clicksend: { username: string; apiKey: string; to: string } | null
+  twilio: { accountSid: string; authToken: string; from: string; to: string } | null
+}
+
+export function storeConfig(env: Env): StoreConfig {
+  return {
+    storeName: env.STORE_NAME || 'お店',
+    stampGoal: clampInt(env.STAMP_GOAL, 10, 1, 100),
+    rewardName: env.REWARD_NAME || 'ご来店特典クーポン',
+    winbackDays: clampInt(env.WINBACK_DAYS, 30, 7, 365),
+    googleReviewUrl: env.GOOGLE_REVIEW_URL?.trim() || null,
+    ntfyTopic: env.NTFY_TOPIC?.trim() || null,
+    callmebotUser: env.CALLMEBOT_TELEGRAM_USER?.trim() || null,
+    callmebotPhone:
+      env.CALLMEBOT_PHONE_NUMBER && env.CALLMEBOT_PHONE_APIKEY
+        ? { number: env.CALLMEBOT_PHONE_NUMBER.trim(), apiKey: env.CALLMEBOT_PHONE_APIKEY.trim() }
+        : null,
+    clicksend:
+      env.CLICKSEND_USERNAME && env.CLICKSEND_API_KEY && env.STORE_PHONE_NUMBER
+        ? {
+            username: env.CLICKSEND_USERNAME.trim(),
+            apiKey: env.CLICKSEND_API_KEY.trim(),
+            to: env.STORE_PHONE_NUMBER.trim(),
+          }
+        : null,
+    twilio:
+      env.TWILIO_ACCOUNT_SID && env.TWILIO_AUTH_TOKEN && env.TWILIO_FROM_NUMBER && env.STORE_PHONE_NUMBER
+        ? {
+            accountSid: env.TWILIO_ACCOUNT_SID,
+            authToken: env.TWILIO_AUTH_TOKEN,
+            from: env.TWILIO_FROM_NUMBER,
+            to: env.STORE_PHONE_NUMBER,
+          }
+        : null,
+  }
+}
+
+function clampInt(raw: string | undefined, fallback: number, min: number, max: number): number {
+  const n = Number.parseInt(raw ?? '', 10)
+  if (Number.isNaN(n)) return fallback
+  return Math.min(max, Math.max(min, n))
+}

--- a/packages/plugin-restaurant/src/index.ts
+++ b/packages/plugin-restaurant/src/index.ts
@@ -1,0 +1,71 @@
+/**
+ * LINE Harness Plugin: Restaurant (飲食店特化拡張)
+ *
+ * Cloudflare Worker providing:
+ *  - デジタル会員証・スタンプカード (LIFF)
+ *  - 予約受付 + 前日/当日リマインド (LIFF + cron)
+ *  - 再来店促進 (誕生日クーポン・呼び戻し, cron)
+ *  - スタッフページ (来店コード・押印・特典消込・予約台帳)
+ *  - Admin API (同梱のMCPサーバーが利用)
+ *
+ * Messaging is always delegated to LINE Harness — this worker never calls
+ * LINE's Messaging API directly.
+ */
+import { Hono } from 'hono'
+import type { Env } from './env.js'
+import { storeConfig } from './env.js'
+import type { AppContext } from './middleware/auth.js'
+import { harnessClient } from './lib/harness.js'
+import { liffApi } from './routes/liff.js'
+import { staffApi } from './routes/staff.js'
+import { adminApi } from './routes/admin.js'
+import { cardPage } from './pages/card.js'
+import { reservePage } from './pages/reserve.js'
+import { takeoutPage } from './pages/takeout.js'
+import { staffPage } from './pages/staff.js'
+import { processReservationReminders } from './services/reservations.js'
+import { processPendingNotifications } from './services/review.js'
+import { runDailyJobs } from './services/crm.js'
+
+const app = new Hono<AppContext>()
+
+app.get('/health', (c) => c.json({ status: 'ok', plugin: 'restaurant' }))
+
+// LIFF pages
+app.get('/', (c) => c.redirect('/liff/card'))
+app.get('/liff/card', (c) => c.html(cardPage(c.env.LIFF_ID, storeConfig(c.env).storeName)))
+app.get('/liff/reserve', (c) => c.html(reservePage(c.env.LIFF_ID, storeConfig(c.env).storeName)))
+app.get('/liff/takeout', (c) => c.html(takeoutPage(c.env.LIFF_ID, storeConfig(c.env).storeName)))
+app.get('/staff', (c) => c.html(staffPage(c.env.LIFF_ID, storeConfig(c.env).storeName)))
+
+// APIs
+app.route('/api/liff', liffApi)
+app.route('/api/staff', staffApi)
+app.route('/api/admin', adminApi)
+
+app.notFound((c) => c.json({ success: false, error: 'not found' }, 404))
+app.onError((err, c) => {
+  console.error('[restaurant] unhandled error:', err)
+  return c.json({ success: false, error: 'internal error' }, 500)
+})
+
+export default {
+  fetch: app.fetch,
+
+  async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    const config = storeConfig(env)
+    const client = harnessClient(env)
+    const now = new Date()
+
+    ctx.waitUntil(
+      (async () => {
+        const reminders = await processReservationReminders(env.DB, client, config, now)
+        const queued = await processPendingNotifications(env.DB, client, config)
+        const daily = await runDailyJobs(env.DB, client, config, now)
+        console.log(
+          `[restaurant] cron done: reminders=${reminders} queued=${queued} daily=${daily.ran ? `birthday=${daily.birthday} winback=${daily.winback}` : 'skipped'}`,
+        )
+      })(),
+    )
+  },
+}

--- a/packages/plugin-restaurant/src/lib/dedupe.ts
+++ b/packages/plugin-restaurant/src/lib/dedupe.ts
@@ -1,0 +1,8 @@
+/** INSERT-once guard backed by message_log's UNIQUE dedupe_key. */
+export async function claimOnce(db: D1Database, memberId: string, kind: string, dedupeKey: string): Promise<boolean> {
+  const res = await db
+    .prepare('INSERT INTO message_log (id, member_id, kind, dedupe_key) VALUES (?, ?, ?, ?) ON CONFLICT (dedupe_key) DO NOTHING')
+    .bind(crypto.randomUUID(), memberId, kind, dedupeKey)
+    .run()
+  return Boolean(res.meta.changes)
+}

--- a/packages/plugin-restaurant/src/lib/harness.ts
+++ b/packages/plugin-restaurant/src/lib/harness.ts
@@ -1,0 +1,63 @@
+import { LineHarness } from '@line-harness/sdk'
+import type { Env } from '../env.js'
+
+export function harnessClient(env: Env): LineHarness {
+  return new LineHarness({
+    apiUrl: env.LINE_HARNESS_API_URL,
+    apiKey: env.LINE_HARNESS_API_KEY,
+    lineAccountId: env.LINE_ACCOUNT_ID,
+  })
+}
+
+/**
+ * Resolve a LINE userId to a LINE Harness friend id by paging the friends
+ * list. Harness registers friends on webhook contact, so a LIFF visitor who
+ * has added the account will normally be present. Returns null when not found
+ * (e.g. webhook not yet delivered) — callers must tolerate that and retry on
+ * a later interaction.
+ */
+export async function resolveFriendId(client: LineHarness, lineUserId: string): Promise<string | null> {
+  const pageSize = 200
+  for (let offset = 0; offset < 20_000; offset += pageSize) {
+    const page = await client.friends.list({ limit: pageSize, offset })
+    const hit = page.items.find((f) => (f as { lineUserId?: string }).lineUserId === lineUserId)
+    if (hit) return hit.id
+    if (!page.hasNextPage) return null
+  }
+  return null
+}
+
+/** Send a text message to a friend; swallow errors so one bad send never aborts a cron batch. */
+export async function trySendText(client: LineHarness, friendId: string | null, text: string): Promise<boolean> {
+  if (!friendId) return false
+  try {
+    await client.friends.sendMessage(friendId, text)
+    return true
+  } catch (error) {
+    console.error('[restaurant] send failed:', friendId, error)
+    return false
+  }
+}
+
+/** Find a tag by name or create it. Returns null if the harness rejects both (e.g. no permission). */
+export async function getOrCreateTag(client: LineHarness, name: string): Promise<string | null> {
+  try {
+    const tags = await client.tags.list()
+    const hit = tags.find((t) => t.name === name)
+    if (hit) return hit.id
+    const created = await client.tags.create({ name })
+    return created.id
+  } catch (error) {
+    console.error('[restaurant] tag setup failed:', name, error)
+    return null
+  }
+}
+
+export async function tryAddTag(client: LineHarness, friendId: string | null, tagId: string | null): Promise<void> {
+  if (!friendId || !tagId) return
+  try {
+    await client.friends.addTag(friendId, tagId)
+  } catch {
+    // already tagged or transient failure — non-fatal
+  }
+}

--- a/packages/plugin-restaurant/src/lib/logic.ts
+++ b/packages/plugin-restaurant/src/lib/logic.ts
@@ -1,0 +1,205 @@
+/**
+ * Pure domain logic — no I/O so it stays unit-testable.
+ * All customer-facing times are JST (the plugin targets restaurants in Japan).
+ */
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000
+
+export interface JstParts {
+  date: string // 'YYYY-MM-DD'
+  time: string // 'HH:mm'
+  hour: number
+  monthDay: string // 'MM-DD'
+  year: number
+}
+
+export function jstParts(now: Date): JstParts {
+  const j = new Date(now.getTime() + JST_OFFSET_MS)
+  const date = j.toISOString().slice(0, 10)
+  const time = j.toISOString().slice(11, 16)
+  return {
+    date,
+    time,
+    hour: j.getUTCHours(),
+    monthDay: date.slice(5),
+    year: j.getUTCFullYear(),
+  }
+}
+
+/** 'YYYY-MM-DD' + 'HH:mm' interpreted as JST → UTC ISO string */
+export function jstToUtcIso(date: string, time: string): string {
+  const utc = new Date(`${date}T${time}:00+09:00`)
+  return utc.toISOString()
+}
+
+/**
+ * D1 stores datetimes as 'YYYY-MM-DD HH:MM:SS' (UTC, from datetime('now')).
+ * Keep every stored timestamp in that format so SQL string comparisons stay
+ * correct, and convert at the edges with these two helpers.
+ */
+export function isoToSqlite(iso: string): string {
+  return iso.replace('T', ' ').slice(0, 19)
+}
+
+export function sqliteToIso(s: string): string {
+  return s.includes('T') ? s : `${s.replace(' ', 'T')}Z`
+}
+
+const WEEKDAYS_JA = ['日', '月', '火', '水', '木', '金', '土']
+
+/** UTC ISO → '7月8日(水) 19:00' */
+export function formatJst(iso: string): string {
+  const j = new Date(new Date(iso).getTime() + JST_OFFSET_MS)
+  const m = j.getUTCMonth() + 1
+  const d = j.getUTCDate()
+  const w = WEEKDAYS_JA[j.getUTCDay()]
+  const hh = String(j.getUTCHours()).padStart(2, '0')
+  const mm = String(j.getUTCMinutes()).padStart(2, '0')
+  return `${m}月${d}日(${w}) ${hh}:${mm}`
+}
+
+/** UTC ISO → JST 'YYYY-MM-DD' */
+export function jstDateOf(iso: string): string {
+  return new Date(new Date(iso).getTime() + JST_OFFSET_MS).toISOString().slice(0, 10)
+}
+
+// ---------------------------------------------------------------------------
+// Stamp card
+
+export interface StampResult {
+  newCount: number
+  rewardEarned: boolean
+}
+
+/** Adding one stamp: reaching the goal earns a reward and resets the card. */
+export function addStampToCard(currentCount: number, goal: number): StampResult {
+  const next = currentCount + 1
+  if (next >= goal) return { newCount: 0, rewardEarned: true }
+  return { newCount: next, rewardEarned: false }
+}
+
+// ---------------------------------------------------------------------------
+// Birthday
+
+/**
+ * birthday: 'MM-DD' or 'YYYY-MM-DD'. Matches on the JST month-day.
+ * Feb 29 birthdays match Feb 28 on non-leap years (jstMonthDay never emits 02-29 then).
+ */
+export function isBirthday(birthday: string | null | undefined, jstMonthDay: string): boolean {
+  if (!birthday) return false
+  const md = birthday.length === 10 ? birthday.slice(5) : birthday
+  if (!/^\d{2}-\d{2}$/.test(md)) return false
+  if (md === '02-29' && jstMonthDay === '02-28') return true
+  return md === jstMonthDay
+}
+
+// ---------------------------------------------------------------------------
+// Reservation reminders
+
+export type ReminderKind = 'day_before' | 'same_day'
+
+/**
+ * Which reminder (if any) is due for a reservation at `reservedAtIso` when the
+ * cron fires at `now`.
+ *  - day_before: from 18:00 JST on the previous day
+ *  - same_day:   from 2 hours before the reservation
+ * Sent-flags are handled by the caller; here we only judge the time windows.
+ * Nothing is due once the reservation time has passed.
+ */
+export function dueReminders(reservedAtIso: string, now: Date): ReminderKind[] {
+  const reservedAt = new Date(reservedAtIso)
+  if (now.getTime() >= reservedAt.getTime()) return []
+
+  const due: ReminderKind[] = []
+
+  const resDateJst = jstDateOf(reservedAtIso)
+  const dayBefore = new Date(new Date(`${resDateJst}T18:00:00+09:00`).getTime() - 24 * 60 * 60 * 1000)
+  if (now.getTime() >= dayBefore.getTime()) due.push('day_before')
+
+  const sameDay = new Date(reservedAt.getTime() - 2 * 60 * 60 * 1000)
+  if (now.getTime() >= sameDay.getTime()) due.push('same_day')
+
+  return due
+}
+
+// ---------------------------------------------------------------------------
+// Winback
+
+/** True when the member's last visit is `winbackDays` or more days ago. */
+export function isWinbackTarget(lastVisitAtIso: string | null | undefined, winbackDays: number, now: Date): boolean {
+  if (!lastVisitAtIso) return false
+  const elapsed = now.getTime() - new Date(lastVisitAtIso).getTime()
+  return elapsed >= winbackDays * 24 * 60 * 60 * 1000
+}
+
+// ---------------------------------------------------------------------------
+// Takeout
+
+export interface MenuItemLike {
+  id: string
+  name: string
+  price: number
+  is_available: number
+}
+
+export interface OrderLine {
+  id: string
+  name: string
+  price: number
+  qty: number
+}
+
+export type BuildOrderResult = { ok: true; lines: OrderLine[]; total: number } | { ok: false; error: string }
+
+/** 注文リクエストをメニュー実データと突合して明細と合計を作る（価格はクライアント申告を信用しない） */
+export function buildOrderLines(
+  menu: MenuItemLike[],
+  requested: { id?: string; qty?: number }[],
+): BuildOrderResult {
+  if (!Array.isArray(requested) || requested.length === 0) return { ok: false, error: '商品を選択してください' }
+  const byId = new Map(menu.map((m) => [m.id, m]))
+  const lines: OrderLine[] = []
+  for (const req of requested) {
+    const qty = Math.trunc(Number(req.qty ?? 0))
+    if (qty === 0) continue
+    if (!Number.isFinite(qty) || qty < 1 || qty > 20) return { ok: false, error: '数量は1〜20で指定してください' }
+    const item = req.id ? byId.get(req.id) : undefined
+    if (!item || !item.is_available) return { ok: false, error: '取り扱いのない商品が含まれています' }
+    lines.push({ id: item.id, name: item.name, price: item.price, qty })
+  }
+  if (lines.length === 0) return { ok: false, error: '商品を選択してください' }
+  const total = lines.reduce((sum, l) => sum + l.price * l.qty, 0)
+  return { ok: true, lines, total }
+}
+
+/**
+ * 受取時刻の検証: 本日（JST）の 'HH:mm'。現在時刻+15分以降のみ受付。
+ * OKなら UTC ISO を返す。
+ */
+export function validatePickupTime(time: string, now: Date): { ok: true; iso: string } | { ok: false; error: string } {
+  if (!/^\d{2}:\d{2}$/.test(time)) return { ok: false, error: '受取時間の形式が正しくありません' }
+  const today = jstParts(now).date
+  const iso = jstToUtcIso(today, time)
+  if (Number.isNaN(new Date(iso).getTime())) return { ok: false, error: '受取時間が不正です' }
+  if (new Date(iso).getTime() < now.getTime() + 15 * 60 * 1000) {
+    return { ok: false, error: '受取時間は15分後以降で指定してください' }
+  }
+  return { ok: true, iso }
+}
+
+// ---------------------------------------------------------------------------
+// Codes
+
+const CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789' // no 0/O/1/I/L
+
+export function randomCode(length: number, randomValues: Uint8Array): string {
+  let out = ''
+  for (let i = 0; i < length; i++) {
+    out += CODE_ALPHABET[(randomValues[i] as number) % CODE_ALPHABET.length]
+  }
+  return out
+}
+
+export function formatMemberNo(seq: number): string {
+  return `R-${String(seq).padStart(6, '0')}`
+}

--- a/packages/plugin-restaurant/src/middleware/auth.ts
+++ b/packages/plugin-restaurant/src/middleware/auth.ts
@@ -1,0 +1,78 @@
+import type { Context, MiddlewareHandler } from 'hono'
+import type { Env } from '../env.js'
+
+export interface LineUser {
+  userId: string
+  displayName: string
+}
+
+export type AppContext = {
+  Bindings: Env
+  Variables: {
+    lineUser: LineUser
+  }
+}
+
+/**
+ * LIFF auth: the page sends the LIFF access token as `Authorization: Bearer <token>`.
+ * We verify it server-side against LINE's verify endpoint (never trust a raw
+ * userId from the client) and then fetch the profile to get the userId.
+ */
+export const liffAuth: MiddlewareHandler<AppContext> = async (c, next) => {
+  const token = bearerToken(c)
+  if (!token) return c.json({ success: false, error: 'missing token' }, 401)
+
+  const verifyRes = await fetch(
+    `https://api.line.me/oauth2/v2.1/verify?access_token=${encodeURIComponent(token)}`,
+  )
+  if (!verifyRes.ok) return c.json({ success: false, error: 'invalid token' }, 401)
+  const verify = (await verifyRes.json()) as { client_id: string; expires_in: number }
+  if (verify.expires_in <= 0) return c.json({ success: false, error: 'token expired' }, 401)
+  const expectedChannel = c.env.LIFF_CHANNEL_ID
+  if (expectedChannel && verify.client_id !== expectedChannel) {
+    return c.json({ success: false, error: 'token issued for another channel' }, 401)
+  }
+
+  const profileRes = await fetch('https://api.line.me/v2/profile', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!profileRes.ok) return c.json({ success: false, error: 'profile fetch failed' }, 401)
+  const profile = (await profileRes.json()) as { userId: string; displayName: string }
+
+  c.set('lineUser', { userId: profile.userId, displayName: profile.displayName })
+  await next()
+}
+
+/** Staff endpoints: `X-Staff-Pin` header must match the STAFF_PIN secret. */
+export const staffAuth: MiddlewareHandler<AppContext> = async (c, next) => {
+  const pin = c.req.header('X-Staff-Pin')
+  if (!c.env.STAFF_PIN || !pin || !timingSafeEqual(pin, c.env.STAFF_PIN)) {
+    return c.json({ success: false, error: 'unauthorized' }, 401)
+  }
+  await next()
+}
+
+/** Admin/MCP endpoints: Bearer PLUGIN_API_KEY. */
+export const adminAuth: MiddlewareHandler<AppContext> = async (c, next) => {
+  const token = bearerToken(c)
+  if (!c.env.PLUGIN_API_KEY || !token || !timingSafeEqual(token, c.env.PLUGIN_API_KEY)) {
+    return c.json({ success: false, error: 'unauthorized' }, 401)
+  }
+  await next()
+}
+
+function bearerToken(c: Context<AppContext>): string | null {
+  const header = c.req.header('Authorization')
+  if (!header?.startsWith('Bearer ')) return null
+  return header.slice('Bearer '.length).trim() || null
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder()
+  const ab = enc.encode(a)
+  const bb = enc.encode(b)
+  if (ab.length !== bb.length) return false
+  let diff = 0
+  for (let i = 0; i < ab.length; i++) diff |= (ab[i] as number) ^ (bb[i] as number)
+  return diff === 0
+}

--- a/packages/plugin-restaurant/src/pages/card.ts
+++ b/packages/plugin-restaurant/src/pages/card.ts
@@ -1,0 +1,200 @@
+import { BASE_CSS, escapeHtml, escapeJs } from './shared.js'
+
+export function cardPage(liffId: string, storeName: string): string {
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>${escapeHtml(storeName)} 会員証</title>
+<style>${BASE_CSS}
+  .member-card { background: linear-gradient(135deg, #1c1917, #44403c); color: #fff;
+    border-radius: 16px; padding: 22px; margin-top: 14px; }
+  .member-card .store { font-size: 13px; opacity: .8; }
+  .member-card .no { font-size: 26px; font-weight: 800; letter-spacing: 2px; margin-top: 4px; }
+  .member-card .name { font-size: 14px; margin-top: 8px; opacity: .9; }
+  .stamps { display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px; margin-top: 12px; }
+  .stamp { aspect-ratio: 1; border-radius: 50%; border: 2px dashed var(--line);
+    display: flex; align-items: center; justify-content: center; font-size: 22px; color: #d6d3d1; }
+  .stamp.filled { border: 2px solid var(--brand); background: #fff7ed; color: var(--brand); }
+  .reward-item { border: 1.5px dashed var(--brand); border-radius: 10px; padding: 12px; margin-top: 10px; background: #fff7ed; }
+  .reward-item .code { font-size: 20px; font-weight: 800; letter-spacing: 2px; color: var(--brand-dark); }
+</style>
+</head>
+<body>
+<div class="header"><h1>${escapeHtml(storeName)}</h1></div>
+<div class="wrap">
+  <div id="loading" class="muted" style="text-align:center;padding:30px">読み込み中…</div>
+
+  <div id="main" class="hidden">
+    <div class="member-card">
+      <div class="store">${escapeHtml(storeName)} デジタル会員証</div>
+      <div class="no" id="memberNo"></div>
+      <div class="name" id="memberName"></div>
+    </div>
+
+    <div class="card">
+      <h2>スタンプカード <span class="muted" id="stampLabel"></span></h2>
+      <div class="stamps" id="stamps"></div>
+      <p class="muted" style="margin-top:10px">ご来店 <span id="totalVisits"></span> 回目までありがとうございます</p>
+      <label for="visitCode">本日の来店コード（店内掲示の4桁）</label>
+      <input id="visitCode" maxlength="4" autocapitalize="characters" autocomplete="off" placeholder="例: AB3K">
+      <button id="stampBtn">スタンプをもらう</button>
+      <div class="msg" id="stampMsg"></div>
+    </div>
+
+    <div class="card" id="rewardsCard">
+      <h2>ご利用可能な特典</h2>
+      <div id="rewards"></div>
+      <p class="muted" id="noRewards">まだ特典はありません。スタンプを集めるともらえます！</p>
+    </div>
+
+    <div class="card" id="birthdayCard">
+      <h2>お誕生日登録</h2>
+      <p class="muted">登録すると、お誕生日に特典が届きます🎂</p>
+      <div class="row">
+        <select id="bMonth"></select>
+        <select id="bDay"></select>
+      </div>
+      <button id="birthdayBtn" class="ghost">誕生日を登録する</button>
+      <div class="msg" id="birthdayMsg"></div>
+    </div>
+
+    <div class="card">
+      <h2>ご予約・テイクアウト</h2>
+      <div class="row">
+        <button id="reserveBtn" class="ghost">お席の予約</button>
+        <button id="takeoutBtn" class="ghost">テイクアウト</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>
+<script>
+const LIFF_ID = ${escapeJs(liffId)};
+let TOKEN = null;
+
+async function api(path, opts = {}) {
+  const res = await fetch('/api/liff' + path, {
+    ...opts,
+    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + TOKEN, ...(opts.headers || {}) },
+  });
+  return res.json();
+}
+
+function showMsg(id, ok, text) {
+  const el = document.getElementById(id);
+  el.className = 'msg ' + (ok ? 'ok' : 'err');
+  el.textContent = text;
+}
+
+function render(d) {
+  document.getElementById('memberNo').textContent = d.memberNo;
+  document.getElementById('memberName').textContent = (d.displayName || '') + ' 様';
+  document.getElementById('totalVisits').textContent = d.totalVisits + 1;
+  document.getElementById('stampLabel').textContent = d.stampCount + ' / ' + d.stampGoal + '個で「' + d.rewardName + '」';
+  const stamps = document.getElementById('stamps');
+  stamps.innerHTML = '';
+  for (let i = 0; i < d.stampGoal; i++) {
+    const s = document.createElement('div');
+    s.className = 'stamp' + (i < d.stampCount ? ' filled' : '');
+    s.textContent = i < d.stampCount ? '🍽' : (i + 1);
+    stamps.appendChild(s);
+  }
+  const rewards = document.getElementById('rewards');
+  rewards.innerHTML = '';
+  document.getElementById('noRewards').style.display = d.rewards.length ? 'none' : 'block';
+  for (const r of d.rewards) {
+    const div = document.createElement('div');
+    div.className = 'reward-item';
+    div.innerHTML = '<div>' + r.name + '</div><div class="code">' + r.code + '</div>'
+      + (r.expiresAt ? '<div class="muted">有効期限: ' + r.expiresAt + '</div>' : '');
+    rewards.appendChild(div);
+  }
+  if (d.birthday) document.getElementById('birthdayCard').classList.add('hidden');
+}
+
+async function refresh() {
+  const res = await api('/me', { method: 'POST' });
+  if (res.success) {
+    render(res.data);
+    document.getElementById('loading').classList.add('hidden');
+    document.getElementById('main').classList.remove('hidden');
+  } else {
+    document.getElementById('loading').textContent = '読み込みに失敗しました: ' + (res.error || '');
+  }
+}
+
+// 来店QR経由（?code=XXXX）ならスキャンだけで自動スタンプ
+function getUrlCode() {
+  const sp = new URLSearchParams(location.search);
+  if (sp.get('code')) return sp.get('code');
+  const st = sp.get('liff.state'); // LIFF初回リダイレクトはクエリがliff.stateに入る
+  if (st) {
+    try { return new URLSearchParams(st.replace(/^[^?]*\??/, '')).get('code'); } catch (e) {}
+  }
+  return null;
+}
+
+async function autoStampFromQr() {
+  const code = getUrlCode();
+  if (!code || sessionStorage.getItem('qr_stamp_done')) return;
+  sessionStorage.setItem('qr_stamp_done', '1'); // リロードでの二重送信ガード（サーバー側にも1日1回制限あり）
+  const res = await api('/stamp', { method: 'POST', body: JSON.stringify({ code } ) });
+  if (res.success) {
+    showMsg('stampMsg', true, res.data.rewardEarned
+      ? '🎉 ご来店ありがとうございます！スタンプ満了で特典コード ' + res.data.rewardCode + ' を獲得しました'
+      : '🎉 ご来店ありがとうございます！スタンプを押しました（' + res.data.stampCount + ' / ' + res.data.stampGoal + '）');
+    await refresh();
+  } else if (res.reason !== 'already_today') {
+    showMsg('stampMsg', false, res.error || 'スタンプを押せませんでした');
+  }
+}
+
+document.getElementById('stampBtn').addEventListener('click', async () => {
+  const btn = document.getElementById('stampBtn');
+  btn.disabled = true;
+  try {
+    const code = document.getElementById('visitCode').value;
+    const res = await api('/stamp', { method: 'POST', body: JSON.stringify({ code }) });
+    if (res.success) {
+      showMsg('stampMsg', true, res.data.rewardEarned
+        ? '🎉 スタンプ満了！特典コード ' + res.data.rewardCode + ' を獲得しました'
+        : 'スタンプを押しました！（' + res.data.stampCount + ' / ' + res.data.stampGoal + '）');
+      document.getElementById('visitCode').value = '';
+      await refresh();
+    } else {
+      showMsg('stampMsg', false, res.error || 'エラーが発生しました');
+    }
+  } finally { btn.disabled = false; }
+});
+
+document.getElementById('birthdayBtn').addEventListener('click', async () => {
+  const mm = document.getElementById('bMonth').value, dd = document.getElementById('bDay').value;
+  const res = await api('/profile', { method: 'POST', body: JSON.stringify({ birthday: mm + '-' + dd }) });
+  if (res.success) { showMsg('birthdayMsg', true, '登録しました！お誕生日をお楽しみに🎂'); }
+  else { showMsg('birthdayMsg', false, res.error || 'エラーが発生しました'); }
+});
+
+document.getElementById('reserveBtn').addEventListener('click', () => { location.href = '/liff/reserve'; });
+document.getElementById('takeoutBtn').addEventListener('click', () => { location.href = '/liff/takeout'; });
+
+(function initSelects() {
+  const m = document.getElementById('bMonth'), d = document.getElementById('bDay');
+  for (let i = 1; i <= 12; i++) m.add(new Option(i + '月', String(i).padStart(2, '0')));
+  for (let i = 1; i <= 31; i++) d.add(new Option(i + '日', String(i).padStart(2, '0')));
+})();
+
+liff.init({ liffId: LIFF_ID }).then(async () => {
+  if (!liff.isLoggedIn()) { liff.login({ redirectUri: location.href }); return; }
+  TOKEN = liff.getAccessToken();
+  await refresh();
+  await autoStampFromQr();
+}).catch((e) => {
+  document.getElementById('loading').textContent = 'LIFFの初期化に失敗しました: ' + e.message;
+});
+</script>
+</body>
+</html>`
+}

--- a/packages/plugin-restaurant/src/pages/reserve.ts
+++ b/packages/plugin-restaurant/src/pages/reserve.ts
@@ -1,0 +1,149 @@
+import { BASE_CSS, escapeHtml, escapeJs } from './shared.js'
+
+export function reservePage(liffId: string, storeName: string): string {
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>${escapeHtml(storeName)} 予約</title>
+<style>${BASE_CSS}
+  .res-item { border: 1px solid var(--line); border-radius: 10px; padding: 12px; margin-top: 10px; }
+  .res-item .when { font-weight: 700; }
+  .res-item button { margin-top: 8px; padding: 8px; font-size: 13px; }
+</style>
+</head>
+<body>
+<div class="header"><h1>${escapeHtml(storeName)} お席のご予約</h1></div>
+<div class="wrap">
+  <div id="loading" class="muted" style="text-align:center;padding:30px">読み込み中…</div>
+
+  <div id="main" class="hidden">
+    <div class="card">
+      <h2>新規予約</h2>
+      <div class="row">
+        <div><label for="rDate">日付</label><input type="date" id="rDate"></div>
+        <div><label for="rTime">時間</label><select id="rTime"></select></div>
+      </div>
+      <div class="row">
+        <div><label for="rParty">人数</label><select id="rParty"></select></div>
+        <div><label for="rPhone">電話番号（任意）</label><input type="tel" id="rPhone" placeholder="090-0000-0000"></div>
+      </div>
+      <label for="rName">お名前</label>
+      <input id="rName" placeholder="山田太郎">
+      <label for="rNote">ご要望（任意）</label>
+      <textarea id="rNote" rows="2" placeholder="アレルギー・お祝い・お席の希望など"></textarea>
+      <button id="submitBtn">この内容で予約する</button>
+      <div class="msg" id="submitMsg"></div>
+    </div>
+
+    <div class="card">
+      <h2>ご予約一覧</h2>
+      <div id="resList"></div>
+      <p class="muted" id="noRes">今後のご予約はありません</p>
+    </div>
+
+    <div class="card">
+      <button id="backBtn" class="ghost">会員証にもどる</button>
+    </div>
+  </div>
+</div>
+
+<script src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>
+<script>
+const LIFF_ID = ${escapeJs(liffId)};
+let TOKEN = null;
+
+async function api(path, opts = {}) {
+  const res = await fetch('/api/liff' + path, {
+    ...opts,
+    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + TOKEN, ...(opts.headers || {}) },
+  });
+  return res.json();
+}
+
+function showMsg(id, ok, text) {
+  const el = document.getElementById(id);
+  el.className = 'msg ' + (ok ? 'ok' : 'err');
+  el.textContent = text;
+}
+
+async function loadList() {
+  const res = await api('/reservations');
+  const list = document.getElementById('resList');
+  list.innerHTML = '';
+  const items = res.success ? res.data : [];
+  document.getElementById('noRes').style.display = items.length ? 'none' : 'block';
+  for (const r of items) {
+    const div = document.createElement('div');
+    div.className = 'res-item';
+    const cancel = document.createElement('button');
+    cancel.className = 'ghost';
+    cancel.textContent = 'この予約をキャンセルする';
+    cancel.addEventListener('click', async () => {
+      if (!confirm(r.reservedAt + ' の予約をキャンセルしますか？')) return;
+      const del = await api('/reservations/' + r.id, { method: 'DELETE' });
+      if (!del.success) alert(del.error || 'キャンセルに失敗しました');
+      await loadList();
+    });
+    div.innerHTML = '<div class="when">' + r.reservedAt + '　' + r.partySize + '名</div>'
+      + '<div class="muted">' + r.name + ' 様' + (r.note ? '｜' + r.note : '') + '</div>';
+    div.appendChild(cancel);
+    list.appendChild(div);
+  }
+}
+
+document.getElementById('submitBtn').addEventListener('click', async () => {
+  const btn = document.getElementById('submitBtn');
+  btn.disabled = true;
+  try {
+    const res = await api('/reservations', {
+      method: 'POST',
+      body: JSON.stringify({
+        date: document.getElementById('rDate').value,
+        time: document.getElementById('rTime').value,
+        partySize: Number(document.getElementById('rParty').value),
+        name: document.getElementById('rName').value,
+        phone: document.getElementById('rPhone').value,
+        note: document.getElementById('rNote').value,
+      }),
+    });
+    if (res.success) {
+      showMsg('submitMsg', true, '✅ ' + res.data.reservedAt + '・' + res.data.partySize + '名で予約しました。LINEに確認メッセージをお送りします。');
+      await loadList();
+    } else {
+      showMsg('submitMsg', false, res.error || '予約に失敗しました');
+    }
+  } finally { btn.disabled = false; }
+});
+
+document.getElementById('backBtn').addEventListener('click', () => { location.href = '/liff/card'; });
+
+(function initForm() {
+  const d = document.getElementById('rDate');
+  const today = new Date(Date.now() + 9 * 3600 * 1000).toISOString().slice(0, 10);
+  d.min = today; d.value = today;
+  const t = document.getElementById('rTime');
+  for (let h = 11; h <= 21; h++) for (const m of ['00', '30']) {
+    const v = String(h).padStart(2, '0') + ':' + m;
+    t.add(new Option(v, v));
+  }
+  t.value = '18:00';
+  const p = document.getElementById('rParty');
+  for (let i = 1; i <= 20; i++) p.add(new Option(i + '名', String(i)));
+  p.value = '2';
+})();
+
+liff.init({ liffId: LIFF_ID }).then(() => {
+  if (!liff.isLoggedIn()) { liff.login({ redirectUri: location.href }); return; }
+  TOKEN = liff.getAccessToken();
+  document.getElementById('loading').classList.add('hidden');
+  document.getElementById('main').classList.remove('hidden');
+  loadList();
+}).catch((e) => {
+  document.getElementById('loading').textContent = 'LIFFの初期化に失敗しました: ' + e.message;
+});
+</script>
+</body>
+</html>`
+}

--- a/packages/plugin-restaurant/src/pages/shared.ts
+++ b/packages/plugin-restaurant/src/pages/shared.ts
@@ -1,0 +1,44 @@
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/** For values embedded inside inline <script> string literals. */
+export function escapeJs(s: string): string {
+  return JSON.stringify(s)
+}
+
+export const BASE_CSS = /* css */ `
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  :root {
+    --brand: #b45309; --brand-dark: #92400e; --bg: #faf7f2; --card: #ffffff;
+    --text: #1c1917; --muted: #78716c; --line: #e7e5e4; --ok: #15803d; --err: #b91c1c;
+  }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
+    background: var(--bg); color: var(--text); line-height: 1.6; padding-bottom: 40px; }
+  .wrap { max-width: 480px; margin: 0 auto; padding: 16px; }
+  .header { background: linear-gradient(135deg, var(--brand), var(--brand-dark)); color: #fff;
+    padding: 20px 16px; text-align: center; }
+  .header h1 { font-size: 18px; font-weight: 700; }
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 14px;
+    padding: 18px; margin-top: 14px; box-shadow: 0 1px 3px rgba(0,0,0,.05); }
+  .card h2 { font-size: 15px; margin-bottom: 10px; color: var(--brand-dark); }
+  label { display: block; font-size: 13px; color: var(--muted); margin: 10px 0 4px; }
+  input, select, textarea { width: 100%; padding: 12px; border: 1px solid var(--line);
+    border-radius: 10px; font-size: 16px; background: #fff; }
+  button { width: 100%; padding: 14px; margin-top: 14px; border: 0; border-radius: 10px;
+    background: var(--brand); color: #fff; font-size: 16px; font-weight: 700; cursor: pointer; }
+  button:disabled { opacity: .5; }
+  button.ghost { background: #fff; color: var(--brand); border: 1.5px solid var(--brand); }
+  .msg { margin-top: 10px; font-size: 14px; padding: 10px 12px; border-radius: 8px; display: none; }
+  .msg.ok { display: block; background: #f0fdf4; color: var(--ok); }
+  .msg.err { display: block; background: #fef2f2; color: var(--err); }
+  .muted { color: var(--muted); font-size: 13px; }
+  .row { display: flex; gap: 10px; }
+  .row > * { flex: 1; }
+  .hidden { display: none !important; }
+`

--- a/packages/plugin-restaurant/src/pages/staff.ts
+++ b/packages/plugin-restaurant/src/pages/staff.ts
@@ -1,0 +1,351 @@
+import { BASE_CSS, escapeHtml, escapeJs } from './shared.js'
+
+export function staffPage(liffId: string, storeName: string): string {
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>${escapeHtml(storeName)} スタッフ</title>
+<style>${BASE_CSS}
+  .wrap { max-width: 640px; }
+  .code-display { text-align: center; font-size: 42px; font-weight: 800; letter-spacing: 8px;
+    color: var(--brand-dark); padding: 10px 0; }
+  .summary { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+  .summary .box { text-align: center; border: 1px solid var(--line); border-radius: 10px; padding: 10px; }
+  .summary .n { font-size: 24px; font-weight: 800; color: var(--brand-dark); }
+  table { width: 100%; border-collapse: collapse; margin-top: 10px; font-size: 14px; }
+  th, td { text-align: left; padding: 8px 6px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  .status-btns button { width: auto; padding: 6px 10px; margin: 2px 4px 0 0; font-size: 12px; display: inline-block; }
+  .st-seated { color: var(--ok); font-weight: 700; }
+  .st-cancelled, .st-no_show { color: var(--err); font-weight: 700; }
+</style>
+</head>
+<body>
+<div class="header"><h1>${escapeHtml(storeName)} スタッフページ</h1></div>
+<div class="wrap">
+  <div class="card" id="loginCard">
+    <h2>スタッフ認証</h2>
+    <label for="pin">PIN</label>
+    <input id="pin" type="password" autocomplete="off">
+    <button id="loginBtn">ログイン</button>
+    <div class="msg" id="loginMsg"></div>
+  </div>
+
+  <div id="main" class="hidden">
+    <div class="card">
+      <h2>本日のサマリー</h2>
+      <div class="summary">
+        <div class="box"><div class="n" id="sumMembers">-</div><div class="muted">会員数</div></div>
+        <div class="box"><div class="n" id="sumVisits">-</div><div class="muted">本日来店</div></div>
+        <div class="box"><div class="n" id="sumRes">-</div><div class="muted">本日予約</div></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>本日の来店コード・来店QR（店内掲示用）</h2>
+      <div class="code-display" id="visitCode">----</div>
+      <div id="visitQr" style="display:flex;justify-content:center;padding:8px 0"></div>
+      <p class="muted">お客様がQRを読み取ると<b>スキャンだけで自動的にスタンプ</b>が押されます（コード手入力も可）。日付が変わると自動更新されるので、画面掲示か毎日の印刷でご利用ください。</p>
+    </div>
+
+    <div class="card">
+      <h2>スタンプ付与（会員番号で）</h2>
+      <input id="stampMemberNo" placeholder="R-000123" autocapitalize="characters">
+      <button id="stampBtn">スタンプを押す</button>
+      <div class="msg" id="stampMsg"></div>
+    </div>
+
+    <div class="card">
+      <h2>特典・クーポンの消込</h2>
+      <input id="redeemCode" placeholder="RW-XXXXXX / CP-XXXXXX" autocapitalize="characters">
+      <label for="redeemMemberNo">会員番号（CP-クーポン時・任意。入れると来店記録＆レビュー依頼が動く）</label>
+      <input id="redeemMemberNo" placeholder="R-000123" autocapitalize="characters">
+      <button id="redeemBtn">消込する</button>
+      <div class="msg" id="redeemMsg"></div>
+    </div>
+
+    <div class="card">
+      <h2>テイクアウト注文</h2>
+      <input type="date" id="toDate">
+      <div id="toList"></div>
+      <p class="muted" id="noTo">この日の注文はありません</p>
+    </div>
+
+    <div class="card">
+      <h2>テイクアウトメニュー管理</h2>
+      <div id="menuList"></div>
+      <p class="muted" id="noMenu">メニューがまだありません。下のフォームから追加してください。</p>
+      <div style="border-top:1px solid var(--line);margin-top:14px;padding-top:4px">
+        <input type="hidden" id="mId">
+        <label for="mName">商品名 <span id="mEditing" class="muted"></span></label>
+        <input id="mName" placeholder="唐揚げ弁当">
+        <div class="row">
+          <div><label for="mPrice">価格（円・税込）</label><input id="mPrice" type="number" inputmode="numeric" placeholder="800"></div>
+          <div><label for="mSort">表示順</label><input id="mSort" type="number" inputmode="numeric" value="0"></div>
+        </div>
+        <label for="mDesc">説明（任意）</label>
+        <input id="mDesc" placeholder="自家製ダレの唐揚げ5個入り">
+        <button id="mSaveBtn">メニューを追加する</button>
+        <button id="mClearBtn" class="ghost hidden">編集をやめる</button>
+        <div class="msg" id="mMsg"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>予約一覧</h2>
+      <input type="date" id="resDate">
+      <table>
+        <thead><tr><th>時間</th><th>お名前 / 内容</th><th>状態</th></tr></thead>
+        <tbody id="resBody"></tbody>
+      </table>
+      <p class="muted" id="noRes">この日の予約はありません</p>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/gh/davidshimjs/qrcodejs/qrcode.min.js"></script>
+<script>
+const LIFF_ID = ${escapeJs(liffId)};
+let PIN = sessionStorage.getItem('staff_pin') || '';
+
+async function api(path, opts = {}) {
+  const res = await fetch('/api/staff' + path, {
+    ...opts,
+    headers: { 'Content-Type': 'application/json', 'X-Staff-Pin': PIN, ...(opts.headers || {}) },
+  });
+  if (res.status === 401) { logout(); throw new Error('unauthorized'); }
+  return res.json();
+}
+
+function logout() {
+  sessionStorage.removeItem('staff_pin');
+  document.getElementById('main').classList.add('hidden');
+  document.getElementById('loginCard').classList.remove('hidden');
+}
+
+function showMsg(id, ok, text) {
+  const el = document.getElementById(id);
+  el.className = 'msg ' + (ok ? 'ok' : 'err');
+  el.textContent = text;
+}
+
+const STATUS_JA = { confirmed: '確定', seated: '来店', cancelled: 'キャンセル', no_show: '無断' };
+
+async function loadAll() {
+  const [sum, code] = await Promise.all([api('/summary'), api('/visit-code')]);
+  if (sum.success) {
+    document.getElementById('sumMembers').textContent = sum.data.members;
+    document.getElementById('sumVisits').textContent = sum.data.visitsToday;
+    document.getElementById('sumRes').textContent = sum.data.reservationsToday;
+  }
+  if (code.success) {
+    document.getElementById('visitCode').textContent = code.data.code;
+    const qrBox = document.getElementById('visitQr');
+    qrBox.innerHTML = '';
+    if (LIFF_ID && typeof QRCode !== 'undefined') {
+      new QRCode(qrBox, { text: 'https://liff.line.me/' + LIFF_ID + '?code=' + code.data.code, width: 180, height: 180 });
+    }
+  }
+  await loadReservations();
+  await loadTakeout();
+  await loadMenu();
+}
+
+async function loadReservations() {
+  const date = document.getElementById('resDate').value;
+  const res = await api('/reservations?date=' + date);
+  const body = document.getElementById('resBody');
+  body.innerHTML = '';
+  const items = res.success ? res.data : [];
+  document.getElementById('noRes').style.display = items.length ? 'none' : 'block';
+  for (const r of items) {
+    const tr = document.createElement('tr');
+    const btns = document.createElement('td');
+    btns.className = 'status-btns';
+    if (r.status === 'confirmed') {
+      for (const [st, label] of [['seated', '来店'], ['no_show', '無断'], ['cancelled', '取消']]) {
+        const b = document.createElement('button');
+        b.textContent = label;
+        b.className = st === 'seated' ? '' : 'ghost';
+        b.addEventListener('click', async () => {
+          await api('/reservations/' + r.id, { method: 'PATCH', body: JSON.stringify({ status: st }) });
+          await loadReservations();
+        });
+        btns.appendChild(b);
+      }
+    } else {
+      btns.innerHTML = '<span class="st-' + r.status + '">' + (STATUS_JA[r.status] || r.status) + '</span>';
+    }
+    const info = document.createElement('td');
+    info.innerHTML = r.name + ' 様 ' + r.partySize + '名'
+      + '<div class="muted">' + r.memberNo + (r.phone ? '｜' + r.phone : '') + (r.note ? '｜' + r.note : '') + '</div>';
+    const time = document.createElement('td');
+    time.textContent = r.time;
+    tr.appendChild(time); tr.appendChild(info); tr.appendChild(btns);
+    body.appendChild(tr);
+  }
+}
+
+async function enter() {
+  try {
+    const res = await api('/summary');
+    if (!res.success) throw new Error();
+    document.getElementById('loginCard').classList.add('hidden');
+    document.getElementById('main').classList.remove('hidden');
+    sessionStorage.setItem('staff_pin', PIN);
+    await loadAll();
+  } catch {
+    showMsg('loginMsg', false, 'PINが違います');
+  }
+}
+
+document.getElementById('loginBtn').addEventListener('click', () => {
+  PIN = document.getElementById('pin').value.trim();
+  enter();
+});
+
+document.getElementById('stampBtn').addEventListener('click', async () => {
+  const res = await api('/stamp', { method: 'POST', body: JSON.stringify({ memberNo: document.getElementById('stampMemberNo').value }) });
+  if (res.success) {
+    showMsg('stampMsg', true, (res.data.displayName || res.data.memberNo) + ' 様に押印（' + res.data.stampCount + '個'
+      + (res.data.rewardEarned ? '・🎉特典発行 ' + res.data.rewardCode : '') + '）');
+    document.getElementById('stampMemberNo').value = '';
+    loadAll();
+  } else showMsg('stampMsg', false, res.error || 'エラー');
+});
+
+document.getElementById('redeemBtn').addEventListener('click', async () => {
+  const res = await api('/redeem', { method: 'POST', body: JSON.stringify({
+    code: document.getElementById('redeemCode').value,
+    memberNo: document.getElementById('redeemMemberNo').value,
+  }) });
+  if (res.success) {
+    showMsg('redeemMsg', true, res.data.kind === 'campaign'
+      ? '「' + res.data.name + '」を消込みました（累計' + res.data.usedCount + '回目）'
+      : '「' + res.data.name + '」を使用済みにしました' + (res.data.memberNo ? '（' + res.data.memberNo + ' の来店を記録）' : ''));
+    document.getElementById('redeemCode').value = '';
+    document.getElementById('redeemMemberNo').value = '';
+  } else showMsg('redeemMsg', false, res.error || 'エラー');
+});
+
+const TO_STATUS_JA = { pending: '受付待ち', accepted: '調理中', ready: '準備完了', completed: '受渡済', cancelled: 'キャンセル' };
+const TO_NEXT = { pending: [['accepted', '調理開始'], ['cancelled', '取消']], accepted: [['ready', '準備完了→通知']], ready: [['completed', '受渡完了']] };
+
+async function loadTakeout() {
+  const date = document.getElementById('toDate').value;
+  const res = await api('/takeout?date=' + date);
+  const box = document.getElementById('toList');
+  box.innerHTML = '';
+  const items = res.success ? res.data : [];
+  document.getElementById('noTo').style.display = items.length ? 'none' : 'block';
+  for (const o of items) {
+    const div = document.createElement('div');
+    div.style.cssText = 'border:1px solid var(--line);border-radius:10px;padding:10px;margin-top:8px';
+    div.innerHTML = '<b>' + o.orderNo + '</b>　' + o.pickupAt.split(' ')[1] + ' 受取　<span class="muted">' + (TO_STATUS_JA[o.status] || o.status) + '</span>'
+      + '<div>' + o.items.map(function(l){ return l.name + '×' + l.qty; }).join('、') + '　¥' + o.total.toLocaleString() + '</div>'
+      + '<div class="muted">' + o.memberNo + (o.note ? '｜' + o.note : '') + '</div>';
+    const btns = document.createElement('div');
+    btns.className = 'status-btns';
+    for (const [st, label] of (TO_NEXT[o.status] || [])) {
+      const b = document.createElement('button');
+      b.textContent = label;
+      b.className = st === 'cancelled' ? 'ghost' : '';
+      b.addEventListener('click', async () => {
+        await api('/takeout/' + o.id, { method: 'PATCH', body: JSON.stringify({ status: st }) });
+        await loadTakeout();
+      });
+      btns.appendChild(b);
+    }
+    div.appendChild(btns);
+    box.appendChild(div);
+  }
+}
+
+document.getElementById('toDate').addEventListener('change', loadTakeout);
+
+// --- テイクアウトメニュー管理 ---
+let MENU_ITEMS = [];
+
+async function loadMenu() {
+  const res = await api('/takeout-menu');
+  MENU_ITEMS = res.success ? res.data : [];
+  const box = document.getElementById('menuList');
+  box.innerHTML = '';
+  document.getElementById('noMenu').style.display = MENU_ITEMS.length ? 'none' : 'block';
+  for (const m of MENU_ITEMS) {
+    const div = document.createElement('div');
+    div.style.cssText = 'display:flex;align-items:center;gap:8px;padding:8px 0;border-bottom:1px solid var(--line)'
+      + (m.isAvailable ? '' : ';opacity:.5');
+    const info = document.createElement('div');
+    info.style.flex = '1';
+    info.innerHTML = '<b>' + m.name + '</b>　¥' + m.price.toLocaleString()
+      + (m.isAvailable ? '' : '　<span class="muted">[非公開]</span>')
+      + (m.description ? '<div class="muted">' + m.description + '</div>' : '');
+    const edit = document.createElement('button');
+    edit.textContent = '編集'; edit.className = 'ghost';
+    edit.style.cssText = 'width:auto;padding:6px 12px;margin:0;font-size:13px';
+    edit.addEventListener('click', () => {
+      document.getElementById('mId').value = m.id;
+      document.getElementById('mName').value = m.name;
+      document.getElementById('mPrice').value = m.price;
+      document.getElementById('mSort').value = m.sortOrder;
+      document.getElementById('mDesc').value = m.description || '';
+      document.getElementById('mEditing').textContent = '（「' + m.name + '」を編集中）';
+      document.getElementById('mSaveBtn').textContent = '変更を保存する';
+      document.getElementById('mClearBtn').classList.remove('hidden');
+    });
+    const toggle = document.createElement('button');
+    toggle.textContent = m.isAvailable ? '非公開に' : '公開する';
+    toggle.className = m.isAvailable ? 'ghost' : '';
+    toggle.style.cssText = 'width:auto;padding:6px 12px;margin:0;font-size:13px';
+    toggle.addEventListener('click', async () => {
+      await api('/takeout-menu', { method: 'POST', body: JSON.stringify({
+        id: m.id, name: m.name, price: m.price, description: m.description || undefined,
+        sortOrder: m.sortOrder, isAvailable: !m.isAvailable,
+      }) });
+      await loadMenu();
+    });
+    div.append(info, edit, toggle);
+    box.appendChild(div);
+  }
+}
+
+function clearMenuForm() {
+  for (const id of ['mId', 'mName', 'mPrice', 'mDesc']) document.getElementById(id).value = '';
+  document.getElementById('mSort').value = '0';
+  document.getElementById('mEditing').textContent = '';
+  document.getElementById('mSaveBtn').textContent = 'メニューを追加する';
+  document.getElementById('mClearBtn').classList.add('hidden');
+}
+
+document.getElementById('mSaveBtn').addEventListener('click', async () => {
+  const id = document.getElementById('mId').value;
+  const res = await api('/takeout-menu', { method: 'POST', body: JSON.stringify({
+    id: id || undefined,
+    name: document.getElementById('mName').value,
+    price: Number(document.getElementById('mPrice').value),
+    description: document.getElementById('mDesc').value || undefined,
+    sortOrder: Number(document.getElementById('mSort').value) || 0,
+  }) });
+  if (res.success) {
+    showMsg('mMsg', true, '「' + res.data.name + '」を' + (id ? '更新' : '追加') + 'しました');
+    clearMenuForm();
+    await loadMenu();
+  } else showMsg('mMsg', false, res.error || 'エラー');
+});
+
+document.getElementById('mClearBtn').addEventListener('click', clearMenuForm);
+
+document.getElementById('resDate').addEventListener('change', loadReservations);
+
+(function init() {
+  const today = new Date(Date.now() + 9 * 3600 * 1000).toISOString().slice(0, 10);
+  document.getElementById('resDate').value = today;
+  document.getElementById('toDate').value = today;
+  if (PIN) enter();
+})();
+</script>
+</body>
+</html>`
+}

--- a/packages/plugin-restaurant/src/pages/takeout.ts
+++ b/packages/plugin-restaurant/src/pages/takeout.ts
@@ -1,0 +1,239 @@
+import { BASE_CSS, escapeHtml, escapeJs } from './shared.js'
+
+export function takeoutPage(liffId: string, storeName: string): string {
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>${escapeHtml(storeName)} テイクアウト</title>
+<style>${BASE_CSS}
+  .menu-item { display: flex; align-items: center; gap: 10px; padding: 12px 0; border-bottom: 1px solid var(--line); }
+  .menu-item .info { flex: 1; }
+  .menu-item .nm { font-weight: 700; }
+  .menu-item .pr { color: var(--brand-dark); font-weight: 700; }
+  .qty { display: flex; align-items: center; gap: 8px; }
+  .qty button { width: 34px; height: 34px; padding: 0; margin: 0; border-radius: 50%; font-size: 18px; }
+  .qty .n { min-width: 22px; text-align: center; font-weight: 700; }
+  .total-bar { position: sticky; bottom: 0; background: var(--card); border-top: 2px solid var(--brand);
+    padding: 12px 16px; display: flex; justify-content: space-between; align-items: center; font-weight: 800; }
+  .order-item { border: 1px solid var(--line); border-radius: 10px; padding: 12px; margin-top: 10px; }
+  .order-item .st { font-size: 12px; font-weight: 700; }
+  .st-pending { color: var(--muted); } .st-accepted { color: var(--brand-dark); } .st-ready { color: var(--ok); }
+  .order-item button { margin-top: 8px; padding: 8px; font-size: 13px; }
+  .slide-wrap { position: relative; margin-top: 10px; height: 52px; border-radius: 26px;
+    background: linear-gradient(90deg, #fff7ed, #ffedd5); border: 1.5px solid var(--brand); overflow: hidden; }
+  .slide-wrap .label { position: absolute; inset: 0; display: flex; align-items: center;
+    justify-content: center; font-size: 14px; font-weight: 700; color: var(--brand-dark); pointer-events: none; }
+  .slide-wrap input[type=range] { -webkit-appearance: none; appearance: none; position: absolute; inset: 0;
+    width: 100%; height: 100%; margin: 0; background: transparent; }
+  .slide-wrap input[type=range]::-webkit-slider-thumb { -webkit-appearance: none; appearance: none;
+    width: 46px; height: 46px; border-radius: 50%; background: var(--brand); border: 3px solid #fff;
+    box-shadow: 0 2px 6px rgba(0,0,0,.25); cursor: grab; }
+</style>
+</head>
+<body>
+<div class="header"><h1>${escapeHtml(storeName)} テイクアウト</h1></div>
+<div class="wrap">
+  <div id="loading" class="muted" style="text-align:center;padding:30px">読み込み中…</div>
+
+  <div id="main" class="hidden">
+    <div class="card">
+      <h2>メニュー</h2>
+      <div id="menu"></div>
+      <p class="muted" id="noMenu" style="margin-top:10px">現在テイクアウトメニューの準備中です</p>
+      <label for="pickupTime">受取時間（本日・15分後以降）</label>
+      <select id="pickupTime"></select>
+      <label for="orderNote">ご要望（任意）</label>
+      <input id="orderNote" placeholder="例: 箸を2膳お願いします">
+      <button id="orderBtn">注文する（支払いは店頭）</button>
+      <div class="msg" id="orderMsg"></div>
+    </div>
+
+    <div class="card">
+      <h2>進行中のご注文</h2>
+      <div id="orders"></div>
+      <p class="muted" id="noOrders">進行中のご注文はありません</p>
+    </div>
+
+    <div class="card"><button id="backBtn" class="ghost">会員証にもどる</button></div>
+  </div>
+</div>
+<div class="total-bar hidden" id="totalBar"><span>合計</span><span id="totalYen">¥0</span></div>
+
+<script src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>
+<script>
+const LIFF_ID = ${escapeJs(liffId)};
+let TOKEN = null;
+let MENU = [];
+const CART = {}; // id -> qty
+const STATUS_JA = { pending: '受付待ち', accepted: '調理中', ready: '準備完了！' };
+
+async function api(path, opts = {}) {
+  const res = await fetch('/api/liff' + path, {
+    ...opts,
+    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + TOKEN, ...(opts.headers || {}) },
+  });
+  return res.json();
+}
+
+function showMsg(id, ok, text) {
+  const el = document.getElementById(id);
+  el.className = 'msg ' + (ok ? 'ok' : 'err');
+  el.textContent = text;
+}
+
+function renderMenu() {
+  const box = document.getElementById('menu');
+  box.innerHTML = '';
+  document.getElementById('noMenu').style.display = MENU.length ? 'none' : 'block';
+  for (const m of MENU) {
+    const row = document.createElement('div');
+    row.className = 'menu-item';
+    const info = document.createElement('div');
+    info.className = 'info';
+    info.innerHTML = '<div class="nm">' + m.name + '</div>'
+      + (m.description ? '<div class="muted">' + m.description + '</div>' : '')
+      + '<div class="pr">¥' + m.price.toLocaleString() + '</div>';
+    const qty = document.createElement('div');
+    qty.className = 'qty';
+    const minus = document.createElement('button'); minus.textContent = '−'; minus.className = 'ghost';
+    const n = document.createElement('span'); n.className = 'n'; n.textContent = CART[m.id] || 0;
+    const plus = document.createElement('button'); plus.textContent = '＋';
+    minus.addEventListener('click', () => { CART[m.id] = Math.max(0, (CART[m.id] || 0) - 1); n.textContent = CART[m.id]; renderTotal(); });
+    plus.addEventListener('click', () => { CART[m.id] = Math.min(20, (CART[m.id] || 0) + 1); n.textContent = CART[m.id]; renderTotal(); });
+    qty.append(minus, n, plus);
+    row.append(info, qty);
+    box.appendChild(row);
+  }
+}
+
+function renderTotal() {
+  let total = 0;
+  for (const m of MENU) total += (CART[m.id] || 0) * m.price;
+  document.getElementById('totalYen').textContent = '¥' + total.toLocaleString();
+  document.getElementById('totalBar').classList.toggle('hidden', total === 0);
+}
+
+async function loadOrders() {
+  const res = await api('/takeout/orders');
+  const box = document.getElementById('orders');
+  box.innerHTML = '';
+  const items = res.success ? res.data : [];
+  document.getElementById('noOrders').style.display = items.length ? 'none' : 'block';
+  for (const o of items) {
+    const div = document.createElement('div');
+    div.className = 'order-item';
+    div.innerHTML = '<div class="st st-' + o.status + '">' + (STATUS_JA[o.status] || o.status) + '　' + o.orderNo + '</div>'
+      + '<div>' + o.items.map(function(l){ return l.name + '×' + l.qty; }).join('、') + '</div>'
+      + '<div class="muted">受取: ' + o.pickupAt + '　合計 ¥' + o.total.toLocaleString() + '</div>';
+    if (o.status === 'pending') {
+      const cancel = document.createElement('button');
+      cancel.className = 'ghost';
+      cancel.textContent = 'キャンセルする';
+      cancel.addEventListener('click', async () => {
+        if (!confirm(o.orderNo + ' をキャンセルしますか？')) return;
+        const del = await api('/takeout/orders/' + o.id, { method: 'DELETE' });
+        if (!del.success) alert(del.error || 'キャンセルできませんでした');
+        await loadOrders();
+      });
+      div.appendChild(cancel);
+    }
+    if (o.status === 'accepted' || o.status === 'ready') {
+      div.appendChild(buildReceiveSlider(o));
+    }
+    box.appendChild(div);
+  }
+}
+
+// スライドで受け取り完了（スタッフの前で操作してもらう）
+function buildReceiveSlider(o) {
+  const wrap = document.createElement('div');
+  wrap.className = 'slide-wrap';
+  const label = document.createElement('div');
+  label.className = 'label';
+  label.textContent = '≫ スライドして受け取り完了（スタッフの前で）';
+  const range = document.createElement('input');
+  range.type = 'range'; range.min = '0'; range.max = '100'; range.value = '0';
+  let busy = false;
+  const finish = async () => {
+    if (busy) return;
+    if (Number(range.value) >= 97) {
+      busy = true;
+      label.textContent = '処理中…';
+      const res = await api('/takeout/orders/' + o.id + '/receive', { method: 'POST' });
+      if (res.success) {
+        label.textContent = '✅ 受け取りありがとうございました！';
+        setTimeout(loadOrders, 1200);
+      } else {
+        alert(res.error || 'エラーが発生しました');
+        range.value = '0';
+        label.textContent = '≫ スライドして受け取り完了（スタッフの前で）';
+        busy = false;
+      }
+    } else {
+      range.value = '0';
+    }
+  };
+  range.addEventListener('change', finish);
+  range.addEventListener('touchend', finish);
+  range.addEventListener('mouseup', finish);
+  wrap.append(label, range);
+  return wrap;
+}
+
+document.getElementById('orderBtn').addEventListener('click', async () => {
+  const btn = document.getElementById('orderBtn');
+  btn.disabled = true;
+  try {
+    const items = Object.entries(CART).filter(([, q]) => q > 0).map(([id, qty]) => ({ id, qty }));
+    const res = await api('/takeout/orders', {
+      method: 'POST',
+      body: JSON.stringify({
+        items,
+        pickupTime: document.getElementById('pickupTime').value,
+        note: document.getElementById('orderNote').value,
+      }),
+    });
+    if (res.success) {
+      showMsg('orderMsg', true, '✅ ' + res.data.orderNo + ' で承りました。' + res.data.pickupAt + ' にお越しください。');
+      for (const k of Object.keys(CART)) delete CART[k];
+      renderMenu(); renderTotal();
+      await loadOrders();
+    } else {
+      showMsg('orderMsg', false, res.error || '注文に失敗しました');
+    }
+  } finally { btn.disabled = false; }
+});
+
+document.getElementById('backBtn').addEventListener('click', () => { location.href = '/liff/card'; });
+
+(function initTimes() {
+  const sel = document.getElementById('pickupTime');
+  const nowJst = new Date(Date.now() + 9 * 3600 * 1000);
+  const start = new Date(nowJst.getTime() + 20 * 60 * 1000); // 20分後から15分刻み
+  start.setUTCMinutes(Math.ceil(start.getUTCMinutes() / 15) * 15, 0, 0);
+  for (let i = 0; i < 32; i++) {
+    const t = new Date(start.getTime() + i * 15 * 60 * 1000);
+    if (t.getUTCDate() !== nowJst.getUTCDate()) break; // 本日分のみ
+    const v = String(t.getUTCHours()).padStart(2, '0') + ':' + String(t.getUTCMinutes()).padStart(2, '0');
+    sel.add(new Option(v, v));
+  }
+})();
+
+liff.init({ liffId: LIFF_ID }).then(async () => {
+  if (!liff.isLoggedIn()) { liff.login({ redirectUri: location.href }); return; }
+  TOKEN = liff.getAccessToken();
+  const res = await api('/takeout/menu');
+  MENU = res.success ? res.data : [];
+  renderMenu(); renderTotal();
+  document.getElementById('loading').classList.add('hidden');
+  document.getElementById('main').classList.remove('hidden');
+  loadOrders();
+}).catch((e) => {
+  document.getElementById('loading').textContent = 'LIFFの初期化に失敗しました: ' + e.message;
+});
+</script>
+</body>
+</html>`
+}

--- a/packages/plugin-restaurant/src/routes/admin.ts
+++ b/packages/plugin-restaurant/src/routes/admin.ts
@@ -1,0 +1,160 @@
+import { Hono } from 'hono'
+import { storeConfig } from '../env.js'
+import type { AppContext } from '../middleware/auth.js'
+import { adminAuth } from '../middleware/auth.js'
+import { harnessClient, trySendText } from '../lib/harness.js'
+import { formatJst, jstParts, sqliteToIso } from '../lib/logic.js'
+import type { MemberRow } from '../services/members.js'
+import { findMemberByNo } from '../services/members.js'
+import { issueReward } from '../services/stamps.js'
+import { listReservationsByDate } from '../services/reservations.js'
+import { createCampaignCoupon, listCampaignCoupons } from '../services/campaigns.js'
+import { listMenu, upsertMenuItem } from '../services/takeout.js'
+
+/** Admin API — consumed by the bundled MCP server (Bearer PLUGIN_API_KEY). */
+export const adminApi = new Hono<AppContext>()
+
+adminApi.use('*', adminAuth)
+
+adminApi.get('/reservations', async (c) => {
+  const date = c.req.query('date') ?? jstParts(new Date()).date
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ success: false, error: 'dateはYYYY-MM-DD' }, 400)
+  const items = await listReservationsByDate(c.env.DB, date)
+  return c.json({
+    success: true,
+    data: items.map((r) => ({
+      id: r.id,
+      reservedAt: formatJst(sqliteToIso(r.reserved_at)),
+      name: r.name,
+      phone: r.phone,
+      partySize: r.party_size,
+      note: r.note,
+      status: r.status,
+      memberNo: r.member_no,
+    })),
+  })
+})
+
+adminApi.get('/members/:memberNo', async (c) => {
+  const member = await findMemberByNo(c.env.DB, c.req.param('memberNo'))
+  if (!member) return c.json({ success: false, error: '会員が見つかりません' }, 404)
+  return c.json({ success: true, data: publicMember(member) })
+})
+
+adminApi.get('/stats', async (c) => {
+  const db = c.env.DB
+  const [members, visits30, rewardsIssued, rewardsRedeemed, upcoming] = await Promise.all([
+    db.prepare('SELECT COUNT(*) AS n FROM members').first<{ n: number }>(),
+    db.prepare("SELECT COUNT(*) AS n FROM visits WHERE visited_at > datetime('now', '-30 days')").first<{ n: number }>(),
+    db.prepare('SELECT COUNT(*) AS n FROM rewards').first<{ n: number }>(),
+    db.prepare("SELECT COUNT(*) AS n FROM rewards WHERE status = 'redeemed'").first<{ n: number }>(),
+    db.prepare("SELECT COUNT(*) AS n FROM reservations WHERE status = 'confirmed' AND reserved_at > datetime('now')").first<{ n: number }>(),
+  ])
+  return c.json({
+    success: true,
+    data: {
+      members: members?.n ?? 0,
+      visitsLast30Days: visits30?.n ?? 0,
+      rewardsIssued: rewardsIssued?.n ?? 0,
+      rewardsRedeemed: rewardsRedeemed?.n ?? 0,
+      upcomingReservations: upcoming?.n ?? 0,
+    },
+  })
+})
+
+/** 手動特典発行（LINE通知付き） */
+adminApi.post('/rewards', async (c) => {
+  const body = await c.req.json<{ memberNo?: string; name?: string }>().catch(() => ({}) as Record<string, never>)
+  const member = await findMemberByNo(c.env.DB, body.memberNo ?? '')
+  if (!member) return c.json({ success: false, error: '会員が見つかりません' }, 404)
+  const rewardName = (body.name ?? '').trim() || storeConfig(c.env).rewardName
+
+  const code = await issueReward(c.env.DB, member.id, rewardName, 'manual')
+  await trySendText(
+    harnessClient(c.env),
+    member.friend_id,
+    `【${storeConfig(c.env).storeName}】特典をお贈りします🎁\n\n${rewardName}\n特典コード: ${code}\n（有効期限: 発行から90日）\n\nご来店の際にスタッフへこの画面をお見せください。`,
+  )
+  return c.json({ success: true, data: { memberNo: member.member_no, code, name: rewardName } })
+})
+
+/** テイクアウトメニュー一覧（非公開含む） */
+adminApi.get('/takeout/menu', async (c) => {
+  const menu = await listMenu(c.env.DB, true)
+  return c.json({
+    success: true,
+    data: menu.map((m) => ({
+      id: m.id,
+      name: m.name,
+      price: m.price,
+      description: m.description,
+      isAvailable: Boolean(m.is_available),
+      sortOrder: m.sort_order,
+    })),
+  })
+})
+
+/** テイクアウトメニュー登録・更新（idを渡すと更新） */
+adminApi.post('/takeout/menu', async (c) => {
+  const body = await c.req
+    .json<{ id?: string; name?: string; price?: number; description?: string; isAvailable?: boolean; sortOrder?: number }>()
+    .catch(() => ({}) as Record<string, never>)
+  try {
+    const item = await upsertMenuItem(c.env.DB, {
+      id: body.id,
+      name: body.name ?? '',
+      price: Number(body.price),
+      description: body.description,
+      isAvailable: body.isAvailable,
+      sortOrder: body.sortOrder,
+    })
+    return c.json({ success: true, data: { id: item.id, name: item.name, price: item.price } })
+  } catch (e) {
+    return c.json({ success: false, error: e instanceof Error ? e.message : 'エラー' }, 400)
+  }
+})
+
+/** キャンペーンクーポン作成（全員共通コード） */
+adminApi.post('/campaigns', async (c) => {
+  const body = await c.req
+    .json<{ name?: string; discountText?: string; expiresAt?: string }>()
+    .catch(() => ({}) as Record<string, never>)
+  try {
+    const coupon = await createCampaignCoupon(c.env.DB, {
+      name: body.name ?? '',
+      discountText: body.discountText,
+      expiresAt: body.expiresAt,
+    })
+    return c.json({ success: true, data: publicCampaign(coupon) })
+  } catch (e) {
+    return c.json({ success: false, error: e instanceof Error ? e.message : 'エラー' }, 400)
+  }
+})
+
+adminApi.get('/campaigns', async (c) => {
+  const items = await listCampaignCoupons(c.env.DB)
+  return c.json({ success: true, data: items.map(publicCampaign) })
+})
+
+function publicCampaign(coupon: import('../services/campaigns.js').CampaignCouponRow) {
+  return {
+    name: coupon.name,
+    code: coupon.code,
+    discountText: coupon.discount_text,
+    status: coupon.status,
+    usedCount: coupon.used_count,
+    expiresAt: coupon.expires_at ? formatJst(sqliteToIso(coupon.expires_at)) : null,
+  }
+}
+
+function publicMember(member: MemberRow) {
+  return {
+    memberNo: member.member_no,
+    displayName: member.display_name,
+    birthday: member.birthday,
+    stampCount: member.stamp_count,
+    totalVisits: member.total_visits,
+    lastVisitAt: member.last_visit_at ? formatJst(sqliteToIso(member.last_visit_at)) : null,
+    createdAt: formatJst(sqliteToIso(member.created_at)),
+  }
+}

--- a/packages/plugin-restaurant/src/routes/liff.ts
+++ b/packages/plugin-restaurant/src/routes/liff.ts
@@ -1,0 +1,220 @@
+import { Hono } from 'hono'
+import { storeConfig } from '../env.js'
+import type { AppContext } from '../middleware/auth.js'
+import { liffAuth } from '../middleware/auth.js'
+import { harnessClient } from '../lib/harness.js'
+import { sqliteToIso, formatJst } from '../lib/logic.js'
+import { getOrCreateMember, setBirthday } from '../services/members.js'
+import { checkVisitCode, grantStamp, listRewards } from '../services/stamps.js'
+import {
+  cancelReservation,
+  createReservation,
+  listMemberReservations,
+} from '../services/reservations.js'
+import {
+  cancelMemberOrder,
+  createTakeoutOrder,
+  listMemberOrders,
+  listMenu,
+  publicOrder,
+  receiveOrderBySlide,
+} from '../services/takeout.js'
+
+export const liffApi = new Hono<AppContext>()
+
+liffApi.use('*', liffAuth)
+
+/** 会員証: 登録済みなら取得、未登録なら会員番号を発行して登録 */
+liffApi.post('/me', async (c) => {
+  const user = c.get('lineUser')
+  const client = harnessClient(c.env)
+  const config = storeConfig(c.env)
+  const member = await getOrCreateMember(c.env.DB, client, user.userId, user.displayName)
+  const rewards = await listRewards(c.env.DB, member.id)
+  return c.json({
+    success: true,
+    data: {
+      memberNo: member.member_no,
+      displayName: member.display_name,
+      birthday: member.birthday,
+      stampCount: member.stamp_count,
+      stampGoal: config.stampGoal,
+      totalVisits: member.total_visits,
+      storeName: config.storeName,
+      rewardName: config.rewardName,
+      rewards: rewards.map((r) => ({
+        name: r.name,
+        code: r.code,
+        expiresAt: r.expires_at ? formatJst(sqliteToIso(r.expires_at)).split(' ')[0] : null,
+      })),
+    },
+  })
+})
+
+/** 誕生日登録（MM-DD） */
+liffApi.post('/profile', async (c) => {
+  const user = c.get('lineUser')
+  const client = harnessClient(c.env)
+  const member = await getOrCreateMember(c.env.DB, client, user.userId, user.displayName)
+  const body = await c.req.json<{ birthday?: string }>().catch(() => ({}) as { birthday?: string })
+  const birthday = (body.birthday ?? '').trim()
+  if (!/^\d{2}-\d{2}$/.test(birthday)) {
+    return c.json({ success: false, error: '誕生日は MM-DD 形式で指定してください' }, 400)
+  }
+  const [mm, dd] = birthday.split('-').map((v) => Number.parseInt(v, 10))
+  if (!mm || mm < 1 || mm > 12 || !dd || dd < 1 || dd > 31) {
+    return c.json({ success: false, error: '誕生日の値が不正です' }, 400)
+  }
+  await setBirthday(c.env.DB, member.id, birthday)
+  return c.json({ success: true, data: { birthday } })
+})
+
+/** 来店コードでスタンプ取得 */
+liffApi.post('/stamp', async (c) => {
+  const user = c.get('lineUser')
+  const client = harnessClient(c.env)
+  const config = storeConfig(c.env)
+  const member = await getOrCreateMember(c.env.DB, client, user.userId, user.displayName)
+  const body = await c.req.json<{ code?: string }>().catch(() => ({}) as { code?: string })
+  const code = (body.code ?? '').trim()
+  if (!code) return c.json({ success: false, error: 'コードを入力してください' }, 400)
+
+  const check = await checkVisitCode(c.env.DB, member, code, new Date())
+  if (check !== 'ok') {
+    const messages: Record<Exclude<typeof check, 'ok'>, string> = {
+      wrong: 'コードが違います。店内掲示の本日のコードをご確認ください。',
+      not_ready: '本日のコードがまだ発行されていません。スタッフにお声がけください。',
+      rate_limited: '試行回数の上限に達しました。スタッフにお声がけください。',
+      already_today: '本日のスタンプは取得済みです。またのご来店をお待ちしております！',
+    }
+    return c.json({ success: false, error: messages[check], reason: check }, 400)
+  }
+
+  const outcome = await grantStamp(c.env.DB, client, config, member, 'store_code')
+  return c.json({ success: true, data: outcome })
+})
+
+/** 予約作成 */
+liffApi.post('/reservations', async (c) => {
+  const user = c.get('lineUser')
+  const client = harnessClient(c.env)
+  const config = storeConfig(c.env)
+  const member = await getOrCreateMember(c.env.DB, client, user.userId, user.displayName)
+  const body = await c.req
+    .json<{ date?: string; time?: string; partySize?: number; name?: string; phone?: string; note?: string }>()
+    .catch(() => ({}) as Record<string, never>)
+
+  const result = await createReservation(c.env.DB, client, config, member, {
+    date: body.date ?? '',
+    time: body.time ?? '',
+    partySize: Number(body.partySize ?? 0),
+    name: body.name ?? member.display_name ?? '',
+    phone: body.phone,
+    note: body.note,
+  })
+  if (!result.ok) return c.json({ success: false, error: result.error }, 400)
+  return c.json({
+    success: true,
+    data: {
+      id: result.reservation.id,
+      reservedAt: formatJst(sqliteToIso(result.reservation.reserved_at)),
+      partySize: result.reservation.party_size,
+    },
+  })
+})
+
+/** 自分の予約一覧（今後の確定分） */
+liffApi.get('/reservations', async (c) => {
+  const user = c.get('lineUser')
+  const client = harnessClient(c.env)
+  const member = await getOrCreateMember(c.env.DB, client, user.userId, user.displayName)
+  const items = await listMemberReservations(c.env.DB, member.id)
+  return c.json({
+    success: true,
+    data: items.map((r) => ({
+      id: r.id,
+      reservedAt: formatJst(sqliteToIso(r.reserved_at)),
+      partySize: r.party_size,
+      name: r.name,
+      note: r.note,
+    })),
+  })
+})
+
+/** テイクアウトメニュー */
+liffApi.get('/takeout/menu', async (c) => {
+  const menu = await listMenu(c.env.DB)
+  return c.json({
+    success: true,
+    data: menu.map((m) => ({ id: m.id, name: m.name, price: m.price, description: m.description })),
+  })
+})
+
+/** テイクアウト注文 */
+liffApi.post('/takeout/orders', async (c) => {
+  const user = c.get('lineUser')
+  const client = harnessClient(c.env)
+  const config = storeConfig(c.env)
+  const member = await getOrCreateMember(c.env.DB, client, user.userId, user.displayName)
+  const body = await c.req
+    .json<{ items?: { id?: string; qty?: number }[]; pickupTime?: string; note?: string }>()
+    .catch(() => ({}) as Record<string, never>)
+
+  const result = await createTakeoutOrder(c.env.DB, client, config, member, {
+    items: body.items ?? [],
+    pickupTime: body.pickupTime ?? '',
+    note: body.note,
+  })
+  if (!result.ok) return c.json({ success: false, error: result.error }, 400)
+  return c.json({ success: true, data: publicOrder(result.order) })
+})
+
+/** 自分のテイクアウト注文一覧（進行中のみ） */
+liffApi.get('/takeout/orders', async (c) => {
+  const user = c.get('lineUser')
+  const client = harnessClient(c.env)
+  const member = await getOrCreateMember(c.env.DB, client, user.userId, user.displayName)
+  const orders = await listMemberOrders(c.env.DB, member.id)
+  return c.json({ success: true, data: orders.map(publicOrder) })
+})
+
+/** テイクアウト受け取り完了（スタッフの面前でスライド操作） */
+liffApi.post('/takeout/orders/:id/receive', async (c) => {
+  const user = c.get('lineUser')
+  const client = harnessClient(c.env)
+  const member = await getOrCreateMember(c.env.DB, client, user.userId, user.displayName)
+  const result = await receiveOrderBySlide(c.env.DB, storeConfig(c.env), member, c.req.param('id'))
+  if (!result.ok) return c.json({ success: false, error: result.error }, 400)
+  return c.json({ success: true, data: { orderNo: result.orderNo } })
+})
+
+/** テイクアウト注文キャンセル（調理開始前のみ） */
+liffApi.delete('/takeout/orders/:id', async (c) => {
+  const user = c.get('lineUser')
+  const client = harnessClient(c.env)
+  const member = await getOrCreateMember(c.env.DB, client, user.userId, user.displayName)
+  const result = await cancelMemberOrder(c.env.DB, member, c.req.param('id'))
+  if (result !== 'ok') {
+    return c.json(
+      {
+        success: false,
+        error: result === 'not_found' ? '注文が見つかりません' : '調理開始後のキャンセルはお店に直接ご連絡ください',
+      },
+      400,
+    )
+  }
+  return c.json({ success: true })
+})
+
+/** 予約キャンセル */
+liffApi.delete('/reservations/:id', async (c) => {
+  const user = c.get('lineUser')
+  const client = harnessClient(c.env)
+  const config = storeConfig(c.env)
+  const member = await getOrCreateMember(c.env.DB, client, user.userId, user.displayName)
+  const result = await cancelReservation(c.env.DB, client, config, member, c.req.param('id'))
+  if (result !== 'ok') {
+    return c.json({ success: false, error: result === 'not_found' ? '予約が見つかりません' : 'この予約はキャンセルできません' }, 400)
+  }
+  return c.json({ success: true })
+})

--- a/packages/plugin-restaurant/src/routes/staff.ts
+++ b/packages/plugin-restaurant/src/routes/staff.ts
@@ -1,0 +1,218 @@
+import { Hono } from 'hono'
+import { storeConfig } from '../env.js'
+import type { AppContext } from '../middleware/auth.js'
+import { staffAuth } from '../middleware/auth.js'
+import { harnessClient } from '../lib/harness.js'
+import { formatJst, jstParts, sqliteToIso } from '../lib/logic.js'
+import { findMemberByNo } from '../services/members.js'
+import { getTodayVisitCode, grantStamp, redeemReward } from '../services/stamps.js'
+import { redeemCampaignCoupon } from '../services/campaigns.js'
+import { markVisited, queueReviewAsk } from '../services/review.js'
+import { listMenu, listOrdersByDate, publicOrder, setOrderStatus, upsertMenuItem } from '../services/takeout.js'
+import { listReservationsByDate, setReservationStatus } from '../services/reservations.js'
+
+export const staffApi = new Hono<AppContext>()
+
+staffApi.use('*', staffAuth)
+
+/** 本日の来店コード（店内掲示用） */
+staffApi.get('/visit-code', async (c) => {
+  const code = await getTodayVisitCode(c.env.DB, new Date())
+  return c.json({ success: true, data: { date: jstParts(new Date()).date, code } })
+})
+
+/** 会員番号でスタンプ付与 */
+staffApi.post('/stamp', async (c) => {
+  const body = await c.req.json<{ memberNo?: string }>().catch(() => ({}) as { memberNo?: string })
+  const memberNo = (body.memberNo ?? '').trim()
+  if (!memberNo) return c.json({ success: false, error: '会員番号を入力してください' }, 400)
+
+  const member = await findMemberByNo(c.env.DB, memberNo)
+  if (!member) return c.json({ success: false, error: '会員が見つかりません' }, 404)
+
+  const outcome = await grantStamp(c.env.DB, harnessClient(c.env), storeConfig(c.env), member, 'staff')
+  return c.json({
+    success: true,
+    data: { memberNo: member.member_no, displayName: member.display_name, ...outcome },
+  })
+})
+
+/**
+ * 特典コード消込（RW-個人特典 / CP-キャンペーン共通クーポン）。
+ * 消込＝来店とみなし、last_visit_at 更新とGoogleレビュー依頼のキュー投入も行う。
+ * CP- は会員に紐づかないコードのため、memberNo を添えると来店判定できる。
+ */
+staffApi.post('/redeem', async (c) => {
+  const body = await c.req
+    .json<{ code?: string; memberNo?: string }>()
+    .catch(() => ({}) as { code?: string; memberNo?: string })
+  const code = (body.code ?? '').trim()
+  if (!code) return c.json({ success: false, error: '特典コードを入力してください' }, 400)
+
+  if (code.toUpperCase().startsWith('CP-')) {
+    const member = body.memberNo?.trim() ? await findMemberByNo(c.env.DB, body.memberNo) : null
+    const campaign = await redeemCampaignCoupon(c.env.DB, code, member?.id)
+    if (!campaign.ok) {
+      const messages = {
+        not_found: 'クーポンが見つかりません',
+        ended: 'このキャンペーンは終了しています',
+        expired: 'このクーポンは期限切れです',
+      } as const
+      return c.json({ success: false, error: messages[campaign.reason] }, 400)
+    }
+    if (member) {
+      await markVisited(c.env.DB, member.id)
+      await queueReviewAsk(c.env.DB, storeConfig(c.env), member, new Date())
+    }
+    return c.json({
+      success: true,
+      data: {
+        name: campaign.coupon.name,
+        code: campaign.coupon.code,
+        kind: 'campaign',
+        usedCount: campaign.coupon.used_count,
+        memberNo: member?.member_no ?? null,
+      },
+    })
+  }
+
+  const result = await redeemReward(c.env.DB, code)
+  if (!result.ok) {
+    const messages = {
+      not_found: '特典が見つかりません',
+      already_redeemed: 'この特典は使用済みです',
+      expired: 'この特典は期限切れです',
+    } as const
+    return c.json({ success: false, error: messages[result.reason] }, 400)
+  }
+
+  // 個人特典は所有者が確定しているので、そのまま来店判定
+  const owner = await c.env.DB
+    .prepare('SELECT id, friend_id, member_no FROM members WHERE id = ?')
+    .bind(result.reward.member_id)
+    .first<{ id: string; friend_id: string | null; member_no: string }>()
+  if (owner) {
+    await markVisited(c.env.DB, owner.id)
+    await queueReviewAsk(c.env.DB, storeConfig(c.env), owner, new Date())
+  }
+  return c.json({
+    success: true,
+    data: { name: result.reward.name, code: result.reward.code, kind: 'reward', memberNo: owner?.member_no ?? null },
+  })
+})
+
+/** 指定日（JST, 省略時は本日）の予約一覧 */
+staffApi.get('/reservations', async (c) => {
+  const date = c.req.query('date') ?? jstParts(new Date()).date
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ success: false, error: 'dateはYYYY-MM-DD' }, 400)
+  const items = await listReservationsByDate(c.env.DB, date)
+  return c.json({
+    success: true,
+    data: items.map((r) => ({
+      id: r.id,
+      time: formatJst(sqliteToIso(r.reserved_at)).split(' ')[1],
+      name: r.name,
+      phone: r.phone,
+      partySize: r.party_size,
+      note: r.note,
+      status: r.status,
+      memberNo: r.member_no,
+    })),
+  })
+})
+
+/** 予約ステータス変更（seated / no_show / cancelled / confirmed）。seated は来店判定になる */
+staffApi.patch('/reservations/:id', async (c) => {
+  const body = await c.req.json<{ status?: string }>().catch(() => ({}) as { status?: string })
+  const updated = await setReservationStatus(c.env.DB, c.req.param('id'), body.status ?? '')
+  if (!updated) return c.json({ success: false, error: '予約が見つからないか、ステータスが不正です' }, 400)
+
+  if (updated.status === 'seated') {
+    const member = await c.env.DB
+      .prepare('SELECT id, friend_id FROM members WHERE id = ?')
+      .bind(updated.member_id)
+      .first<{ id: string; friend_id: string | null }>()
+    if (member) {
+      await markVisited(c.env.DB, member.id)
+      await queueReviewAsk(c.env.DB, storeConfig(c.env), member, new Date())
+    }
+  }
+  return c.json({ success: true, data: { id: updated.id, status: updated.status } })
+})
+
+/** 指定日（JST, 省略時は本日）のテイクアウト注文一覧 */
+staffApi.get('/takeout', async (c) => {
+  const date = c.req.query('date') ?? jstParts(new Date()).date
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return c.json({ success: false, error: 'dateはYYYY-MM-DD' }, 400)
+  const items = await listOrdersByDate(c.env.DB, date)
+  return c.json({ success: true, data: items.map(publicOrder) })
+})
+
+/** テイクアウト注文のステータス変更（accepted / ready / completed / cancelled） */
+staffApi.patch('/takeout/:id', async (c) => {
+  const body = await c.req.json<{ status?: string }>().catch(() => ({}) as { status?: string })
+  const updated = await setOrderStatus(
+    c.env.DB,
+    harnessClient(c.env),
+    storeConfig(c.env),
+    c.req.param('id'),
+    body.status ?? '',
+  )
+  if (!updated) return c.json({ success: false, error: '注文が見つからないか、ステータスが不正です' }, 400)
+  return c.json({ success: true, data: { id: updated.id, orderNo: updated.order_no, status: updated.status } })
+})
+
+/** テイクアウトメニュー一覧（非公開含む・スタッフ管理用） */
+staffApi.get('/takeout-menu', async (c) => {
+  const menu = await listMenu(c.env.DB, true)
+  return c.json({
+    success: true,
+    data: menu.map((m) => ({
+      id: m.id,
+      name: m.name,
+      price: m.price,
+      description: m.description,
+      isAvailable: Boolean(m.is_available),
+      sortOrder: m.sort_order,
+    })),
+  })
+})
+
+/** テイクアウトメニュー登録・更新（idを渡すと更新） */
+staffApi.post('/takeout-menu', async (c) => {
+  const body = await c.req
+    .json<{ id?: string; name?: string; price?: number; description?: string; isAvailable?: boolean; sortOrder?: number }>()
+    .catch(() => ({}) as Record<string, never>)
+  try {
+    const item = await upsertMenuItem(c.env.DB, {
+      id: body.id,
+      name: body.name ?? '',
+      price: Number(body.price),
+      description: body.description,
+      isAvailable: body.isAvailable,
+      sortOrder: body.sortOrder,
+    })
+    return c.json({
+      success: true,
+      data: { id: item.id, name: item.name, price: item.price, isAvailable: Boolean(item.is_available) },
+    })
+  } catch (e) {
+    return c.json({ success: false, error: e instanceof Error ? e.message : 'エラー' }, 400)
+  }
+})
+
+/** サマリー（本日の来店数・予約数・会員数） */
+staffApi.get('/summary', async (c) => {
+  const today = jstParts(new Date()).date
+  const [members, visits, reservations] = await Promise.all([
+    c.env.DB.prepare('SELECT COUNT(*) AS n FROM members').first<{ n: number }>(),
+    c.env.DB.prepare("SELECT COUNT(*) AS n FROM visits WHERE date(visited_at, '+9 hours') = ?").bind(today).first<{ n: number }>(),
+    c.env.DB.prepare("SELECT COUNT(*) AS n FROM reservations WHERE date(reserved_at, '+9 hours') = ? AND status = 'confirmed'")
+      .bind(today)
+      .first<{ n: number }>(),
+  ])
+  return c.json({
+    success: true,
+    data: { members: members?.n ?? 0, visitsToday: visits?.n ?? 0, reservationsToday: reservations?.n ?? 0 },
+  })
+})

--- a/packages/plugin-restaurant/src/services/campaigns.ts
+++ b/packages/plugin-restaurant/src/services/campaigns.ts
@@ -1,0 +1,94 @@
+import { isoToSqlite, randomCode } from '../lib/logic.js'
+
+export interface CampaignCouponRow {
+  id: string
+  name: string
+  code: string
+  discount_text: string | null
+  status: 'active' | 'ended'
+  used_count: number
+  expires_at: string | null
+  created_at: string
+}
+
+export interface CreateCampaignInput {
+  name: string
+  discountText?: string
+  /** ISO 8601 or 'YYYY-MM-DD'（JSTの終日=翌日00:00 JSTまで） */
+  expiresAt?: string
+}
+
+export async function createCampaignCoupon(db: D1Database, input: CreateCampaignInput): Promise<CampaignCouponRow> {
+  const name = input.name.trim()
+  if (!name) throw new Error('キャンペーン名は必須です')
+
+  let expiresAt: string | null = null
+  if (input.expiresAt) {
+    const raw = /^\d{4}-\d{2}-\d{2}$/.test(input.expiresAt)
+      ? `${input.expiresAt}T23:59:59+09:00` // 日付だけならJST終日
+      : input.expiresAt
+    const d = new Date(raw)
+    if (Number.isNaN(d.getTime())) throw new Error('expiresAt が不正です')
+    expiresAt = isoToSqlite(d.toISOString())
+  }
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const bytes = new Uint8Array(6)
+    crypto.getRandomValues(bytes)
+    const code = `CP-${randomCode(6, bytes)}`
+    try {
+      await db
+        .prepare(
+          'INSERT INTO campaign_coupons (id, name, code, discount_text, expires_at) VALUES (?, ?, ?, ?, ?)',
+        )
+        .bind(crypto.randomUUID(), name, code, input.discountText?.trim() || null, expiresAt)
+        .run()
+      const row = await db.prepare('SELECT * FROM campaign_coupons WHERE code = ?').bind(code).first<CampaignCouponRow>()
+      if (!row) throw new Error('campaign insert failed')
+      return row
+    } catch (e) {
+      if (attempt === 4) throw e
+      // UNIQUE collision — retry with a fresh code
+    }
+  }
+  throw new Error('campaign code generation failed')
+}
+
+export async function listCampaignCoupons(db: D1Database): Promise<CampaignCouponRow[]> {
+  const { results } = await db
+    .prepare('SELECT * FROM campaign_coupons ORDER BY created_at DESC LIMIT 100')
+    .all<CampaignCouponRow>()
+  return results
+}
+
+export type CampaignRedeemResult =
+  | { ok: true; coupon: CampaignCouponRow }
+  | { ok: false; reason: 'not_found' | 'ended' | 'expired' }
+
+/**
+ * 共通クーポンの消込（多回数使用可・使用回数をカウント）。
+ * memberId を渡すと「誰が使ったか」を campaign_redemptions に記録する（来店判定用）。
+ */
+export async function redeemCampaignCoupon(
+  db: D1Database,
+  code: string,
+  memberId?: string | null,
+): Promise<CampaignRedeemResult> {
+  const coupon = await db
+    .prepare('SELECT * FROM campaign_coupons WHERE code = ?')
+    .bind(code.trim().toUpperCase())
+    .first<CampaignCouponRow>()
+  if (!coupon) return { ok: false, reason: 'not_found' }
+  if (coupon.status !== 'active') return { ok: false, reason: 'ended' }
+  if (coupon.expires_at && coupon.expires_at <= isoToSqlite(new Date().toISOString())) {
+    return { ok: false, reason: 'expired' }
+  }
+  await db.batch([
+    db.prepare('UPDATE campaign_coupons SET used_count = used_count + 1 WHERE id = ?').bind(coupon.id),
+    db
+      .prepare('INSERT INTO campaign_redemptions (id, coupon_id, member_id) VALUES (?, ?, ?)')
+      .bind(crypto.randomUUID(), coupon.id, memberId ?? null),
+  ])
+  coupon.used_count += 1
+  return { ok: true, coupon }
+}

--- a/packages/plugin-restaurant/src/services/crm.ts
+++ b/packages/plugin-restaurant/src/services/crm.ts
@@ -1,0 +1,95 @@
+import type { LineHarness } from '@line-harness/sdk'
+import type { StoreConfig } from '../env.js'
+import { isBirthday, isWinbackTarget, jstParts, sqliteToIso } from '../lib/logic.js'
+import { getOrCreateTag, tryAddTag, trySendText } from '../lib/harness.js'
+import { claimOnce } from '../lib/dedupe.js'
+import type { MemberRow } from './members.js'
+import { issueReward } from './stamps.js'
+
+const WINBACK_TAG_NAME = '離反リスク'
+/** 呼び戻しは一度送ったら60日間は再送しない */
+const WINBACK_COOLDOWN_DAYS = 60
+
+/**
+ * Daily jobs (birthday coupons + winback), guarded so they run once per JST
+ * day even though the cron fires every 10 minutes. First firing after 10:00
+ * JST wins.
+ */
+export async function runDailyJobs(
+  db: D1Database,
+  client: LineHarness,
+  config: StoreConfig,
+  now: Date,
+): Promise<{ ran: boolean; birthday: number; winback: number }> {
+  const parts = jstParts(now)
+  if (parts.hour < 10) return { ran: false, birthday: 0, winback: 0 }
+
+  const claimed = await db
+    .prepare("INSERT INTO settings (key, value) VALUES (?, 'done') ON CONFLICT (key) DO NOTHING")
+    .bind(`daily_jobs:${parts.date}`)
+    .run()
+  if (!claimed.meta.changes) return { ran: false, birthday: 0, winback: 0 }
+
+  const birthday = await sendBirthdayCoupons(db, client, config, now)
+  const winback = await sendWinbackMessages(db, client, config, now)
+  return { ran: true, birthday, winback }
+}
+
+async function sendBirthdayCoupons(db: D1Database, client: LineHarness, config: StoreConfig, now: Date): Promise<number> {
+  const parts = jstParts(now)
+  const { results } = await db
+    .prepare('SELECT * FROM members WHERE birthday IS NOT NULL AND friend_id IS NOT NULL')
+    .all<MemberRow>()
+
+  let sent = 0
+  for (const member of results) {
+    if (!isBirthday(member.birthday, parts.monthDay)) continue
+    const dedupeKey = `birthday:${parts.year}:${member.id}`
+    if (!(await claimOnce(db, member.id, 'birthday', dedupeKey))) continue
+
+    const code = await issueReward(db, member.id, `お誕生日特典（${config.rewardName}）`, 'birthday')
+    const delivered = await trySendText(
+      client,
+      member.friend_id,
+      `🎂 お誕生日おめでとうございます！\n【${config.storeName}】から、ささやかですがお誕生日特典をお贈りします。\n\n特典コード: ${code}\n（有効期限: 発行から90日）\n\nご来店の際にスタッフへこの画面をお見せください。お会いできるのを楽しみにしています！`,
+    )
+    if (delivered) sent++
+  }
+  return sent
+}
+
+async function sendWinbackMessages(db: D1Database, client: LineHarness, config: StoreConfig, now: Date): Promise<number> {
+  const { results } = await db
+    .prepare('SELECT * FROM members WHERE last_visit_at IS NOT NULL AND friend_id IS NOT NULL')
+    .all<MemberRow>()
+
+  const tagId = results.length > 0 ? await getOrCreateTag(client, WINBACK_TAG_NAME) : null
+
+  let sent = 0
+  for (const member of results) {
+    if (!isWinbackTarget(sqliteToIso(member.last_visit_at as string), config.winbackDays, now)) continue
+
+    const recent = await db
+      .prepare(
+        `SELECT 1 FROM message_log WHERE member_id = ? AND kind = 'winback'
+         AND sent_at > datetime('now', ?) LIMIT 1`,
+      )
+      .bind(member.id, `-${WINBACK_COOLDOWN_DAYS} days`)
+      .first()
+    if (recent) continue
+
+    const dedupeKey = `winback:${jstParts(now).date}:${member.id}`
+    if (!(await claimOnce(db, member.id, 'winback', dedupeKey))) continue
+
+    const code = await issueReward(db, member.id, `カムバック特典（${config.rewardName}）`, 'winback')
+    const delivered = await trySendText(
+      client,
+      member.friend_id,
+      `お久しぶりです、【${config.storeName}】です🍽\n最近お会いできず寂しく思っています。\n\n次回ご来店で使える特典をご用意しました。\n特典コード: ${code}\n（有効期限: 発行から90日）\n\nまたのお越しを心よりお待ちしております！`,
+    )
+    await tryAddTag(client, member.friend_id, tagId)
+    if (delivered) sent++
+  }
+  return sent
+}
+

--- a/packages/plugin-restaurant/src/services/members.ts
+++ b/packages/plugin-restaurant/src/services/members.ts
@@ -1,0 +1,91 @@
+import type { LineHarness } from '@line-harness/sdk'
+import { formatMemberNo } from '../lib/logic.js'
+import { resolveFriendId } from '../lib/harness.js'
+
+export interface MemberRow {
+  id: string
+  line_user_id: string
+  friend_id: string | null
+  member_no: string
+  display_name: string | null
+  birthday: string | null
+  stamp_count: number
+  total_visits: number
+  last_visit_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export async function findMemberByLineUserId(db: D1Database, lineUserId: string): Promise<MemberRow | null> {
+  return await db.prepare('SELECT * FROM members WHERE line_user_id = ?').bind(lineUserId).first<MemberRow>()
+}
+
+export async function findMemberByNo(db: D1Database, memberNo: string): Promise<MemberRow | null> {
+  return await db
+    .prepare('SELECT * FROM members WHERE member_no = ?')
+    .bind(memberNo.trim().toUpperCase())
+    .first<MemberRow>()
+}
+
+/**
+ * Get or register the member for a verified LINE user. On first registration
+ * we also try to resolve the LINE Harness friend id (retried on later visits
+ * while it stays null).
+ */
+export async function getOrCreateMember(
+  db: D1Database,
+  client: LineHarness,
+  lineUserId: string,
+  displayName: string,
+): Promise<MemberRow> {
+  const existing = await findMemberByLineUserId(db, lineUserId)
+  if (existing) {
+    if (!existing.friend_id) {
+      const friendId = await resolveFriendId(client, lineUserId).catch(() => null)
+      if (friendId) {
+        await db
+          .prepare("UPDATE members SET friend_id = ?, updated_at = datetime('now') WHERE id = ?")
+          .bind(friendId, existing.id)
+          .run()
+        existing.friend_id = friendId
+      }
+    }
+    return existing
+  }
+
+  const seq = await nextMemberSeq(db)
+  const memberNo = formatMemberNo(seq)
+  const id = crypto.randomUUID()
+  const friendId = await resolveFriendId(client, lineUserId).catch(() => null)
+
+  await db
+    .prepare(
+      'INSERT INTO members (id, line_user_id, friend_id, member_no, display_name) VALUES (?, ?, ?, ?, ?)',
+    )
+    .bind(id, lineUserId, friendId, memberNo, displayName)
+    .run()
+
+  const created = await findMemberByLineUserId(db, lineUserId)
+  if (!created) throw new Error('member insert failed')
+  return created
+}
+
+export async function setBirthday(db: D1Database, memberId: string, birthday: string): Promise<void> {
+  await db
+    .prepare("UPDATE members SET birthday = ?, updated_at = datetime('now') WHERE id = ?")
+    .bind(birthday, memberId)
+    .run()
+}
+
+/** Atomic member number sequence stored in settings. */
+async function nextMemberSeq(db: D1Database): Promise<number> {
+  const row = await db
+    .prepare(
+      `INSERT INTO settings (key, value) VALUES ('member_seq', '1')
+       ON CONFLICT (key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT), updated_at = datetime('now')
+       RETURNING value`,
+    )
+    .first<{ value: string }>()
+  if (!row) throw new Error('member_seq update failed')
+  return Number.parseInt(row.value, 10)
+}

--- a/packages/plugin-restaurant/src/services/reservations.ts
+++ b/packages/plugin-restaurant/src/services/reservations.ts
@@ -1,0 +1,195 @@
+import type { LineHarness } from '@line-harness/sdk'
+import type { StoreConfig } from '../env.js'
+import { dueReminders, formatJst, isoToSqlite, jstToUtcIso, sqliteToIso } from '../lib/logic.js'
+import { trySendText } from '../lib/harness.js'
+import type { MemberRow } from './members.js'
+
+export interface ReservationRow {
+  id: string
+  member_id: string
+  name: string
+  phone: string | null
+  party_size: number
+  reserved_at: string
+  note: string | null
+  status: 'confirmed' | 'cancelled' | 'seated' | 'no_show'
+  remind_day_before_sent: number
+  remind_same_day_sent: number
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateReservationInput {
+  date: string // 'YYYY-MM-DD' (JST)
+  time: string // 'HH:mm' (JST)
+  partySize: number
+  name: string
+  phone?: string
+  note?: string
+}
+
+export type CreateResult = { ok: true; reservation: ReservationRow } | { ok: false; error: string }
+
+export async function createReservation(
+  db: D1Database,
+  client: LineHarness,
+  config: StoreConfig,
+  member: MemberRow,
+  input: CreateReservationInput,
+): Promise<CreateResult> {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(input.date) || !/^\d{2}:\d{2}$/.test(input.time)) {
+    return { ok: false, error: '日時の形式が正しくありません' }
+  }
+  const partySize = Math.trunc(input.partySize)
+  if (!Number.isFinite(partySize) || partySize < 1 || partySize > 100) {
+    return { ok: false, error: '人数は1〜100名で指定してください' }
+  }
+  const name = input.name.trim()
+  if (!name) return { ok: false, error: 'お名前を入力してください' }
+
+  const reservedAt = jstToUtcIso(input.date, input.time)
+  if (Number.isNaN(new Date(reservedAt).getTime())) return { ok: false, error: '日時が不正です' }
+  if (new Date(reservedAt).getTime() <= Date.now()) {
+    return { ok: false, error: '過去の日時は予約できません' }
+  }
+
+  const id = crypto.randomUUID()
+  await db
+    .prepare(
+      `INSERT INTO reservations (id, member_id, name, phone, party_size, reserved_at, note)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(id, member.id, name, input.phone?.trim() || null, partySize, isoToSqlite(reservedAt), input.note?.trim() || null)
+    .run()
+
+  const reservation = await getReservation(db, id)
+  if (!reservation) return { ok: false, error: '予約の保存に失敗しました' }
+
+  await trySendText(
+    client,
+    member.friend_id,
+    `✅ ご予約を承りました。\n\n【${config.storeName}】\n日時: ${formatJst(reservedAt)}\n人数: ${partySize}名\nお名前: ${name}様\n${input.note?.trim() ? `備考: ${input.note.trim()}\n` : ''}\n変更・キャンセルは会員証メニューの「予約」からお手続きください。当日お会いできるのを楽しみにしております！`,
+  )
+
+  return { ok: true, reservation }
+}
+
+export async function getReservation(db: D1Database, id: string): Promise<ReservationRow | null> {
+  return await db.prepare('SELECT * FROM reservations WHERE id = ?').bind(id).first<ReservationRow>()
+}
+
+export async function listMemberReservations(db: D1Database, memberId: string): Promise<ReservationRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM reservations WHERE member_id = ? AND status = 'confirmed' AND reserved_at > datetime('now')
+       ORDER BY reserved_at ASC`,
+    )
+    .bind(memberId)
+    .all<ReservationRow>()
+  return results
+}
+
+export async function listReservationsByDate(db: D1Database, jstDate: string): Promise<(ReservationRow & { member_no: string })[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT r.*, m.member_no FROM reservations r JOIN members m ON m.id = r.member_id
+       WHERE date(r.reserved_at, '+9 hours') = ? ORDER BY r.reserved_at ASC`,
+    )
+    .bind(jstDate)
+    .all<ReservationRow & { member_no: string }>()
+  return results
+}
+
+export type CancelResult = 'ok' | 'not_found' | 'not_cancellable'
+
+export async function cancelReservation(
+  db: D1Database,
+  client: LineHarness,
+  config: StoreConfig,
+  member: MemberRow,
+  reservationId: string,
+): Promise<CancelResult> {
+  const reservation = await getReservation(db, reservationId)
+  if (!reservation || reservation.member_id !== member.id) return 'not_found'
+  if (reservation.status !== 'confirmed') return 'not_cancellable'
+
+  await db
+    .prepare("UPDATE reservations SET status = 'cancelled', updated_at = datetime('now') WHERE id = ?")
+    .bind(reservationId)
+    .run()
+
+  await trySendText(
+    client,
+    member.friend_id,
+    `ご予約（${formatJst(sqliteToIso(reservation.reserved_at))}・${reservation.party_size}名）をキャンセルしました。\nまたのご利用をお待ちしております。【${config.storeName}】`,
+  )
+  return 'ok'
+}
+
+const STAFF_STATUSES: ReservationRow['status'][] = ['confirmed', 'cancelled', 'seated', 'no_show']
+
+export async function setReservationStatus(
+  db: D1Database,
+  reservationId: string,
+  status: string,
+): Promise<ReservationRow | null> {
+  if (!STAFF_STATUSES.includes(status as ReservationRow['status'])) return null
+  const reservation = await getReservation(db, reservationId)
+  if (!reservation) return null
+  await db
+    .prepare("UPDATE reservations SET status = ?, updated_at = datetime('now') WHERE id = ?")
+    .bind(status, reservationId)
+    .run()
+  return await getReservation(db, reservationId)
+}
+
+/**
+ * Cron entry: send day-before (18:00 JST) and same-day (2h before) reminders
+ * for confirmed reservations. Flags guarantee each reminder goes out once.
+ */
+export async function processReservationReminders(
+  db: D1Database,
+  client: LineHarness,
+  config: StoreConfig,
+  now: Date,
+): Promise<number> {
+  const { results } = await db
+    .prepare(
+      `SELECT r.*, m.friend_id FROM reservations r JOIN members m ON m.id = r.member_id
+       WHERE r.status = 'confirmed' AND r.reserved_at > datetime('now')
+       AND (r.remind_day_before_sent = 0 OR r.remind_same_day_sent = 0)`,
+    )
+    .all<ReservationRow & { friend_id: string | null }>()
+
+  let sent = 0
+  for (const r of results) {
+    const due = dueReminders(sqliteToIso(r.reserved_at), now)
+
+    if (due.includes('day_before') && !r.remind_day_before_sent) {
+      const delivered = await trySendText(
+        client,
+        r.friend_id,
+        `【${config.storeName}】明日のご予約のご確認です。\n\n日時: ${formatJst(sqliteToIso(r.reserved_at))}\n人数: ${r.party_size}名\n\nご変更・キャンセルは会員証メニューの「予約」からお願いいたします。お待ちしております！`,
+      )
+      await db
+        .prepare("UPDATE reservations SET remind_day_before_sent = 1, updated_at = datetime('now') WHERE id = ?")
+        .bind(r.id)
+        .run()
+      if (delivered) sent++
+    }
+
+    if (due.includes('same_day') && !r.remind_same_day_sent) {
+      const delivered = await trySendText(
+        client,
+        r.friend_id,
+        `【${config.storeName}】本日 ${formatJst(sqliteToIso(r.reserved_at)).split(' ')[1]} より ${r.party_size}名様でご予約を承っております。\nお気をつけてお越しください🍽`,
+      )
+      await db
+        .prepare("UPDATE reservations SET remind_same_day_sent = 1, updated_at = datetime('now') WHERE id = ?")
+        .bind(r.id)
+        .run()
+      if (delivered) sent++
+    }
+  }
+  return sent
+}

--- a/packages/plugin-restaurant/src/services/review.ts
+++ b/packages/plugin-restaurant/src/services/review.ts
@@ -1,0 +1,85 @@
+import type { LineHarness } from '@line-harness/sdk'
+import type { StoreConfig } from '../env.js'
+import { isoToSqlite, jstParts } from '../lib/logic.js'
+import { trySendText } from '../lib/harness.js'
+import { claimOnce } from '../lib/dedupe.js'
+import type { MemberRow } from './members.js'
+
+/** 来店からレビュー依頼送信までの遅延（滞在中に届かないよう2時間後） */
+const REVIEW_ASK_DELAY_MS = 2 * 60 * 60 * 1000
+/** 同一会員へのレビュー依頼は90日に1回まで */
+const REVIEW_ASK_COOLDOWN_DAYS = 90
+
+/** クーポン消込など「来店した」と判断できたときに呼ぶ（last_visit_at 更新のみ・スタンプは別管理） */
+export async function markVisited(db: D1Database, memberId: string): Promise<void> {
+  await db
+    .prepare("UPDATE members SET last_visit_at = datetime('now'), updated_at = datetime('now') WHERE id = ?")
+    .bind(memberId)
+    .run()
+}
+
+/**
+ * 来店判定（スタンプ取得・クーポン消込）を起点に、2時間後のGoogleレビュー
+ * 依頼をキューに積む。GOOGLE_REVIEW_URL 未設定なら何もしない。
+ * 90日クールダウン + dedupe_key で重複送信を防ぐ。
+ */
+export async function queueReviewAsk(
+  db: D1Database,
+  config: StoreConfig,
+  member: Pick<MemberRow, 'id' | 'friend_id'>,
+  now: Date,
+): Promise<boolean> {
+  if (!config.googleReviewUrl || !member.friend_id) return false
+
+  const recent = await db
+    .prepare(
+      `SELECT 1 FROM message_log WHERE member_id = ? AND kind = 'review_ask'
+       AND sent_at > datetime('now', ?) LIMIT 1`,
+    )
+    .bind(member.id, `-${REVIEW_ASK_COOLDOWN_DAYS} days`)
+    .first()
+  if (recent) return false
+
+  const dedupeKey = `review_ask:${jstParts(now).date}:${member.id}`
+  if (!(await claimOnce(db, member.id, 'review_ask', dedupeKey))) return false
+
+  const sendAt = isoToSqlite(new Date(now.getTime() + REVIEW_ASK_DELAY_MS).toISOString())
+  await db
+    .prepare("INSERT INTO pending_notifications (id, member_id, kind, send_at) VALUES (?, ?, 'review_ask', ?)")
+    .bind(crypto.randomUUID(), member.id, sendAt)
+    .run()
+  return true
+}
+
+/** Cron: 送信時刻を過ぎたキューを配信する */
+export async function processPendingNotifications(
+  db: D1Database,
+  client: LineHarness,
+  config: StoreConfig,
+): Promise<number> {
+  const { results } = await db
+    .prepare(
+      `SELECT p.id, p.kind, m.friend_id FROM pending_notifications p
+       JOIN members m ON m.id = p.member_id
+       WHERE p.status = 'pending' AND p.send_at <= datetime('now')
+       LIMIT 50`,
+    )
+    .all<{ id: string; kind: string; friend_id: string | null }>()
+
+  let sent = 0
+  for (const row of results) {
+    if (row.kind === 'review_ask' && config.googleReviewUrl) {
+      const delivered = await trySendText(
+        client,
+        row.friend_id,
+        `本日は【${config.storeName}】にご来店いただきありがとうございました🙏\n\nもしよろしければ、Googleでの感想投稿にご協力いただけると励みになります⭐\n${config.googleReviewUrl}\n\nまたのお越しを心よりお待ちしております！`,
+      )
+      if (delivered) sent++
+    }
+    await db
+      .prepare("UPDATE pending_notifications SET status = 'sent' WHERE id = ?")
+      .bind(row.id)
+      .run()
+  }
+  return sent
+}

--- a/packages/plugin-restaurant/src/services/stamps.ts
+++ b/packages/plugin-restaurant/src/services/stamps.ts
@@ -1,0 +1,180 @@
+import type { LineHarness } from '@line-harness/sdk'
+import type { StoreConfig } from '../env.js'
+import { addStampToCard, jstParts, randomCode } from '../lib/logic.js'
+import { trySendText } from '../lib/harness.js'
+import { queueReviewAsk } from './review.js'
+import type { MemberRow } from './members.js'
+
+export type StampSource = 'store_code' | 'staff' | 'reservation'
+
+export interface StampOutcome {
+  stampCount: number
+  stampGoal: number
+  rewardEarned: boolean
+  rewardCode: string | null
+}
+
+const MAX_CODE_ATTEMPTS_PER_DAY = 10
+
+/**
+ * Today's store code (JST-rotated, 4 chars). Created lazily on first staff
+ * fetch of the day; customers can only verify, never mint.
+ */
+export async function getTodayVisitCode(db: D1Database, now: Date): Promise<string> {
+  const key = `visit_code:${jstParts(now).date}`
+  const existing = await db.prepare('SELECT value FROM settings WHERE key = ?').bind(key).first<{ value: string }>()
+  if (existing) return existing.value
+
+  const bytes = new Uint8Array(4)
+  crypto.getRandomValues(bytes)
+  const code = randomCode(4, bytes)
+  // Another isolate may have raced us — keep whichever landed first.
+  await db
+    .prepare('INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT (key) DO NOTHING')
+    .bind(key, code)
+    .run()
+  const final = await db.prepare('SELECT value FROM settings WHERE key = ?').bind(key).first<{ value: string }>()
+  return final?.value ?? code
+}
+
+export type CodeCheck = 'ok' | 'wrong' | 'not_ready' | 'rate_limited' | 'already_today'
+
+/** Verify a customer-entered store code, with a per-member daily attempt cap. */
+export async function checkVisitCode(db: D1Database, member: MemberRow, input: string, now: Date): Promise<CodeCheck> {
+  const today = jstParts(now).date
+
+  const stampedToday = await db
+    .prepare("SELECT 1 FROM visits WHERE member_id = ? AND date(visited_at, '+9 hours') = ? LIMIT 1")
+    .bind(member.id, today)
+    .first()
+  if (stampedToday) return 'already_today'
+
+  const attemptsKey = `code_attempts:${today}:${member.id}`
+  const attempts = await db
+    .prepare(
+      `INSERT INTO settings (key, value) VALUES (?, '1')
+       ON CONFLICT (key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT), updated_at = datetime('now')
+       RETURNING value`,
+    )
+    .bind(attemptsKey)
+    .first<{ value: string }>()
+  if (Number.parseInt(attempts?.value ?? '1', 10) > MAX_CODE_ATTEMPTS_PER_DAY) return 'rate_limited'
+
+  const codeRow = await db
+    .prepare('SELECT value FROM settings WHERE key = ?')
+    .bind(`visit_code:${today}`)
+    .first<{ value: string }>()
+  if (!codeRow) return 'not_ready'
+  return codeRow.value === input.trim().toUpperCase() ? 'ok' : 'wrong'
+}
+
+/**
+ * Record a visit and add one stamp. When the card fills up, issue a reward,
+ * reset the card, and notify the member on LINE.
+ */
+export async function grantStamp(
+  db: D1Database,
+  client: LineHarness,
+  config: StoreConfig,
+  member: MemberRow,
+  source: StampSource,
+): Promise<StampOutcome> {
+  const { newCount, rewardEarned } = addStampToCard(member.stamp_count, config.stampGoal)
+
+  await db.batch([
+    db
+      .prepare('INSERT INTO visits (id, member_id, source) VALUES (?, ?, ?)')
+      .bind(crypto.randomUUID(), member.id, source),
+    db
+      .prepare(
+        `UPDATE members SET stamp_count = ?, total_visits = total_visits + 1,
+         last_visit_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
+      )
+      .bind(newCount, member.id),
+  ])
+
+  await queueReviewAsk(db, config, member, new Date())
+
+  let rewardCode: string | null = null
+  if (rewardEarned) {
+    rewardCode = await issueReward(db, member.id, config.rewardName, 'stamp')
+    await trySendText(
+      client,
+      member.friend_id,
+      `🎉 スタンプが${config.stampGoal}個たまりました！\n「${config.rewardName}」をプレゼントします。\n\n特典コード: ${rewardCode}\n\n次回ご来店時にスタッフへこの画面をお見せください。（会員証の「特典」からいつでも確認できます）`,
+    )
+  }
+
+  return { stampCount: newCount, stampGoal: config.stampGoal, rewardEarned, rewardCode }
+}
+
+/** Issue a reward coupon (90-day expiry) and return its redeem code. */
+export async function issueReward(
+  db: D1Database,
+  memberId: string,
+  name: string,
+  kind: 'stamp' | 'birthday' | 'winback' | 'manual',
+): Promise<string> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const bytes = new Uint8Array(6)
+    crypto.getRandomValues(bytes)
+    const code = `RW-${randomCode(6, bytes)}`
+    try {
+      await db
+        .prepare(
+          `INSERT INTO rewards (id, member_id, name, code, kind, expires_at)
+           VALUES (?, ?, ?, ?, ?, datetime('now', '+90 days'))`,
+        )
+        .bind(crypto.randomUUID(), memberId, name, code, kind)
+        .run()
+      return code
+    } catch {
+      // UNIQUE collision on code — retry with a fresh one
+    }
+  }
+  throw new Error('reward code generation failed')
+}
+
+export interface RewardRow {
+  id: string
+  member_id: string
+  name: string
+  code: string
+  kind: string
+  status: string
+  issued_at: string
+  redeemed_at: string | null
+  expires_at: string | null
+}
+
+export async function listRewards(db: D1Database, memberId: string): Promise<RewardRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM rewards WHERE member_id = ? AND status = 'issued'
+       AND (expires_at IS NULL OR expires_at > datetime('now'))
+       ORDER BY issued_at DESC`,
+    )
+    .bind(memberId)
+    .all<RewardRow>()
+  return results
+}
+
+export type RedeemResult = { ok: true; reward: RewardRow } | { ok: false; reason: 'not_found' | 'already_redeemed' | 'expired' }
+
+export async function redeemReward(db: D1Database, code: string): Promise<RedeemResult> {
+  const reward = await db
+    .prepare('SELECT * FROM rewards WHERE code = ?')
+    .bind(code.trim().toUpperCase())
+    .first<RewardRow>()
+  if (!reward) return { ok: false, reason: 'not_found' }
+  if (reward.status === 'redeemed') return { ok: false, reason: 'already_redeemed' }
+  if (reward.status === 'expired' || (reward.expires_at && reward.expires_at <= new Date().toISOString().replace('T', ' ').slice(0, 19)))
+    return { ok: false, reason: 'expired' }
+
+  await db
+    .prepare("UPDATE rewards SET status = 'redeemed', redeemed_at = datetime('now') WHERE id = ?")
+    .bind(reward.id)
+    .run()
+  reward.status = 'redeemed'
+  return { ok: true, reward }
+}

--- a/packages/plugin-restaurant/src/services/takeout.ts
+++ b/packages/plugin-restaurant/src/services/takeout.ts
@@ -1,0 +1,413 @@
+import type { LineHarness } from '@line-harness/sdk'
+import type { StoreConfig } from '../env.js'
+import {
+  buildOrderLines,
+  formatJst,
+  isoToSqlite,
+  jstParts,
+  sqliteToIso,
+  validatePickupTime,
+  type OrderLine,
+} from '../lib/logic.js'
+import { trySendText } from '../lib/harness.js'
+import { markVisited, queueReviewAsk } from './review.js'
+import type { MemberRow } from './members.js'
+
+export interface MenuItemRow {
+  id: string
+  name: string
+  price: number
+  description: string | null
+  is_available: number
+  sort_order: number
+  created_at: string
+  updated_at: string
+}
+
+export interface TakeoutOrderRow {
+  id: string
+  member_id: string
+  order_no: string
+  items: string // JSON OrderLine[]
+  total: number
+  pickup_at: string
+  note: string | null
+  status: 'pending' | 'accepted' | 'ready' | 'completed' | 'cancelled'
+  created_at: string
+  updated_at: string
+}
+
+// ---------------------------------------------------------------- メニュー
+
+export async function listMenu(db: D1Database, includeUnavailable = false): Promise<MenuItemRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM takeout_menu_items ${includeUnavailable ? '' : 'WHERE is_available = 1'}
+       ORDER BY sort_order ASC, created_at ASC`,
+    )
+    .all<MenuItemRow>()
+  return results
+}
+
+export interface UpsertMenuItemInput {
+  id?: string
+  name: string
+  price: number
+  description?: string
+  isAvailable?: boolean
+  sortOrder?: number
+}
+
+export async function upsertMenuItem(db: D1Database, input: UpsertMenuItemInput): Promise<MenuItemRow> {
+  const name = input.name?.trim()
+  const price = Math.trunc(Number(input.price))
+  if (!name) throw new Error('商品名は必須です')
+  if (!Number.isFinite(price) || price < 0 || price > 1_000_000) throw new Error('価格が不正です')
+
+  const id = input.id ?? crypto.randomUUID()
+  await db
+    .prepare(
+      `INSERT INTO takeout_menu_items (id, name, price, description, is_available, sort_order)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT (id) DO UPDATE SET
+         name = excluded.name, price = excluded.price, description = excluded.description,
+         is_available = excluded.is_available, sort_order = excluded.sort_order,
+         updated_at = datetime('now')`,
+    )
+    .bind(id, name, price, input.description?.trim() || null, input.isAvailable === false ? 0 : 1, input.sortOrder ?? 0)
+    .run()
+  const row = await db.prepare('SELECT * FROM takeout_menu_items WHERE id = ?').bind(id).first<MenuItemRow>()
+  if (!row) throw new Error('menu upsert failed')
+  return row
+}
+
+// ---------------------------------------------------------------- 注文
+
+export interface CreateOrderInput {
+  items: { id?: string; qty?: number }[]
+  pickupTime: string // 'HH:mm' JST（本日）
+  note?: string
+}
+
+export type CreateOrderResult = { ok: true; order: TakeoutOrderRow } | { ok: false; error: string }
+
+export async function createTakeoutOrder(
+  db: D1Database,
+  client: LineHarness,
+  config: StoreConfig,
+  member: MemberRow,
+  input: CreateOrderInput,
+): Promise<CreateOrderResult> {
+  const menu = await listMenu(db)
+  const built = buildOrderLines(menu, input.items ?? [])
+  if (!built.ok) return { ok: false, error: built.error }
+
+  const now = new Date()
+  const pickup = validatePickupTime(input.pickupTime ?? '', now)
+  if (!pickup.ok) return { ok: false, error: pickup.error }
+
+  const orderNo = await nextOrderNo(db, now)
+  const id = crypto.randomUUID()
+  await db
+    .prepare(
+      `INSERT INTO takeout_orders (id, member_id, order_no, items, total, pickup_at, note)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(id, member.id, orderNo, JSON.stringify(built.lines), built.total, isoToSqlite(pickup.iso), input.note?.trim() || null)
+    .run()
+  const order = await db.prepare('SELECT * FROM takeout_orders WHERE id = ?').bind(id).first<TakeoutOrderRow>()
+  if (!order) return { ok: false, error: '注文の保存に失敗しました' }
+
+  await trySendText(
+    client,
+    member.friend_id,
+    `🥡 テイクアウトのご注文を承りました。\n\n【${config.storeName}】注文番号: ${orderNo}\n受取時間: ${formatJst(pickup.iso)}\n\n${formatLines(built.lines)}\n合計: ¥${built.total.toLocaleString()}\n\n準備ができましたら改めてお知らせします。お支払いは店頭でお願いいたします。`,
+  )
+
+  // 店側通知はすべてベストエフォート（各関数内で握りつぶす）なので並列に投げる
+  await Promise.all([
+    notifyNtfy(
+      config,
+      `新規テイクアウト注文 ${orderNo}`,
+      `${formatJst(pickup.iso)} 受取 / ¥${built.total.toLocaleString()}\n${built.lines.map((l) => `${l.name}×${l.qty}`).join('、')}${input.note?.trim() ? `\n備考: ${input.note.trim()}` : ''}`,
+    ),
+    notifyCallmebot(config, orderNo, built.lines, pickup.iso),
+    notifyCallmebotPhone(config, orderNo, built.lines, pickup.iso),
+    notifyClickSend(config, orderNo, built.lines, pickup.iso),
+    notifyPhoneCall(config, orderNo, built.lines, pickup.iso),
+  ])
+
+  return { ok: true, order }
+}
+
+/**
+ * お客様自身による受け取り完了（LIFFのスライド操作）。
+ * スタッフの面前でスライドしてもらう運用。調理中(accepted)以降で有効。
+ * 完了＝来店確定として review パイプラインにつなぐ。
+ */
+export async function receiveOrderBySlide(
+  db: D1Database,
+  config: StoreConfig,
+  member: MemberRow,
+  orderId: string,
+): Promise<{ ok: true; orderNo: string } | { ok: false; error: string }> {
+  const order = await db.prepare('SELECT * FROM takeout_orders WHERE id = ?').bind(orderId).first<TakeoutOrderRow>()
+  if (!order || order.member_id !== member.id) return { ok: false, error: '注文が見つかりません' }
+  if (order.status !== 'accepted' && order.status !== 'ready') {
+    return { ok: false, error: order.status === 'completed' ? 'この注文は受け取り済みです' : 'まだ受け取りできる状態ではありません' }
+  }
+
+  await db
+    .prepare("UPDATE takeout_orders SET status = 'completed', updated_at = datetime('now') WHERE id = ?")
+    .bind(orderId)
+    .run()
+  await markVisited(db, member.id)
+  await queueReviewAsk(db, config, member, new Date())
+  return { ok: true, orderNo: order.order_no }
+}
+
+export async function listMemberOrders(db: D1Database, memberId: string): Promise<TakeoutOrderRow[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT * FROM takeout_orders WHERE member_id = ?
+       AND status IN ('pending', 'accepted', 'ready') ORDER BY pickup_at ASC`,
+    )
+    .bind(memberId)
+    .all<TakeoutOrderRow>()
+  return results
+}
+
+export async function cancelMemberOrder(db: D1Database, member: MemberRow, orderId: string): Promise<'ok' | 'not_found' | 'not_cancellable'> {
+  const order = await db.prepare('SELECT * FROM takeout_orders WHERE id = ?').bind(orderId).first<TakeoutOrderRow>()
+  if (!order || order.member_id !== member.id) return 'not_found'
+  if (order.status !== 'pending') return 'not_cancellable' // 調理開始(accepted)後はお店に電話
+  await db
+    .prepare("UPDATE takeout_orders SET status = 'cancelled', updated_at = datetime('now') WHERE id = ?")
+    .bind(orderId)
+    .run()
+  return 'ok'
+}
+
+export async function listOrdersByDate(db: D1Database, jstDate: string): Promise<(TakeoutOrderRow & { member_no: string })[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT o.*, m.member_no FROM takeout_orders o JOIN members m ON m.id = o.member_id
+       WHERE date(o.pickup_at, '+9 hours') = ? ORDER BY o.pickup_at ASC`,
+    )
+    .bind(jstDate)
+    .all<TakeoutOrderRow & { member_no: string }>()
+  return results
+}
+
+const ORDER_STATUSES: TakeoutOrderRow['status'][] = ['pending', 'accepted', 'ready', 'completed', 'cancelled']
+
+/** スタッフによるステータス変更。ready / cancelled はお客様にLINE通知する */
+export async function setOrderStatus(
+  db: D1Database,
+  client: LineHarness,
+  config: StoreConfig,
+  orderId: string,
+  status: string,
+): Promise<TakeoutOrderRow | null> {
+  if (!ORDER_STATUSES.includes(status as TakeoutOrderRow['status'])) return null
+  const order = await db.prepare('SELECT * FROM takeout_orders WHERE id = ?').bind(orderId).first<TakeoutOrderRow>()
+  if (!order) return null
+
+  await db
+    .prepare("UPDATE takeout_orders SET status = ?, updated_at = datetime('now') WHERE id = ?")
+    .bind(status, orderId)
+    .run()
+
+  const friend = await db
+    .prepare('SELECT friend_id FROM members WHERE id = ?')
+    .bind(order.member_id)
+    .first<{ friend_id: string | null }>()
+
+  if (status === 'ready') {
+    await trySendText(
+      client,
+      friend?.friend_id ?? null,
+      `🍱 ご注文（${order.order_no}）のご準備ができました！\n【${config.storeName}】にてお待ちしております。\nお会計は店頭でお願いいたします。`,
+    )
+  } else if (status === 'completed') {
+    // 受渡完了＝来店確定。レビュー依頼の起点にする
+    await markVisited(db, order.member_id)
+    await queueReviewAsk(db, config, { id: order.member_id, friend_id: friend?.friend_id ?? null }, new Date())
+  } else if (status === 'cancelled') {
+    await trySendText(
+      client,
+      friend?.friend_id ?? null,
+      `ご注文（${order.order_no}）はキャンセルとなりました。\nご不明点は【${config.storeName}】までお問い合わせください。`,
+    )
+  }
+
+  return await db.prepare('SELECT * FROM takeout_orders WHERE id = ?').bind(orderId).first<TakeoutOrderRow>()
+}
+
+// ---------------------------------------------------------------- helpers
+
+/** 当日連番の注文番号 T-001（JST日付でリセット） */
+async function nextOrderNo(db: D1Database, now: Date): Promise<string> {
+  const key = `takeout_seq:${jstParts(now).date}`
+  const row = await db
+    .prepare(
+      `INSERT INTO settings (key, value) VALUES (?, '1')
+       ON CONFLICT (key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT), updated_at = datetime('now')
+       RETURNING value`,
+    )
+    .bind(key)
+    .first<{ value: string }>()
+  return `T-${String(Number.parseInt(row?.value ?? '1', 10)).padStart(3, '0')}`
+}
+
+function formatLines(lines: OrderLine[]): string {
+  return lines.map((l) => `・${l.name} ×${l.qty}　¥${(l.price * l.qty).toLocaleString()}`).join('\n')
+}
+
+/**
+ * 無料の自動音声通話（CallMeBot）。店長のTelegramに音声通話が着信し、
+ * 注文内容を日本語TTSで読み上げる。CALLMEBOT_TELEGRAM_USER 設定時のみ。
+ * 事前に Telegram で @CallMeBot_txtbot に /start を送って認可しておくこと。
+ * 個人利用向けの無料サービスのためベストエフォート（失敗しても注文は成立）。
+ */
+async function notifyCallmebot(config: StoreConfig, orderNo: string, lines: OrderLine[], pickupIso: string): Promise<void> {
+  if (!config.callmebotUser) return
+  try {
+    const text = (
+      `テイクアウトの新しい注文です。番号${orderNo.replace('T-', '')}番。` +
+      `受け取りは${formatJst(pickupIso).split(' ')[1]}。` +
+      `${lines.map((l) => `${l.name}${l.qty}点`).join('、')}。`
+    ).slice(0, 256)
+    const url =
+      `https://api.callmebot.com/start.php?user=${encodeURIComponent(config.callmebotUser)}` +
+      `&text=${encodeURIComponent(text)}&lang=ja-JP-Standard-B&rpt=2`
+    const res = await fetch(url)
+    if (!res.ok) console.error('[restaurant] callmebot failed:', res.status)
+  } catch (error) {
+    console.error('[restaurant] callmebot error:', error)
+  }
+}
+
+/**
+ * CallMeBot有料プラン（InOut.bot）での実電話（GSM/固定）架電。
+ * 月$1〜3で5〜30回の上限があるため低頻度店向け。日本語TTSは上位プランのみ。
+ */
+async function notifyCallmebotPhone(config: StoreConfig, orderNo: string, lines: OrderLine[], pickupIso: string): Promise<void> {
+  if (!config.callmebotPhone) return
+  try {
+    const text = (
+      `テイクアウトの新しい注文です。番号${orderNo.replace('T-', '')}番。` +
+      `受け取りは${formatJst(pickupIso).split(' ')[1]}。` +
+      `${lines.map((l) => `${l.name}${l.qty}点`).join('、')}。`
+    ).slice(0, 256)
+    const url =
+      `https://api.callmebot.com/call.php?phone=${encodeURIComponent(config.callmebotPhone.number)}` +
+      `&text=${encodeURIComponent(text)}&lang=ja-JP-Standard-B&rpt=2&apikey=${encodeURIComponent(config.callmebotPhone.apiKey)}`
+    const res = await fetch(url)
+    if (!res.ok) console.error('[restaurant] callmebot phone failed:', res.status)
+  } catch (error) {
+    console.error('[restaurant] callmebot phone error:', error)
+  }
+}
+
+/**
+ * ClickSendでの実電話（固定/携帯）架電。審査なし・従量課金・回数無制限。
+ * CallMeBotの月次上限を超える店の移行先。CLICKSEND_USERNAME/API_KEY + STORE_PHONE_NUMBER 設定時のみ。
+ */
+async function notifyClickSend(config: StoreConfig, orderNo: string, lines: OrderLine[], pickupIso: string): Promise<void> {
+  if (!config.clicksend) return
+  try {
+    const body = (
+      `こちらは、${config.storeName}の、テイクアウト注文システムです。` +
+      `新しい注文が入りました。番号${orderNo.replace('T-', '')}番。` +
+      `受け取りは${formatJst(pickupIso).split(' ')[1]}。` +
+      `${lines.map((l) => `${l.name}${l.qty}点`).join('、')}。`
+    ).slice(0, 300)
+    const res = await fetch('https://rest.clicksend.com/v3/voice/send', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${btoa(`${config.clicksend.username}:${config.clicksend.apiKey}`)}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messages: [
+          {
+            source: 'line-harness-restaurant',
+            to: config.clicksend.to,
+            body,
+            voice: 'female',
+            lang: 'ja-jp',
+            machine_detection: 0,
+          },
+        ],
+      }),
+    })
+    if (!res.ok) console.error('[restaurant] clicksend failed:', res.status, await res.text())
+  } catch (error) {
+    console.error('[restaurant] clicksend error:', error)
+  }
+}
+
+/**
+ * 新規注文の店舗への自動架電（Twilio・環境変数がすべて設定されたときのみ）。
+ * 失敗しても注文は成立させる。通話内容は日本語TTSで注文番号と受取時刻を2回読み上げる。
+ */
+async function notifyPhoneCall(config: StoreConfig, orderNo: string, lines: OrderLine[], pickupIso: string): Promise<void> {
+  if (!config.twilio) return
+  try {
+    const speech =
+      `こちらは、${config.storeName}の、テイクアウト注文システムです。` +
+      `新しい注文が入りました。注文番号、${orderNo.replace('T-', 'ティー')}。` +
+      `受け取り時刻は、${formatJst(pickupIso).split(' ')[1]}。` +
+      `内容は、${lines.map((l) => `${l.name}が${l.qty}点`).join('、')}です。` +
+      `詳細はスタッフページをご確認ください。`
+    const twiml = `<Response><Say language="ja-JP" loop="2">${speech
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')}</Say></Response>`
+
+    const params = new URLSearchParams({ To: config.twilio.to, From: config.twilio.from, Twiml: twiml })
+    const res = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${config.twilio.accountSid}/Calls.json`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${btoa(`${config.twilio.accountSid}:${config.twilio.authToken}`)}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: params.toString(),
+      },
+    )
+    if (!res.ok) console.error('[restaurant] twilio call failed:', res.status, await res.text())
+  } catch (error) {
+    console.error('[restaurant] twilio call error:', error)
+  }
+}
+
+/** ntfy.sh へのスタッフ向けプッシュ（NTFY_TOPIC 設定時のみ・失敗しても注文は成立させる） */
+async function notifyNtfy(config: StoreConfig, title: string, body: string): Promise<void> {
+  if (!config.ntfyTopic) return
+  try {
+    // Priority: urgent = ntfyアプリ側の設定で「アラーム音を鳴らし続ける」対象にできる（着信の代替）
+    await fetch(`https://ntfy.sh/${config.ntfyTopic}`, {
+      method: 'POST',
+      headers: { Title: encodeURIComponent(title), Priority: 'urgent', Tags: 'rotating_light,bento' },
+      body,
+    })
+  } catch (error) {
+    console.error('[restaurant] ntfy failed:', error)
+  }
+}
+
+export function publicOrder(order: TakeoutOrderRow & { member_no?: string }) {
+  return {
+    id: order.id,
+    orderNo: order.order_no,
+    items: JSON.parse(order.items) as OrderLine[],
+    total: order.total,
+    pickupAt: formatJst(sqliteToIso(order.pickup_at)),
+    note: order.note,
+    status: order.status,
+    ...(order.member_no ? { memberNo: order.member_no } : {}),
+  }
+}

--- a/packages/plugin-restaurant/test/logic.test.ts
+++ b/packages/plugin-restaurant/test/logic.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest'
+import {
+  addStampToCard,
+  buildOrderLines,
+  dueReminders,
+  formatJst,
+  isBirthday,
+  isWinbackTarget,
+  isoToSqlite,
+  jstParts,
+  jstToUtcIso,
+  randomCode,
+  formatMemberNo,
+  sqliteToIso,
+  validatePickupTime,
+} from '../src/lib/logic.js'
+import { storeConfig } from '../src/env.js'
+
+describe('jstParts / jstToUtcIso', () => {
+  it('converts UTC to JST date parts', () => {
+    // 2026-07-06 20:30 UTC = 2026-07-07 05:30 JST
+    const parts = jstParts(new Date('2026-07-06T20:30:00Z'))
+    expect(parts.date).toBe('2026-07-07')
+    expect(parts.time).toBe('05:30')
+    expect(parts.monthDay).toBe('07-07')
+    expect(parts.year).toBe(2026)
+  })
+
+  it('converts JST wall clock to UTC ISO', () => {
+    expect(jstToUtcIso('2026-07-08', '19:00')).toBe('2026-07-08T10:00:00.000Z')
+  })
+
+  it('roundtrips sqlite format', () => {
+    const iso = '2026-07-08T10:00:00.000Z'
+    expect(sqliteToIso(isoToSqlite(iso))).toBe('2026-07-08T10:00:00Z')
+  })
+})
+
+describe('formatJst', () => {
+  it('formats UTC ISO as JST Japanese string', () => {
+    expect(formatJst('2026-07-08T10:00:00Z')).toBe('7月8日(水) 19:00')
+  })
+})
+
+describe('addStampToCard', () => {
+  it('increments below the goal', () => {
+    expect(addStampToCard(3, 10)).toEqual({ newCount: 4, rewardEarned: false })
+  })
+  it('earns a reward and resets at the goal', () => {
+    expect(addStampToCard(9, 10)).toEqual({ newCount: 0, rewardEarned: true })
+  })
+  it('handles goal of 1 (every visit is a reward)', () => {
+    expect(addStampToCard(0, 1)).toEqual({ newCount: 0, rewardEarned: true })
+  })
+})
+
+describe('isBirthday', () => {
+  it('matches MM-DD', () => {
+    expect(isBirthday('07-07', '07-07')).toBe(true)
+    expect(isBirthday('07-08', '07-07')).toBe(false)
+  })
+  it('matches YYYY-MM-DD by month-day', () => {
+    expect(isBirthday('1990-07-07', '07-07')).toBe(true)
+  })
+  it('treats Feb 29 birthdays as Feb 28 on non-leap years', () => {
+    expect(isBirthday('02-29', '02-28')).toBe(true)
+    expect(isBirthday('02-29', '02-29')).toBe(true)
+  })
+  it('rejects null and malformed values', () => {
+    expect(isBirthday(null, '07-07')).toBe(false)
+    expect(isBirthday('7月7日', '07-07')).toBe(false)
+  })
+})
+
+describe('dueReminders', () => {
+  // Reservation: 2026-07-08 19:00 JST = 2026-07-08T10:00:00Z
+  const reservedAt = '2026-07-08T10:00:00.000Z'
+
+  it('nothing due well before the day-before window', () => {
+    // 2026-07-07 17:59 JST
+    expect(dueReminders(reservedAt, new Date('2026-07-07T08:59:00Z'))).toEqual([])
+  })
+
+  it('day_before due from 18:00 JST the previous day', () => {
+    // 2026-07-07 18:00 JST
+    expect(dueReminders(reservedAt, new Date('2026-07-07T09:00:00Z'))).toEqual(['day_before'])
+  })
+
+  it('same_day due from 2 hours before', () => {
+    // 2026-07-08 17:00 JST (2h before 19:00)
+    expect(dueReminders(reservedAt, new Date('2026-07-08T08:00:00Z'))).toEqual(['day_before', 'same_day'])
+  })
+
+  it('nothing due once the reservation time has passed', () => {
+    expect(dueReminders(reservedAt, new Date('2026-07-08T10:00:00Z'))).toEqual([])
+    expect(dueReminders(reservedAt, new Date('2026-07-09T00:00:00Z'))).toEqual([])
+  })
+})
+
+describe('isWinbackTarget', () => {
+  const now = new Date('2026-07-06T00:00:00Z')
+  it('true when the last visit is old enough', () => {
+    expect(isWinbackTarget('2026-06-01T00:00:00Z', 30, now)).toBe(true)
+  })
+  it('false for recent visitors', () => {
+    expect(isWinbackTarget('2026-06-20T00:00:00Z', 30, now)).toBe(false)
+  })
+  it('false when never visited', () => {
+    expect(isWinbackTarget(null, 30, now)).toBe(false)
+  })
+})
+
+describe('buildOrderLines', () => {
+  const menu = [
+    { id: 'a', name: '唐揚げ弁当', price: 800, is_available: 1 },
+    { id: 'b', name: '焼き魚弁当', price: 900, is_available: 1 },
+    { id: 'c', name: '売切弁当', price: 500, is_available: 0 },
+  ]
+
+  it('computes totals from server-side prices', () => {
+    const r = buildOrderLines(menu, [{ id: 'a', qty: 2 }, { id: 'b', qty: 1 }])
+    expect(r).toEqual({
+      ok: true,
+      lines: [
+        { id: 'a', name: '唐揚げ弁当', price: 800, qty: 2 },
+        { id: 'b', name: '焼き魚弁当', price: 900, qty: 1 },
+      ],
+      total: 2500,
+    })
+  })
+
+  it('ignores zero-qty lines but rejects an all-zero order', () => {
+    const r = buildOrderLines(menu, [{ id: 'a', qty: 2 }, { id: 'b', qty: 0 }])
+    expect(r.ok && r.total).toBe(1600)
+    expect(buildOrderLines(menu, [{ id: 'a', qty: 0 }]).ok).toBe(false)
+  })
+
+  it('rejects unavailable or unknown items and bad quantities', () => {
+    expect(buildOrderLines(menu, [{ id: 'c', qty: 1 }]).ok).toBe(false)
+    expect(buildOrderLines(menu, [{ id: 'zzz', qty: 1 }]).ok).toBe(false)
+    expect(buildOrderLines(menu, [{ id: 'a', qty: 21 }]).ok).toBe(false)
+    expect(buildOrderLines(menu, [{ id: 'a', qty: -1 }]).ok).toBe(false)
+    expect(buildOrderLines(menu, []).ok).toBe(false)
+  })
+})
+
+describe('validatePickupTime', () => {
+  // now = 2026-07-06 18:00 JST
+  const now = new Date('2026-07-06T09:00:00Z')
+
+  it('accepts a time at least 15 minutes ahead (JST today)', () => {
+    const r = validatePickupTime('19:00', now)
+    expect(r).toEqual({ ok: true, iso: '2026-07-06T10:00:00.000Z' })
+  })
+
+  it('rejects times in the past or too soon', () => {
+    expect(validatePickupTime('17:00', now).ok).toBe(false)
+    expect(validatePickupTime('18:10', now).ok).toBe(false)
+  })
+
+  it('rejects malformed input', () => {
+    expect(validatePickupTime('7pm', now).ok).toBe(false)
+    expect(validatePickupTime('', now).ok).toBe(false)
+  })
+})
+
+describe('codes', () => {
+  it('randomCode uses only unambiguous characters', () => {
+    const bytes = new Uint8Array(64)
+    for (let i = 0; i < bytes.length; i++) bytes[i] = i * 7
+    const code = randomCode(64, bytes)
+    expect(code).toHaveLength(64)
+    expect(code).not.toMatch(/[01OIL]/)
+  })
+  it('formats member numbers with zero padding', () => {
+    expect(formatMemberNo(123)).toBe('R-000123')
+  })
+})
+
+describe('storeConfig phone notification gating', () => {
+  const base = {
+    DB: {} as never,
+    LINE_HARNESS_API_URL: 'https://example.com',
+    LINE_HARNESS_API_KEY: 'k',
+    LIFF_ID: 'liff',
+    STORE_NAME: 'テスト食堂',
+    STAMP_GOAL: '10',
+    REWARD_NAME: '特典',
+    WINBACK_DAYS: '30',
+    STAFF_PIN: '0000',
+    PLUGIN_API_KEY: 'pk',
+  }
+
+  it('disables all phone channels by default', () => {
+    const config = storeConfig({ ...base })
+    expect(config.callmebotUser).toBeNull()
+    expect(config.callmebotPhone).toBeNull()
+    expect(config.clicksend).toBeNull()
+    expect(config.twilio).toBeNull()
+  })
+
+  it('enables callmebot phone only when number and apikey are both set', () => {
+    expect(storeConfig({ ...base, CALLMEBOT_PHONE_NUMBER: '+819000000000' }).callmebotPhone).toBeNull()
+    expect(storeConfig({ ...base, CALLMEBOT_PHONE_APIKEY: 'key' }).callmebotPhone).toBeNull()
+    const config = storeConfig({ ...base, CALLMEBOT_PHONE_NUMBER: ' +819000000000 ', CALLMEBOT_PHONE_APIKEY: ' key ' })
+    expect(config.callmebotPhone).toEqual({ number: '+819000000000', apiKey: 'key' })
+  })
+
+  it('enables clicksend only when username, apikey and store phone are all set', () => {
+    expect(storeConfig({ ...base, CLICKSEND_USERNAME: 'u', CLICKSEND_API_KEY: 'k2' }).clicksend).toBeNull()
+    const config = storeConfig({
+      ...base,
+      CLICKSEND_USERNAME: 'u',
+      CLICKSEND_API_KEY: 'k2',
+      STORE_PHONE_NUMBER: '+815000000000',
+    })
+    expect(config.clicksend).toEqual({ username: 'u', apiKey: 'k2', to: '+815000000000' })
+  })
+
+  it('enables twilio only when all four variables are set', () => {
+    expect(
+      storeConfig({ ...base, TWILIO_ACCOUNT_SID: 'AC1', TWILIO_AUTH_TOKEN: 't', TWILIO_FROM_NUMBER: '+815011111111' })
+        .twilio,
+    ).toBeNull()
+    const config = storeConfig({
+      ...base,
+      TWILIO_ACCOUNT_SID: 'AC1',
+      TWILIO_AUTH_TOKEN: 't',
+      TWILIO_FROM_NUMBER: '+815011111111',
+      STORE_PHONE_NUMBER: '+815000000000',
+    })
+    expect(config.twilio).toEqual({ accountSid: 'AC1', authToken: 't', from: '+815011111111', to: '+815000000000' })
+  })
+})

--- a/packages/plugin-restaurant/tools/campaign.mjs
+++ b/packages/plugin-restaurant/tools/campaign.mjs
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+/**
+ * 配信自動生成パイプライン（飲食店プラグイン用）
+ *
+ *   キャンペーン概要ひとつから
+ *     1. Claude (claude -p) が配信文面・コピー・画像プロンプトを生成
+ *     2. Codex image_gen がリッチメッセージ用バナー画像・クーポン画像を生成
+ *     3. （--coupon 時）プラグインAPIで共通クーポン CP-XXXXXX を発行
+ *     4. LINE Harness に画像アップロード → テキスト配信 + Flexリッチ配信を作成
+ *   までを一気通貫で行う。
+ *
+ * 使い方:
+ *   node tools/campaign.mjs --brief "雨の日限定10%オフ。雨の日に来店したら全品10%引き" \
+ *     [--coupon] [--discount "10%OFF"] [--expires 2026-07-31] \
+ *     [--target all|tag:<tagId>] [--send draft|now] [--skip-images] [--model sonnet]
+ *
+ * 既定は draft（Harness管理画面で内容確認後に送信）。--send now で
+ * テキスト→リッチの順に即時送信する。
+ *
+ * 必要な環境変数（パッケージ直下の .env でも可）:
+ *   LINE_HARNESS_API_URL / LINE_HARNESS_API_KEY
+ *   RESTAURANT_PLUGIN_URL / RESTAURANT_PLUGIN_API_KEY   ← --coupon 時のみ
+ *   STORE_NAME / LIFF_ID                                 ← 未設定なら wrangler.toml から補完
+ *
+ * 前提: claude CLI / Codex CLI（ログイン済み・image_gen 用）/ macOS sips
+ */
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const PKG_ROOT = path.resolve(__dirname, '..')
+
+// ---------------------------------------------------------------- args/env
+
+function arg(name, fallback = null) {
+  const i = process.argv.indexOf(name)
+  return i !== -1 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--')
+    ? process.argv[i + 1]
+    : fallback
+}
+const flag = (name) => process.argv.includes(name)
+
+const brief = arg('--brief')
+if (!brief) {
+  console.error('usage: node tools/campaign.mjs --brief "<キャンペーン概要>" [--coupon] [--expires YYYY-MM-DD] [--target all|tag:<id>] [--send draft|now] [--skip-images]')
+  process.exit(1)
+}
+const withCoupon = flag('--coupon')
+const discount = arg('--discount', '')
+const expires = arg('--expires', '')
+const target = arg('--target', 'all')
+const sendMode = arg('--send', 'draft')
+const skipImages = flag('--skip-images')
+const bannerUrlOverride = arg('--banner-url') // 既存画像URLを使い回す（生成スキップ）
+const couponUrlOverride = arg('--coupon-image-url')
+const model = arg('--model', 'sonnet')
+const outDir = arg('--out', path.join(__dirname, 'out', new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)))
+
+// .env（パッケージ直下）を補完読み込み
+const envFile = path.join(PKG_ROOT, '.env')
+if (fs.existsSync(envFile)) {
+  for (const line of fs.readFileSync(envFile, 'utf8').split('\n')) {
+    const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/)
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2].replace(/^["']|["']$/g, '')
+  }
+}
+
+// wrangler.toml の [vars] から STORE_NAME / LIFF_ID / LINE_HARNESS_API_URL を補完
+function varFromWranglerToml(key) {
+  try {
+    const toml = fs.readFileSync(path.join(PKG_ROOT, 'wrangler.toml'), 'utf8')
+    const m = toml.match(new RegExp(`^${key}\\s*=\\s*"([^"]*)"`, 'm'))
+    return m ? m[1] : null
+  } catch {
+    return null
+  }
+}
+
+const HARNESS_URL = (process.env.LINE_HARNESS_API_URL || varFromWranglerToml('LINE_HARNESS_API_URL') || '').replace(/\/$/, '')
+const HARNESS_KEY = process.env.LINE_HARNESS_API_KEY || ''
+const STORE_NAME = process.env.STORE_NAME || varFromWranglerToml('STORE_NAME') || 'お店'
+const LIFF_ID = process.env.LIFF_ID || varFromWranglerToml('LIFF_ID') || ''
+const PLUGIN_URL = (process.env.RESTAURANT_PLUGIN_URL || '').replace(/\/$/, '')
+const PLUGIN_KEY = process.env.RESTAURANT_PLUGIN_API_KEY || ''
+
+if (!HARNESS_URL || !HARNESS_KEY) {
+  console.error('LINE_HARNESS_API_URL / LINE_HARNESS_API_KEY を設定してください（.env 可）')
+  process.exit(1)
+}
+if (withCoupon && (!PLUGIN_URL || !PLUGIN_KEY)) {
+  console.error('--coupon には RESTAURANT_PLUGIN_URL / RESTAURANT_PLUGIN_API_KEY が必要です')
+  process.exit(1)
+}
+if (!['draft', 'now'].includes(sendMode)) {
+  console.error('--send は draft か now')
+  process.exit(1)
+}
+let targetType = 'all'
+let targetTagId
+if (target.startsWith('tag:')) {
+  targetType = 'tag'
+  targetTagId = target.slice(4)
+} else if (target !== 'all') {
+  console.error('--target は all か tag:<tagId>')
+  process.exit(1)
+}
+
+fs.mkdirSync(outDir, { recursive: true })
+const log = (msg) => console.error(`[campaign] ${msg}`)
+
+// ---------------------------------------------------------------- helpers
+
+async function harness(pathName, init = {}) {
+  const res = await fetch(`${HARNESS_URL}${pathName}`, {
+    ...init,
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${HARNESS_KEY}`, ...(init.headers || {}) },
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok || body.success === false) throw new Error(`Harness ${pathName}: ${body.error || res.status}`)
+  return body.data
+}
+
+async function pluginApi(pathName, init = {}) {
+  const res = await fetch(`${PLUGIN_URL}/api/admin${pathName}`, {
+    ...init,
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${PLUGIN_KEY}`, ...(init.headers || {}) },
+  })
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok || body.success === false) throw new Error(`Plugin ${pathName}: ${body.error || res.status}`)
+  return body.data
+}
+
+// ---------------------------------------------------------------- 1. コピー生成 (Claude)
+
+function generateCopy() {
+  log(`コピー生成中 (claude -p, model=${model}) …`)
+  const prompt = `あなたは飲食店のLINE公式アカウント配信のコピーライターです。
+店舗名: ${STORE_NAME}
+キャンペーン概要: ${brief}
+${withCoupon ? `クーポン: あり（割引表記: ${discount || '概要から適切に決める'}、有効期限: ${expires || '未定'}）` : 'クーポン: なし'}
+
+以下のキーを持つJSONオブジェクトだけを出力してください。コードフェンスや説明文は一切禁止。
+{
+  "title": "社内管理用の短いキャンペーン名（20字以内）",
+  "textMessage": "1通目のテキスト配信文。絵文字を適度に使い、改行を含む180字以内。押し付けがましくなく、来店したくなる文面",
+  "headline": "リッチメッセージの見出し（15字以内・体言止め可）",
+  "sub": "サブコピー（30字以内）",
+  "cta": "ボタン文言（10字以内、例: 会員証を見る）",
+  "discountText": "割引の短い表記（例: 10%OFF。クーポンなしなら空文字）",
+  "bannerImagePrompt": "バナー用の写真の英語プロンプト。料理・シズル感中心の正方形構図。スタイルや照明も指定",
+  "couponImagePrompt": "クーポン背景用の写真の英語プロンプト。横長構図で余白のある落ち着いた雰囲気",
+  "altText": "リッチメッセージの代替テキスト（30字以内）"
+}`
+  const raw = execFileSync('claude', ['-p', prompt, '--model', model], {
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+    timeout: 180_000,
+  })
+  const jsonText = raw.replace(/^[\s\S]*?(\{[\s\S]*\})[\s\S]*$/, '$1')
+  const copy = JSON.parse(jsonText)
+  for (const key of ['title', 'textMessage', 'headline', 'cta', 'bannerImagePrompt', 'altText']) {
+    if (!copy[key]) throw new Error(`コピー生成の欠落キー: ${key}`)
+  }
+  fs.writeFileSync(path.join(outDir, 'copy.json'), JSON.stringify(copy, null, 2))
+  return copy
+}
+
+// ---------------------------------------------------------------- 2. 画像生成 (Codex image_gen)
+
+const NO_TEXT = ' Use your built-in image_gen tool; do NOT search for a CLI. Absolutely no text, letters, numbers or logos in the image.'
+
+function generateImage(prompt, outPng, label) {
+  log(`${label} 画像生成中 (Codex image_gen) …`)
+  execFileSync('node', [path.join(__dirname, 'gen-image.mjs'), prompt + NO_TEXT, outPng, '--timeout', '420'], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    timeout: 480_000,
+  })
+  if (!fs.existsSync(outPng)) throw new Error(`${label} 画像の生成に失敗しました`)
+  // 1040px・JPEG化で軽量化（LINE推奨サイズ/アップロード上限対策）
+  const jpg = outPng.replace(/\.png$/, '.jpg')
+  execFileSync('sips', ['-Z', '1040', '-s', 'format', 'jpeg', '-s', 'formatOptions', '82', outPng, '--out', jpg], { stdio: 'ignore' })
+  return jpg
+}
+
+async function uploadImage(filePath, filename) {
+  const data = fs.readFileSync(filePath).toString('base64')
+  const uploaded = await harness('/api/images', {
+    method: 'POST',
+    body: JSON.stringify({ data, mimeType: 'image/jpeg', filename }),
+  })
+  return uploaded.url
+}
+
+// ---------------------------------------------------------------- 3. Flex 組み立て
+
+function buildFlex(copy, bannerUrl, coupon, couponUrl) {
+  const liffUrl = LIFF_ID ? `https://liff.line.me/${LIFF_ID}` : null
+  const button = liffUrl
+    ? {
+        type: 'button',
+        style: 'primary',
+        color: '#b45309',
+        action: { type: 'uri', label: copy.cta, uri: liffUrl },
+      }
+    : null
+
+  const bannerBubble = {
+    type: 'bubble',
+    hero: {
+      type: 'image',
+      url: bannerUrl,
+      size: 'full',
+      aspectRatio: '1:1',
+      aspectMode: 'cover',
+      ...(liffUrl ? { action: { type: 'uri', uri: liffUrl } } : {}),
+    },
+    body: {
+      type: 'box',
+      layout: 'vertical',
+      spacing: 'sm',
+      contents: [
+        { type: 'text', text: copy.headline, weight: 'bold', size: 'xl', wrap: true },
+        ...(copy.sub ? [{ type: 'text', text: copy.sub, size: 'sm', color: '#78716c', wrap: true }] : []),
+      ],
+    },
+    ...(button ? { footer: { type: 'box', layout: 'vertical', contents: [button] } } : {}),
+  }
+
+  if (!coupon) return bannerBubble
+
+  const couponBubble = {
+    type: 'bubble',
+    ...(couponUrl
+      ? { hero: { type: 'image', url: couponUrl, size: 'full', aspectRatio: '20:13', aspectMode: 'cover' } }
+      : {}),
+    body: {
+      type: 'box',
+      layout: 'vertical',
+      spacing: 'md',
+      contents: [
+        { type: 'text', text: 'COUPON', size: 'xs', color: '#b45309', weight: 'bold' },
+        { type: 'text', text: coupon.name, weight: 'bold', size: 'lg', wrap: true },
+        ...(coupon.discountText
+          ? [{ type: 'text', text: coupon.discountText, weight: 'bold', size: '3xl', color: '#b45309' }]
+          : []),
+        {
+          type: 'box',
+          layout: 'vertical',
+          backgroundColor: '#fff7ed',
+          cornerRadius: 'md',
+          paddingAll: 'md',
+          contents: [
+            { type: 'text', text: 'クーポンコード', size: 'xs', color: '#78716c', align: 'center' },
+            { type: 'text', text: coupon.code, weight: 'bold', size: 'xxl', align: 'center', color: '#92400e' },
+          ],
+        },
+        {
+          type: 'text',
+          text: `ご注文時にスタッフへこの画面をご提示ください${coupon.expiresAt ? `\n有効期限: ${coupon.expiresAt}` : ''}`,
+          size: 'xs',
+          color: '#78716c',
+          wrap: true,
+        },
+      ],
+    },
+    ...(button ? { footer: { type: 'box', layout: 'vertical', contents: [button] } } : {}),
+  }
+
+  return { type: 'carousel', contents: [bannerBubble, couponBubble] }
+}
+
+// ---------------------------------------------------------------- main
+
+async function main() {
+  const copy = generateCopy()
+  log(`コピー完成: ${copy.title}`)
+
+  // 共通クーポン発行
+  let coupon = null
+  if (withCoupon) {
+    log('共通クーポン発行中 …')
+    coupon = await pluginApi('/campaigns', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: copy.title,
+        discountText: copy.discountText || discount || undefined,
+        expiresAt: expires || undefined,
+      }),
+    })
+    log(`クーポン発行: ${coupon.code}`)
+    // クーポンコードをテキスト配信にも記載
+    copy.textMessage += `\n\n🎟 クーポンコード: ${coupon.code}${coupon.expiresAt ? `（${coupon.expiresAt}まで）` : ''}\nご注文時にスタッフへご提示ください。`
+  }
+
+  // 画像生成 → アップロード（URL指定があれば生成スキップ）
+  let bannerUrl = bannerUrlOverride
+  let couponUrl = couponUrlOverride
+  if (!skipImages && !bannerUrl) {
+    const bannerJpg = generateImage(copy.bannerImagePrompt, path.join(outDir, 'banner.png'), 'バナー')
+    bannerUrl = await uploadImage(bannerJpg, 'campaign-banner.jpg')
+    log(`バナーアップロード: ${bannerUrl}`)
+  }
+  if (!skipImages && withCoupon && !couponUrl && copy.couponImagePrompt) {
+    const couponJpg = generateImage(copy.couponImagePrompt, path.join(outDir, 'coupon.png'), 'クーポン')
+    couponUrl = await uploadImage(couponJpg, 'campaign-coupon.jpg')
+    log(`クーポン画像アップロード: ${couponUrl}`)
+  }
+
+  // 配信作成（1通目: テキスト → 2通目: リッチ）
+  const targetFields = { targetType, ...(targetTagId ? { targetTagId } : {}) }
+  const textBroadcast = await harness('/api/broadcasts', {
+    method: 'POST',
+    body: JSON.stringify({ title: `${copy.title}（テキスト）`, messageType: 'text', messageContent: copy.textMessage, ...targetFields }),
+  })
+
+  let richBroadcast = null
+  if (bannerUrl) {
+    const flex = buildFlex(copy, bannerUrl, coupon, couponUrl)
+    fs.writeFileSync(path.join(outDir, 'flex.json'), JSON.stringify(flex, null, 2))
+    richBroadcast = await harness('/api/broadcasts', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: `${copy.title}（リッチ）`,
+        messageType: 'flex',
+        messageContent: JSON.stringify(flex),
+        altText: copy.altText,
+        ...targetFields,
+      }),
+    })
+  }
+
+  if (sendMode === 'now') {
+    log('送信中（テキスト → リッチの順）…')
+    await harness(`/api/broadcasts/${textBroadcast.id}/send`, { method: 'POST' })
+    if (richBroadcast) {
+      await new Promise((r) => setTimeout(r, 3000))
+      await harness(`/api/broadcasts/${richBroadcast.id}/send`, { method: 'POST' })
+    }
+  }
+
+  const summary = {
+    ok: true,
+    mode: sendMode,
+    title: copy.title,
+    textBroadcastId: textBroadcast.id,
+    richBroadcastId: richBroadcast?.id ?? null,
+    coupon: coupon ? { code: coupon.code, expiresAt: coupon.expiresAt } : null,
+    images: { banner: bannerUrl, coupon: couponUrl },
+    outDir,
+  }
+  fs.writeFileSync(path.join(outDir, 'summary.json'), JSON.stringify(summary, null, 2))
+  console.log(JSON.stringify(summary, null, 2))
+  if (sendMode === 'draft') {
+    log('ドラフト作成のみ完了。Harness管理画面の「配信」で内容を確認して送信してください。')
+  }
+}
+
+main().catch((e) => {
+  console.error(`[campaign] 失敗: ${e.message}`)
+  process.exit(1)
+})

--- a/packages/plugin-restaurant/tools/gen-image.mjs
+++ b/packages/plugin-restaurant/tools/gen-image.mjs
@@ -1,0 +1,135 @@
+// Codex image_gen → ファイル取得（信頼版）
+// 依存: Node 組み込みのみ（child_process / fs）。
+//
+// なぜ必要か:
+//   Codex に「生成して保存して」と頼むと、後処理で generated_images から
+//   "最新ファイル" を find して別スレッドの古い画像を取り違えてコピーすることがある
+//   （実際に企業サイト画像が混入する事故が起きた）。本スクリプトは Codex に
+//   「生成だけ」させ、そのタスク自身のスレッドフォルダ
+//   ~/.codex/generated_images/<threadId>/ig_*.png から最新を“こちらが”回収する。
+//
+// 使い方:
+//   node scripts/gen-image.mjs "<prompt>" <out.png> [--timeout 360]
+//
+// 出力(JSON): { ok, out, threadId, jobId, picked }
+//
+// 注意: Codex にログイン必須（image_gen はモデルのツール）。未ログインなら
+//   `!codex login`（対話）をユーザーに依頼すること。
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const HOME = os.homedir();
+const GEN_ROOT = path.join(HOME, ".codex", "generated_images");
+
+function arg(name, fb = null) {
+  const i = process.argv.indexOf(name);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fb;
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const prompt = process.argv[2];
+const out = process.argv[3];
+if (!prompt || !out || prompt.startsWith("--")) {
+  console.error('usage: node scripts/gen-image.mjs "<prompt>" <out.png> [--timeout 360]');
+  process.exit(1);
+}
+const timeoutSec = parseInt(arg("--timeout", "360"), 10);
+
+// --- companion を解決（最新バージョンを選ぶ） ---
+function resolveCompanion() {
+  const base = path.join(HOME, ".claude/plugins/cache/openai-codex/codex");
+  if (!fs.existsSync(base)) return null;
+  const vers = fs
+    .readdirSync(base)
+    .filter((d) => fs.existsSync(path.join(base, d, "scripts/codex-companion.mjs")))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  if (!vers.length) return null;
+  return path.join(base, vers[vers.length - 1], "scripts/codex-companion.mjs");
+}
+const CC = resolveCompanion();
+if (!CC) {
+  console.error("codex-companion.mjs が見つかりません（Codex プラグイン未導入？）");
+  process.exit(1);
+}
+
+// --- ジョブのログファイルを探す ---
+function findLog(jobId) {
+  const base = path.join(HOME, ".claude/plugins/data/codex-openai-codex/state");
+  if (!fs.existsSync(base)) return null;
+  for (const d of fs.readdirSync(base)) {
+    const p = path.join(base, d, "jobs", `${jobId}.log`);
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+function newestPng(dir) {
+  if (!fs.existsSync(dir)) return null;
+  const pngs = fs
+    .readdirSync(dir)
+    .filter((f) => f.toLowerCase().endsWith(".png"))
+    .map((f) => ({ f: path.join(dir, f), t: fs.statSync(path.join(dir, f)).mtimeMs }))
+    .sort((a, b) => b.t - a.t);
+  return pngs.length ? pngs[0].f : null;
+}
+
+const wrapped =
+  "Use ONLY your built-in image_gen tool to generate this image. Do NOT search for or use any CLI. " +
+  "Do NOT copy or move files. Just generate it. PROMPT: " +
+  prompt;
+
+let started;
+try {
+  started = execFileSync("node", [CC, "task", "--background", "--write", wrapped], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+} catch (e) {
+  console.error("companion task の起動に失敗:", e.message);
+  process.exit(1);
+}
+const jobId = (started.match(/task-[a-z0-9-]+/i) || [])[0];
+if (!jobId) {
+  console.error("jobId を取得できませんでした:\n" + started);
+  process.exit(1);
+}
+
+const deadline = Date.now() + timeoutSec * 1000;
+let threadId = null;
+let log = null;
+while (Date.now() < deadline) {
+  if (!log) log = findLog(jobId);
+  if (log && fs.existsSync(log)) {
+    const txt = fs.readFileSync(log, "utf8");
+    if (!threadId) {
+      const m = txt.match(/Thread ready \(([0-9a-f-]{36})\)/i);
+      if (m) threadId = m[1];
+    }
+    const done = /Final output/.test(txt);
+    if (threadId) {
+      const img = newestPng(path.join(GEN_ROOT, threadId));
+      if (img && done) {
+        fs.mkdirSync(path.dirname(path.resolve(out)), { recursive: true });
+        fs.copyFileSync(img, path.resolve(out));
+        console.log(JSON.stringify({ ok: true, out: path.resolve(out), threadId, jobId, picked: img }, null, 2));
+        process.exit(0);
+      }
+    }
+  }
+  await sleep(6000);
+}
+
+// タイムアウト時、スレッドが分かっていれば最後の望みで回収
+if (threadId) {
+  const img = newestPng(path.join(GEN_ROOT, threadId));
+  if (img) {
+    fs.mkdirSync(path.dirname(path.resolve(out)), { recursive: true });
+    fs.copyFileSync(img, path.resolve(out));
+    console.log(JSON.stringify({ ok: true, out: path.resolve(out), threadId, jobId, picked: img, note: "timeout-but-recovered" }, null, 2));
+    process.exit(0);
+  }
+}
+console.error(JSON.stringify({ ok: false, jobId, threadId, error: "画像を回収できませんでした（タイムアウト/未ログインの可能性）" }, null, 2));
+process.exit(1);

--- a/packages/plugin-restaurant/tsconfig.json
+++ b/packages/plugin-restaurant/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*.ts", "mcp-server/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/plugin-restaurant/vitest.config.ts
+++ b/packages/plugin-restaurant/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+})

--- a/packages/plugin-restaurant/wrangler.toml
+++ b/packages/plugin-restaurant/wrangler.toml
@@ -1,0 +1,51 @@
+name = "line-harness-plugin-restaurant"
+main = "src/index.ts"
+compatibility_date = "2024-06-01"
+
+# Cron: every 10 minutes — reservation reminders + (once per day) birthday / winback jobs
+[triggers]
+crons = ["*/10 * * * *"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "restaurant-plugin"
+database_id = "REPLACE_WITH_YOUR_D1_ID"
+
+[vars]
+# LINE Harness API connection
+LINE_HARNESS_API_URL = "https://your-line-harness.example.com"
+# LIFF app ID (create one in LINE Developers console; endpoint = this worker's /liff/card)
+LIFF_ID = "0000000000-XXXXXXXX"
+# Store profile
+STORE_NAME = "サンプル食堂"
+# Stamp card: stamps needed for one reward
+STAMP_GOAL = "10"
+REWARD_NAME = "お食事10%OFFクーポン"
+# Winback: days since last visit before sending a come-back message
+WINBACK_DAYS = "30"
+# Googleマップの口コミ投稿URL（設定すると来店2時間後にレビュー依頼を自動送信）
+# 取得方法: Googleビジネスプロフィール > 「クチコミを増やす」の短縮URL
+# GOOGLE_REVIEW_URL = "https://g.page/r/XXXXXXXX/review"
+# 新規テイクアウト注文をスタッフ端末にプッシュする ntfy.sh トピック（任意）
+# NTFY_TOPIC = "your-store-takeout-xxxxxxxx"
+# 無料の自動音声通話: 店長のTelegramに着信して注文を読み上げ（CallMeBot・任意）
+# 事前にTelegramで @CallMeBot_txtbot に /start を送って認可しておく
+# CALLMEBOT_TELEGRAM_USER = "@tenchou"
+# CallMeBot有料プラン($1-3/月・月5〜30回上限)で実電話に架電する場合（低頻度店向け）
+# APIキーはsecret: wrangler secret put CALLMEBOT_PHONE_APIKEY
+# CALLMEBOT_PHONE_NUMBER = "+81521234567"
+# ClickSendで実電話に架電（審査なし・従量課金・回数無制限。CallMeBot上限超え店の移行先）
+# 宛先は下の STORE_PHONE_NUMBER を使う。APIキーはsecret: wrangler secret put CLICKSEND_API_KEY
+# CLICKSEND_USERNAME = "your-clicksend-username"
+# 新規テイクアウト注文で店舗に自動架電（任意・Twilioアカウント必要）
+# 4つすべて設定されたときのみ有効。AUTH_TOKENはsecret: wrangler secret put TWILIO_AUTH_TOKEN
+# TWILIO_ACCOUNT_SID = "ACxxxxxxxx"
+# TWILIO_FROM_NUMBER = "+815012345678"   # Twilioで購入した番号
+# STORE_PHONE_NUMBER = "+819012345678"   # お店の電話
+# Optional: LINE account ID for multi-account harness setups
+# LINE_ACCOUNT_ID = ""
+
+# Secrets — set via `wrangler secret put <NAME>`:
+#   LINE_HARNESS_API_KEY   LINE Harness API key
+#   STAFF_PIN              PIN for the staff page (/staff)
+#   PLUGIN_API_KEY         Bearer key for /api/admin/* (MCP server)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,37 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/plugin-restaurant:
+    dependencies:
+      '@line-harness/sdk':
+        specifier: workspace:*
+        version: link:../sdk
+      hono:
+        specifier: ^4.6.0
+        version: 4.12.8
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20240620.0
+        version: 4.20260317.1
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.1
+        version: 1.28.0(zod@3.25.76)
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@25.5.0)(lightningcss@1.32.0)
+      wrangler:
+        specifier: ^3.60.0
+        version: 3.114.17(@cloudflare/workers-types@4.20260317.1)
+      zod:
+        specifier: ^3.24.4
+        version: 3.25.76
+
   packages/plugin-template:
     dependencies:
       '@line-harness/sdk':


### PR DESCRIPTION
## 概要

飲食店向けの独立プラグイン Worker `@line-harness/plugin-restaurant` を追加します。`@line-harness/sdk` の上に構築し、メッセージ送信はすべて LINE Harness に委譲します（この Worker は LINE API を直接呼びません）。

### 機能

- **デジタルスタンプカード / 会員証**（LIFF）
- **予約**（リマインダー・誕生日・ウィンバック自動化、10分毎 cron）
- **テイクアウト注文** — 店側通知は5系統すべて任意・併用可:
  1. ntfy.sh プッシュ（無料）
  2. CallMeBot Telegram 音声通話（無料・日本語TTS）
  3. CallMeBot 実電話架電（導入時の標準・審査なし）
  4. ClickSend 実電話架電（回数無制限・繁盛店の移行先）
  5. Twilio 架電（最後の手段）

  通知はすべてベストエフォート（失敗しても注文は成立）で並列発火。
- **Google レビュー導線**（来店確定 → 2時間後にレビュー依頼）
- **スタッフページ**（PIN 認証）と admin API（MCP サーバー同梱）

### テスト・CI

- 単体テスト30件（JST 時刻処理・注文組み立て・受取時刻検証・電話系設定のゲーティング）
- 専用ワークフロー `plugin-restaurant-ci.yml` を追加（sdk build → typecheck → test → build）。ローカルで全手順グリーン確認済み。

## マージゲート評価（docs/OSS-SANDBOX-MERGE-GATE.md）

- **新規パッケージのみの追加**で、既存の worker / apps / packages には一切触れていません（`pnpm-lock.yaml` の追記のみ）。既存利用者の fork のデプロイには影響しません。
- プラグイン自体は cron・LIFF・webhook 副作用を含むため、**店舗導入時には sandbox 検証を推奨**します（D1 ID は placeholder のまま＝デフォルトでは deploy 対象になりません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)