### PR TITLE
sync: update バナー改善 (文言/リンク/dev非表示) + /o OGP 対応

### DIFF
--- a/apps/web/src/app/booking/menus/page.tsx
+++ b/apps/web/src/app/booking/menus/page.tsx
@@ -31,10 +31,11 @@ export default function MenusPage() {
   const [tags, setTags] = useState<Tag[]>([])
 
   const liffId = selectedAccount?.liffId ?? null
+  const workerBase = process.env.NEXT_PUBLIC_API_URL ?? ''
 
   async function copyMenuUrl(menuId: string) {
-    if (!liffId) return
-    const url = `https://liff.line.me/${liffId}/?page=salon-book&menu_id=${menuId}`
+    if (!workerBase || !liffId) return
+    const url = `${workerBase}/o?liffId=${encodeURIComponent(liffId)}&page=salon-book&menu_id=${encodeURIComponent(menuId)}`
     try {
       await navigator.clipboard.writeText(url)
       setCopiedMenuId(menuId)
@@ -196,7 +197,7 @@ export default function MenusPage() {
                             type="button"
                             onClick={() => copyMenuUrl(m.id)}
                             className="text-blue-600 hover:underline"
-                            title={`https://liff.line.me/${liffId}/?page=salon-book&menu_id=${m.id}`}
+                            title={`${workerBase}/o?liffId=${encodeURIComponent(liffId)}&page=salon-book&menu_id=${encodeURIComponent(m.id)}`}
                           >
                             {copiedMenuId === m.id ? '✓ コピー済' : '専用URL'}
                           </button>

--- a/apps/web/src/components/shared/image-uploader.tsx
+++ b/apps/web/src/components/shared/image-uploader.tsx
@@ -105,24 +105,36 @@ export default function ImageUploader({ mode, value, onChange, label }: ImageUpl
   return (
     <div className="space-y-2">
       {label && <div className="text-sm font-medium text-gray-700">{label}</div>}
-      {mode === 'url' && (
-        <div className="flex justify-end">
-          <button
-            type="button"
-            onClick={() => setManualUrlMode((v) => !v)}
-            className="text-xs text-emerald-700 underline"
-          >
-            {manualUrlMode ? '画像アップロードに戻す' : 'URL を直接入力'}
-          </button>
-        </div>
-      )}
-      {mode === 'url' && manualUrlMode ? (
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => setManualUrlMode((v) => !v)}
+          className="text-xs text-emerald-700 underline"
+        >
+          {manualUrlMode ? '画像アップロードに戻す' : 'URL を直接入力'}
+        </button>
+      </div>
+      {manualUrlMode ? (
         <input
           type="url"
-          value={value?.mode === 'url' ? value.url : ''}
+          value={
+            value === null
+              ? ''
+              : value.mode === 'url'
+                ? value.url
+                : value.originalContentUrl
+          }
           onChange={(e) => {
             const url = e.target.value
-            onChange(url ? { mode: 'url', url } : null)
+            if (!url) {
+              onChange(null)
+              return
+            }
+            if (mode === 'url') {
+              onChange({ mode: 'url', url })
+            } else {
+              onChange({ mode: 'line-image', originalContentUrl: url, previewImageUrl: url })
+            }
           }}
           placeholder="https://... (外部 CDN / R2 URL)"
           className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"

--- a/apps/web/src/components/update/update-banner.tsx
+++ b/apps/web/src/components/update/update-banner.tsx
@@ -18,6 +18,13 @@ type Status =
 
 const updateBannerEnabled = process.env.NEXT_PUBLIC_UPDATE_BANNER_ENABLED !== 'false'
 
+// inject-version を通さないビルド (自前 CI/CD やローカル dev) のバージョン placeholder。
+// この場合「manifest に無い」のは当たり前なので fork 警告バナーは出さない。
+const DEV_VERSION = '0.0.0-dev'
+
+export const MANUAL_UPDATE_GUIDE_URL =
+  'https://github.com/Shudesu/line-harness-oss/blob/main/docs/wiki/26-Manual-Update.md'
+
 export function UpdateBanner() {
   const [status, setStatus] = useState<Status>({ kind: 'loading' })
 
@@ -27,10 +34,12 @@ export function UpdateBanner() {
     let cancelled = false
     ;(async () => {
       try {
-        const [current, manifest] = await Promise.all([
-          getCurrentVersion(),
-          getManifest(),
-        ])
+        const current = await getCurrentVersion()
+        if (cancelled) return
+        // バージョン未埋め込みビルドでは manifest 照合自体が無意味なので
+        // バナーを出さない (自前デプロイ運用では正常な状態)。
+        if (current.version === DEV_VERSION) return
+        const manifest = await getManifest()
         if (cancelled) return
         const fork = detectFork(current, manifest)
         if (fork.kind === 'fork') {
@@ -74,17 +83,24 @@ export function UpdateBanner() {
   }
 
   if (status.kind === 'fork') {
+    // 「改造検知」のような警告調は使わない: カスタマイズ運用は正当な使い方で、
+    // ここで伝えるべきは「自動更新の対象外」という事実だけ (詳細 reason は title に)。
     return (
-      <div className="bg-amber-100 text-amber-900 px-4 py-2 border-b text-sm">
-        改造を検知しました (v{status.version}, {status.reason}).{' '}
+      <div
+        className="bg-amber-50 text-amber-900 px-4 py-2 border-b text-sm"
+        title={status.reason}
+      >
+        カスタマイズ版で動作中です（v{status.version}）。そのままお使いいただけます。
+        更新したい場合は{' '}
         <a
           className="underline"
-          href="https://theharness.com/wiki/updates/manual"
+          href={MANUAL_UPDATE_GUIDE_URL}
           target="_blank"
           rel="noreferrer"
         >
-          手動更新ガイド →
-        </a>
+          手動アップデートガイド
+        </a>{' '}
+        をご覧ください。
       </div>
     )
   }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -569,6 +569,10 @@ ${longPressBlock}
 // - page は `/r/:ref` と同じ allowlist (salon-book / event / event-me)
 // - mobile UA は「LINEで開く」ボタン、desktop は QR を返す (`/r/:ref` 同等)
 app.get('/o', async (c) => {
+  if (isLinkPreviewBot(c.req.header('user-agent') || '')) {
+    return c.html(await buildOgForLiffPath(c.env.DB, new URL(c.req.url)));
+  }
+
   const liffId = c.req.query('liffId') || '';
   if (!/^[0-9]+-[A-Za-z0-9]+$/.test(liffId)) {
     return c.text('Invalid liffId', 400);
@@ -718,10 +722,15 @@ async function buildOgForLiffPath(db: D1Database, url: URL): Promise<string> {
       }
     }
 
-    if (!event) {
-      // liffId 指定でアカウント特定したが strict query で event が引けなかった、
-      // または liffId 無しのフォールバック。account の branding を持ち越すと
-      // event とアカウントの組み合わせが不整合になるのでリセットする。
+    if (!event && !liffIdFromQuery) {
+      // liffId 指定が URL に無い場合（旧 /events/:id パス等）のみ、event 単独
+      // lookup と event 所属 account からの branding を許可する。
+      //
+      // liffId 指定があるのに strict query が空ということは「URL の liffId
+      // アカウントに属さない event」なので、ここで event 単独 lookup に落とすと
+      // 他アカの event 詳細・branding が bot プレビューに漏れる。event=null の
+      // まま外側のアカウントデフォルト OG（liffId 由来 account）にフォールバック
+      // させて漏洩を防ぐ。
       account = null;
       event = await db
         .prepare(

--- a/docs/wiki/26-Manual-Update.md
+++ b/docs/wiki/26-Manual-Update.md
@@ -1,0 +1,56 @@
+# 手動アップデートガイド
+
+LINE Harness を手動で最新版に更新する手順です。
+
+自動アップデート（管理画面のバナー / `create-line-harness update`）は、**公式リリースと構成が一致するインストール**（vanilla ビルド）でのみ利用できます。以下のような場合は自動更新の対象外になり、このガイドの手動手順で更新します:
+
+- コードをカスタマイズしている（フォーク運用）
+- 自前の CI/CD（GitHub Actions 等）でデプロイしている
+- ビルドにバージョン情報が埋め込まれていない（`v0.0.0-dev` 表示）
+
+> カスタマイズ版であること自体は問題ではありません。自動更新が「勝手にあなたの変更を上書きしない」ための安全装置として無効になるだけです。
+
+## 方法 1: create-line-harness でインストールした場合
+
+```bash
+npx create-line-harness@latest update
+```
+
+vanilla ビルドであれば、バックアップ（ロールバック用スナップショット）付きで自動更新されます。
+
+## 方法 2: git クローンして運用している場合
+
+```bash
+# 1. 最新を取得
+git pull origin main
+
+# 2. 依存を更新
+pnpm install
+
+# 3. DB マイグレーションを適用（未適用分のみ）
+cd apps/worker
+npx wrangler d1 migrations apply <your-database> --remote
+
+# 4. デプロイ
+npx wrangler deploy                      # Worker
+pnpm --filter web build                  # 管理画面（Pages にデプロイ）
+```
+
+自前の CI/CD がある場合は main を pull / merge して push すれば通常のデプロイフローで反映されます。
+
+## 方法 3: フォークして独自変更がある場合
+
+1. upstream を remote に追加して取り込みます:
+
+```bash
+git remote add upstream https://github.com/Shudesu/line-harness-oss.git
+git fetch upstream
+git merge upstream/main   # コンフリクトがあれば解消
+```
+
+2. その後は方法 2 の手順 2〜4 と同じです。
+
+## リリース情報
+
+- 最新リリースと変更内容: [GitHub Releases](https://github.com/Shudesu/line-harness-oss/releases)
+- リリースノート: [Release-Notes](Release-Notes.md)

--- a/packages/create-line-harness/src/commands/update.ts
+++ b/packages/create-line-harness/src/commands/update.ts
@@ -466,11 +466,11 @@ export async function runUpdate(repoDir: string): Promise<void> {
   // 3) Fork detection — block automatic update if hashes don't match
   const fork = detectFork(current, manifest);
   if (fork.kind === "fork") {
-    p.log.warn(pc.yellow(`改造を検知: ${fork.reason}`));
+    p.log.info(pc.yellow(`カスタマイズ版を検出しました (${fork.reason})`));
     p.log.info(
-      `自動アップデートは無効化されます。\n手動更新手順は wiki を参照してください:\n  https://theharness.com/wiki/updates/manual`,
+      `カスタマイズされたインストールを上書きしないよう、自動アップデートは適用しません。\nそのままご利用いただけます。更新したい場合は手動アップデートガイドをご覧ください:\n  https://github.com/Shudesu/line-harness-oss/blob/main/docs/wiki/26-Manual-Update.md`,
     );
-    p.outro(pc.yellow("自動アップデートをスキップしました"));
+    p.outro(pc.yellow("自動アップデートをスキップしました (インストールはそのまま動作します)"));
     process.exit(0);
   }
 


### PR DESCRIPTION
Private main 08cfa64 からの同期。

- **update バナー**: 「改造を検知しました」→ 案内調の文言に変更。version 未埋め込みビルド (0.0.0-dev) では非表示。リンク切れだった手動更新ガイドを新設の docs/wiki/26-Manual-Update.md に差し替え
- **create-line-harness update**: 同様の文言・リンク修正
- **/o 共有 URL の OGP 対応**: bot UA に OGP HTML を返しリンクプレビューが出るように