### PR TITLE
sync: ASP アフィリエイト計測機能

### DIFF
--- a/apps/liff/src/App.tsx
+++ b/apps/liff/src/App.tsx
@@ -5,6 +5,7 @@ import Event from './pages/Event.js';
 import EventConfirm from './pages/EventConfirm.js';
 import EventDone from './pages/EventDone.js';
 import EventBookings from './pages/EventBookings.js';
+import Affiliate from './pages/Affiliate.js';
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
       <Route path="/events/:id/confirm" element={<EventConfirm />} />
       <Route path="/events/:id/done" element={<EventDone />} />
       <Route path="/events/:id" element={<Event />} />
+      <Route path="/affiliate" element={<Affiliate />} />
       <Route path="/" element={<Navigate to="/booking" replace />} />
       <Route
         path="*"

--- a/apps/liff/src/pages/Affiliate.tsx
+++ b/apps/liff/src/pages/Affiliate.tsx
@@ -1,0 +1,335 @@
+import liff from '@line/liff';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const BASE = import.meta.env.VITE_API_BASE ?? '';
+
+interface AffiliateData {
+  id: string;
+  name: string;
+  code: string;
+  commissionRate: number;
+  isActive: boolean;
+  friendId: string;
+}
+
+interface AffiliateLinkData {
+  refCode: string;
+  label: string | null;
+  url: string;
+  clickCount: number;
+  friendAdds: number;
+  conversions: number;
+}
+
+type State =
+  | { phase: 'loading' }
+  | { phase: 'not_registered' }
+  | { phase: 'registered'; affiliate: AffiliateData; links: AffiliateLinkData[] }
+  | { phase: 'error'; message: string };
+
+async function getAccessToken(): Promise<string> {
+  const token = liff.getAccessToken();
+  if (!token) throw new Error('LINE アクセストークンを取得できませんでした');
+  return token;
+}
+
+async function fetchMe(): Promise<
+  | { registered: true; affiliate: AffiliateData; links: AffiliateLinkData[] }
+  | { registered: false }
+> {
+  const token = await getAccessToken();
+  const url = `${BASE}/api/liff/affiliate/me?lineAccessToken=${encodeURIComponent(token)}`;
+  const res = await fetch(url);
+  if (res.status === 404) return { registered: false };
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `API ${res.status}`);
+  }
+  const data = (await res.json()) as { affiliate: AffiliateData; links: AffiliateLinkData[] };
+  return { registered: true, affiliate: data.affiliate, links: data.links };
+}
+
+async function postRegister(): Promise<{ affiliate: AffiliateData; links: AffiliateLinkData[] }> {
+  const token = await getAccessToken();
+  const res = await fetch(`${BASE}/api/liff/affiliate/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ lineAccessToken: token }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `API ${res.status}`);
+  }
+  return (await res.json()) as { affiliate: AffiliateData; links: AffiliateLinkData[] };
+}
+
+async function postAddLink(label: string | null): Promise<AffiliateLinkData> {
+  const token = await getAccessToken();
+  const res = await fetch(`${BASE}/api/liff/affiliate/links`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ lineAccessToken: token, label: label || null }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `API ${res.status}`);
+  }
+  const data = (await res.json()) as { link: AffiliateLinkData };
+  return data.link;
+}
+
+/**
+ * Copy `text` with graceful degradation for LIFF WebViews:
+ *   1. navigator.clipboard.writeText  — modern, needs secure context + permission
+ *   2. document.execCommand('copy')   — legacy textarea-select fallback
+ *   3. neither worked → caller shows the URL selected for manual copy
+ * Returns true only when the browser confirms the copy succeeded.
+ */
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to execCommand
+  }
+
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.top = '-9999px';
+    ta.style.left = '-9999px';
+    ta.setAttribute('readonly', '');
+    document.body.appendChild(ta);
+    ta.select();
+    ta.setSelectionRange(0, ta.value.length);
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    if (ok) return true;
+  } catch {
+    // fall through to manual-copy fallback
+  }
+
+  return false;
+}
+
+function LinkRow({ link }: { link: AffiliateLinkData }) {
+  const [copied, setCopied] = useState(false);
+  // manualCopy: both programmatic paths failed → surface the URL selected so the
+  // user can long-press / Ctrl+C it themselves.
+  const [manualCopy, setManualCopy] = useState(false);
+  const urlRef = useRef<HTMLInputElement>(null);
+
+  async function handleCopy() {
+    const ok = await copyText(link.url);
+    if (ok) {
+      setManualCopy(false);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      return;
+    }
+    setManualCopy(true);
+    setTimeout(() => {
+      const el = urlRef.current;
+      if (el) {
+        el.focus();
+        el.select();
+        el.setSelectionRange(0, el.value.length);
+      }
+    }, 0);
+  }
+
+  return (
+    <div className="border rounded p-3 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          {link.label && (
+            <div className="text-xs font-medium text-gray-700 mb-1">{link.label}</div>
+          )}
+          <div className="text-xs text-gray-500 break-all">{link.url}</div>
+        </div>
+        <button
+          onClick={handleCopy}
+          className="shrink-0 text-xs bg-gray-100 hover:bg-gray-200 px-2 py-1 rounded transition-colors"
+        >
+          {copied ? 'コピーしました' : 'コピー'}
+        </button>
+      </div>
+      {manualCopy && (
+        <div className="space-y-1">
+          <p className="text-xs text-gray-500">
+            自動コピーできませんでした。下のURLを選択してコピーしてください。
+          </p>
+          <input
+            ref={urlRef}
+            type="text"
+            readOnly
+            value={link.url}
+            onFocus={(e) => e.currentTarget.select()}
+            className="w-full border rounded px-2 py-1 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          />
+        </div>
+      )}
+      <div className="flex gap-4 text-xs text-gray-600">
+        <span>クリック: <strong>{link.clickCount}</strong></span>
+        <span>友だち追加: <strong>{link.friendAdds}</strong></span>
+        <span>成約: <strong>{link.conversions}</strong></span>
+      </div>
+    </div>
+  );
+}
+
+export default function Affiliate() {
+  const [state, setState] = useState<State>({ phase: 'loading' });
+  const [registerBusy, setRegisterBusy] = useState(false);
+  const [addLabel, setAddLabel] = useState('');
+  const [addBusy, setAddBusy] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+  // registerCalledRef guards against a double-tap firing two POSTs while the
+  // first is in flight. It is released in `finally` so that a *failed* register
+  // can be retried — the button intentionally becomes clickable again on error.
+  const registerCalledRef = useRef(false);
+
+  const loadMe = useCallback(async () => {
+    setState({ phase: 'loading' });
+    try {
+      const result = await fetchMe();
+      if (result.registered) {
+        setState({ phase: 'registered', affiliate: result.affiliate, links: result.links });
+      } else {
+        setState({ phase: 'not_registered' });
+      }
+    } catch (e) {
+      setState({ phase: 'error', message: e instanceof Error ? e.message : String(e) });
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadMe();
+  }, [loadMe]);
+
+  async function handleRegister() {
+    if (registerBusy || registerCalledRef.current) return;
+    registerCalledRef.current = true;
+    setRegisterBusy(true);
+    try {
+      const data = await postRegister();
+      setState({ phase: 'registered', affiliate: data.affiliate, links: data.links });
+    } catch (e) {
+      setState({ phase: 'error', message: e instanceof Error ? e.message : String(e) });
+    } finally {
+      // Release on both success and failure: success repaints to the registered
+      // view (button gone), failure repaints to the error view whose retry path
+      // re-runs loadMe → not_registered, so allowing another attempt is correct.
+      setRegisterBusy(false);
+      registerCalledRef.current = false;
+    }
+  }
+
+  async function handleAddLink() {
+    if (addBusy) return;
+    setAddBusy(true);
+    setAddError(null);
+    try {
+      const link = await postAddLink(addLabel.trim() || null);
+      setState((prev) => {
+        if (prev.phase !== 'registered') return prev;
+        return { ...prev, links: [...prev.links, link] };
+      });
+      setAddLabel('');
+    } catch (e) {
+      setAddError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setAddBusy(false);
+    }
+  }
+
+  if (state.phase === 'loading') {
+    return (
+      <div className="text-center text-gray-500 py-16">読み込み中...</div>
+    );
+  }
+
+  if (state.phase === 'error') {
+    return (
+      <div className="max-w-md mx-auto p-4">
+        <div className="bg-red-50 text-red-700 p-3 rounded text-sm">{state.message}</div>
+        <button
+          onClick={loadMe}
+          className="mt-3 text-sm text-blue-600 underline"
+        >
+          再読み込み
+        </button>
+      </div>
+    );
+  }
+
+  if (state.phase === 'not_registered') {
+    return (
+      <div className="max-w-md mx-auto p-4 space-y-4">
+        <h1 className="text-lg font-bold">アフィリエイト</h1>
+        <p className="text-sm text-gray-600">
+          あなた専用の紹介リンクを発行して、友だち追加を紹介できます。
+        </p>
+        <button
+          onClick={handleRegister}
+          disabled={registerBusy}
+          className="w-full bg-green-600 text-white py-3 rounded font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+        >
+          {registerBusy ? '登録中...' : 'アフィリエイターに登録する'}
+        </button>
+      </div>
+    );
+  }
+
+  // registered
+  const { links } = state;
+  const atLimit = links.length >= 20;
+
+  return (
+    <div className="max-w-md mx-auto p-4 pb-12 space-y-4">
+      <h1 className="text-lg font-bold">アフィリエイト</h1>
+
+      {/* Link list */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-gray-700">紹介リンク一覧</h2>
+        {links.length === 0 ? (
+          <div className="text-sm text-gray-500 py-4 text-center">リンクがまだありません</div>
+        ) : (
+          links.map((link) => <LinkRow key={link.refCode} link={link} />)
+        )}
+      </section>
+
+      {/* Add link form */}
+      <section className="border rounded p-3 space-y-2">
+        <h2 className="text-sm font-semibold text-gray-700">リンクを追加</h2>
+        {atLimit ? (
+          <div className="text-sm text-red-600">リンクの上限（20本）に達しています</div>
+        ) : (
+          <>
+            <input
+              type="text"
+              value={addLabel}
+              onChange={(e) => setAddLabel(e.target.value)}
+              placeholder="ラベル（任意）"
+              className="w-full border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+              disabled={addBusy}
+            />
+            {addError && (
+              <div className="text-xs text-red-600">{addError}</div>
+            )}
+            <button
+              onClick={handleAddLink}
+              disabled={addBusy}
+              className="w-full bg-blue-600 text-white py-2 rounded text-sm font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+            >
+              {addBusy ? '追加中...' : 'リンクを追加する'}
+            </button>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/accounts/page.tsx
+++ b/apps/web/src/app/accounts/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/accounts/account-form-fields'
 import AccountSetupUrls from '@/components/accounts/account-setup-urls'
 import AccountEditModal from '@/components/accounts/account-edit-modal'
+import LinkBaseUrlSetting from '@/components/accounts/link-base-url-setting'
 
 interface LineAccountListItem {
   id: string
@@ -342,6 +343,10 @@ export default function AccountsPage() {
           ))}
         </div>
       )}
+      <div className="mt-8">
+        <h2 className="text-sm font-semibold text-gray-700 mb-3">グローバル設定</h2>
+        <LinkBaseUrlSetting />
+      </div>
       <CcPromptButton prompts={ccPrompts} />
       {showReorder && (
         <ReorderMode

--- a/apps/web/src/app/affiliates/page.tsx
+++ b/apps/web/src/app/affiliates/page.tsx
@@ -1,202 +1,481 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import Header from '@/components/layout/header'
-
-import { fetchApi } from '@/lib/api'
-import { useAccount } from '@/contexts/account-context'
+import { api } from '@/lib/api'
 
 const WORKER_BASE = process.env.NEXT_PUBLIC_API_URL
 if (!WORKER_BASE) {
   throw new Error('NEXT_PUBLIC_API_URL is not set. Build cannot proceed.')
 }
 
-interface RefRoute {
-  refCode: string
-  name: string
-  friendCount: number
-  clickCount: number
-  latestAt: string | null
-}
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
 
-interface RefSummaryData {
-  routes: RefRoute[]
-  totalFriends: number
-  friendsWithRef: number
-  friendsWithoutRef: number
-}
-
-interface RefFriend {
+interface AffiliateItem {
   id: string
-  displayName: string
-  trackedAt: string | null
-}
-
-interface RefDetailData {
-  refCode: string
   name: string
-  friends: RefFriend[]
+  code: string
+  commissionRate: number
+  isActive: boolean
+  createdAt: string
+  friendId: string | null
 }
 
-export default function AttributionPage() {
-  const { selectedAccountId } = useAccount()
-  const [summary, setSummary] = useState<RefSummaryData | null>(null)
+interface AffiliateReportRow {
+  affiliateId: string
+  affiliateName: string
+  code: string
+  commissionRate: number
+  totalClicks: number
+  totalConversions: number
+  totalRevenue: number
+  linkCount: number
+  friendAdds: number
+}
+
+/** Merged for the list view */
+interface AffiliateListRow extends AffiliateItem {
+  totalClicks: number
+  totalConversions: number
+  totalRevenue: number
+  estimatedCommission: number
+  linkCount: number
+  friendAdds: number
+}
+
+interface AffiliateLink {
+  id: string
+  affiliate_id: string
+  ref_code: string
+  label: string | null
+  line_account_id: string | null
+  is_active: number
+  created_at: string
+  click_count: number
+}
+
+interface ReportV2 {
+  affiliateId: string
+  affiliateName: string
+  code: string
+  commissionRate: number
+  clicks: number
+  linkClicks: number
+  friendAdds: number
+  conversions: number
+  conversionsByPoint: Array<{ conversionPointId: string; name: string; count: number; value: number }>
+  revenue: number
+  estimatedCommission: number
+  duplicateFlags: Array<{ friendId: string; identityKey: string }>
+}
+
+interface JourneySummary {
+  friendId: string
+  displayName: string | null
+  addedAt: string
+  refCode: string | null
+  touchCount: number
+  formCount: number
+  conversionCount: number
+  lastEventAt: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' })
+}
+
+function formatYen(n: number): string {
+  return `¥${Math.round(n).toLocaleString('ja-JP')}`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+const JOURNEY_PAGE_SIZE = 30
+
+export default function AffiliatesPage() {
+  // ── list ───────────────────────────────────────────────────────────────────
+  const [rows, setRows] = useState<AffiliateListRow[]>([])
   const [loading, setLoading] = useState(true)
-  const [selectedRef, setSelectedRef] = useState<string | null>(null)
-  const [detail, setDetail] = useState<RefDetailData | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // ── selected affiliate (detail panel) ─────────────────────────────────────
+  const [selectedId, setSelectedId] = useState<string | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
-  const [copiedCode, setCopiedCode] = useState<string | null>(null)
+  const [report, setReport] = useState<ReportV2 | null>(null)
+  const [links, setLinks] = useState<AffiliateLink[]>([])
 
-  const loadSummary = useCallback(async () => {
+  // ── journeys (cursor-paginated) ────────────────────────────────────────────
+  const [journeys, setJourneys] = useState<JourneySummary[]>([])
+  const [journeyLoading, setJourneyLoading] = useState(false)
+  const [journeyMore, setJourneyMore] = useState(false)
+  const [journeyLoadingMore, setJourneyLoadingMore] = useState(false)
+  const journeyCursorRef = useRef<{ beforeAt: string; beforeId: string } | null>(null)
+
+  // ── load list ──────────────────────────────────────────────────────────────
+  const loadList = useCallback(async () => {
     setLoading(true)
+    setError(null)
     try {
-      const query = selectedAccountId ? `?lineAccountId=${selectedAccountId}` : ''
-      const res = await fetchApi<{ success: boolean; data: RefSummaryData }>(`/api/analytics/ref-summary${query}`)
-      setSummary(res.data)
-    } catch {
-      // silent
+      const [affiliatesRes, reportRes] = await Promise.all([
+        api.affiliates.list(),
+        api.affiliates.allReport(),
+      ])
+      if (!affiliatesRes.success) throw new Error('affiliates fetch failed')
+      if (!reportRes.success) throw new Error('report fetch failed')
+
+      const affiliates = affiliatesRes.data as unknown as AffiliateItem[]
+      const reportMap = new Map<string, AffiliateReportRow>()
+      for (const r of (reportRes.data as unknown as AffiliateReportRow[])) {
+        reportMap.set(r.affiliateId, r)
+      }
+
+      const merged: AffiliateListRow[] = affiliates.map((a) => {
+        const rep = reportMap.get(a.id)
+        return {
+          ...a,
+          totalClicks: rep?.totalClicks ?? 0,
+          totalConversions: rep?.totalConversions ?? 0,
+          totalRevenue: rep?.totalRevenue ?? 0,
+          estimatedCommission: ((rep?.totalRevenue ?? 0) * a.commissionRate) / 100,
+          linkCount: rep?.linkCount ?? 0,
+          friendAdds: rep?.friendAdds ?? 0,
+        }
+      })
+      setRows(merged)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '読み込みエラー')
+    } finally {
+      setLoading(false)
     }
-    setLoading(false)
-  }, [selectedAccountId])
+  }, [])
 
-  useEffect(() => {
-    loadSummary()
-    // Refresh when tab becomes visible
-    const handleVisibility = () => { if (document.visibilityState === 'visible') loadSummary() }
-    document.addEventListener('visibilitychange', handleVisibility)
-    return () => document.removeEventListener('visibilitychange', handleVisibility)
-  }, [loadSummary])
+  useEffect(() => { void loadList() }, [loadList])
 
-  const handleRowClick = async (refCode: string) => {
-    if (selectedRef === refCode) {
-      setSelectedRef(null)
-      setDetail(null)
+  // ── load detail (report v2 + links) ────────────────────────────────────────
+  const loadDetail = useCallback(async (id: string) => {
+    setDetailLoading(true)
+    setReport(null)
+    setLinks([])
+    setJourneys([])
+    setJourneyMore(false)
+    journeyCursorRef.current = null
+    try {
+      const [reportRes, linksRes] = await Promise.all([
+        api.affiliates.reportV2(id),
+        api.affiliates.links(id),
+      ])
+      if (reportRes.success) setReport(reportRes.data as unknown as ReportV2)
+      if (linksRes.success) setLinks(linksRes.data as unknown as AffiliateLink[])
+    } catch { /* silent — detail is optional */ }
+    setDetailLoading(false)
+  }, [])
+
+  // ── load first page of journeys ────────────────────────────────────────────
+  const loadJourneys = useCallback(async (id: string) => {
+    setJourneyLoading(true)
+    try {
+      const res = await api.affiliates.journeys(id, { limit: JOURNEY_PAGE_SIZE })
+      if (res.success) {
+        setJourneys(res.data)
+        journeyCursorRef.current = res.nextCursor ?? null
+        setJourneyMore(Boolean(res.nextCursor))
+      }
+    } catch { /* silent */ }
+    setJourneyLoading(false)
+  }, [])
+
+  // ── load more journeys ─────────────────────────────────────────────────────
+  const loadMoreJourneys = useCallback(async (id: string) => {
+    if (journeyLoadingMore) return
+    const cursor = journeyCursorRef.current
+    if (!cursor) { setJourneyMore(false); return }
+    setJourneyLoadingMore(true)
+    try {
+      const res = await api.affiliates.journeys(id, {
+        limit: JOURNEY_PAGE_SIZE,
+        beforeAt: cursor.beforeAt,
+        beforeId: cursor.beforeId,
+      })
+      if (res.success) {
+        setJourneys((prev) => {
+          const seen = new Set(prev.map((j) => j.friendId))
+          return [...prev, ...res.data.filter((j) => !seen.has(j.friendId))]
+        })
+        journeyCursorRef.current = res.nextCursor ?? null
+        setJourneyMore(Boolean(res.nextCursor))
+      }
+    } catch { /* silent */ }
+    setJourneyLoadingMore(false)
+  }, [journeyLoadingMore])
+
+  // ── row click ──────────────────────────────────────────────────────────────
+  const handleRowClick = useCallback((id: string) => {
+    if (selectedId === id) {
+      setSelectedId(null)
       return
     }
-    setSelectedRef(refCode)
-    setDetailLoading(true)
-    try {
-      const query = selectedAccountId ? `?lineAccountId=${selectedAccountId}` : ''
-      const res = await fetchApi<{ success: boolean; data: RefDetailData }>(`/api/analytics/ref/${encodeURIComponent(refCode)}${query}`)
-      setDetail(res.data)
-    } catch {
-      setDetail(null)
-    }
-    setDetailLoading(false)
-  }
+    setSelectedId(id)
+    void loadDetail(id)
+    void loadJourneys(id)
+  }, [selectedId, loadDetail, loadJourneys])
 
-  const handleCopy = async (refCode: string) => {
-    const url = `${WORKER_BASE}/auth/line?ref=${encodeURIComponent(refCode)}`
-    await navigator.clipboard.writeText(url)
-    setCopiedCode(refCode)
-    setTimeout(() => setCopiedCode(null), 2000)
-  }
-
-  const formatDate = (iso: string | null) => {
-    if (!iso) return '—'
-    return new Date(iso).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' })
-  }
+  // ─────────────────────────────────────────────────────────────────────────
+  // Render
+  // ─────────────────────────────────────────────────────────────────────────
 
   return (
     <div>
       <Header
-        title="流入経路分析"
-        description="ref コード別の友だち獲得・クリック実績"
+        title="ASP アフィリエイト"
+        description="アフィリエイター別の成果・コミッション・帰属ジャーニー管理"
       />
 
-      {/* Summary cards */}
-      {summary && (
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-          <div className="bg-white rounded-xl p-5 border border-gray-100">
-            <p className="text-sm text-gray-500">総友だち数</p>
-            <p className="text-3xl font-bold text-gray-900 mt-1">{summary.totalFriends}</p>
-          </div>
-          <div className="bg-white rounded-xl p-5 border border-gray-100">
-            <p className="text-sm text-gray-500">ref 経由</p>
-            <p className="text-3xl font-bold text-green-600 mt-1">{summary.friendsWithRef}</p>
-          </div>
-          <div className="bg-white rounded-xl p-5 border border-gray-100">
-            <p className="text-sm text-gray-500">ref 不明</p>
-            <p className="text-3xl font-bold text-gray-400 mt-1">{summary.friendsWithoutRef}</p>
-          </div>
-          <div className="bg-white rounded-xl p-5 border border-gray-100">
-            <p className="text-sm text-gray-500">経路数</p>
-            <p className="text-3xl font-bold text-blue-600 mt-1">{summary.routes.length}</p>
-          </div>
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+          {error}
         </div>
       )}
 
-      {/* Table */}
       {loading ? (
         <div className="bg-white rounded-lg border border-gray-200 p-8 text-center text-gray-400">
           読み込み中...
         </div>
-      ) : !summary || summary.routes.length === 0 ? (
+      ) : rows.length === 0 ? (
         <div className="bg-white rounded-lg border border-gray-200 p-8 text-center text-gray-400">
-          流入経路がまだ登録されていません
+          アフィリエイターがまだ登録されていません
         </div>
       ) : (
         <div className="bg-white rounded-lg border border-gray-200 overflow-x-auto">
-          <table className="w-full min-w-[720px]">
+          <table className="w-full min-w-[900px]">
             <thead className="bg-gray-50 border-b border-gray-200">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">ref コード</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">経路名</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">友だち数</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">クリック数</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">最新追加日</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">URL</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">名前</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">コード</th>
+                <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase">友だち紐付</th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">リンク数</th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">クリック</th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">友だち追加</th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">CV</th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">売上</th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">参考報酬</th>
+                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">率</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">状態</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
-              {summary.routes.map((route) => {
-                const authUrl = `${WORKER_BASE}/auth/line?ref=${encodeURIComponent(route.refCode)}`
-                const isExpanded = selectedRef === route.refCode
+              {rows.map((row) => {
+                const isExpanded = selectedId === row.id
                 return (
                   <>
                     <tr
-                      key={route.refCode}
-                      className="hover:bg-gray-50 cursor-pointer"
-                      onClick={() => handleRowClick(route.refCode)}
+                      key={row.id}
+                      className={`cursor-pointer transition-colors ${isExpanded ? 'bg-blue-50' : 'hover:bg-gray-50'}`}
+                      onClick={() => handleRowClick(row.id)}
                     >
-                      <td className="px-4 py-3 text-sm font-mono text-blue-600">{route.refCode}</td>
-                      <td className="px-4 py-3 text-sm font-medium text-gray-900">{route.name}</td>
-                      <td className="px-4 py-3 text-sm text-right font-semibold text-gray-900">{route.friendCount}</td>
-                      <td className="px-4 py-3 text-sm text-right text-gray-600">{route.clickCount}</td>
-                      <td className="px-4 py-3 text-sm text-gray-500">{formatDate(route.latestAt)}</td>
-                      <td className="px-4 py-3 text-sm" onClick={(e) => e.stopPropagation()}>
-                        <div className="flex items-center gap-2">
-                          <span className="text-xs text-gray-400 truncate max-w-[180px]">{authUrl}</span>
-                          <button
-                            onClick={() => handleCopy(route.refCode)}
-                            className="text-xs text-blue-500 hover:text-blue-700 shrink-0"
-                          >
-                            {copiedCode === route.refCode ? 'コピー済' : 'コピー'}
-                          </button>
-                        </div>
+                      <td className="px-4 py-3 text-sm font-medium text-gray-900">{row.name}</td>
+                      <td className="px-4 py-3 text-sm font-mono text-blue-600">{row.code}</td>
+                      <td className="px-4 py-3 text-sm text-center">
+                        {row.friendId
+                          ? <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">あり</span>
+                          : <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500">なし</span>
+                        }
+                      </td>
+                      <td className="px-4 py-3 text-sm text-right text-gray-700">{row.linkCount.toLocaleString()}</td>
+                      <td className="px-4 py-3 text-sm text-right text-gray-700">{row.totalClicks.toLocaleString()}</td>
+                      <td className="px-4 py-3 text-sm text-right font-semibold text-blue-600">{row.friendAdds.toLocaleString()}</td>
+                      <td className="px-4 py-3 text-sm text-right font-semibold text-gray-900">{row.totalConversions.toLocaleString()}</td>
+                      <td className="px-4 py-3 text-sm text-right text-gray-700">{formatYen(row.totalRevenue)}</td>
+                      <td className="px-4 py-3 text-sm text-right font-semibold text-emerald-600">{formatYen(row.estimatedCommission)}</td>
+                      <td className="px-4 py-3 text-sm text-right text-gray-500">{row.commissionRate}%</td>
+                      <td className="px-4 py-3 text-sm">
+                        {row.isActive
+                          ? <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">有効</span>
+                          : <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500">無効</span>
+                        }
                       </td>
                     </tr>
+
+                    {/* Detail expansion row */}
                     {isExpanded && (
-                      <tr key={`${route.refCode}-detail`}>
-                        <td colSpan={6} className="px-6 py-4 bg-gray-50">
+                      <tr key={`${row.id}-detail`}>
+                        <td colSpan={11} className="px-6 py-5 bg-blue-50 border-t border-blue-100">
                           {detailLoading ? (
                             <p className="text-sm text-gray-400">読み込み中...</p>
-                          ) : detail && detail.friends.length > 0 ? (
-                            <div>
-                              <p className="text-xs font-semibold text-gray-500 uppercase mb-3">
-                                このルートから追加した友だち ({detail.friends.length}人)
-                              </p>
-                              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
-                                {detail.friends.map((f) => (
-                                  <div key={f.id} className="flex items-center justify-between bg-white rounded-lg px-3 py-2 border border-gray-100">
-                                    <span className="text-sm text-gray-800 font-medium truncate">{f.displayName}</span>
-                                    <span className="text-xs text-gray-400 ml-2 shrink-0">{formatDate(f.trackedAt)}</span>
-                                  </div>
-                                ))}
-                              </div>
-                            </div>
                           ) : (
-                            <p className="text-sm text-gray-400">このルートから追加した友だちはまだいません</p>
+                            <div className="space-y-6">
+
+                              {/* v2 summary cards */}
+                              {report && (
+                                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                                  <div className="bg-white rounded-lg p-4 border border-gray-100">
+                                    <p className="text-xs text-gray-500">クリック (ref_tracking)</p>
+                                    <p className="text-2xl font-bold text-gray-900 mt-1">{report.clicks.toLocaleString()}</p>
+                                  </div>
+                                  <div className="bg-white rounded-lg p-4 border border-gray-100">
+                                    <p className="text-xs text-gray-500">友だち追加</p>
+                                    <p className="text-2xl font-bold text-blue-600 mt-1">{report.friendAdds.toLocaleString()}</p>
+                                  </div>
+                                  <div className="bg-white rounded-lg p-4 border border-gray-100">
+                                    <p className="text-xs text-gray-500">CV 件数</p>
+                                    <p className="text-2xl font-bold text-gray-900 mt-1">{report.conversions.toLocaleString()}</p>
+                                  </div>
+                                  <div className="bg-white rounded-lg p-4 border border-gray-100">
+                                    <p className="text-xs text-gray-500">参考報酬</p>
+                                    <p className="text-2xl font-bold text-emerald-600 mt-1">{formatYen(report.estimatedCommission)}</p>
+                                  </div>
+                                </div>
+                              )}
+
+                              {/* Duplicate flags */}
+                              {report && report.duplicateFlags.length > 0 && (
+                                <div>
+                                  <p className="text-xs font-semibold text-amber-700 uppercase mb-2">
+                                    重複 identity_key 検出 ({report.duplicateFlags.length} 件)
+                                  </p>
+                                  <div className="flex flex-wrap gap-2">
+                                    {report.duplicateFlags.map((f) => (
+                                      <span
+                                        key={f.friendId}
+                                        className="inline-flex items-center gap-1 px-2 py-1 bg-amber-50 border border-amber-200 rounded text-xs text-amber-800"
+                                      >
+                                        ⚠ {f.friendId.slice(0, 8)}…
+                                      </span>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+
+                              {/* CV by point */}
+                              {report && report.conversionsByPoint.length > 0 && (
+                                <div>
+                                  <p className="text-xs font-semibold text-gray-500 uppercase mb-2">CV ポイント別内訳</p>
+                                  <div className="overflow-x-auto">
+                                    <table className="min-w-[400px] text-sm">
+                                      <thead>
+                                        <tr className="text-left text-xs text-gray-400">
+                                          <th className="pb-1 pr-4">ポイント名</th>
+                                          <th className="pb-1 pr-4 text-right">件数</th>
+                                          <th className="pb-1 text-right">売上合計</th>
+                                        </tr>
+                                      </thead>
+                                      <tbody className="divide-y divide-gray-100">
+                                        {report.conversionsByPoint.map((p) => (
+                                          <tr key={p.conversionPointId}>
+                                            <td className="py-1 pr-4 text-gray-700">{p.name}</td>
+                                            <td className="py-1 pr-4 text-right font-semibold text-gray-900">{p.count}</td>
+                                            <td className="py-1 text-right text-gray-700">{formatYen(p.value)}</td>
+                                          </tr>
+                                        ))}
+                                      </tbody>
+                                    </table>
+                                  </div>
+                                </div>
+                              )}
+
+                              {/* Links table */}
+                              {links.length > 0 && (
+                                <div>
+                                  <p className="text-xs font-semibold text-gray-500 uppercase mb-2">
+                                    リンク別クリック ({links.length} 本)
+                                  </p>
+                                  <div className="overflow-x-auto">
+                                    <table className="min-w-[560px] text-sm">
+                                      <thead>
+                                        <tr className="text-left text-xs text-gray-400">
+                                          <th className="pb-1 pr-4">ref_code</th>
+                                          <th className="pb-1 pr-4">ラベル</th>
+                                          <th className="pb-1 pr-4 text-right">クリック</th>
+                                          <th className="pb-1">状態</th>
+                                        </tr>
+                                      </thead>
+                                      <tbody className="divide-y divide-gray-100">
+                                        {links.map((link) => (
+                                          <tr key={link.id}>
+                                            <td className="py-1 pr-4 font-mono text-blue-600">{link.ref_code}</td>
+                                            <td className="py-1 pr-4 text-gray-600">{link.label ?? '—'}</td>
+                                            <td className="py-1 pr-4 text-right font-semibold text-gray-900">{link.click_count.toLocaleString()}</td>
+                                            <td className="py-1">
+                                              {link.is_active
+                                                ? <span className="text-xs text-green-600">有効</span>
+                                                : <span className="text-xs text-gray-400">無効</span>
+                                              }
+                                            </td>
+                                          </tr>
+                                        ))}
+                                      </tbody>
+                                    </table>
+                                  </div>
+                                </div>
+                              )}
+
+                              {/* Journeys */}
+                              <div>
+                                <p className="text-xs font-semibold text-gray-500 uppercase mb-2">
+                                  帰属ジャーニー ({journeys.length} 件{journeyMore ? '+' : ''})
+                                </p>
+                                {journeyLoading ? (
+                                  <p className="text-sm text-gray-400">読み込み中...</p>
+                                ) : journeys.length === 0 ? (
+                                  <p className="text-sm text-gray-400">帰属された友だちがまだいません</p>
+                                ) : (
+                                  <>
+                                    <div className="overflow-x-auto">
+                                      <table className="min-w-[640px] text-sm">
+                                        <thead>
+                                          <tr className="text-left text-xs text-gray-400">
+                                            <th className="pb-1 pr-4">友だち</th>
+                                            <th className="pb-1 pr-4">追加日</th>
+                                            <th className="pb-1 pr-4">ref_code</th>
+                                            <th className="pb-1 pr-4 text-right">タッチ</th>
+                                            <th className="pb-1 pr-4 text-right">フォーム</th>
+                                            <th className="pb-1 pr-4 text-right">CV</th>
+                                            <th className="pb-1">最終行動</th>
+                                          </tr>
+                                        </thead>
+                                        <tbody className="divide-y divide-gray-100">
+                                          {journeys.map((j) => {
+                                            const isDup = report?.duplicateFlags.some((f) => f.friendId === j.friendId)
+                                            return (
+                                              <tr key={j.friendId} className={isDup ? 'bg-amber-50' : ''}>
+                                                <td className="py-1 pr-4 text-gray-800">
+                                                  {isDup && <span className="mr-1">⚠</span>}
+                                                  {j.displayName ?? <span className="text-gray-400 italic">不明</span>}
+                                                </td>
+                                                <td className="py-1 pr-4 text-gray-500">{formatDate(j.addedAt)}</td>
+                                                <td className="py-1 pr-4 font-mono text-xs text-blue-500">{j.refCode ?? '—'}</td>
+                                                <td className="py-1 pr-4 text-right text-gray-700">{j.touchCount}</td>
+                                                <td className="py-1 pr-4 text-right text-gray-700">{j.formCount}</td>
+                                                <td className="py-1 pr-4 text-right font-semibold text-gray-900">{j.conversionCount}</td>
+                                                <td className="py-1 text-gray-400 text-xs">{formatDate(j.lastEventAt)}</td>
+                                              </tr>
+                                            )
+                                          })}
+                                        </tbody>
+                                      </table>
+                                    </div>
+                                    {journeyMore && (
+                                      <button
+                                        onClick={() => { void loadMoreJourneys(row.id) }}
+                                        disabled={journeyLoadingMore}
+                                        className="mt-3 px-4 py-2 text-sm text-blue-700 hover:bg-blue-100 disabled:opacity-50 rounded-md border border-blue-200"
+                                      >
+                                        {journeyLoadingMore ? '読み込み中...' : 'さらに読み込む'}
+                                      </button>
+                                    )}
+                                  </>
+                                )}
+                              </div>
+
+                            </div>
                           )}
                         </td>
                       </tr>

--- a/apps/web/src/components/accounts/link-base-url-setting.tsx
+++ b/apps/web/src/components/accounts/link-base-url-setting.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { api } from '@/lib/api'
+
+/**
+ * Global short-link base URL setting.
+ *
+ * When set, affiliate click-through links use this domain instead of the
+ * built-in Worker redirect route.  The operator must configure a Redirect
+ * Rule on that domain to forward requests to the Worker's /r/ path.
+ *
+ * This is a deployment-wide setting — not per-account.
+ */
+export default function LinkBaseUrlSetting() {
+  const [value, setValue] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const [saved, setSaved] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await api.accountSettings.getLinkBaseUrl()
+        if (!cancelled && res.success) {
+          setValue(res.data ?? '')
+        }
+      } catch { /* ignore */ }
+      finally { if (!cancelled) setLoading(false) }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError('')
+    setSaved(false)
+    try {
+      const res = await api.accountSettings.updateLinkBaseUrl(value.trim())
+      if (res.success) {
+        // Normalise stored value: strip trailing slash to match server behaviour.
+        setValue(value.trim().replace(/\/$/, ''))
+        setSaved(true)
+        setTimeout(() => setSaved(false), 3000)
+      } else {
+        setError(res.error ?? '保存に失敗しました')
+      }
+    } catch {
+      setError('保存に失敗しました')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return <p className="text-xs text-gray-400">読み込み中...</p>
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
+      <h3 className="text-sm font-semibold text-gray-800 mb-1">短縮リンクドメイン（全アカウント共通）</h3>
+      <p className="text-xs text-gray-500 mb-3">
+        短縮ドメインを使う場合に設定。例: <code className="bg-gray-100 px-1 rounded">https://go.example.com</code>
+        （そのドメインから Worker の /r/ へ転送する Redirect Rule が必要）
+      </p>
+      <div className="flex gap-2 items-start">
+        <div className="flex-1">
+          <input
+            type="url"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="https://go.example.com（空欄でデフォルト /r/ を使用）"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400"
+          />
+          {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
+          {saved && <p className="text-xs text-green-600 mt-1">保存しました</p>}
+        </div>
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="px-3 py-2 rounded-lg bg-gray-100 hover:bg-gray-200 text-xs font-medium disabled:opacity-50 whitespace-nowrap"
+        >
+          {saving ? '保存中...' : '保存'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -388,6 +388,13 @@ export const api = {
         method: 'PUT',
         body: JSON.stringify({ accountId, friendIds }),
       }),
+    getLinkBaseUrl: () =>
+      fetchApi<{ success: boolean; data: string | null }>('/api/account-settings/link-base-url'),
+    updateLinkBaseUrl: (value: string) =>
+      fetchApi<{ success: boolean; error?: string }>('/api/account-settings/link-base-url', {
+        method: 'PUT',
+        body: JSON.stringify({ value }),
+      }),
   },
 
   // ── Round 2 APIs ─────────────────────────────────────────────────────────
@@ -524,6 +531,69 @@ export const api = {
       fetchApi<ApiResponse<{ affiliateId: string; affiliateName: string; code: string; commissionRate: number; totalClicks: number; totalConversions: number; totalRevenue: number }>>(
         `/api/affiliates/${id}/report?` + new URLSearchParams(params as Record<string, string>),
       ),
+    /** v2 report: clicks, friendAdds, conversionsByPoint, estimatedCommission, duplicateFlags */
+    reportV2: (id: string, params?: { startDate?: string; endDate?: string }) =>
+      fetchApi<ApiResponse<{
+        affiliateId: string;
+        affiliateName: string;
+        code: string;
+        commissionRate: number;
+        clicks: number;
+        linkClicks: number;
+        friendAdds: number;
+        conversions: number;
+        conversionsByPoint: Array<{ conversionPointId: string; name: string; count: number; value: number }>;
+        revenue: number;
+        estimatedCommission: number;
+        duplicateFlags: Array<{ friendId: string; identityKey: string }>;
+      }>>(`/api/affiliates/${id}/report?` + new URLSearchParams(params as Record<string, string>)),
+    /** Cursor-paginated attributed-friend journey summaries */
+    journeys: (id: string, params?: { limit?: number; beforeAt?: string; beforeId?: string }) => {
+      const query = new URLSearchParams();
+      if (params?.limit !== undefined) query.set('limit', String(params.limit));
+      if (params?.beforeAt) query.set('beforeAt', params.beforeAt);
+      if (params?.beforeId) query.set('beforeId', params.beforeId);
+      const qs = query.toString();
+      return fetchApi<{
+        success: boolean;
+        data: Array<{
+          friendId: string;
+          displayName: string | null;
+          addedAt: string;
+          refCode: string | null;
+          touchCount: number;
+          formCount: number;
+          conversionCount: number;
+          lastEventAt: string;
+        }>;
+        nextCursor: { beforeAt: string; beforeId: string } | null;
+      }>(`/api/affiliates/${id}/journeys${qs ? `?${qs}` : ''}`);
+    },
+    /** List ref_code links for an affiliate (loaded on detail expand) */
+    links: (id: string) =>
+      fetchApi<ApiResponse<Array<{
+        id: string;
+        affiliate_id: string;
+        ref_code: string;
+        label: string | null;
+        line_account_id: string | null;
+        is_active: number;
+        created_at: string;
+        click_count: number;
+      }>>>(`/api/affiliates/${id}/links`),
+    /** All-affiliates aggregate report (single-pass, no N+1) */
+    allReport: (params?: { startDate?: string; endDate?: string }) =>
+      fetchApi<ApiResponse<Array<{
+        affiliateId: string;
+        affiliateName: string;
+        code: string;
+        commissionRate: number;
+        totalClicks: number;
+        totalConversions: number;
+        totalRevenue: number;
+        linkCount: number;
+        friendAdds: number;
+      }>>>('/api/affiliates-report?' + new URLSearchParams(params as Record<string, string>)),
   },
   templates: {
     list: (category?: string) =>

--- a/apps/worker/src/client/affiliate/main.tsx
+++ b/apps/worker/src/client/affiliate/main.tsx
@@ -1,0 +1,387 @@
+// main.tsx — Affiliate self-serve React entry. Loaded via dynamic import from
+// the LIFF orchestrator (apps/worker/src/client/main.ts) on ?page=affiliate.
+// Caller passes an already-initialized LIFF context; the LINE access token
+// authenticates every /api/liff/affiliate/* call server-side.
+//
+// NOTE: this mirrors apps/liff/src/pages/Affiliate.tsx, but that page imports
+// `@line/liff` and calls liff.getAccessToken() itself. The worker client never
+// bundles @line/liff (the orchestrator uses a `declare const liff` global), so
+// we re-home the same UI here and take the access token via ctx instead.
+
+import { StrictMode, useCallback, useEffect, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import './styles.css';
+
+export interface AffiliateContext {
+  liffId: string;
+  lineUserId: string;
+  /** LINE access token (liff.getAccessToken()); auth for the affiliate API. */
+  lineAccessToken: string;
+}
+
+interface AffiliateData {
+  id: string;
+  name: string;
+  code: string;
+  commissionRate: number;
+  isActive: boolean;
+  friendId: string;
+}
+
+interface AffiliateLinkData {
+  refCode: string;
+  label: string | null;
+  url: string;
+  clickCount: number;
+  friendAdds: number;
+  conversions: number;
+}
+
+type State =
+  | { phase: 'loading' }
+  | { phase: 'not_registered' }
+  | { phase: 'registered'; affiliate: AffiliateData; links: AffiliateLinkData[] }
+  | { phase: 'error'; message: string };
+
+let _root: Root | null = null;
+
+// ─── API ────────────────────────────────────────────────
+
+async function fetchMe(
+  token: string,
+): Promise<
+  | { registered: true; affiliate: AffiliateData; links: AffiliateLinkData[] }
+  | { registered: false }
+> {
+  const url = `/api/liff/affiliate/me?lineAccessToken=${encodeURIComponent(token)}`;
+  const res = await fetch(url);
+  if (res.status === 404) return { registered: false };
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `API ${res.status}`);
+  }
+  const data = (await res.json()) as { affiliate: AffiliateData; links: AffiliateLinkData[] };
+  return { registered: true, affiliate: data.affiliate, links: data.links };
+}
+
+async function postRegister(
+  token: string,
+): Promise<{ affiliate: AffiliateData; links: AffiliateLinkData[] }> {
+  const res = await fetch('/api/liff/affiliate/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ lineAccessToken: token }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `API ${res.status}`);
+  }
+  return (await res.json()) as { affiliate: AffiliateData; links: AffiliateLinkData[] };
+}
+
+async function postAddLink(token: string, label: string | null): Promise<AffiliateLinkData> {
+  const res = await fetch('/api/liff/affiliate/links', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ lineAccessToken: token, label: label || null }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `API ${res.status}`);
+  }
+  const data = (await res.json()) as { link: AffiliateLinkData };
+  return data.link;
+}
+
+// ─── Clipboard ──────────────────────────────────────────
+
+/**
+ * Copy `text` with graceful degradation for LIFF WebViews:
+ *   1. navigator.clipboard.writeText  — modern, needs secure context + permission
+ *   2. document.execCommand('copy')   — legacy textarea-select fallback
+ *   3. neither worked → caller shows the URL selected for manual copy
+ * Returns true only when the browser confirms the copy succeeded.
+ */
+async function copyText(text: string): Promise<boolean> {
+  // 1. Async Clipboard API (may reject in insecure context / denied permission).
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to execCommand
+  }
+
+  // 2. Legacy execCommand('copy') via an off-screen, selected textarea.
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    // Keep it out of view but still selectable (display:none breaks selection).
+    ta.style.position = 'fixed';
+    ta.style.top = '-9999px';
+    ta.style.left = '-9999px';
+    ta.setAttribute('readonly', '');
+    document.body.appendChild(ta);
+    ta.select();
+    ta.setSelectionRange(0, ta.value.length);
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    if (ok) return true;
+  } catch {
+    // fall through to manual-copy fallback
+  }
+
+  return false;
+}
+
+// ─── Components ─────────────────────────────────────────
+
+function LinkRow({ link }: { link: AffiliateLinkData }) {
+  const [copied, setCopied] = useState(false);
+  // manualCopy: both programmatic paths failed → surface the URL selected so the
+  // user can long-press / Ctrl+C it themselves.
+  const [manualCopy, setManualCopy] = useState(false);
+  const urlRef = useRef<HTMLInputElement>(null);
+
+  async function handleCopy() {
+    const ok = await copyText(link.url);
+    if (ok) {
+      setManualCopy(false);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      return;
+    }
+    // Programmatic copy unavailable — reveal a selected input for manual copy.
+    setManualCopy(true);
+    // Select on next paint once the input is mounted.
+    setTimeout(() => {
+      const el = urlRef.current;
+      if (el) {
+        el.focus();
+        el.select();
+        el.setSelectionRange(0, el.value.length);
+      }
+    }, 0);
+  }
+
+  return (
+    <div className="border rounded p-3 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          {link.label && (
+            <div className="text-xs font-medium text-gray-700 mb-1">{link.label}</div>
+          )}
+          <div className="text-xs text-gray-500 break-all">{link.url}</div>
+        </div>
+        <button
+          onClick={handleCopy}
+          className="shrink-0 text-xs bg-gray-100 hover:bg-gray-200 px-2 py-1 rounded transition-colors"
+        >
+          {copied ? 'コピーしました' : 'コピー'}
+        </button>
+      </div>
+      {manualCopy && (
+        <div className="space-y-1">
+          <p className="text-xs text-gray-500">
+            自動コピーできませんでした。下のURLを選択してコピーしてください。
+          </p>
+          <input
+            ref={urlRef}
+            type="text"
+            readOnly
+            value={link.url}
+            onFocus={(e) => e.currentTarget.select()}
+            className="w-full border rounded px-2 py-1 text-xs text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          />
+        </div>
+      )}
+      <div className="flex gap-4 text-xs text-gray-600">
+        <span>クリック: <strong>{link.clickCount}</strong></span>
+        <span>友だち追加: <strong>{link.friendAdds}</strong></span>
+        <span>成約: <strong>{link.conversions}</strong></span>
+      </div>
+    </div>
+  );
+}
+
+function App({ ctx }: { ctx: AffiliateContext }) {
+  const token = ctx.lineAccessToken;
+  const [state, setState] = useState<State>({ phase: 'loading' });
+  const [registerBusy, setRegisterBusy] = useState(false);
+  const [addLabel, setAddLabel] = useState('');
+  const [addBusy, setAddBusy] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+  // registerCalledRef guards against a double-tap firing two POSTs while the
+  // first is in flight. It is released in `finally` so that a *failed* register
+  // can be retried — the button intentionally becomes clickable again on error.
+  const registerCalledRef = useRef(false);
+
+  const loadMe = useCallback(async () => {
+    setState({ phase: 'loading' });
+    try {
+      const result = await fetchMe(token);
+      if (result.registered) {
+        setState({ phase: 'registered', affiliate: result.affiliate, links: result.links });
+      } else {
+        setState({ phase: 'not_registered' });
+      }
+    } catch (e) {
+      setState({ phase: 'error', message: e instanceof Error ? e.message : String(e) });
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void loadMe();
+  }, [loadMe]);
+
+  async function handleRegister() {
+    if (registerBusy || registerCalledRef.current) return;
+    registerCalledRef.current = true;
+    setRegisterBusy(true);
+    try {
+      const data = await postRegister(token);
+      setState({ phase: 'registered', affiliate: data.affiliate, links: data.links });
+    } catch (e) {
+      setState({ phase: 'error', message: e instanceof Error ? e.message : String(e) });
+    } finally {
+      // Release on both success and failure: success repaints to the registered
+      // view (button gone), failure repaints to the error view whose retry path
+      // re-runs loadMe → not_registered, so allowing another attempt is correct.
+      setRegisterBusy(false);
+      registerCalledRef.current = false;
+    }
+  }
+
+  async function handleAddLink() {
+    if (addBusy) return;
+    setAddBusy(true);
+    setAddError(null);
+    try {
+      const link = await postAddLink(token, addLabel.trim() || null);
+      setState((prev) => {
+        if (prev.phase !== 'registered') return prev;
+        return { ...prev, links: [...prev.links, link] };
+      });
+      setAddLabel('');
+    } catch (e) {
+      setAddError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setAddBusy(false);
+    }
+  }
+
+  if (state.phase === 'loading') {
+    return (
+      <div className="af-fade-in flex flex-col items-center justify-center py-20 text-gray-500">
+        <div className="af-spinner mb-3" />
+        <span className="text-sm">読み込み中...</span>
+      </div>
+    );
+  }
+
+  if (state.phase === 'error') {
+    return (
+      <div className="af-fade-in max-w-md mx-auto p-4">
+        <div className="bg-red-50 text-red-700 p-3 rounded text-sm">{state.message}</div>
+        <button onClick={loadMe} className="mt-3 text-sm text-blue-600 underline">
+          再読み込み
+        </button>
+      </div>
+    );
+  }
+
+  if (state.phase === 'not_registered') {
+    return (
+      <div className="af-fade-in max-w-md mx-auto p-4 space-y-4">
+        <h1 className="text-lg font-bold">アフィリエイト</h1>
+        <p className="text-sm text-gray-600">
+          あなた専用の紹介リンクを発行して、友だち追加を紹介できます。
+        </p>
+        <button
+          onClick={handleRegister}
+          disabled={registerBusy}
+          className="w-full bg-green-600 text-white py-3 rounded font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+        >
+          {registerBusy ? '登録中...' : 'アフィリエイターに登録する'}
+        </button>
+      </div>
+    );
+  }
+
+  // registered
+  const { links } = state;
+  const atLimit = links.length >= 20;
+
+  return (
+    <div className="af-fade-in max-w-md mx-auto p-4 pb-12 space-y-4">
+      <h1 className="text-lg font-bold">アフィリエイト</h1>
+
+      {/* Link list */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-gray-700">紹介リンク一覧</h2>
+        {links.length === 0 ? (
+          <div className="text-sm text-gray-500 py-4 text-center">リンクがまだありません</div>
+        ) : (
+          links.map((link) => <LinkRow key={link.refCode} link={link} />)
+        )}
+      </section>
+
+      {/* Add link form */}
+      <section className="border rounded p-3 space-y-2">
+        <h2 className="text-sm font-semibold text-gray-700">リンクを追加</h2>
+        {atLimit ? (
+          <div className="text-sm text-red-600">リンクの上限（20本）に達しています</div>
+        ) : (
+          <>
+            <input
+              type="text"
+              value={addLabel}
+              onChange={(e) => setAddLabel(e.target.value)}
+              placeholder="ラベル（任意）"
+              className="w-full border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+              disabled={addBusy}
+            />
+            {addError && <div className="text-xs text-red-600">{addError}</div>}
+            <button
+              onClick={handleAddLink}
+              disabled={addBusy}
+              className="w-full bg-blue-600 text-white py-2 rounded text-sm font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+            >
+              {addBusy ? '追加中...' : 'リンクを追加する'}
+            </button>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}
+
+// ─── Mount ──────────────────────────────────────────────
+
+export function mountAffiliate(container: HTMLElement, ctx: AffiliateContext): void {
+  // body.af-active gates the namespaced preflight reset + #app inline override.
+  // Add it synchronously before createRoot so the first paint isn't the browser
+  // default (black button borders, list disc) — same rationale as salon-booking.
+  document.body.classList.add('af-active');
+
+  if (_root) {
+    _root.unmount();
+    _root = null;
+  }
+  container.innerHTML = '';
+  _root = createRoot(container);
+  _root.render(
+    <StrictMode>
+      <App ctx={ctx} />
+    </StrictMode>,
+  );
+}
+
+export function unmountAffiliate(): void {
+  if (_root) {
+    _root.unmount();
+    _root = null;
+  }
+  document.body.classList.remove('af-active');
+}

--- a/apps/worker/src/client/affiliate/styles.css
+++ b/apps/worker/src/client/affiliate/styles.css
@@ -1,0 +1,112 @@
+/* affiliate 専用 CSS。salon-booking / event-booking と同じパターン。
+ * Tailwind v4: theme + utilities を取り込み、preflight (base reset) は除外。
+ * preflight を含めると既存 form.ts / Calendar booking 用 inline CSS と衝突する
+ * ため、affiliate namespace (body.af-active 配下) にだけ手動 reset を当てる。
+ */
+@import "tailwindcss/theme.css";
+@import "tailwindcss/utilities.css";
+
+/* ─── affiliate namespace の inline 上書き ─────────────
+ * index.html の friend-add 用 inline:
+ *   body { display:flex; align-items:center; min-height:100vh }
+ *   #app  { max-width:480px; padding:24px 16px; width:100% }
+ * は React アプリでは邪魔なので body と #app 双方を上書き。
+ */
+body.af-active {
+  display: block !important;
+  align-items: stretch !important;
+}
+body.af-active #app {
+  max-width: none !important;
+  padding: 0 !important;
+  width: 100% !important;
+}
+
+/* ─── 必要最低限の preflight ────────────────────────────────
+ * 全ルールは :where(body.af-active) で wrap して specificity を実質 0 にする。
+ * salon-booking の解説参照: utility クラスが常に勝つようにするため。
+ */
+:where(body.af-active),
+:where(body.af-active) *,
+:where(body.af-active) *::before,
+:where(body.af-active) *::after {
+  box-sizing: border-box;
+}
+:where(body.af-active) h1,
+:where(body.af-active) h2,
+:where(body.af-active) h3,
+:where(body.af-active) h4,
+:where(body.af-active) h5,
+:where(body.af-active) h6 {
+  font-size: inherit;
+  font-weight: inherit;
+  margin: 0;
+}
+:where(body.af-active) p,
+:where(body.af-active) dl,
+:where(body.af-active) dd,
+:where(body.af-active) dt,
+:where(body.af-active) ol,
+:where(body.af-active) ul,
+:where(body.af-active) figure,
+:where(body.af-active) blockquote {
+  margin: 0;
+}
+:where(body.af-active) ol,
+:where(body.af-active) ul {
+  list-style: none;
+  padding: 0;
+}
+:where(body.af-active) button {
+  font-family: inherit;
+  font-size: 100%;
+  font-weight: inherit;
+  line-height: inherit;
+  color: inherit;
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  background-image: none;
+  border: 0;
+  cursor: pointer;
+}
+:where(body.af-active) button:disabled {
+  cursor: not-allowed;
+}
+:where(body.af-active) input,
+:where(body.af-active) textarea,
+:where(body.af-active) select {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: inherit;
+  color: inherit;
+  margin: 0;
+}
+:where(body.af-active) img,
+:where(body.af-active) svg,
+:where(body.af-active) video,
+:where(body.af-active) canvas {
+  display: block;
+  max-width: 100%;
+}
+:where(body.af-active) a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/* fade-in アニメーション (salon-booking と同じ言語) */
+@keyframes af-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.af-fade-in { animation: af-fade-in 0.25s ease both; }
+
+/* spinner */
+@keyframes af-spin { to { transform: rotate(360deg); } }
+.af-spinner {
+  width: 32px; height: 32px;
+  border: 3px solid #e5e7eb;
+  border-top-color: #06C755;
+  border-radius: 9999px;
+  animation: af-spin 0.8s linear infinite;
+}

--- a/apps/worker/src/client/affiliate/tsconfig.json
+++ b/apps/worker/src/client/affiliate/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/apps/worker/src/client/main.ts
+++ b/apps/worker/src/client/main.ts
@@ -13,6 +13,7 @@
  *   ?redirect=x       — redirect after linking (for wrapped URLs)
  *   ?page=book        — booking page (calendar slot picker, Google Calendar)
  *   ?page=salon-book  — salon booking flow (React, dynamic-imported)
+ *   ?page=affiliate   — affiliate self-serve page (React, dynamic-imported)
  */
 
 import { initBooking } from './booking.js';
@@ -25,6 +26,7 @@ declare const liff: {
   login(opts?: { redirectUri?: string }): void;
   getProfile(): Promise<{ userId: string; displayName: string; pictureUrl?: string; statusMessage?: string }>;
   getIDToken(): string | null;
+  getAccessToken(): string | null;
   getDecodedIDToken(): { sub: string; name?: string; email?: string; picture?: string } | null;
   getFriendship(): Promise<{ friendFlag: boolean }>;
   isInClient(): boolean;
@@ -491,6 +493,73 @@ async function initEventBooking(initialKind: 'detail' | 'history'): Promise<void
   mountEventBooking(container, ctx, initial);
 }
 
+// ─── Affiliate self-serve (React, dynamic-imported) ──────
+
+async function initAffiliate(): Promise<void> {
+  // salon-booking と同じ初期化シーケンス: profile/accessToken/friendship を
+  // 取得し、未友達なら friend-add gate、友達なら React mount。
+  //
+  // booking 系は id_token で verify するが、affiliate API は LINE access token
+  // (liff.getAccessToken()) を /oauth2/v2.1/verify + /v2/profile で検証するため
+  // ここでは accessToken を取り出して mount context に渡す。
+  const [profile, accessToken, friendship] = await Promise.all([
+    liff.getProfile(),
+    Promise.resolve(liff.getAccessToken()),
+    liff.getFriendship(),
+  ]);
+  if (!accessToken) {
+    showError('LINE 認証情報の取得に失敗しました。LINE アプリ内で再度開いてください。');
+    return;
+  }
+
+  const existingUuid = getSavedUuid();
+  const ref = getRef();
+  const affParams = new URLSearchParams(window.location.search);
+
+  // UUID linking (best-effort) — affiliate API は friends 行を要求するので、
+  // 未 link の初回利用者でも friend-add gate 通過後に行が存在するようにする。
+  apiCall('/api/liff/link', {
+    method: 'POST',
+    body: JSON.stringify({
+      idToken: liff.getIDToken(),
+      displayName: profile.displayName,
+      existingUuid,
+      ref: ref || undefined,
+      ig: affParams.get('ig') || undefined,
+      iga: affParams.get('iga') || undefined,
+      igan: affParams.get('igan') || undefined,
+    }),
+  })
+    .then(async (res) => {
+      if (res.ok) {
+        const data = (await res.json()) as { success: boolean; data?: { userId?: string } };
+        if (data?.data?.userId) saveUuid(data.data.userId);
+      }
+    })
+    .catch(() => {
+      /* silent */
+    });
+
+  // 未友達なら friend-add UI に流す。affiliate API は friends 行 (=友だち) を
+  // 要求するので、ここを skip すると /affiliate/me が friend_not_found で詰む。
+  if (!friendship.friendFlag) {
+    showFriendAdd(profile);
+    return;
+  }
+
+  const container = document.getElementById('app');
+  if (!container) {
+    showError('mount target #app が見つかりません');
+    return;
+  }
+  const { mountAffiliate } = await import('./affiliate/main.js');
+  mountAffiliate(container, {
+    liffId: LIFF_ID,
+    lineUserId: profile.userId,
+    lineAccessToken: accessToken,
+  });
+}
+
 // ─── Entry Point ────────────────────────────────────────
 
 async function main() {
@@ -522,6 +591,8 @@ async function main() {
       await initEventBooking('detail');
     } else if (page === 'event-me') {
       await initEventBooking('history');
+    } else if (page === 'affiliate') {
+      await initAffiliate();
     } else if (page === 'form') {
       const params = new URLSearchParams(window.location.search);
       const formId = params.get('id');

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -8,6 +8,9 @@ import {
   getRandomPoolAccount,
   getPoolAccounts,
   getEntryRouteByRefCode,
+  getLineAccountById,
+  getAffiliateLinkByRefCode,
+  incrementAffiliateLinkClick,
 } from '@line-crm/db';
 import { processStepDeliveries } from './services/step-delivery.js';
 import { processScheduledBroadcasts, processQueuedBroadcasts } from './services/broadcast.js';
@@ -38,6 +41,7 @@ import { usersGrouped } from './routes/users-grouped.js';
 import { inbox } from './routes/inbox.js';
 import { openapi } from './routes/openapi.js';
 import { liffRoutes } from './routes/liff.js';
+import { affiliateSelfRoutes } from './routes/affiliate-self.js';
 // Round 3 ルート
 import { webhooks } from './routes/webhooks.js';
 import { calendar } from './routes/calendar.js';
@@ -161,6 +165,7 @@ app.route('/', usersGrouped);
 app.route('/', inbox);
 app.route('/', openapi);
 app.route('/', liffRoutes);
+app.route('/', affiliateSelfRoutes);
 
 // Mount route groups — Round 3
 app.route('/', webhooks);
@@ -252,8 +257,33 @@ app.get('/r/:ref', async (c) => {
     if (candidate?.is_active) pool = candidate;
   }
 
-  // 2 / 3. fallback to URL query or 'main'
-  if (!pool) {
+  // 1b. affiliate_links fallback (ASP). Only when the ref is NOT a known
+  // entry_route: entry_routes owns the ref namespace, so an existing route
+  // (even one whose pool is paused) keeps its behavior unchanged. An affiliate
+  // ref resolves its LINE account directly (no pool) and lands on that
+  // account's LIFF. is_active=0 links still redirect (spec §8) — pausing an
+  // affiliate link only stops NEW attribution, never breaks existing links.
+  // The click is counted here (the landing page hit), and `ref` still rides
+  // through to LIFF state below so the existing ref_tracking flow attributes
+  // the eventual friend-add via /auth/callback + /api/liff/link.
+  let affiliateResolved = false;
+  if (!route) {
+    const affiliateLink = await getAffiliateLinkByRefCode(c.env.DB, ref);
+    if (affiliateLink) {
+      await incrementAffiliateLinkClick(c.env.DB, ref);
+      affiliateResolved = true;
+      if (affiliateLink.line_account_id) {
+        const account = await getLineAccountById(c.env.DB, affiliateLink.line_account_id);
+        if (account?.liff_id) liffUrl = `https://liff.line.me/${account.liff_id}`;
+      }
+      // line_account_id === null → keep the default LIFF_URL (既定アカウント).
+    }
+  }
+
+  // 2 / 3. fallback to URL query or 'main'. Skipped for affiliate refs, whose
+  // account is already resolved above; falling through to the 'main' pool would
+  // override the affiliate's chosen account.
+  if (!pool && !affiliateResolved) {
     const poolSlug = c.req.query('pool') || 'main';
     pool = await getTrafficPoolBySlug(c.env.DB, poolSlug);
   }

--- a/apps/worker/src/lib/link-base-url.test.ts
+++ b/apps/worker/src/lib/link-base-url.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── DB mock ───────────────────────────────────────────────────────────────────
+// We mock only the getLinkBaseUrl helper from @line-crm/db so the test
+// exercises resolveLinkBaseUrl without a real D1 binding.
+
+const dbMocks = {
+  getLinkBaseUrl: vi.fn<() => Promise<string | null>>(),
+};
+
+vi.mock('@line-crm/db', () => dbMocks);
+
+// Import after mock registration.
+const { resolveLinkBaseUrl } = await import('./link-base-url.js');
+
+const DB = {} as D1Database;
+const ENV_WITH_WORKER_URL = { WORKER_URL: 'https://worker.example.com' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveLinkBaseUrl', () => {
+  describe('no DB setting configured', () => {
+    beforeEach(() => {
+      dbMocks.getLinkBaseUrl.mockResolvedValue(null);
+    });
+
+    it('falls back to WORKER_URL + /r', async () => {
+      const base = await resolveLinkBaseUrl(DB, ENV_WITH_WORKER_URL);
+      expect(base).toBe('https://worker.example.com/r');
+    });
+
+    it('strips trailing slash from WORKER_URL before appending /r', async () => {
+      const base = await resolveLinkBaseUrl(DB, { WORKER_URL: 'https://worker.example.com/' });
+      expect(base).toBe('https://worker.example.com/r');
+    });
+
+    it('forms a full affiliate link correctly', async () => {
+      const base = await resolveLinkBaseUrl(DB, ENV_WITH_WORKER_URL);
+      expect(`${base}/abc123`).toBe('https://worker.example.com/r/abc123');
+    });
+
+    it('throws when WORKER_URL is empty and no DB setting exists', async () => {
+      await expect(resolveLinkBaseUrl(DB, { WORKER_URL: '' })).rejects.toThrow(
+        'WORKER_URL is not configured',
+      );
+    });
+
+    it('throws when WORKER_URL is undefined and no DB setting exists', async () => {
+      await expect(resolveLinkBaseUrl(DB, {})).rejects.toThrow(
+        'WORKER_URL is not configured',
+      );
+    });
+  });
+
+  describe('custom short domain configured in DB', () => {
+    beforeEach(() => {
+      dbMocks.getLinkBaseUrl.mockResolvedValue('https://go.example.com');
+    });
+
+    it('returns the stored domain', async () => {
+      const base = await resolveLinkBaseUrl(DB, ENV_WITH_WORKER_URL);
+      expect(base).toBe('https://go.example.com');
+    });
+
+    it('forms a full affiliate link correctly (no /r in path)', async () => {
+      const base = await resolveLinkBaseUrl(DB, ENV_WITH_WORKER_URL);
+      expect(`${base}/abc123`).toBe('https://go.example.com/abc123');
+    });
+
+    it('uses the stored domain even when WORKER_URL is missing', async () => {
+      // If a custom domain is set, WORKER_URL is irrelevant and must not throw.
+      const base = await resolveLinkBaseUrl(DB, {});
+      expect(base).toBe('https://go.example.com');
+    });
+
+    it('always queries under the __global__ sentinel account ID', async () => {
+      await resolveLinkBaseUrl(DB, ENV_WITH_WORKER_URL);
+      expect(dbMocks.getLinkBaseUrl).toHaveBeenCalledWith(DB, '__global__');
+    });
+  });
+});

--- a/apps/worker/src/lib/link-base-url.ts
+++ b/apps/worker/src/lib/link-base-url.ts
@@ -1,0 +1,44 @@
+import { getLinkBaseUrl } from '@line-crm/db';
+
+/**
+ * Resolve the base URL used to build affiliate link click URLs.
+ *
+ * Priority:
+ *  1. DB-configured `link_base_url` global setting (stored under the sentinel
+ *     accountId `'__global__'`).  This is what operators fill in when they set
+ *     up a custom short domain, e.g. "https://go.example.com".
+ *  2. Fallback: `<WORKER_URL>/r` — the built-in redirect route.
+ *
+ * URL contract for callers:
+ *   The returned string is a *base* — append `/<slug>` to form the full URL:
+ *     `${base}/${link.ref_code}`
+ *
+ *   Whether the base already includes "/r" depends on which branch was taken:
+ *   - Fallback path: includes "/r"  → `https://worker.example.com/r/<slug>`
+ *   - Custom domain: does NOT include "/r" by default (the operator configures
+ *     whatever path prefix they want, and sets up a Redirect Rule accordingly).
+ *     Example with no path: `https://go.example.com/<slug>`
+ *   Callers must not add an extra "/r" segment — the base is authoritative.
+ *
+ * Fails fast if WORKER_URL is empty/undefined and no DB setting is found: this
+ * repo forbids a localhost fallback, and silently emitting a base-less URL would
+ * bake broken affiliate links into client responses.
+ */
+export async function resolveLinkBaseUrl(
+  db: D1Database,
+  env: { WORKER_URL?: string },
+): Promise<string> {
+  const stored = await getLinkBaseUrl(db, '__global__');
+  if (stored) {
+    // Already normalised (no trailing slash) by setLinkBaseUrl.
+    return stored;
+  }
+
+  const workerUrl = env.WORKER_URL?.trim();
+  if (!workerUrl) {
+    throw new Error(
+      'WORKER_URL is not configured; cannot resolve affiliate link base URL',
+    );
+  }
+  return workerUrl.replace(/\/$/, '') + '/r';
+}

--- a/apps/worker/src/routes/account-settings.ts
+++ b/apps/worker/src/routes/account-settings.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { getLinkBaseUrl, setLinkBaseUrl } from '@line-crm/db';
 import type { Env } from '../index.js';
 
 const accountSettings = new Hono<Env>();
@@ -50,6 +51,39 @@ accountSettings.put('/api/account-settings/test-recipients', async (c) => {
   ).run();
 
   return c.json({ success: true });
+});
+
+// ── link_base_url (global setting, stored under sentinel '__global__') ─────────
+
+/**
+ * GET /api/account-settings/link-base-url
+ * Returns the configured short-link base URL (or null if not set).
+ */
+accountSettings.get('/api/account-settings/link-base-url', async (c) => {
+  const value = await getLinkBaseUrl(c.env.DB, '__global__');
+  return c.json({ success: true, data: value });
+});
+
+/**
+ * PUT /api/account-settings/link-base-url
+ * Body: { value: string }
+ * - Empty string clears the setting.
+ * - Must start with https:// (if non-empty).
+ * - Trailing slash is stripped before saving.
+ */
+accountSettings.put('/api/account-settings/link-base-url', async (c) => {
+  const body = await c.req
+    .json<{ value?: string }>()
+    .catch((): { value?: string } => ({}));
+  const value = typeof body.value === 'string' ? body.value : '';
+
+  try {
+    await setLinkBaseUrl(c.env.DB, '__global__', value);
+    return c.json({ success: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Validation error';
+    return c.json({ success: false, error: message }, 400);
+  }
 });
 
 export { accountSettings };

--- a/apps/worker/src/routes/affiliate-journey.test.ts
+++ b/apps/worker/src/routes/affiliate-journey.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The heavy set-based aggregation SQL is covered against real SQLite in
+// packages/db/test/affiliate-report.test.ts. Here we mock @line-crm/db and only
+// assert that the routes wire params/cursors through and shape the response.
+const dbMocks = {
+  // eager module-load deps (mirror other route tests)
+  getLineAccounts: vi.fn().mockResolvedValue([]),
+  getStaffByApiKey: vi.fn(),
+  recoverStalledBroadcasts: vi.fn(),
+  recoverStuckDeliveries: vi.fn(),
+  // affiliate route deps
+  getAffiliateById: vi.fn(),
+  getAffiliateReportV2: vi.fn(),
+  getFriendJourney: vi.fn(),
+  getAffiliateJourneys: vi.fn(),
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+const worker = (await import('../index.js')).default;
+
+const API_KEY = 'test-owner-key';
+const env = {
+  DB: {} as D1Database,
+  LINE_LOGIN_CHANNEL_ID: '2000000000',
+  API_KEY,
+} as unknown as import('../index.js').Env['Bindings'];
+
+// These routes sit behind authMiddleware. getStaffByApiKey is mocked to return
+// undefined, so the env API_KEY owner fallback authenticates the Bearer token.
+function call(path: string, init?: RequestInit) {
+  const headers = new Headers(init?.headers);
+  headers.set('Authorization', `Bearer ${API_KEY}`);
+  return worker.fetch(
+    new Request(`https://worker.example.com${path}`, { ...init, headers }),
+    env,
+    { waitUntil() {}, passThroughOnException() {} } as unknown as ExecutionContext,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.getLineAccounts.mockResolvedValue([]);
+});
+
+describe('GET /api/friends/:id/journey', () => {
+  it('wraps db events under { events } ascending', async () => {
+    const events = [
+      { at: '2026-06-12T00:00:00.000+09:00', type: 'touch', refCode: 'refA', affiliateId: 'aff-A' },
+      { at: '2026-06-17T00:00:00.000+09:00', type: 'friend_add' },
+      { at: '2026-06-27T00:00:00.000+09:00', type: 'touch', refCode: 'refB', affiliateId: 'aff-B' },
+      { at: '2026-07-02T00:00:00.000+09:00', type: 'conversion', refCode: 'refB', affiliateId: 'aff-B' },
+    ];
+    dbMocks.getFriendJourney.mockResolvedValue(events);
+
+    const res = await call('/api/friends/friend-1/journey');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: { events: typeof events } };
+    expect(body.success).toBe(true);
+    expect(body.data.events).toHaveLength(4);
+    expect(body.data.events.map((e) => e.type)).toEqual(['touch', 'friend_add', 'touch', 'conversion']);
+    expect(dbMocks.getFriendJourney).toHaveBeenCalledWith(env.DB, 'friend-1');
+  });
+
+  it('returns empty events for an unknown friend', async () => {
+    dbMocks.getFriendJourney.mockResolvedValue([]);
+    const res = await call('/api/friends/ghost/journey');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { events: unknown[] } };
+    expect(body.data.events).toEqual([]);
+  });
+});
+
+describe('GET /api/affiliates/:id/journeys', () => {
+  it('404s when the affiliate does not exist', async () => {
+    dbMocks.getAffiliateById.mockResolvedValue(null);
+    const res = await call('/api/affiliates/nope/journeys');
+    expect(res.status).toBe(404);
+    expect(dbMocks.getAffiliateJourneys).not.toHaveBeenCalled();
+  });
+
+  it('passes limit + cursor through and returns items + nextCursor', async () => {
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'aff-A' });
+    dbMocks.getAffiliateJourneys.mockResolvedValue({
+      items: [{ friendId: 'friend-1', addedAt: '2026-07-01T00:00:00.000+09:00' }],
+      nextCursor: { beforeAt: '2026-07-01T00:00:00.000+09:00', beforeId: 'friend-1' },
+    });
+
+    const res = await call('/api/affiliates/aff-A/journeys?limit=2&beforeAt=2026-07-05T00:00:00.000%2B09:00&beforeId=friend-9');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: unknown[]; nextCursor: unknown };
+    expect(body.data).toHaveLength(1);
+    expect(body.nextCursor).toEqual({ beforeAt: '2026-07-01T00:00:00.000+09:00', beforeId: 'friend-1' });
+    expect(dbMocks.getAffiliateJourneys).toHaveBeenCalledWith(env.DB, 'aff-A', {
+      limit: 2,
+      beforeAt: '2026-07-05T00:00:00.000+09:00',
+      beforeId: 'friend-9',
+    });
+  });
+});
+
+describe('GET /api/affiliates/:id/report (v2)', () => {
+  it('404s when the report is null', async () => {
+    dbMocks.getAffiliateReportV2.mockResolvedValue(null);
+    const res = await call('/api/affiliates/nope/report');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the v2 report and forwards the identity-key fragment', async () => {
+    const report = {
+      affiliateId: 'aff-A',
+      friendAdds: 1,
+      conversions: 0,
+      clicks: 3,
+      linkClicks: 7,
+      conversionsByPoint: [],
+      revenue: 0,
+      estimatedCommission: 0,
+      duplicateFlags: [],
+    };
+    dbMocks.getAffiliateReportV2.mockResolvedValue(report);
+
+    const res = await call('/api/affiliates/aff-A/report');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: typeof report };
+    expect(body.data.friendAdds).toBe(1);
+    expect(body.data.duplicateFlags).toEqual([]);
+    const callArg = dbMocks.getAffiliateReportV2.mock.calls[0][2] as { identityKeySql: string };
+    expect(typeof callArg.identityKeySql).toBe('string');
+    expect(callArg.identityKeySql).toContain('COALESCE');
+  });
+});

--- a/apps/worker/src/routes/affiliate-links-redirect.test.ts
+++ b/apps/worker/src/routes/affiliate-links-redirect.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock @line-crm/db. index.ts pulls several helpers eagerly at module load, so
+// every referenced export must exist as a stub. The /r/:ref handler is the only
+// thing exercised here; unrelated helpers stay as bare vi.fn().
+const dbMocks = {
+  // eager module-load deps (mirror not-found.test.ts)
+  getLineAccounts: vi.fn().mockResolvedValue([]),
+  getStaffByApiKey: vi.fn(),
+  recoverStalledBroadcasts: vi.fn(),
+  recoverStuckDeliveries: vi.fn(),
+  // /r/:ref resolution helpers
+  getEntryRouteByRefCode: vi.fn(),
+  getTrafficPoolBySlug: vi.fn(),
+  getTrafficPoolById: vi.fn(),
+  getRandomPoolAccount: vi.fn(),
+  getPoolAccounts: vi.fn(),
+  getLineAccountById: vi.fn(),
+  getAffiliateLinkByRefCode: vi.fn(),
+  incrementAffiliateLinkClick: vi.fn(),
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+// Import after the mock so index.ts binds the mocked helpers.
+const worker = (await import('../index.js')).default;
+
+// A stub DB is enough: every query goes through the mocked @line-crm/db
+// helpers, so the binding itself is never touched by the /r/:ref handler.
+const DB = {} as D1Database;
+
+const MOBILE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15';
+
+const env = {
+  DB,
+  LIFF_URL: 'https://liff.line.me/1000000000-DefaultAA',
+} as unknown as import('../index.js').Env['Bindings'];
+
+function get(path: string) {
+  return worker.fetch(
+    new Request(`https://worker.example.com${path}`, {
+      headers: { 'user-agent': MOBILE_UA },
+    }),
+    env,
+    { waitUntil() {}, passThroughOnException() {} } as unknown as ExecutionContext,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.getLineAccounts.mockResolvedValue([]);
+});
+
+describe('/r/:ref — affiliate_links fallback', () => {
+  it('(a) affiliate-only ref → landing page on the link account + click incremented', async () => {
+    // entry_routes miss, affiliate_links hit.
+    dbMocks.getEntryRouteByRefCode.mockResolvedValue(null);
+    dbMocks.getAffiliateLinkByRefCode.mockResolvedValue({
+      id: 'link-1',
+      affiliate_id: 'aff-1',
+      ref_code: 'aff123',
+      label: null,
+      line_account_id: 'acct-9',
+      is_active: 1,
+      created_at: '2026-01-01 00:00:00',
+      click_count: 0,
+    });
+    dbMocks.getLineAccountById.mockResolvedValue({
+      id: 'acct-9',
+      liff_id: '2000000000-BbCcDd',
+    });
+
+    const res = await get('/r/aff123');
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // Click counted exactly once, keyed by the ref_code.
+    expect(dbMocks.incrementAffiliateLinkClick).toHaveBeenCalledTimes(1);
+    expect(dbMocks.incrementAffiliateLinkClick).toHaveBeenCalledWith(DB, 'aff123');
+
+    // Landing page targets the affiliate link's account LIFF, with the ref
+    // carried into LIFF state so downstream ref_tracking still attributes.
+    expect(html).toContain('liff.line.me/2000000000-BbCcDd');
+    expect(html).toContain('ref=aff123');
+    expect(html).toContain('liffId=2000000000-BbCcDd');
+
+    // The pooled 'main' fallback must NOT run for an affiliate ref — its account
+    // is already resolved.
+    expect(dbMocks.getTrafficPoolBySlug).not.toHaveBeenCalled();
+  });
+
+  it('(a2) is_active=0 affiliate link still redirects (spec §8) and counts the click', async () => {
+    dbMocks.getEntryRouteByRefCode.mockResolvedValue(null);
+    dbMocks.getAffiliateLinkByRefCode.mockResolvedValue({
+      id: 'link-2',
+      affiliate_id: 'aff-2',
+      ref_code: 'paused1',
+      label: null,
+      line_account_id: 'acct-9',
+      is_active: 0, // paused
+      created_at: '2026-01-01 00:00:00',
+      click_count: 5,
+    });
+    dbMocks.getLineAccountById.mockResolvedValue({
+      id: 'acct-9',
+      liff_id: '2000000000-BbCcDd',
+    });
+
+    const res = await get('/r/paused1');
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(dbMocks.incrementAffiliateLinkClick).toHaveBeenCalledWith(DB, 'paused1');
+    expect(html).toContain('liff.line.me/2000000000-BbCcDd');
+    expect(html).toContain('ref=paused1');
+  });
+
+  it('(a3) affiliate link with null line_account_id → default LIFF account', async () => {
+    dbMocks.getEntryRouteByRefCode.mockResolvedValue(null);
+    dbMocks.getAffiliateLinkByRefCode.mockResolvedValue({
+      id: 'link-3',
+      affiliate_id: 'aff-3',
+      ref_code: 'nulldef',
+      label: null,
+      line_account_id: null, // → 既定アカウント (env.LIFF_URL)
+      is_active: 1,
+      created_at: '2026-01-01 00:00:00',
+      click_count: 0,
+    });
+
+    const res = await get('/r/nulldef');
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(dbMocks.incrementAffiliateLinkClick).toHaveBeenCalledWith(DB, 'nulldef');
+    // No account lookup when line_account_id is null; default LIFF is used.
+    expect(dbMocks.getLineAccountById).not.toHaveBeenCalled();
+    expect(html).toContain('liff.line.me/1000000000-DefaultAA');
+    expect(html).toContain('ref=nulldef');
+  });
+
+  it('(b) entry_routes ref → legacy behavior unchanged (affiliate path not consulted)', async () => {
+    // entry_route hit with an active pool → pooled account chosen, exactly as
+    // before this task. Affiliate helpers must never be touched.
+    dbMocks.getEntryRouteByRefCode.mockResolvedValue({
+      ref_code: 'route1',
+      pool_id: 'pool-1',
+    });
+    dbMocks.getTrafficPoolById.mockResolvedValue({
+      id: 'pool-1',
+      is_active: 1,
+      liff_id: null,
+    });
+    dbMocks.getRandomPoolAccount.mockResolvedValue({
+      liff_id: '3000000000-PoolAcct',
+    });
+
+    const res = await get('/r/route1');
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toContain('liff.line.me/3000000000-PoolAcct');
+    expect(html).toContain('ref=route1');
+
+    // Affiliate fallback must be entirely bypassed for a known entry_route.
+    expect(dbMocks.getAffiliateLinkByRefCode).not.toHaveBeenCalled();
+    expect(dbMocks.incrementAffiliateLinkClick).not.toHaveBeenCalled();
+  });
+
+  it('(c) ref in neither table → legacy default behavior unchanged', async () => {
+    // entry_routes miss AND affiliate_links miss → falls through to the pooled
+    // 'main' resolution, same as before this task.
+    dbMocks.getEntryRouteByRefCode.mockResolvedValue(null);
+    dbMocks.getAffiliateLinkByRefCode.mockResolvedValue(null);
+    dbMocks.getTrafficPoolBySlug.mockResolvedValue(null); // no 'main' pool
+
+    const res = await get('/r/unknown');
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // No click recorded for an unknown ref.
+    expect(dbMocks.incrementAffiliateLinkClick).not.toHaveBeenCalled();
+    // The 'main' pool fallback ran, proving legacy resolution still fires.
+    expect(dbMocks.getTrafficPoolBySlug).toHaveBeenCalledWith(DB, 'main');
+    // Default LIFF used; ref still carried through.
+    expect(html).toContain('liff.line.me/1000000000-DefaultAA');
+    expect(html).toContain('ref=unknown');
+  });
+});

--- a/apps/worker/src/routes/affiliate-self.test.ts
+++ b/apps/worker/src/routes/affiliate-self.test.ts
@@ -1,0 +1,413 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock @line-crm/db. index.ts pulls several helpers eagerly at module load, so
+// every referenced export must exist as a stub. This suite drives the
+// self-serve affiliate endpoints, so the affiliate CRUD helpers are backed by a
+// tiny in-memory store to exercise idempotency / isolation / the 20-link cap
+// without a real D1 binding.
+const dbMocks = {
+  // eager module-load deps (mirror affiliate-links-redirect.test.ts)
+  getLineAccounts: vi.fn().mockResolvedValue([]),
+  getStaffByApiKey: vi.fn(),
+  recoverStalledBroadcasts: vi.fn(),
+  recoverStuckDeliveries: vi.fn(),
+  // self-serve affiliate helpers
+  getFriendByLineUserId: vi.fn(),
+  getAffiliateByFriendId: vi.fn(),
+  createAffiliate: vi.fn(),
+  createAffiliateLink: vi.fn(),
+  listAffiliateLinks: vi.fn(),
+  countAffiliateLinks: vi.fn(),
+  getAffiliateLinkStats: vi.fn(),
+  generateRefSlug: vi.fn(() => 'slug00'),
+  // account-settings helpers (used by resolveLinkBaseUrl via @line-crm/db)
+  getLinkBaseUrl: vi.fn().mockResolvedValue(null),
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+// Import after the mock so index.ts binds the mocked helpers.
+const worker = (await import('../index.js')).default;
+
+const DB = {} as D1Database;
+
+// The deployment's LINE Login channel. resolveFriendFromLineToken now requires
+// the verify response's client_id to be in the allowed set (env default + DB
+// account login channels), so tokens minted by any other channel are rejected.
+const LOGIN_CHANNEL_ID = '2000000000';
+
+const env = {
+  DB,
+  LIFF_URL: 'https://liff.line.me/1000000000-DefaultAA',
+  WORKER_URL: 'https://worker.example.com',
+  LINE_LOGIN_CHANNEL_ID: LOGIN_CHANNEL_ID,
+} as unknown as import('../index.js').Env['Bindings'];
+
+function call(path: string, init?: RequestInit) {
+  return worker.fetch(
+    new Request(`https://worker.example.com${path}`, init),
+    env,
+    { waitUntil() {}, passThroughOnException() {} } as unknown as ExecutionContext,
+  );
+}
+
+// ── LINE API fetch mock ───────────────────────────────────────────────────────
+// A valid access token maps to a LINE userId. The verify endpoint 200s for any
+// known token; the profile endpoint returns the mapped userId. Unknown tokens
+// 401 at the verify step so resolveFriendFromLineToken returns null.
+const TOKEN_TO_USER: Record<string, string> = {
+  'tok-alice': 'U-alice',
+  'tok-bob': 'U-bob',
+};
+
+function installLineFetchMock(clientId: string = LOGIN_CHANNEL_ID) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+
+      if (url.startsWith('https://api.line.me/oauth2/v2.1/verify')) {
+        const token = new URL(url).searchParams.get('access_token') || '';
+        if (TOKEN_TO_USER[token]) {
+          return new Response(JSON.stringify({ client_id: clientId, expires_in: 100 }), {
+            status: 200,
+          });
+        }
+        return new Response('invalid', { status: 400 });
+      }
+
+      if (url === 'https://api.line.me/v2/profile') {
+        const auth = (init?.headers as Record<string, string>)?.Authorization || '';
+        const token = auth.replace(/^Bearer /, '');
+        const userId = TOKEN_TO_USER[token];
+        if (!userId) return new Response('unauthorized', { status: 401 });
+        return new Response(JSON.stringify({ userId, displayName: 'ignored' }), {
+          status: 200,
+        });
+      }
+
+      return new Response('not found', { status: 404 });
+    }),
+  );
+}
+
+// ── in-memory affiliate store backing the db mocks ────────────────────────────
+type AffRow = { id: string; name: string; code: string; commission_rate: number; is_active: number; created_at: string; friend_id: string };
+type LinkRow = { id: string; affiliate_id: string; ref_code: string; label: string | null; line_account_id: string | null; is_active: number; created_at: string; click_count: number };
+
+let affiliatesByFriend: Map<string, AffRow>;
+let linksByAffiliate: Map<string, LinkRow[]>;
+let statsByAffiliate: Map<string, Map<string, { friendAdds: number; conversions: number }>>;
+let slugCounter: number;
+
+const FRIENDS: Record<string, { id: string; display_name: string }> = {
+  'U-alice': { id: 'friend-alice', display_name: 'Alice' },
+  'U-bob': { id: 'friend-bob', display_name: 'Bob' },
+};
+
+function installStore() {
+  affiliatesByFriend = new Map();
+  linksByAffiliate = new Map();
+  statsByAffiliate = new Map();
+  slugCounter = 0;
+
+  // Per-link stats: empty by default (fresh links → 0). Tests seed real values
+  // via statsByAffiliate to assert they flow through serializeLink.
+  dbMocks.getAffiliateLinkStats.mockImplementation(async (_db: unknown, affiliateId: string) => {
+    return statsByAffiliate.get(affiliateId) ?? new Map();
+  });
+
+  dbMocks.getFriendByLineUserId.mockImplementation(async (_db: unknown, lineUserId: string) => {
+    return FRIENDS[lineUserId] ?? null;
+  });
+
+  dbMocks.getAffiliateByFriendId.mockImplementation(async (_db: unknown, friendId: string) => {
+    for (const aff of affiliatesByFriend.values()) {
+      if (aff.friend_id === friendId) return aff;
+    }
+    return null;
+  });
+
+  dbMocks.createAffiliate.mockImplementation(
+    async (_db: unknown, input: { name: string; code: string; friendId?: string }) => {
+      const aff: AffRow = {
+        id: `aff-${input.friendId ?? input.code}`,
+        name: input.name,
+        code: input.code,
+        commission_rate: 0,
+        is_active: 1,
+        created_at: '2026-01-01 00:00:00',
+        friend_id: input.friendId ?? '',
+      };
+      affiliatesByFriend.set(aff.id, aff);
+      linksByAffiliate.set(aff.id, []);
+      return aff;
+    },
+  );
+
+  dbMocks.createAffiliateLink.mockImplementation(
+    async (_db: unknown, input: { affiliateId: string; label?: string | null }) => {
+      const link: LinkRow = {
+        id: crypto.randomUUID(),
+        affiliate_id: input.affiliateId,
+        ref_code: `slug${String(slugCounter++).padStart(2, '0')}`,
+        label: input.label ?? null,
+        line_account_id: null,
+        is_active: 1,
+        created_at: '2026-01-01 00:00:00',
+        click_count: 0,
+      };
+      const arr = linksByAffiliate.get(input.affiliateId) ?? [];
+      arr.unshift(link);
+      linksByAffiliate.set(input.affiliateId, arr);
+      return link;
+    },
+  );
+
+  dbMocks.listAffiliateLinks.mockImplementation(async (_db: unknown, affiliateId: string) => {
+    return linksByAffiliate.get(affiliateId) ?? [];
+  });
+
+  dbMocks.countAffiliateLinks.mockImplementation(async (_db: unknown, affiliateId: string) => {
+    return (linksByAffiliate.get(affiliateId) ?? []).length;
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  dbMocks.getLineAccounts.mockResolvedValue([]);
+  installLineFetchMock();
+  installStore();
+});
+
+describe('POST /api/liff/affiliate/register — idempotency', () => {
+  it('(a) registers once, then returns the SAME affiliate on repeat calls', async () => {
+    const res1 = await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice' }),
+    });
+    expect(res1.status).toBe(200);
+    const body1 = (await res1.json()) as { affiliate: { id: string; name: string }; links: unknown[] };
+    expect(body1.affiliate.name).toBe('Alice');
+    // Registration auto-issues exactly one link.
+    expect(body1.links).toHaveLength(1);
+
+    // Second call must NOT create a second affiliate — same id returned.
+    const res2 = await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice' }),
+    });
+    expect(res2.status).toBe(200);
+    const body2 = (await res2.json()) as { affiliate: { id: string } };
+    expect(body2.affiliate.id).toBe(body1.affiliate.id);
+    // createAffiliate called exactly once across both registrations.
+    expect(dbMocks.createAffiliate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GET /api/liff/affiliate/me — cross-affiliate isolation', () => {
+  it('(b) a token only ever surfaces its own affiliate data', async () => {
+    // Register alice + bob.
+    await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice' }),
+    });
+    await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-bob' }),
+    });
+
+    const resAlice = await call('/api/liff/affiliate/me?lineAccessToken=tok-alice');
+    const alice = (await resAlice.json()) as { affiliate: { name: string; friendId?: string }; links: unknown[] };
+    expect(alice.affiliate.name).toBe('Alice');
+
+    const resBob = await call('/api/liff/affiliate/me?lineAccessToken=tok-bob');
+    const bob = (await resBob.json()) as { affiliate: { name: string } };
+    expect(bob.affiliate.name).toBe('Bob');
+
+    // Alice's payload must never leak Bob's affiliate id (no shared identity).
+    expect(JSON.stringify(alice)).not.toContain('friend-bob');
+    expect(JSON.stringify(bob)).not.toContain('friend-alice');
+  });
+
+  it('me response shape carries refCode/label/url/clickCount/friendAdds/conversions', async () => {
+    const reg = await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice' }),
+    });
+    const regBody = (await reg.json()) as {
+      affiliate: { id: string };
+      links: Array<{ refCode: string }>;
+    };
+    const affId = regBody.affiliate.id;
+    const refCode = regBody.links[0].refCode;
+
+    // Seed real per-link stats for this affiliate's link; getAffiliateLinkStats
+    // (mocked) surfaces them, and serializeLink must emit the real values.
+    statsByAffiliate.set(affId, new Map([[refCode, { friendAdds: 3, conversions: 2 }]]));
+
+    const res = await call('/api/liff/affiliate/me?lineAccessToken=tok-alice');
+    const body = (await res.json()) as {
+      links: Array<{ refCode: string; label: string | null; url: string; clickCount: number; friendAdds: number; conversions: number }>;
+    };
+    expect(body.links).toHaveLength(1);
+    const link = body.links[0];
+    expect(typeof link.refCode).toBe('string');
+    expect(link.url).toBe(`https://worker.example.com/r/${link.refCode}`);
+    expect(link.clickCount).toBe(0);
+    // Real per-link aggregates now flow through (no longer placeholders).
+    expect(link.friendAdds).toBe(3);
+    expect(link.conversions).toBe(2);
+  });
+
+  it('a link with no stats entry defaults friendAdds/conversions to 0', async () => {
+    await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice' }),
+    });
+    // No statsByAffiliate seeding → getAffiliateLinkStats returns empty map.
+    const res = await call('/api/liff/affiliate/me?lineAccessToken=tok-alice');
+    const body = (await res.json()) as {
+      links: Array<{ friendAdds: number; conversions: number }>;
+    };
+    expect(body.links[0].friendAdds).toBe(0);
+    expect(body.links[0].conversions).toBe(0);
+  });
+});
+
+describe('POST /api/liff/affiliate/links — 20-link cap', () => {
+  it('(c) the 21st self-issued link is rejected with 400', async () => {
+    await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice' }),
+    });
+    // Registration already issued 1 link → 19 more brings us to 20 exactly.
+    for (let i = 0; i < 19; i++) {
+      const r = await call('/api/liff/affiliate/links', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ lineAccessToken: 'tok-alice', label: `L${i}` }),
+      });
+      expect(r.status).toBe(200);
+    }
+    // 20 links now exist. The 21st must be refused.
+    const over = await call('/api/liff/affiliate/links', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice', label: 'over' }),
+    });
+    expect(over.status).toBe(400);
+  });
+});
+
+describe('LINE token verification', () => {
+  it('(d) an invalid token yields 401 on every endpoint', async () => {
+    const reg = await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-nope' }),
+    });
+    expect(reg.status).toBe(401);
+
+    const me = await call('/api/liff/affiliate/me?lineAccessToken=tok-nope');
+    expect(me.status).toBe(401);
+
+    const links = await call('/api/liff/affiliate/links', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-nope' }),
+    });
+    expect(links.status).toBe(401);
+
+    // A friend that never added the bot (verified but no friend row) → 404,
+    // and crucially never creates an affiliate.
+    dbMocks.getFriendByLineUserId.mockImplementationOnce(async () => null);
+    const ghost = await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice' }),
+    });
+    expect(ghost.status).toBe(404);
+  });
+
+  it('(d2) a token minted by a foreign LINE Login channel is rejected with 401', async () => {
+    // verify 200s (token is real) but reports a client_id this deployment does
+    // not own. Without the client_id gate, its lineUserId would resolve to a
+    // local friend and let an unrelated app impersonate an affiliate.
+    installLineFetchMock('9999999999');
+
+    const reg = await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice' }),
+    });
+    expect(reg.status).toBe(401);
+    // Crucially, no affiliate is ever created from a foreign-channel token.
+    expect(dbMocks.createAffiliate).not.toHaveBeenCalled();
+
+    const me = await call('/api/liff/affiliate/me?lineAccessToken=tok-alice');
+    expect(me.status).toBe(401);
+  });
+
+  it('(d3) accepts a token whose client_id matches a DB account login channel', async () => {
+    // Env default channel does NOT match; a DB line_account's login_channel_id
+    // does. Mirrors liff.ts allowing multi-account login channels.
+    installLineFetchMock('3000000000');
+    dbMocks.getLineAccounts.mockResolvedValue([
+      { login_channel_id: '3000000000' } as unknown as never,
+    ]);
+
+    const reg = await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice' }),
+    });
+    expect(reg.status).toBe(200);
+  });
+});
+
+describe('POST /api/liff/affiliate/register — concurrent double-register', () => {
+  it('(e) a UNIQUE(friend_id) violation on INSERT recovers the existing affiliate', async () => {
+    // Simulate the race: getAffiliateByFriendId returns null on the pre-check
+    // (first call), createAffiliate throws the UNIQUE violation the losing
+    // request would hit, and the post-catch getAffiliateByFriendId returns the
+    // row the winning request already committed. Register must stay idempotent.
+    const winner: AffRow = {
+      id: 'aff-winner',
+      name: 'Alice',
+      code: 'wincode',
+      commission_rate: 0,
+      is_active: 1,
+      created_at: '2026-01-01 00:00:00',
+      friend_id: 'friend-alice',
+    };
+    linksByAffiliate.set(winner.id, []);
+
+    // Pre-check: not found yet (this request thinks it's first).
+    dbMocks.getAffiliateByFriendId.mockResolvedValueOnce(null);
+    // INSERT races and loses.
+    dbMocks.createAffiliate.mockRejectedValueOnce(
+      new Error('D1_ERROR: UNIQUE constraint failed: affiliates.friend_id'),
+    );
+    // Post-catch recovery: the winner's committed row is now visible.
+    dbMocks.getAffiliateByFriendId.mockResolvedValueOnce(winner);
+
+    const res = await call('/api/liff/affiliate/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ lineAccessToken: 'tok-alice' }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { affiliate: { id: string } };
+    expect(body.affiliate.id).toBe('aff-winner');
+    // The loser must NOT auto-issue a second first-link.
+    expect(dbMocks.createAffiliateLink).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/routes/affiliate-self.ts
+++ b/apps/worker/src/routes/affiliate-self.ts
@@ -1,0 +1,287 @@
+import { Hono, type Context } from 'hono';
+import {
+  getFriendByLineUserId,
+  getAffiliateByFriendId,
+  createAffiliate,
+  createAffiliateLink,
+  listAffiliateLinks,
+  countAffiliateLinks,
+  generateRefSlug,
+  getLineAccounts,
+  getAffiliateLinkStats,
+  type Affiliate,
+  type AffiliateLink,
+  type AffiliateLinkStat,
+} from '@line-crm/db';
+import { resolveLinkBaseUrl } from '../lib/link-base-url.js';
+import type { Env } from '../index.js';
+
+/**
+ * Self-serve affiliate API for LIFF clients.
+ *
+ * Auth boundary: these endpoints are authenticated ONLY by a LINE access token
+ * that the LIFF SDK obtains client-side. The token is verified against LINE's
+ * OAuth2 + profile endpoints server-side; the resulting LINE userId is resolved
+ * to a friend row, and the affiliate is resolved from THAT friend. Clients never
+ * pass an affiliate_id — it is always derived server-side from the verified
+ * token, so one affiliate can never read or mutate another's data.
+ *
+ * authMiddleware skips `/api/liff/*` (staff auth), so verification lives here.
+ */
+const affiliateSelfRoutes = new Hono<Env>();
+
+/** Max self-issued links per affiliate. The 21st issuance is a 400. */
+const MAX_SELF_LINKS = 20;
+
+type ResolvedFriend = { id: string; display_name: string };
+
+/**
+ * Verify a LINE access token and resolve the backing friend row.
+ *
+ * Returns a discriminated result so callers can pick the right HTTP status in
+ * a single pass:
+ *   - 'invalid_token' → 401 (token could not be verified against LINE)
+ *   - 'no_friend'     → 404 (token verified, but no friend row exists)
+ *   - 'ok'            → proceed with the resolved friend
+ */
+async function resolveFriendFromLineToken(
+  env: Env['Bindings'],
+  accessToken: string,
+): Promise<
+  | { status: 'invalid_token' }
+  | { status: 'no_friend' }
+  | { status: 'ok'; friend: ResolvedFriend }
+> {
+  const db = env.DB;
+  const v = await fetch(
+    'https://api.line.me/oauth2/v2.1/verify?access_token=' +
+      encodeURIComponent(accessToken),
+  );
+  if (!v.ok) return { status: 'invalid_token' };
+
+  // The verify response carries the LINE Login channel (`client_id`) that
+  // minted this token. Reject any token issued by a channel this deployment
+  // does not own — otherwise a token from an unrelated LINE Login app whose
+  // user happens to share a lineUserId could impersonate an affiliate.
+  // Allowed channels = env default + every DB account's login channel, mirroring
+  // the multi-account verification pattern in liff.ts.
+  const verifyBody = await v
+    .json<{ client_id?: string }>()
+    .catch((): { client_id?: string } => ({}));
+  const tokenClientId = verifyBody.client_id;
+  if (!tokenClientId) return { status: 'invalid_token' };
+
+  const allowedChannelIds = new Set<string>();
+  if (env.LINE_LOGIN_CHANNEL_ID) allowedChannelIds.add(env.LINE_LOGIN_CHANNEL_ID);
+  const dbAccounts = await getLineAccounts(db);
+  for (const acct of dbAccounts) {
+    if (acct.login_channel_id) allowedChannelIds.add(acct.login_channel_id);
+  }
+  if (!allowedChannelIds.has(tokenClientId)) return { status: 'invalid_token' };
+
+  const prof = await fetch('https://api.line.me/v2/profile', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!prof.ok) return { status: 'invalid_token' };
+
+  const { userId } = await prof.json<{ userId: string }>();
+  if (!userId) return { status: 'invalid_token' };
+
+  const friend = await getFriendByLineUserId(db, userId);
+  if (!friend) return { status: 'no_friend' };
+  return { status: 'ok', friend: friend as unknown as ResolvedFriend };
+}
+
+/** Map a non-ok resolution to its JSON error response. */
+function unresolvedResponse(
+  c: Context<Env>,
+  result: { status: 'invalid_token' } | { status: 'no_friend' },
+) {
+  if (result.status === 'invalid_token') {
+    return c.json({ success: false, error: 'Invalid LINE access token' }, 401);
+  }
+  return c.json({ success: false, error: 'Friend not found' }, 404);
+}
+
+/**
+ * Shape each affiliate link into the client-facing row. `stats` maps ref_code →
+ * per-link counters (getAffiliateLinkStats). A link absent from the map (e.g. a
+ * freshly issued link with no activity yet) defaults to zeros.
+ */
+function serializeLink(
+  link: AffiliateLink,
+  baseUrl: string,
+  stats?: Map<string, AffiliateLinkStat>,
+) {
+  const s = stats?.get(link.ref_code);
+  return {
+    refCode: link.ref_code,
+    label: link.label,
+    url: `${baseUrl}/${link.ref_code}`,
+    clickCount: link.click_count,
+    friendAdds: s?.friendAdds ?? 0,
+    conversions: s?.conversions ?? 0,
+  };
+}
+
+function serializeAffiliate(aff: Affiliate) {
+  return {
+    id: aff.id,
+    name: aff.name,
+    code: aff.code,
+    commissionRate: aff.commission_rate,
+    isActive: Boolean(aff.is_active),
+    friendId: aff.friend_id,
+  };
+}
+
+/**
+ * POST /api/liff/affiliate/register — idempotent self-registration.
+ * Body: { lineAccessToken }. If already registered, returns the existing
+ * affiliate + links. On first registration, auto-issues one link.
+ */
+affiliateSelfRoutes.post('/api/liff/affiliate/register', async (c) => {
+  try {
+    const body = await c.req
+      .json<{ lineAccessToken?: string }>()
+      .catch((): { lineAccessToken?: string } => ({}));
+    const token = body.lineAccessToken;
+    if (!token) {
+      return c.json({ success: false, error: 'lineAccessToken is required' }, 400);
+    }
+
+    const db = c.env.DB;
+    const resolved = await resolveFriendFromLineToken(c.env, token);
+    if (resolved.status !== 'ok') {
+      return unresolvedResponse(c, resolved);
+    }
+    const friend = resolved.friend;
+
+    const existing = await getAffiliateByFriendId(db, friend.id);
+    if (existing) {
+      const links = await listAffiliateLinks(db, existing.id);
+      const baseUrl = await resolveLinkBaseUrl(db, c.env);
+      const stats = await getAffiliateLinkStats(db, existing.id);
+      return c.json({
+        affiliate: serializeAffiliate(existing),
+        links: links.map((l) => serializeLink(l, baseUrl, stats)),
+      });
+    }
+
+    let affiliate: Affiliate;
+    try {
+      affiliate = await createAffiliate(db, {
+        name: friend.display_name || 'Affiliate',
+        code: generateRefSlug(),
+        friendId: friend.id,
+      });
+    } catch (createErr) {
+      // Concurrent double-register: two requests both passed the getAffiliateBy-
+      // FriendId check, then raced the INSERT. The UNIQUE(friend_id) index makes
+      // the loser throw — recover by returning the winner's row so register stays
+      // idempotent even under a race. Re-throw anything that isn't the expected
+      // uniqueness collision.
+      const raced = await getAffiliateByFriendId(db, friend.id);
+      if (!raced) throw createErr;
+      const links = await listAffiliateLinks(db, raced.id);
+      const baseUrl = await resolveLinkBaseUrl(db, c.env);
+      const stats = await getAffiliateLinkStats(db, raced.id);
+      return c.json({
+        affiliate: serializeAffiliate(raced),
+        links: links.map((l) => serializeLink(l, baseUrl, stats)),
+      });
+    }
+    // Auto-issue the first link on registration.
+    const firstLink = await createAffiliateLink(db, { affiliateId: affiliate.id });
+    const baseUrl = await resolveLinkBaseUrl(db, c.env);
+    return c.json({
+      affiliate: serializeAffiliate(affiliate),
+      links: [serializeLink(firstLink, baseUrl)],
+    });
+  } catch (err) {
+    console.error('POST /api/liff/affiliate/register error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
+/**
+ * GET /api/liff/affiliate/me?lineAccessToken= — return the caller's affiliate
+ * profile + links. 404 if the caller is a friend but not yet registered.
+ */
+affiliateSelfRoutes.get('/api/liff/affiliate/me', async (c) => {
+  try {
+    const token = c.req.query('lineAccessToken');
+    if (!token) {
+      return c.json({ success: false, error: 'lineAccessToken is required' }, 400);
+    }
+
+    const db = c.env.DB;
+    const resolved = await resolveFriendFromLineToken(c.env, token);
+    if (resolved.status !== 'ok') {
+      return unresolvedResponse(c, resolved);
+    }
+    const friend = resolved.friend;
+
+    const affiliate = await getAffiliateByFriendId(db, friend.id);
+    if (!affiliate) {
+      return c.json({ success: false, error: 'Not registered as an affiliate' }, 404);
+    }
+
+    const links = await listAffiliateLinks(db, affiliate.id);
+    const baseUrl = await resolveLinkBaseUrl(db, c.env);
+    const stats = await getAffiliateLinkStats(db, affiliate.id);
+    return c.json({
+      affiliate: serializeAffiliate(affiliate),
+      links: links.map((l) => serializeLink(l, baseUrl, stats)),
+    });
+  } catch (err) {
+    console.error('GET /api/liff/affiliate/me error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
+/**
+ * POST /api/liff/affiliate/links — issue a new self-serve link.
+ * Body: { lineAccessToken, label? }. Enforces the 20-link cap (21st → 400).
+ */
+affiliateSelfRoutes.post('/api/liff/affiliate/links', async (c) => {
+  try {
+    const body = await c.req
+      .json<{ lineAccessToken?: string; label?: string | null }>()
+      .catch((): { lineAccessToken?: string; label?: string | null } => ({}));
+    const token = body.lineAccessToken;
+    if (!token) {
+      return c.json({ success: false, error: 'lineAccessToken is required' }, 400);
+    }
+
+    const db = c.env.DB;
+    const resolved = await resolveFriendFromLineToken(c.env, token);
+    if (resolved.status !== 'ok') {
+      return unresolvedResponse(c, resolved);
+    }
+    const friend = resolved.friend;
+
+    const affiliate = await getAffiliateByFriendId(db, friend.id);
+    if (!affiliate) {
+      return c.json({ success: false, error: 'Not registered as an affiliate' }, 404);
+    }
+
+    const count = await countAffiliateLinks(db, affiliate.id);
+    if (count >= MAX_SELF_LINKS) {
+      return c.json(
+        { success: false, error: `Link limit reached (max ${MAX_SELF_LINKS})` },
+        400,
+      );
+    }
+
+    const label = typeof body.label === 'string' ? body.label : null;
+    const link = await createAffiliateLink(db, { affiliateId: affiliate.id, label });
+    const baseUrl = await resolveLinkBaseUrl(db, c.env);
+    return c.json({ link: serializeLink(link, baseUrl) });
+  } catch (err) {
+    console.error('POST /api/liff/affiliate/links error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
+export { affiliateSelfRoutes };

--- a/apps/worker/src/routes/affiliates.ts
+++ b/apps/worker/src/routes/affiliates.ts
@@ -8,12 +8,17 @@ import {
   deleteAffiliate,
   recordAffiliateClick,
   getAffiliateReport,
+  getAffiliateReportV2,
+  getFriendJourney,
+  getAffiliateJourneys,
+  listAffiliateLinks,
 } from '@line-crm/db';
+import { IDENTITY_KEY_SQL } from '../lib/identity-key.js';
 import type { Env } from '../index.js';
 
 const affiliates = new Hono<Env>();
 
-function serializeAffiliate(row: { id: string; name: string; code: string; commission_rate: number; is_active: number; created_at: string }) {
+function serializeAffiliate(row: { id: string; name: string; code: string; commission_rate: number; is_active: number; created_at: string; friend_id?: string | null }) {
   return {
     id: row.id,
     name: row.name,
@@ -21,6 +26,7 @@ function serializeAffiliate(row: { id: string; name: string; code: string; commi
     commissionRate: row.commission_rate,
     isActive: Boolean(row.is_active),
     createdAt: row.created_at,
+    friendId: row.friend_id ?? null,
   };
 }
 
@@ -107,20 +113,70 @@ affiliates.delete('/api/affiliates/:id', async (c) => {
   }
 });
 
-// GET /api/affiliates/:id/report - affiliate performance report
+// GET /api/affiliates/:id/report - affiliate performance report (v2)
+// Extends the legacy report with ref_tracking-based clicks, add-time friendAdds,
+// conversionsByPoint, estimatedCommission and identity-key duplicateFlags.
 affiliates.get('/api/affiliates/:id/report', async (c) => {
   try {
-    const report = await getAffiliateReport(c.env.DB, c.req.param('id'), {
+    const report = await getAffiliateReportV2(c.env.DB, c.req.param('id'), {
       startDate: c.req.query('startDate'),
       endDate: c.req.query('endDate'),
+      identityKeySql: IDENTITY_KEY_SQL,
     });
 
-    if (report.length === 0) {
+    if (!report) {
       return c.json({ success: false, error: 'Affiliate not found' }, 404);
     }
-    return c.json({ success: true, data: report[0] });
+    return c.json({ success: true, data: report });
   } catch (err) {
     console.error('GET /api/affiliates/:id/report error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
+// GET /api/affiliates/:id/journeys - attributed-friend journey summaries
+// Cursor-paginated on (addedAt, friendId), same scheme as GET /api/chats.
+affiliates.get('/api/affiliates/:id/journeys', async (c) => {
+  try {
+    const affiliate = await getAffiliateById(c.env.DB, c.req.param('id'));
+    if (!affiliate) {
+      return c.json({ success: false, error: 'Affiliate not found' }, 404);
+    }
+    const limitParam = Number.parseInt(c.req.query('limit') ?? '', 10);
+    const page = await getAffiliateJourneys(c.env.DB, c.req.param('id'), {
+      limit: Number.isFinite(limitParam) ? limitParam : undefined,
+      beforeAt: c.req.query('beforeAt') || undefined,
+      beforeId: c.req.query('beforeId') || undefined,
+    });
+    return c.json({ success: true, data: page.items, nextCursor: page.nextCursor });
+  } catch (err) {
+    console.error('GET /api/affiliates/:id/journeys error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
+// GET /api/affiliates/:id/links - list all ref_code links for an affiliate
+affiliates.get('/api/affiliates/:id/links', async (c) => {
+  try {
+    const affiliate = await getAffiliateById(c.env.DB, c.req.param('id'));
+    if (!affiliate) {
+      return c.json({ success: false, error: 'Affiliate not found' }, 404);
+    }
+    const links = await listAffiliateLinks(c.env.DB, c.req.param('id'));
+    return c.json({ success: true, data: links });
+  } catch (err) {
+    console.error('GET /api/affiliates/:id/links error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
+// GET /api/friends/:id/journey - time-ordered event journey for one friend
+affiliates.get('/api/friends/:id/journey', async (c) => {
+  try {
+    const events = await getFriendJourney(c.env.DB, c.req.param('id'));
+    return c.json({ success: true, data: { events } });
+  } catch (err) {
+    console.error('GET /api/friends/:id/journey error:', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });

--- a/docs/wiki/27-Affiliate-ASP.md
+++ b/docs/wiki/27-Affiliate-ASP.md
@@ -1,0 +1,345 @@
+# 27. アフィリエイト ASP（セルフサーブ計測）
+
+LINE Harness に内蔵されたセルフサーブ型アフィリエイト計測機能のリファレンスです。リンク発行からクリック・友だち追加・コンバージョンまでを時系列で計測し、帰属計算からレポート出力まで一気通貫で処理します。
+
+---
+
+## 1. 機能概要
+
+```
+アフィリエイター
+  ↓  LIFF (?page=affiliate) でセルフ登録
+  ↓  媒体別リンクを最大 20 本発行
+  ↓
+ユーザー
+  ↓  短縮リンクをクリック → ref_tracking に記録
+  ↓  LINE 友だち追加
+  ↓  コンバージョン発生
+  ↓
+システム
+  ↓  last-touch / 90日窓でアフィリエイターに帰属
+  ↓  CV 時点のレートでコミッション確定（後から不変）
+  ↓
+管理者
+     /affiliates 画面でレポート確認・重複フラグ確認
+```
+
+主な特徴:
+
+- **セルフサーブ**: アフィリエイターが管理者の手を借りずに LIFF から登録・リンク発行・実績確認
+- **ref_code ベース追跡**: 6〜8 文字の base62 スラグ。リンク毎に独立した計測
+- **スナップショット CV**: コンバージョン発生時にアフィリエイター・レートを確定。後からレートを変更しても過去レポートは変わらない
+- **重複検知**: `identity_key`（電話番号・UID 等の複合キー）が同一の友だちが複数帰属した場合に⚠フラグ
+
+---
+
+## 2. アフィリエイター向け: LIFF でのセルフサーブ操作
+
+### 2-1. 登録
+
+LIFF アプリを `?page=affiliate` 付きで開くとアフィリエイト登録フローが起動します。
+
+```
+https://liff.line.me/<YOUR_LIFF_ID>?page=affiliate
+```
+
+初回アクセス時に LINE ログイン（LIFF SDK が自動実行）が走り、取得した `lineAccessToken` をサーバーに送信して登録が完了します。すでに登録済みの場合は既存のデータを返す（冪等）。
+
+登録時に最初のリンクが自動発行されます。
+
+### 2-2. リンク発行（媒体別ラベル付き）
+
+1. LIFF 上の「リンクを追加」ボタンをクリック
+2. 媒体を表すラベルを入力（例: `Instagram`, `YouTube`, `Twitter`）
+3. `https://go.example.com/<ref_code>` 形式の短縮 URL が発行される
+
+**上限: アフィリエイター 1 人あたり 20 本**。21 本目の発行は 400 エラー。
+
+リンクの形式（`LINK_BASE_URL` 設定時）:
+
+```
+https://go.example.com/Ab3XyZ
+```
+
+`LINK_BASE_URL` 未設定時は Worker 組み込みのリダイレクトルートを使用:
+
+```
+https://<your-worker>/r/Ab3XyZ
+```
+
+### 2-3. 実績確認
+
+LIFF の自分のダッシュボードで以下が確認できます:
+
+| 項目 | 説明 |
+|------|------|
+| クリック数 | リンク毎の `click_count`（リダイレクトヒット数） |
+| 友だち追加数 | 追加時点で last-touch 帰属されたユニーク人数 |
+| コンバージョン数 | 帰属された CV イベント数 |
+| コミッション（参考） | `revenue × commissionRate`（支払い確定は管理者側） |
+
+---
+
+## 3. 帰属ルール
+
+### 3-1. last-touch / 90 日窓
+
+友だちの `ref_tracking` テーブルを参照し、**友だち追加日時から遡って 90 日以内**の最新タッチ（`julianday` 比較）を持つアフィリエイトリンクの所有者が帰属先になります。
+
+```
+帰属先 = argmax_{t ∈ touches} julianday(t.created_at)
+         where julianday(friend.created_at) - 90 <= julianday(t.created_at)
+               AND julianday(t.created_at) <= julianday(friend.created_at)
+               AND t.ref_code → affiliate_link が存在する
+```
+
+参照実装: `packages/db/src/affiliate-attribution.ts` `resolveAffiliateAttribution()`
+
+### 3-2. 自己クリック除外
+
+アフィリエイター自身の LINE 友だち UUID（`affiliates.friend_id`）と `ref_tracking.friend_id` が一致するタッチは帰属から除外されます。自分のリンクを自分で踏んでも成果にはなりません。
+
+```sql
+AND (a.friend_id IS NULL OR a.friend_id != rt.friend_id)
+```
+
+### 3-3. CV 時スナップショット
+
+コンバージョン発生時、`conversion_events` テーブルに以下を書き込みます:
+
+- `affiliate_id`: 帰属先アフィリエイター
+- `attributed_ref_code`: 帰属元 ref_code
+- コンバージョンポイントの `value`（CV 時点の値）
+
+レポート計算は `conversion_events.affiliate_id` を参照するため、**後からアフィリエイターの `commission_rate` を変更しても過去のレポート数値は不変**です。
+
+参照実装: `packages/db/src/affiliate-report.ts` `getAffiliateReportV2()`
+
+---
+
+## 4. 管理者向け: /affiliates 画面
+
+### 4-1. 一覧画面の列
+
+| 列 | 内容 |
+|----|------|
+| 名前 / コード | アフィリエイター名と識別コード |
+| リンク数 | 発行済み ref_code の本数 |
+| クリック（RT） | `ref_tracking` カウント（実タッチ数） |
+| リンククリック | `click_count` 合計（リダイレクトヒット） |
+| 友だち追加 | 追加時点 last-touch で帰属されたユニーク友だち数 |
+| CV 数 | `conversion_events` 帰属件数 |
+| 売上 | CV ポイント `value` の合計 |
+| 推定コミッション | 売上 × `commission_rate` |
+| ステータス | active / paused |
+
+### 4-2. 詳細画面
+
+- **CV 内訳**: CV ポイント別の件数・売上を表示
+- **ジャーニー**: 帰属友だちの一覧（追加日時 / ref_code / タッチ数 / フォーム数 / CV 数 / 最終イベント）。カーソルページネーション（最大 200 件/ページ）
+- **リンク一覧**: 各 ref_code の URL・ラベル・クリック数
+
+### 4-3. ⚠ 重複フラグ（`duplicateFlags`）
+
+レポートに `duplicateFlags` フィールドがあります。これは**帰属友だちのうち `identity_key` が同一の友だちが 2 人以上存在する**場合に表示されます。
+
+`identity_key` は LINE UID・電話番号・メールアドレス等を組み合わせた複合キーで、実質的に同一人物を示します。同じ人が複数のアカウントで友だち追加して CV を水増ししているサインです。
+
+```json
+"duplicateFlags": [
+  { "friendId": "<uuid-A>", "identityKey": "<hashed-key>" },
+  { "friendId": "<uuid-B>", "identityKey": "<hashed-key>" }
+]
+```
+
+参照実装: `packages/db/src/affiliate-report.ts` `getAffiliateReportV2()` の `duplicateFlags` ブロック
+
+### 4-4. ジャーニー API（管理者向け）
+
+友だち単体のタイムライン（タッチ → 友だち追加 → フォーム → CV）を取得できます:
+
+```bash
+GET /api/friends/:id/journey
+```
+
+イベント種別は `touch` / `friend_add` / `form` / `conversion` の 4 種類。同一友だちの複数 ref_code タッチの順序やどの時点でどの ref_code が last-touch になったかを確認するのに使います。
+
+---
+
+## 5. 短縮 URL 設定
+
+### 5-1. アカウント設定（管理画面）
+
+管理画面の「アカウント設定」→「リンクベース URL」に独自ドメインを入力します。
+
+```
+https://go.example.com
+```
+
+- `https://` で始まること（バリデーション必須）
+- 末尾スラッシュは自動除去
+- 空文字で保存するとリセット（Worker 組み込みの `/r` に戻る）
+
+内部的には `account_settings` テーブルの `link_base_url` キー（`accountId = '__global__'`）に保存されます。
+
+### 5-2. ドメイン側 Redirect Rule の設定
+
+独自ドメイン（例: `go.example.com`）でリンクを受け取り、Worker のリダイレクトルートに転送します。Cloudflare の「Redirect Rules」を使う場合の設定例:
+
+| 項目 | 値 |
+|------|-----|
+| If (URL path) | matches `/*` |
+| Then (Redirect to) | `https://<your-worker>/r/${path}` |
+| Status code | 301 |
+
+`${path}` はマッチしたパス部分（スラッシュ含む）に展開されます。
+
+**例**:  
+`https://go.example.com/Ab3XyZ` → 301 → `https://<your-worker>/r/Ab3XyZ`
+
+Worker の `/r/:ref` ルートが ref_code を解決し、LINE 公式アカウントへのリンクを含むランディングページにリダイレクトします。
+
+---
+
+## 6. API リファレンス
+
+### 認証方式
+
+| 種別 | 方式 |
+|------|------|
+| 管理者 API (`/api/affiliates/*`) | `Authorization: Bearer <API_KEY>` ヘッダー |
+| セルフ API (`/api/liff/affiliate/*`) | リクエストボディまたはクエリの `lineAccessToken`（LIFF SDK 発行トークンをサーバー側で LINE OAuth API に検証） |
+| クリック記録（公開） | 認証不要 |
+
+### セルフ API（アフィリエイター向け）
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| `POST` | `/api/liff/affiliate/register` | 登録（冪等）。未登録なら作成 + 1 本目リンクを自動発行 |
+| `GET` | `/api/liff/affiliate/me` | 自分のプロフィール + リンク一覧 |
+| `POST` | `/api/liff/affiliate/links` | リンクを 1 本追加（20 本上限）|
+
+**POST /api/liff/affiliate/register**
+
+```json
+// リクエストボディ
+{ "lineAccessToken": "<LIFF_ACCESS_TOKEN>" }
+
+// レスポンス 200
+{
+  "affiliate": {
+    "id": "<uuid>",
+    "name": "<display_name>",
+    "code": "<base62_code>",
+    "commissionRate": 0.1,
+    "isActive": true,
+    "friendId": "<friend_uuid>"
+  },
+  "links": [
+    {
+      "refCode": "Ab3XyZ",
+      "label": null,
+      "url": "https://go.example.com/Ab3XyZ",
+      "clickCount": 0,
+      "friendAdds": 0,
+      "conversions": 0
+    }
+  ]
+}
+```
+
+**GET /api/liff/affiliate/me**
+
+```
+GET /api/liff/affiliate/me?lineAccessToken=<token>
+```
+
+レスポンス形式は `register` と同一。未登録の場合は 404。
+
+**POST /api/liff/affiliate/links**
+
+```json
+// リクエストボディ
+{ "lineAccessToken": "<LIFF_ACCESS_TOKEN>", "label": "Instagram" }
+
+// レスポンス 200
+{ "link": { "refCode": "Cd4WqR", "label": "Instagram", "url": "...", "clickCount": 0, "friendAdds": 0, "conversions": 0 } }
+```
+
+上限超過時は 400: `{ "error": "Link limit reached (max 20)" }`
+
+### ジャーニー API
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| `GET` | `/api/affiliates/:id/journeys` | アフィリエイターに帰属した友だちの一覧（カーソルページ） |
+| `GET` | `/api/friends/:id/journey` | 友だち 1 人のタイムライン（全イベント時系列） |
+
+**GET /api/affiliates/:id/journeys**
+
+クエリパラメータ:
+
+| パラメータ | 型 | 既定 | 説明 |
+|-----------|-----|------|------|
+| `limit` | integer | 50 | 最大 200 |
+| `beforeAt` | ISO 8601 | — | カーソル（前ページの末尾 `addedAt`） |
+| `beforeId` | string | — | カーソル（前ページの末尾 `friendId`） |
+
+```json
+// レスポンス
+{
+  "success": true,
+  "data": [
+    {
+      "friendId": "<uuid>",
+      "displayName": "山田太郎",
+      "addedAt": "2026-07-01T10:00:00.000+09:00",
+      "refCode": "Ab3XyZ",
+      "touchCount": 3,
+      "formCount": 1,
+      "conversionCount": 1,
+      "lastEventAt": "2026-07-05T14:30:00.000+09:00"
+    }
+  ],
+  "nextCursor": { "beforeAt": "...", "beforeId": "..." }
+}
+```
+
+`nextCursor` が `null` の場合は最終ページです。
+
+### レポート API
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| `GET` | `/api/affiliates/:id/report` | アフィリエイター 1 人の詳細レポート（v2） |
+| `GET` | `/api/affiliates-report` | 全アフィリエイター一覧レポート |
+
+**GET /api/affiliates/:id/report**
+
+クエリパラメータ: `startDate` / `endDate`（ISO 8601 日付、省略可）
+
+```json
+// レスポンス
+{
+  "success": true,
+  "data": {
+    "affiliateId": "<uuid>",
+    "affiliateName": "田中さん",
+    "code": "<code>",
+    "commissionRate": 0.1,
+    "clicks": 80,
+    "linkClicks": 95,
+    "friendAdds": 12,
+    "conversions": 4,
+    "conversionsByPoint": [
+      { "conversionPointId": "<uuid>", "name": "商品A購入", "count": 3, "value": 29400 },
+      { "conversionPointId": "<uuid>", "name": "メルマガ登録", "count": 1, "value": 0 }
+    ],
+    "revenue": 29400,
+    "estimatedCommission": 2940,
+    "duplicateFlags": []
+  }
+}
+```
+
+`clicks` は `ref_tracking` の実タッチ数、`linkClicks` はリダイレクトヒット（`affiliate_links.click_count` 合計）です。両者はボットフィルタリング方法の違いにより一致しないことがあります。

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -104,6 +104,7 @@ LINE Harness は、LINE公式アカウント向けのオープンソース CRM /
 21. **[Operations](22-Operations.md)** — 運用、監視、トラブルシューティング
 22. **[Claude Code Integration](23-Claude-Code-Integration.md)** — AI連携、プロンプト例
 23. **[MCP Server](24-MCP-Server.md)** — MCP Server セットアップ、ツール一覧、URL自動追跡
+27. **[Affiliate ASP](27-Affiliate-ASP.md)** — セルフサーブ型アフィリエイト計測、last-touch帰属、重複フラグ、API
 
 ## D1テーブル一覧（42テーブル）
 

--- a/packages/db/bootstrap-meta.json
+++ b/packages/db/bootstrap-meta.json
@@ -50,7 +50,8 @@
     "042_tracked_links_og.sql",
     "043_events_og.sql",
     "044_forms_og.sql",
-    "045_menus_auto_tag.sql"
+    "045_menus_auto_tag.sql",
+    "046_affiliate_links.sql"
   ],
-  "migrationCount": 51
+  "migrationCount": 52
 }

--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -71,12 +71,24 @@ CREATE TABLE affiliate_clicks (
   created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
 
+CREATE TABLE affiliate_links (
+  id              TEXT PRIMARY KEY,
+  affiliate_id    TEXT NOT NULL REFERENCES affiliates (id),
+  ref_code        TEXT NOT NULL UNIQUE,
+  label           TEXT,
+  line_account_id TEXT REFERENCES line_accounts (id),
+  is_active       INTEGER NOT NULL DEFAULT 1,
+  created_at      TEXT NOT NULL,
+  click_count     INTEGER NOT NULL DEFAULT 0
+);
+
 CREATE TABLE affiliates (
   id              TEXT PRIMARY KEY,
   name            TEXT NOT NULL,
   code            TEXT NOT NULL UNIQUE,
   commission_rate REAL NOT NULL DEFAULT 0,
   is_active       INTEGER NOT NULL DEFAULT 1,
+  friend_id       TEXT REFERENCES friends (id),
   created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
 
@@ -229,13 +241,15 @@ CREATE TABLE chats (
 , line_account_id TEXT);
 
 CREATE TABLE conversion_events (
-  id                  TEXT PRIMARY KEY,
-  conversion_point_id TEXT NOT NULL REFERENCES conversion_points (id) ON DELETE CASCADE,
-  friend_id           TEXT NOT NULL REFERENCES friends (id) ON DELETE CASCADE,
-  user_id             TEXT,
-  affiliate_code      TEXT,
-  metadata            TEXT,
-  created_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+  id                   TEXT PRIMARY KEY,
+  conversion_point_id  TEXT NOT NULL REFERENCES conversion_points (id) ON DELETE CASCADE,
+  friend_id            TEXT NOT NULL REFERENCES friends (id) ON DELETE CASCADE,
+  user_id              TEXT,
+  affiliate_code       TEXT,
+  metadata             TEXT,
+  affiliate_id         TEXT REFERENCES affiliates (id),
+  attributed_ref_code  TEXT,
+  created_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
 
 CREATE TABLE conversion_points (
@@ -428,6 +442,8 @@ CREATE TABLE friends (
   user_id          TEXT,
   ig_igsid         TEXT,
   score            INTEGER NOT NULL DEFAULT 0,
+  last_ref_code    TEXT,
+  last_ref_at      TEXT,
   created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   updated_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 , ref_code TEXT, metadata TEXT NOT NULL DEFAULT '{}', line_account_id TEXT REFERENCES line_accounts(id), first_tracked_link_id TEXT REFERENCES tracked_links (id) ON DELETE SET NULL);
@@ -815,6 +831,10 @@ CREATE INDEX idx_ad_conversion_logs_status ON ad_conversion_logs (status);
 
 CREATE INDEX idx_affiliate_clicks_affiliate ON affiliate_clicks (affiliate_id);
 
+CREATE INDEX idx_affiliate_links_affiliate ON affiliate_links (affiliate_id);
+
+CREATE UNIQUE INDEX idx_affiliates_friend ON affiliates (friend_id) WHERE friend_id IS NOT NULL;
+
 CREATE INDEX idx_auto_replies_template_id ON auto_replies(template_id);
 
 CREATE INDEX idx_automation_logs_automation ON automation_logs (automation_id);
@@ -931,7 +951,11 @@ CREATE INDEX idx_notifications_status ON notifications (status);
 
 CREATE INDEX idx_ref_tracking_friend ON ref_tracking (friend_id);
 
+CREATE INDEX idx_ref_tracking_friend_created ON ref_tracking(friend_id, created_at);
+
 CREATE INDEX idx_ref_tracking_ref    ON ref_tracking (ref_code);
+
+CREATE INDEX idx_ref_tracking_ref_created ON ref_tracking(ref_code, created_at);
 
 CREATE INDEX idx_reminder_steps_reminder ON reminder_steps (reminder_id);
 

--- a/packages/db/migrations/046_affiliate_links.sql
+++ b/packages/db/migrations/046_affiliate_links.sql
@@ -1,0 +1,27 @@
+-- 046_affiliate_links.sql — ASP: affiliate self-serve links + last-touch attribution
+ALTER TABLE affiliates ADD COLUMN friend_id TEXT REFERENCES friends(id);
+-- One affiliate per friend (partial unique — NULL friend_id stays unconstrained,
+-- so admin-created affiliates without a backing friend are unaffected). This is
+-- the structural guarantee behind the idempotent self-register endpoint.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_affiliates_friend ON affiliates(friend_id) WHERE friend_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS affiliate_links (
+  id              TEXT PRIMARY KEY,
+  affiliate_id    TEXT NOT NULL REFERENCES affiliates(id),
+  ref_code        TEXT NOT NULL UNIQUE,
+  label           TEXT,
+  line_account_id TEXT REFERENCES line_accounts(id),
+  is_active       INTEGER NOT NULL DEFAULT 1,
+  created_at      TEXT NOT NULL,
+  click_count     INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_affiliate_links_affiliate ON affiliate_links(affiliate_id);
+
+ALTER TABLE friends ADD COLUMN last_ref_code TEXT;
+ALTER TABLE friends ADD COLUMN last_ref_at TEXT;
+
+ALTER TABLE conversion_events ADD COLUMN affiliate_id TEXT REFERENCES affiliates(id);
+ALTER TABLE conversion_events ADD COLUMN attributed_ref_code TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_ref_tracking_friend_created ON ref_tracking(friend_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_ref_tracking_ref_created ON ref_tracking(ref_code, created_at);

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -14,6 +14,8 @@ CREATE TABLE IF NOT EXISTS friends (
   user_id          TEXT,
   ig_igsid         TEXT,
   score            INTEGER NOT NULL DEFAULT 0,
+  last_ref_code    TEXT,
+  last_ref_at      TEXT,
   created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   updated_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
@@ -270,13 +272,15 @@ CREATE TABLE IF NOT EXISTS conversion_points (
 -- Round 2: Conversion Events (CV Records)
 -- ============================================================
 CREATE TABLE IF NOT EXISTS conversion_events (
-  id                  TEXT PRIMARY KEY,
-  conversion_point_id TEXT NOT NULL REFERENCES conversion_points (id) ON DELETE CASCADE,
-  friend_id           TEXT NOT NULL REFERENCES friends (id) ON DELETE CASCADE,
-  user_id             TEXT,
-  affiliate_code      TEXT,
-  metadata            TEXT,
-  created_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+  id                   TEXT PRIMARY KEY,
+  conversion_point_id  TEXT NOT NULL REFERENCES conversion_points (id) ON DELETE CASCADE,
+  friend_id            TEXT NOT NULL REFERENCES friends (id) ON DELETE CASCADE,
+  user_id              TEXT,
+  affiliate_code       TEXT,
+  metadata             TEXT,
+  affiliate_id         TEXT REFERENCES affiliates (id),
+  attributed_ref_code  TEXT,
+  created_at           TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_conversion_events_point ON conversion_events (conversion_point_id);
@@ -292,8 +296,27 @@ CREATE TABLE IF NOT EXISTS affiliates (
   code            TEXT NOT NULL UNIQUE,
   commission_rate REAL NOT NULL DEFAULT 0,
   is_active       INTEGER NOT NULL DEFAULT 1,
+  friend_id       TEXT REFERENCES friends (id),
   created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_affiliates_friend ON affiliates (friend_id) WHERE friend_id IS NOT NULL;
+
+-- ============================================================
+-- Round 2: Affiliate Self-Serve Links (migration 046)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS affiliate_links (
+  id              TEXT PRIMARY KEY,
+  affiliate_id    TEXT NOT NULL REFERENCES affiliates (id),
+  ref_code        TEXT NOT NULL UNIQUE,
+  label           TEXT,
+  line_account_id TEXT REFERENCES line_accounts (id),
+  is_active       INTEGER NOT NULL DEFAULT 1,
+  created_at      TEXT NOT NULL,
+  click_count     INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_affiliate_links_affiliate ON affiliate_links (affiliate_id);
 
 -- ============================================================
 -- Round 2: Affiliate Clicks

--- a/packages/db/src/account-settings.ts
+++ b/packages/db/src/account-settings.ts
@@ -1,0 +1,104 @@
+/**
+ * account_settings table helpers.
+ *
+ * The table stores arbitrary key/value pairs keyed by (line_account_id, key).
+ * Each setting is a JSON-encoded string so the column type never changes.
+ */
+
+/**
+ * Retrieve a raw setting value (JSON string) for an account.
+ * Returns null when the key is not set.
+ */
+export async function getAccountSetting(
+  db: D1Database,
+  accountId: string,
+  key: string,
+): Promise<string | null> {
+  const row = await db
+    .prepare(`SELECT value FROM account_settings WHERE line_account_id = ? AND key = ?`)
+    .bind(accountId, key)
+    .first<{ value: string }>();
+  return row?.value ?? null;
+}
+
+/**
+ * Upsert a raw setting value (JSON string) for an account.
+ */
+export async function setAccountSetting(
+  db: D1Database,
+  accountId: string,
+  key: string,
+  value: string,
+): Promise<void> {
+  const id = crypto.randomUUID();
+  const now = new Date(Date.now() + 9 * 60 * 60_000)
+    .toISOString()
+    .replace('Z', '+09:00');
+
+  await db
+    .prepare(
+      `INSERT INTO account_settings (id, line_account_id, key, value, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT (line_account_id, key) DO UPDATE SET value = ?, updated_at = ?`,
+    )
+    .bind(id, accountId, key, value, now, now, value, now)
+    .run();
+}
+
+// ── link_base_url ─────────────────────────────────────────────────────────────
+
+const LINK_BASE_URL_KEY = 'link_base_url';
+
+/**
+ * Get the configured short-link base URL for an account.
+ * Returns null when not set (caller should fall back to WORKER_URL/r).
+ * The stored value has no trailing slash.
+ */
+export async function getLinkBaseUrl(
+  db: D1Database,
+  accountId: string,
+): Promise<string | null> {
+  const raw = await getAccountSetting(db, accountId, LINK_BASE_URL_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as string;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate and persist a link_base_url value for an account.
+ *
+ * Rules:
+ *  - Empty string clears the setting (returns without storing).
+ *  - Must start with "https://".
+ *  - Trailing slash is stripped before saving.
+ *
+ * Throws a descriptive Error on validation failure.
+ */
+export async function setLinkBaseUrl(
+  db: D1Database,
+  accountId: string,
+  value: string,
+): Promise<void> {
+  const trimmed = value.trim();
+
+  if (trimmed === '') {
+    // Clear the setting.
+    await db
+      .prepare(
+        `DELETE FROM account_settings WHERE line_account_id = ? AND key = ?`,
+      )
+      .bind(accountId, LINK_BASE_URL_KEY)
+      .run();
+    return;
+  }
+
+  if (!trimmed.startsWith('https://')) {
+    throw new Error('link_base_url must start with https://');
+  }
+
+  const normalized = trimmed.replace(/\/$/, '');
+  await setAccountSetting(db, accountId, LINK_BASE_URL_KEY, JSON.stringify(normalized));
+}

--- a/packages/db/src/affiliate-attribution.ts
+++ b/packages/db/src/affiliate-attribution.ts
@@ -1,0 +1,56 @@
+import { jstNow } from './utils.js';
+// =============================================================================
+// Affiliate Attribution — last-touch resolution (ASP)
+// =============================================================================
+//
+// Resolves which affiliate (if any) a conversion should be credited to, using
+// the most-recent eligible ref-tracking touch within the attribution window.
+//
+// Rules (see spec §8):
+//  - last-touch: the newest eligible touch wins
+//  - window: touches older than ATTRIBUTION_WINDOW_DAYS are ignored
+//  - only touches whose ref_code maps to an affiliate_link count
+//  - self-clicks (the friend is the affiliate's own friend_id) are excluded
+//  - is_active=0 links STILL attribute here; the report layer distinguishes
+//    paused links, not this resolver.
+
+export const ATTRIBUTION_WINDOW_DAYS = 90;
+
+/**
+ * Resolve the last-touch affiliate attribution for a friend.
+ *
+ * @param at Reference timestamp (JST ISO). Defaults to jstNow().
+ *           Touches must fall within [at - 90 days, at].
+ * @returns The winning affiliate + ref_code, or null if none is eligible.
+ *
+ * Timestamp comparison note:
+ *  ref_tracking.created_at is stored as a JST ISO string with a +09:00 offset
+ *  (e.g. "2026-07-07T12:00:00.000+09:00"). SQLite's datetime() emits a
+ *  space-separated UTC-normalized string, so a raw string comparison against
+ *  datetime(?, '-90 days') mixes formats and produces boundary errors. We use
+ *  julianday(), which parses the offset into a true instant, so the window and
+ *  ordering compare real points in time regardless of textual format.
+ */
+export async function resolveAffiliateAttribution(
+  db: D1Database,
+  friendId: string,
+  at?: string, // 省略時 jstNow()
+): Promise<{ affiliateId: string; refCode: string } | null> {
+  const now = at ?? jstNow();
+  const row = await db
+    .prepare(
+      `SELECT al.affiliate_id AS affiliate_id, rt.ref_code AS ref_code
+         FROM ref_tracking rt
+         JOIN affiliate_links al ON al.ref_code = rt.ref_code
+         JOIN affiliates a ON a.id = al.affiliate_id
+        WHERE rt.friend_id = ?
+          AND julianday(rt.created_at) >= julianday(?) - ${ATTRIBUTION_WINDOW_DAYS}
+          AND julianday(rt.created_at) <= julianday(?)
+          AND (a.friend_id IS NULL OR a.friend_id != rt.friend_id)  -- 自己クリック除外
+        ORDER BY julianday(rt.created_at) DESC
+        LIMIT 1`,
+    )
+    .bind(friendId, now, now)
+    .first<{ affiliate_id: string; ref_code: string }>();
+  return row ? { affiliateId: row.affiliate_id, refCode: row.ref_code } : null;
+}

--- a/packages/db/src/affiliate-links.ts
+++ b/packages/db/src/affiliate-links.ts
@@ -1,0 +1,177 @@
+import { jstNow } from './utils.js';
+import type { Affiliate } from './affiliates.js';
+// =============================================================================
+// Affiliate Links — ASP ref-code CRUD + slug generation
+// =============================================================================
+
+export interface AffiliateLink {
+  id: string;
+  affiliate_id: string;
+  ref_code: string;
+  label: string | null;
+  line_account_id: string | null;
+  is_active: number;
+  created_at: string;
+  click_count: number;
+}
+
+// ── slug generation ──────────────────────────────────────────────────────────
+
+const BASE62_CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+/**
+ * Generate a base62 slug of the given length using crypto.getRandomValues.
+ * Default length is 6 (standard). Pass 8 for the extended fallback.
+ */
+export function generateRefSlug(length = 6): string {
+  const bytes = new Uint8Array(length * 2); // over-allocate to reduce modulo bias
+  crypto.getRandomValues(bytes);
+  let result = '';
+  let i = 0;
+  while (result.length < length) {
+    // Use rejection sampling to avoid modulo bias (62 is not a power of 2)
+    const byte = bytes[i % bytes.length];
+    i++;
+    if (byte < 248) {
+      // 248 = floor(256 / 62) * 62 — anything >= 248 is biased, skip it
+      result += BASE62_CHARS[byte % 62];
+    }
+    // Refresh bytes if we run out (very unlikely for length <= 8)
+    if (i >= bytes.length && result.length < length) {
+      crypto.getRandomValues(bytes);
+      i = 0;
+    }
+  }
+  return result;
+}
+
+// ── createAffiliateLink ──────────────────────────────────────────────────────
+
+export interface CreateAffiliateLinkInput {
+  affiliateId: string;
+  label?: string | null;
+  lineAccountId?: string | null;
+}
+
+/**
+ * Insert an affiliate link row with a unique base62 ref_code.
+ *
+ * Collision retry strategy:
+ *  - Attempt 1..3: 6-char slug
+ *  - Attempt 4+  : 8-char slug (virtually collision-free)
+ *
+ * The optional `_slugGen` parameter allows tests to inject a deterministic
+ * generator without touching the public signature behaviour.
+ */
+export async function createAffiliateLink(
+  db: D1Database,
+  input: CreateAffiliateLinkInput,
+  _slugGen: (len: number) => string = generateRefSlug,
+): Promise<AffiliateLink> {
+  const id = crypto.randomUUID();
+  const now = jstNow();
+
+  let attempt = 0;
+  while (true) {
+    attempt++;
+    const len = attempt <= 3 ? 6 : 8;
+    const refCode = _slugGen(len);
+
+    try {
+      await db
+        .prepare(
+          `INSERT INTO affiliate_links
+             (id, affiliate_id, ref_code, label, line_account_id, is_active, created_at)
+           VALUES (?, ?, ?, ?, ?, 1, ?)`,
+        )
+        .bind(
+          id,
+          input.affiliateId,
+          refCode,
+          input.label ?? null,
+          input.lineAccountId ?? null,
+          now,
+        )
+        .run();
+
+      // Insert succeeded — fetch and return the row
+      return (await db
+        .prepare(`SELECT * FROM affiliate_links WHERE id = ?`)
+        .bind(id)
+        .first<AffiliateLink>())!;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/UNIQUE constraint failed/i.test(msg)) {
+        // Collision — retry with a new slug
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+// ── getAffiliateLinkByRefCode ────────────────────────────────────────────────
+
+export async function getAffiliateLinkByRefCode(
+  db: D1Database,
+  refCode: string,
+): Promise<AffiliateLink | null> {
+  return db
+    .prepare(`SELECT * FROM affiliate_links WHERE ref_code = ?`)
+    .bind(refCode)
+    .first<AffiliateLink>();
+}
+
+// ── listAffiliateLinks ───────────────────────────────────────────────────────
+
+export async function listAffiliateLinks(
+  db: D1Database,
+  affiliateId: string,
+): Promise<AffiliateLink[]> {
+  const result = await db
+    .prepare(
+      `SELECT * FROM affiliate_links WHERE affiliate_id = ? ORDER BY created_at DESC`,
+    )
+    .bind(affiliateId)
+    .all<AffiliateLink>();
+  return result.results;
+}
+
+// ── countAffiliateLinks ──────────────────────────────────────────────────────
+
+export async function countAffiliateLinks(
+  db: D1Database,
+  affiliateId: string,
+): Promise<number> {
+  const row = await db
+    .prepare(`SELECT COUNT(*) AS cnt FROM affiliate_links WHERE affiliate_id = ?`)
+    .bind(affiliateId)
+    .first<{ cnt: number }>();
+  return row?.cnt ?? 0;
+}
+
+// ── incrementAffiliateLinkClick ──────────────────────────────────────────────
+
+export async function incrementAffiliateLinkClick(
+  db: D1Database,
+  refCode: string,
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE affiliate_links SET click_count = click_count + 1 WHERE ref_code = ?`,
+    )
+    .bind(refCode)
+    .run();
+}
+
+// ── getAffiliateByFriendId ───────────────────────────────────────────────────
+
+export async function getAffiliateByFriendId(
+  db: D1Database,
+  friendId: string,
+): Promise<Affiliate | null> {
+  return db
+    .prepare(`SELECT * FROM affiliates WHERE friend_id = ?`)
+    .bind(friendId)
+    .first<Affiliate>();
+}

--- a/packages/db/src/affiliate-report.ts
+++ b/packages/db/src/affiliate-report.ts
@@ -1,0 +1,552 @@
+import { ATTRIBUTION_WINDOW_DAYS } from './affiliate-attribution.js';
+
+// =============================================================================
+// Affiliate Report v2 + Journey aggregation (ASP)
+// =============================================================================
+//
+// Set-based aggregation for affiliate reporting and per-friend journeys. These
+// mirror the last-touch rules of resolveAffiliateAttribution (see that file's
+// header), expressed as JOINs so a report never fans a friend list back into an
+// `IN (?, ?, …)` bind list (D1 caps bind vars at ~100; see
+// feedback-d1-no-large-in-clauses).
+//
+// Timestamp comparison note (Task 4 boundary-bug lesson):
+//   ref_tracking.created_at / friends.created_at can be JST ISO (+09:00) or a
+//   SQLite datetime('now') space-separated UTC string. Raw string comparison
+//   mixes formats and produces boundary errors. Every window / ordering check
+//   below uses julianday() so it compares real instants regardless of format.
+
+// ── friendAdds: attributed-at-add-time last-touch ────────────────────────────
+//
+// A friend "belongs" to an affiliate for the friendAdds metric when, at the
+// friend's created_at instant, the winning last-touch (newest eligible touch
+// within the 90-day window, self-clicks excluded) maps to that affiliate.
+//
+// Expressed set-based: the friend's own newest eligible touch (by julianday)
+// within [created_at - 90d, created_at] whose ref_code maps to an affiliate,
+// excluding self-clicks. A correlated subquery picks that winning ref_code per
+// friend; we then group by the winning affiliate.
+//
+// This fragment references `friends f` from the outer query.
+//
+// Exported so the all-affiliates aggregate (getAffiliateReport in affiliates.ts)
+// resolves each friend's winning affiliate with the *identical* expression: a
+// single pass over friends, grouped by winner, so the list view's friend_adds
+// column matches the per-affiliate report exactly.
+export const FRIEND_ADD_WINNER_SUBQUERY = `
+  SELECT al2.affiliate_id
+    FROM ref_tracking rt2
+    JOIN affiliate_links al2 ON al2.ref_code = rt2.ref_code
+    JOIN affiliates a2 ON a2.id = al2.affiliate_id
+   WHERE rt2.friend_id = f.id
+     AND julianday(rt2.created_at) >= julianday(f.created_at) - ${ATTRIBUTION_WINDOW_DAYS}
+     AND julianday(rt2.created_at) <= julianday(f.created_at)
+     AND (a2.friend_id IS NULL OR a2.friend_id != rt2.friend_id)
+   ORDER BY julianday(rt2.created_at) DESC
+   LIMIT 1
+`;
+
+export interface AffiliateReportV2 {
+  affiliateId: string;
+  affiliateName: string;
+  code: string;
+  commissionRate: number;
+  /** ref_tracking touches whose ref_code maps to one of this affiliate's links. */
+  clicks: number;
+  /** Denormalized click_count summed across the affiliate's links (redirect hits). */
+  linkClicks: number;
+  /** Friends whose add-time last-touch attribution is this affiliate. */
+  friendAdds: number;
+  /** Conversions attributed to this affiliate (conversion_events snapshot). */
+  conversions: number;
+  /** Conversion count broken down by conversion point. */
+  conversionsByPoint: Array<{ conversionPointId: string; name: string; count: number; value: number }>;
+  /** Sum of conversion point values across attributed conversions. */
+  revenue: number;
+  /** revenue * commissionRate. */
+  estimatedCommission: number;
+  /** Attributed friends sharing an identity_key within this affiliate (>=2). */
+  duplicateFlags: Array<{ friendId: string; identityKey: string }>;
+}
+
+export interface AffiliateReportOptions {
+  startDate?: string;
+  endDate?: string;
+  /**
+   * The canonical IDENTITY_KEY_SQL fragment (from the worker's lib/identity-key).
+   * Passed in so packages/db stays decoupled from apps/worker while reusing the
+   * exact same duplicate-detection expression. Must reference `friends.*`.
+   */
+  identityKeySql: string;
+}
+
+/**
+ * Compute the v2 affiliate report for a single affiliate. Returns null when the
+ * affiliate does not exist.
+ */
+export async function getAffiliateReportV2(
+  db: D1Database,
+  affiliateId: string,
+  opts: AffiliateReportOptions,
+): Promise<AffiliateReportV2 | null> {
+  const affiliate = await db
+    .prepare(`SELECT id, name, code, commission_rate FROM affiliates WHERE id = ?`)
+    .bind(affiliateId)
+    .first<{ id: string; name: string; code: string; commission_rate: number }>();
+  if (!affiliate) return null;
+
+  const { startDate, endDate, identityKeySql } = opts;
+
+  // ── clicks: ref_tracking touches on this affiliate's links ─────────────────
+  const clickConds: string[] = ['al.affiliate_id = ?'];
+  const clickBinds: unknown[] = [affiliateId];
+  if (startDate) {
+    clickConds.push('julianday(rt.created_at) >= julianday(?)');
+    clickBinds.push(startDate);
+  }
+  if (endDate) {
+    clickConds.push('julianday(rt.created_at) <= julianday(?)');
+    clickBinds.push(endDate);
+  }
+  const clicksRow = await db
+    .prepare(
+      `SELECT COUNT(*) AS clicks
+         FROM ref_tracking rt
+         JOIN affiliate_links al ON al.ref_code = rt.ref_code
+        WHERE ${clickConds.join(' AND ')}`,
+    )
+    .bind(...clickBinds)
+    .first<{ clicks: number }>();
+
+  // ── linkClicks: denormalized click_count on the affiliate's links ──────────
+  const linkClicksRow = await db
+    .prepare(
+      `SELECT COALESCE(SUM(click_count), 0) AS link_clicks
+         FROM affiliate_links WHERE affiliate_id = ?`,
+    )
+    .bind(affiliateId)
+    .first<{ link_clicks: number }>();
+
+  // ── friendAdds: friends whose add-time last-touch is this affiliate ────────
+  // Correlated subquery resolves each friend's winning affiliate at their
+  // created_at; the outer WHERE keeps only friends won by this affiliate.
+  // friends.created_at date filter (if given) bounds which adds are counted.
+  const friendAddConds: string[] = [`(${FRIEND_ADD_WINNER_SUBQUERY}) = ?`];
+  const friendAddBinds: unknown[] = [affiliateId];
+  if (startDate) {
+    friendAddConds.push('julianday(f.created_at) >= julianday(?)');
+    friendAddBinds.push(startDate);
+  }
+  if (endDate) {
+    friendAddConds.push('julianday(f.created_at) <= julianday(?)');
+    friendAddBinds.push(endDate);
+  }
+  const friendAddsRow = await db
+    .prepare(
+      `SELECT COUNT(*) AS friend_adds
+         FROM friends f
+        WHERE ${friendAddConds.join(' AND ')}`,
+    )
+    .bind(...friendAddBinds)
+    .first<{ friend_adds: number }>();
+
+  // ── conversions + conversionsByPoint + revenue ─────────────────────────────
+  // conversion_events already snapshots affiliate_id at CV time, so we only read
+  // that column (no re-attribution). Joined to conversion_points for value/name.
+  const cvConds: string[] = ['ce.affiliate_id = ?'];
+  const cvBinds: unknown[] = [affiliateId];
+  if (startDate) {
+    cvConds.push('julianday(ce.created_at) >= julianday(?)');
+    cvBinds.push(startDate);
+  }
+  if (endDate) {
+    cvConds.push('julianday(ce.created_at) <= julianday(?)');
+    cvBinds.push(endDate);
+  }
+  const byPoint = await db
+    .prepare(
+      `SELECT cp.id AS conversion_point_id,
+              cp.name AS name,
+              COUNT(*) AS count,
+              COALESCE(SUM(cp.value), 0) AS value
+         FROM conversion_events ce
+         JOIN conversion_points cp ON cp.id = ce.conversion_point_id
+        WHERE ${cvConds.join(' AND ')}
+        GROUP BY cp.id, cp.name
+        ORDER BY count DESC`,
+    )
+    .bind(...cvBinds)
+    .all<{ conversion_point_id: string; name: string; count: number; value: number }>();
+
+  const conversionsByPoint = byPoint.results.map((r) => ({
+    conversionPointId: r.conversion_point_id,
+    name: r.name,
+    count: r.count,
+    value: r.value,
+  }));
+  const conversions = conversionsByPoint.reduce((s, p) => s + p.count, 0);
+  const revenue = conversionsByPoint.reduce((s, p) => s + p.value, 0);
+  const estimatedCommission = revenue * affiliate.commission_rate;
+
+  // ── duplicateFlags: attributed friends sharing an identity_key ─────────────
+  // "Attributed friend" here = friend whose add-time last-touch is this
+  // affiliate (same winner subquery as friendAdds). Among those, flag every
+  // friend whose identity_key is shared by >=2 friends in the set.
+  // No IN(?) fan-out: the shared-key set is a self-JOIN-free windowless GROUP BY
+  // subquery, joined back to the base set.
+  const dupRows = await db
+    .prepare(
+      `WITH attributed AS (
+         SELECT friends.id AS friend_id, (${identityKeySql}) AS identity_key
+           FROM friends
+          WHERE (
+            SELECT al2.affiliate_id
+              FROM ref_tracking rt2
+              JOIN affiliate_links al2 ON al2.ref_code = rt2.ref_code
+              JOIN affiliates a2 ON a2.id = al2.affiliate_id
+             WHERE rt2.friend_id = friends.id
+               AND julianday(rt2.created_at) >= julianday(friends.created_at) - ${ATTRIBUTION_WINDOW_DAYS}
+               AND julianday(rt2.created_at) <= julianday(friends.created_at)
+               AND (a2.friend_id IS NULL OR a2.friend_id != rt2.friend_id)
+             ORDER BY julianday(rt2.created_at) DESC
+             LIMIT 1
+          ) = ?
+       ),
+       dup_keys AS (
+         SELECT identity_key FROM attributed
+          GROUP BY identity_key HAVING COUNT(*) >= 2
+       )
+       SELECT a.friend_id, a.identity_key
+         FROM attributed a
+         JOIN dup_keys d ON d.identity_key = a.identity_key
+        ORDER BY a.identity_key, a.friend_id`,
+    )
+    .bind(affiliateId)
+    .all<{ friend_id: string; identity_key: string }>();
+
+  const duplicateFlags = dupRows.results.map((r) => ({
+    friendId: r.friend_id,
+    identityKey: r.identity_key,
+  }));
+
+  return {
+    affiliateId: affiliate.id,
+    affiliateName: affiliate.name,
+    code: affiliate.code,
+    commissionRate: affiliate.commission_rate,
+    clicks: clicksRow?.clicks ?? 0,
+    linkClicks: linkClicksRow?.link_clicks ?? 0,
+    friendAdds: friendAddsRow?.friend_adds ?? 0,
+    conversions,
+    conversionsByPoint,
+    revenue,
+    estimatedCommission,
+    duplicateFlags,
+  };
+}
+
+// ── Per-link stats (self API) ────────────────────────────────────────────────
+
+/** Per-link performance counters keyed by ref_code. */
+export interface AffiliateLinkStat {
+  friendAdds: number;
+  conversions: number;
+}
+
+/**
+ * Per-ref_code friendAdds + conversions for a single affiliate, returned as a
+ * Map keyed by ref_code. Links with no activity are simply absent from the map
+ * (callers default those to 0).
+ *
+ * Semantics are chosen so per-link sums reconcile with the per-affiliate report:
+ *
+ *   - conversions: grouped from conversion_events by attributed_ref_code, scoped
+ *     to this affiliate via the affiliate_id snapshot. (getAffiliateReportV2's
+ *     conversions counts the same rows, just without the per-ref_code grouping.)
+ *
+ *   - friendAdds: resolved with the IDENTICAL add-time last-touch winner logic as
+ *     the per-affiliate friendAdds — a friend belongs to the affiliate when its
+ *     winning ref_code maps to one of the affiliate's links. We reuse the winner
+ *     subquery (which returns affiliate_id) to keep only friends won by THIS
+ *     affiliate, then a parallel subquery yields that same winner's ref_code so we
+ *     can COUNT per ref_code. Summing this map's friendAdds equals the
+ *     per-affiliate friendAdds exactly (same winner, same window, same self-click
+ *     exclusion).
+ */
+export async function getAffiliateLinkStats(
+  db: D1Database,
+  affiliateId: string,
+): Promise<Map<string, AffiliateLinkStat>> {
+  const stats = new Map<string, AffiliateLinkStat>();
+  const ensure = (refCode: string): AffiliateLinkStat => {
+    let s = stats.get(refCode);
+    if (!s) {
+      s = { friendAdds: 0, conversions: 0 };
+      stats.set(refCode, s);
+    }
+    return s;
+  };
+
+  // conversions per link: attributed_ref_code grouped, scoped by affiliate_id
+  // snapshot. NULL attributed_ref_code rows (attributed by id but without a
+  // ref_code) can't map to a link, so they're excluded from the per-link view.
+  const cvRows = await db
+    .prepare(
+      `SELECT attributed_ref_code AS ref_code, COUNT(*) AS conversions
+         FROM conversion_events
+        WHERE affiliate_id = ? AND attributed_ref_code IS NOT NULL
+        GROUP BY attributed_ref_code`,
+    )
+    .bind(affiliateId)
+    .all<{ ref_code: string; conversions: number }>();
+  for (const r of cvRows.results) {
+    ensure(r.ref_code).conversions = r.conversions;
+  }
+
+  // friendAdds per link: same winner logic as per-affiliate friendAdds, but we
+  // bucket by the WINNING ref_code. The outer WHERE keeps only friends whose
+  // winning affiliate is this one (FRIEND_ADD_WINNER_SUBQUERY), and the parallel
+  // subquery re-resolves that winner's ref_code to GROUP BY.
+  const faRows = await db
+    .prepare(
+      `SELECT winner_ref_code AS ref_code, COUNT(*) AS friend_adds
+         FROM (
+           SELECT (
+             SELECT rt2.ref_code
+               FROM ref_tracking rt2
+               JOIN affiliate_links al2 ON al2.ref_code = rt2.ref_code
+               JOIN affiliates a2 ON a2.id = al2.affiliate_id
+              WHERE rt2.friend_id = f.id
+                AND julianday(rt2.created_at) >= julianday(f.created_at) - ${ATTRIBUTION_WINDOW_DAYS}
+                AND julianday(rt2.created_at) <= julianday(f.created_at)
+                AND (a2.friend_id IS NULL OR a2.friend_id != rt2.friend_id)
+              ORDER BY julianday(rt2.created_at) DESC
+              LIMIT 1
+           ) AS winner_ref_code
+             FROM friends f
+            WHERE (${FRIEND_ADD_WINNER_SUBQUERY}) = ?
+         )
+        WHERE winner_ref_code IS NOT NULL
+        GROUP BY winner_ref_code`,
+    )
+    .bind(affiliateId)
+    .all<{ ref_code: string; friend_adds: number }>();
+  for (const r of faRows.results) {
+    ensure(r.ref_code).friendAdds = r.friend_adds;
+  }
+
+  return stats;
+}
+
+// ── Journey (single friend) ──────────────────────────────────────────────────
+
+export type JourneyEventType = 'touch' | 'friend_add' | 'form' | 'conversion';
+
+export interface JourneyEvent {
+  at: string;
+  type: JourneyEventType;
+  refCode?: string;
+  affiliateId?: string;
+  label?: string;
+  detail?: string;
+}
+
+/**
+ * Time-ordered (ascending) journey for one friend: ref_tracking touches,
+ * the friend_add moment, form submissions, and conversions. A single UNION ALL
+ * over the four sources ordered by julianday() so mixed timestamp formats sort
+ * by true instant.
+ */
+export async function getFriendJourney(
+  db: D1Database,
+  friendId: string,
+): Promise<JourneyEvent[]> {
+  const friend = await db
+    .prepare(`SELECT id FROM friends WHERE id = ?`)
+    .bind(friendId)
+    .first<{ id: string }>();
+  if (!friend) return [];
+
+  const rows = await db
+    .prepare(
+      `SELECT at, type, ref_code, affiliate_id, label, detail FROM (
+         -- touches
+         SELECT rt.created_at AS at, 'touch' AS type, rt.ref_code AS ref_code,
+                al.affiliate_id AS affiliate_id, NULL AS label, rt.source_url AS detail
+           FROM ref_tracking rt
+           LEFT JOIN affiliate_links al ON al.ref_code = rt.ref_code
+          WHERE rt.friend_id = ?
+         UNION ALL
+         -- friend add
+         SELECT f.created_at AS at, 'friend_add' AS type, NULL AS ref_code,
+                NULL AS affiliate_id, NULL AS label, NULL AS detail
+           FROM friends f WHERE f.id = ?
+         UNION ALL
+         -- form submissions
+         SELECT fs.created_at AS at, 'form' AS type, NULL AS ref_code,
+                NULL AS affiliate_id, fo.name AS label, NULL AS detail
+           FROM form_submissions fs
+           LEFT JOIN forms fo ON fo.id = fs.form_id
+          WHERE fs.friend_id = ?
+         UNION ALL
+         -- conversions
+         SELECT ce.created_at AS at, 'conversion' AS type, ce.attributed_ref_code AS ref_code,
+                ce.affiliate_id AS affiliate_id, cp.name AS label, NULL AS detail
+           FROM conversion_events ce
+           LEFT JOIN conversion_points cp ON cp.id = ce.conversion_point_id
+          WHERE ce.friend_id = ?
+       )
+       ORDER BY julianday(at) ASC, type ASC`,
+    )
+    .bind(friendId, friendId, friendId, friendId)
+    .all<{
+      at: string;
+      type: JourneyEventType;
+      ref_code: string | null;
+      affiliate_id: string | null;
+      label: string | null;
+      detail: string | null;
+    }>();
+
+  return rows.results.map((r) => {
+    const ev: JourneyEvent = { at: r.at, type: r.type };
+    if (r.ref_code != null) ev.refCode = r.ref_code;
+    if (r.affiliate_id != null) ev.affiliateId = r.affiliate_id;
+    if (r.label != null) ev.label = r.label;
+    if (r.detail != null) ev.detail = r.detail;
+    return ev;
+  });
+}
+
+// ── Journeys (per affiliate, cursor-paginated) ───────────────────────────────
+
+export interface AffiliateJourneySummary {
+  friendId: string;
+  displayName: string | null;
+  addedAt: string;
+  refCode: string | null;
+  touchCount: number;
+  formCount: number;
+  conversionCount: number;
+  lastEventAt: string;
+}
+
+export interface AffiliateJourneysPage {
+  items: AffiliateJourneySummary[];
+  nextCursor: { beforeAt: string; beforeId: string } | null;
+}
+
+/**
+ * Per-affiliate friend journey summaries, newest add first, cursor-paginated on
+ * the (added_at, friend_id) composite cursor — same scheme as GET /api/chats.
+ * Offset paging is avoided because concurrent new adds would shift rows and drop
+ * items across pages.
+ *
+ * "Attributed friend" = friend whose add-time last-touch is this affiliate
+ * (identical winner subquery as friendAdds).
+ */
+export async function getAffiliateJourneys(
+  db: D1Database,
+  affiliateId: string,
+  opts: { limit?: number; beforeAt?: string; beforeId?: string } = {},
+): Promise<AffiliateJourneysPage> {
+  const limit = Math.min(200, Math.max(1, opts.limit ?? 50));
+  const useCursor = Boolean(opts.beforeAt && opts.beforeId);
+
+  const binds: unknown[] = [affiliateId];
+  let cursorClause = '';
+  if (useCursor) {
+    // (added_at, friend_id) strictly-before cursor, compared by real instant.
+    cursorClause = `AND (
+      julianday(f.created_at) < julianday(?)
+      OR (julianday(f.created_at) = julianday(?) AND f.id < ?)
+    )`;
+    binds.push(opts.beforeAt, opts.beforeAt, opts.beforeId);
+  }
+  // fetch limit+1 to detect whether another page exists
+  binds.push(limit + 1);
+
+  const rows = await db
+    .prepare(
+      `WITH attributed AS (
+         SELECT f.id AS friend_id, f.display_name AS display_name, f.created_at AS added_at,
+                (
+                  SELECT rt2.ref_code
+                    FROM ref_tracking rt2
+                    JOIN affiliate_links al2 ON al2.ref_code = rt2.ref_code
+                    JOIN affiliates a2 ON a2.id = al2.affiliate_id
+                   WHERE rt2.friend_id = f.id
+                     AND julianday(rt2.created_at) >= julianday(f.created_at) - ${ATTRIBUTION_WINDOW_DAYS}
+                     AND julianday(rt2.created_at) <= julianday(f.created_at)
+                     AND (a2.friend_id IS NULL OR a2.friend_id != rt2.friend_id)
+                   ORDER BY julianday(rt2.created_at) DESC
+                   LIMIT 1
+                ) AS ref_code
+           FROM friends f
+          WHERE (
+            SELECT al3.affiliate_id
+              FROM ref_tracking rt3
+              JOIN affiliate_links al3 ON al3.ref_code = rt3.ref_code
+              JOIN affiliates a3 ON a3.id = al3.affiliate_id
+             WHERE rt3.friend_id = f.id
+               AND julianday(rt3.created_at) >= julianday(f.created_at) - ${ATTRIBUTION_WINDOW_DAYS}
+               AND julianday(rt3.created_at) <= julianday(f.created_at)
+               AND (a3.friend_id IS NULL OR a3.friend_id != rt3.friend_id)
+             ORDER BY julianday(rt3.created_at) DESC
+             LIMIT 1
+          ) = ?
+            ${cursorClause}
+       )
+       SELECT
+         at.friend_id,
+         at.display_name,
+         at.added_at,
+         at.ref_code,
+         (SELECT COUNT(*) FROM ref_tracking rt WHERE rt.friend_id = at.friend_id) AS touch_count,
+         (SELECT COUNT(*) FROM form_submissions fs WHERE fs.friend_id = at.friend_id) AS form_count,
+         (SELECT COUNT(*) FROM conversion_events ce WHERE ce.friend_id = at.friend_id) AS conversion_count,
+         -- newest event across all sources, as an ISO string, chosen by real instant
+         (SELECT ev_at FROM (
+            SELECT at.added_at AS ev_at
+            UNION ALL SELECT rt.created_at FROM ref_tracking rt WHERE rt.friend_id = at.friend_id
+            UNION ALL SELECT fs.created_at FROM form_submissions fs WHERE fs.friend_id = at.friend_id
+            UNION ALL SELECT ce.created_at FROM conversion_events ce WHERE ce.friend_id = at.friend_id
+          ) ORDER BY julianday(ev_at) DESC LIMIT 1) AS last_event_at
+       FROM attributed at
+       ORDER BY julianday(at.added_at) DESC, at.friend_id DESC
+       LIMIT ?`,
+    )
+    .bind(...binds)
+    .all<{
+      friend_id: string;
+      display_name: string | null;
+      added_at: string;
+      ref_code: string | null;
+      touch_count: number;
+      form_count: number;
+      conversion_count: number;
+      last_event_at: string;
+    }>();
+
+  const results = rows.results;
+  const hasMore = results.length > limit;
+  const page = hasMore ? results.slice(0, limit) : results;
+
+  const items: AffiliateJourneySummary[] = page.map((r) => ({
+    friendId: r.friend_id,
+    displayName: r.display_name,
+    addedAt: r.added_at,
+    refCode: r.ref_code,
+    touchCount: r.touch_count,
+    formCount: r.form_count,
+    conversionCount: r.conversion_count,
+    lastEventAt: r.last_event_at,
+  }));
+
+  const nextCursor =
+    hasMore && page.length > 0
+      ? { beforeAt: page[page.length - 1].added_at, beforeId: page[page.length - 1].friend_id }
+      : null;
+
+  return { items, nextCursor };
+}

--- a/packages/db/src/affiliates.ts
+++ b/packages/db/src/affiliates.ts
@@ -1,4 +1,5 @@
 import { jstNow } from './utils.js';
+import { FRIEND_ADD_WINNER_SUBQUERY } from './affiliate-report.js';
 // =============================================================================
 // Affiliates — Affiliate & Tracking System
 // =============================================================================
@@ -10,6 +11,7 @@ export interface Affiliate {
   commission_rate: number;
   is_active: number;
   created_at: string;
+  friend_id: string | null;
 }
 
 export interface AffiliateClick {
@@ -53,6 +55,8 @@ export interface CreateAffiliateInput {
   name: string;
   code: string;
   commissionRate?: number;
+  /** Optional LINE friend UUID to bind for self-serve (LIFF) affiliates. */
+  friendId?: string | null;
 }
 
 export async function createAffiliate(
@@ -64,10 +68,10 @@ export async function createAffiliate(
 
   await db
     .prepare(
-      `INSERT INTO affiliates (id, name, code, commission_rate, is_active, created_at)
-       VALUES (?, ?, ?, ?, 1, ?)`,
+      `INSERT INTO affiliates (id, name, code, commission_rate, is_active, created_at, friend_id)
+       VALUES (?, ?, ?, ?, 1, ?, ?)`,
     )
-    .bind(id, input.name, input.code, input.commissionRate ?? 0, now)
+    .bind(id, input.name, input.code, input.commissionRate ?? 0, now, input.friendId ?? null)
     .run();
 
   return (await getAffiliateById(db, id))!;
@@ -148,9 +152,24 @@ export interface AffiliateReport {
   affiliateName: string;
   code: string;
   commissionRate: number;
+  /**
+   * ref_tracking touches on this affiliate's links — the SAME source as the
+   * detail panel's "クリック (ref_tracking)" card (getAffiliateReportV2.clicks),
+   * so the list column and the expanded detail always agree.
+   */
   totalClicks: number;
+  /**
+   * Conversions attributed to this affiliate via EITHER the affiliate_id
+   * snapshot (ASP ref-code path) OR the legacy affiliate_code match. The OR keeps
+   * each conversion_events row counted at most once per affiliate (a row matching
+   * both predicates for the same affiliate is not double-counted).
+   */
   totalConversions: number;
   totalRevenue: number;
+  /** Number of affiliate_links (ref_codes) belonging to this affiliate. */
+  linkCount: number;
+  /** Friends whose add-time last-touch attribution is this affiliate. */
+  friendAdds: number;
 }
 
 export async function getAffiliateReport(
@@ -168,48 +187,90 @@ export async function getAffiliateReport(
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
-  // Build date conditions for subqueries using parameterized queries
+  // Build date conditions for subqueries using parameterized queries.
+  //   clicks  → ref_tracking.created_at (rt), compared by julianday so mixed
+  //             JST/UTC timestamp formats sort by true instant (matches v2).
+  //   cv      → conversion_events.created_at (ce).
   let clickDateCond = '';
   let cvDateCond = '';
   const clickDateBinds: unknown[] = [];
   const cvDateBinds: unknown[] = [];
   if (opts.startDate) {
-    clickDateCond += ` AND ac.created_at >= ?`;
+    clickDateCond += ` AND julianday(rt.created_at) >= julianday(?)`;
     cvDateCond += ` AND ce.created_at >= ?`;
     clickDateBinds.push(opts.startDate);
     cvDateBinds.push(opts.startDate);
   }
   if (opts.endDate) {
-    clickDateCond += ` AND ac.created_at <= ?`;
+    clickDateCond += ` AND julianday(rt.created_at) <= julianday(?)`;
     cvDateCond += ` AND ce.created_at <= ?`;
     clickDateBinds.push(opts.endDate);
     cvDateBinds.push(opts.endDate);
   }
 
+  // ── friend_adds: single pass over friends → winner affiliate → COUNT ────────
+  // Resolves each friend's add-time last-touch winner with the SAME expression
+  // as getAffiliateReportV2's friendAdds (FRIEND_ADD_WINNER_SUBQUERY, 90-day
+  // window / julianday / self-click excluded / last-touch). One scan of friends
+  // buckets by winning affiliate_id; the outer LEFT JOIN attaches per-affiliate
+  // counts without an IN(?,…) fan-out. Date filter (if any) bounds add time by
+  // julianday to match the per-affiliate report exactly (not raw string compare).
+  const friendAddWindowConds: string[] = [];
+  const friendAddBinds: unknown[] = [];
+  if (opts.startDate) {
+    friendAddWindowConds.push('julianday(f.created_at) >= julianday(?)');
+    friendAddBinds.push(opts.startDate);
+  }
+  if (opts.endDate) {
+    friendAddWindowConds.push('julianday(f.created_at) <= julianday(?)');
+    friendAddBinds.push(opts.endDate);
+  }
+  const friendAddWhere =
+    friendAddWindowConds.length > 0 ? `WHERE ${friendAddWindowConds.join(' AND ')}` : '';
+  const friendAddsCte = `
+    SELECT winner_affiliate_id AS affiliate_id, COUNT(*) AS friend_adds
+      FROM (
+        SELECT (${FRIEND_ADD_WINNER_SUBQUERY}) AS winner_affiliate_id
+          FROM friends f
+          ${friendAddWhere}
+      )
+     WHERE winner_affiliate_id IS NOT NULL
+     GROUP BY winner_affiliate_id`;
+
   // D1 bind order must match the ? placeholders left-to-right in the SQL.
   // The subqueries each reference their own set of date params, so we must
-  // supply them for each subquery occurrence (clicks, conversions, revenue).
+  // supply them for each subquery occurrence (clicks, conversions, revenue),
+  // followed by the friend_adds CTE and finally the outer WHERE clause.
   const dateBindsForRevenue = [...cvDateBinds]; // revenue subquery reuses cv date conditions
   const allBinds = [
     ...clickDateBinds,   // for total_clicks subquery
     ...cvDateBinds,      // for total_conversions subquery
     ...dateBindsForRevenue, // for total_revenue subquery
+    ...friendAddBinds,   // for the friend_adds CTE date window
     ...values,           // for the outer WHERE clause
   ];
 
   const result = await db
     .prepare(
-      `SELECT
+      `WITH friend_adds AS (${friendAddsCte})
+       SELECT
          a.id as affiliate_id,
          a.name as affiliate_name,
          a.code,
          a.commission_rate,
-         (SELECT COUNT(*) FROM affiliate_clicks ac WHERE ac.affiliate_id = a.id${clickDateCond}) as total_clicks,
-         (SELECT COUNT(*) FROM conversion_events ce WHERE ce.affiliate_code = a.code${cvDateCond}) as total_conversions,
+         (SELECT COUNT(*)
+            FROM ref_tracking rt
+            JOIN affiliate_links al ON al.ref_code = rt.ref_code
+           WHERE al.affiliate_id = a.id${clickDateCond}) as total_clicks,
+         (SELECT COUNT(*) FROM conversion_events ce
+          WHERE (ce.affiliate_id = a.id OR ce.affiliate_code = a.code)${cvDateCond}) as total_conversions,
          (SELECT COALESCE(SUM(cp.value), 0) FROM conversion_events ce
           JOIN conversion_points cp ON cp.id = ce.conversion_point_id
-          WHERE ce.affiliate_code = a.code${cvDateCond}) as total_revenue
+          WHERE (ce.affiliate_id = a.id OR ce.affiliate_code = a.code)${cvDateCond}) as total_revenue,
+         (SELECT COUNT(*) FROM affiliate_links al WHERE al.affiliate_id = a.id) as link_count,
+         COALESCE(fa.friend_adds, 0) as friend_adds
        FROM affiliates a
+       LEFT JOIN friend_adds fa ON fa.affiliate_id = a.id
        ${where}
        ORDER BY total_conversions DESC`,
     )
@@ -222,6 +283,8 @@ export async function getAffiliateReport(
       total_clicks: number;
       total_conversions: number;
       total_revenue: number;
+      link_count: number;
+      friend_adds: number;
     }>();
 
   return result.results.map((r) => ({
@@ -232,5 +295,7 @@ export async function getAffiliateReport(
     totalClicks: r.total_clicks,
     totalConversions: r.total_conversions,
     totalRevenue: r.total_revenue,
+    linkCount: r.link_count,
+    friendAdds: r.friend_adds,
   }));
 }

--- a/packages/db/src/conversions.ts
+++ b/packages/db/src/conversions.ts
@@ -1,4 +1,5 @@
 import { jstNow } from './utils.js';
+import { resolveAffiliateAttribution } from './affiliate-attribution.js';
 // =============================================================================
 // Conversion Points & Events — CV Tracking
 // =============================================================================
@@ -19,6 +20,8 @@ export interface ConversionEvent {
   affiliate_code: string | null;
   metadata: string | null;
   created_at: string;
+  affiliate_id: string | null;
+  attributed_ref_code: string | null;
 }
 
 // ── Conversion Points CRUD ──────────────────────────────────────────────────
@@ -88,10 +91,13 @@ export async function trackConversion(
   const id = crypto.randomUUID();
   const now = jstNow();
 
+  // Resolve last-touch affiliate attribution before inserting the event.
+  const attr = await resolveAffiliateAttribution(db, input.friendId);
+
   await db
     .prepare(
-      `INSERT INTO conversion_events (id, conversion_point_id, friend_id, user_id, affiliate_code, metadata, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO conversion_events (id, conversion_point_id, friend_id, user_id, affiliate_code, metadata, created_at, affiliate_id, attributed_ref_code)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .bind(
       id,
@@ -101,6 +107,8 @@ export async function trackConversion(
       input.affiliateCode ?? null,
       input.metadata ?? null,
       now,
+      attr?.affiliateId ?? null,
+      attr?.refCode ?? null,
     )
     .run();
 

--- a/packages/db/src/entry-routes.ts
+++ b/packages/db/src/entry-routes.ts
@@ -265,6 +265,13 @@ export async function recordRefTracking(
     )
     .run();
 
+  if (opts.friendId) {
+    await db
+      .prepare(`UPDATE friends SET last_ref_code = ?, last_ref_at = ? WHERE id = ?`)
+      .bind(opts.refCode, now, opts.friendId)
+      .run();
+  }
+
   return (await db
     .prepare(`SELECT * FROM ref_tracking WHERE id = ?`)
     .bind(id)

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -28,6 +28,10 @@ export * from './auto-replies';
 export * from './traffic-pools';
 export * from './message-templates';
 export * from './rich-menus';
+export * from './affiliate-links';
+export * from './affiliate-attribution';
+export * from './affiliate-report';
+export * from './account-settings';
 
 /**
  * Thin wrapper around D1Database.

--- a/packages/db/test/046_affiliate_links.test.ts
+++ b/packages/db/test/046_affiliate_links.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = join(__dirname, '..');
+const MIGRATIONS_DIR = join(PKG_ROOT, 'migrations');
+
+const BENIGN = /duplicate column name|already exists/i;
+
+function execSafe(db: Database.Database, sql: string): void {
+  for (const stmt of sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    try {
+      db.exec(stmt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!BENIGN.test(msg)) throw err;
+    }
+  }
+}
+
+/**
+ * Build an in-memory DB by applying schema.sql + all migrations through 046
+ * (mirrors the bootstrap test's applyMigrationReplay approach).
+ */
+function setupDbWithMigrations(): Database.Database {
+  const db = new Database(':memory:');
+  execSafe(db, readFileSync(join(PKG_ROOT, 'schema.sql'), 'utf8'));
+
+  const migrationFiles = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+
+  for (const file of migrationFiles) {
+    execSafe(db, readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+  }
+
+  return db;
+}
+
+describe('046_affiliate_links', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = setupDbWithMigrations();
+  });
+
+  test('affiliate_links table and new columns exist', () => {
+    const cols = (t: string) =>
+      (db.prepare(`PRAGMA table_info(${t})`).all() as Array<{ name: string }>).map(
+        (r) => r.name,
+      );
+
+    expect(cols('affiliate_links')).toEqual(
+      expect.arrayContaining([
+        'id',
+        'affiliate_id',
+        'ref_code',
+        'label',
+        'line_account_id',
+        'is_active',
+        'created_at',
+        'click_count',
+      ]),
+    );
+    expect(cols('affiliates')).toContain('friend_id');
+    expect(cols('friends')).toEqual(
+      expect.arrayContaining(['last_ref_code', 'last_ref_at']),
+    );
+    expect(cols('conversion_events')).toEqual(
+      expect.arrayContaining(['affiliate_id', 'attributed_ref_code']),
+    );
+  });
+
+  test('affiliate_links ref_code is UNIQUE', () => {
+    db.exec(
+      `INSERT INTO friends (id, line_user_id, display_name, created_at, updated_at)
+       VALUES ('f-1', 'U0000000000000000000000000000001', 'Test User',
+               '2024-01-01T00:00:00.000', '2024-01-01T00:00:00.000')`,
+    );
+    db.exec(
+      `INSERT INTO line_accounts (id, channel_id, name, channel_secret, channel_access_token, created_at, updated_at)
+       VALUES ('la-1', 'ch-001', 'Test Account', 'secret-001', 'token-001',
+               '2024-01-01T00:00:00.000', '2024-01-01T00:00:00.000')`,
+    );
+    db.exec(
+      `INSERT INTO affiliates (id, name, code, is_active, created_at)
+       VALUES ('aff-1', 'Test Affiliate', 'CODE001', 1, '2024-01-01T00:00:00.000')`,
+    );
+    db.exec(
+      `INSERT INTO affiliate_links (id, affiliate_id, ref_code, is_active, created_at)
+       VALUES ('al-1', 'aff-1', 'REF001', 1, '2024-01-01T00:00:00.000')`,
+    );
+    expect(() =>
+      db.exec(
+        `INSERT INTO affiliate_links (id, affiliate_id, ref_code, is_active, created_at)
+         VALUES ('al-2', 'aff-1', 'REF001', 1, '2024-01-01T00:00:00.000')`,
+      ),
+    ).toThrow(/UNIQUE constraint failed/);
+  });
+
+  test('all four new indexes exist', () => {
+    const getIndex = (name: string) =>
+      db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?`,
+        )
+        .get(name) as { name: string } | undefined;
+
+    expect(getIndex('idx_ref_tracking_friend_created')).toBeDefined();
+    expect(getIndex('idx_ref_tracking_ref_created')).toBeDefined();
+    expect(getIndex('idx_affiliate_links_affiliate')).toBeDefined();
+    expect(getIndex('idx_affiliates_friend')).toBeDefined();
+  });
+
+  test('idx_affiliates_friend is a partial UNIQUE index on friend_id', () => {
+    const idx = db
+      .prepare(
+        `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_affiliates_friend'`,
+      )
+      .get() as { sql: string } | undefined;
+    expect(idx).toBeDefined();
+    expect(idx!.sql).toMatch(/UNIQUE\s+INDEX/i);
+    expect(idx!.sql).toMatch(/WHERE\s+friend_id\s+IS\s+NOT\s+NULL/i);
+  });
+
+  test('affiliates.friend_id is UNIQUE per friend, but NULL is unconstrained', () => {
+    db.exec(
+      `INSERT INTO friends (id, line_user_id, display_name, created_at, updated_at)
+       VALUES ('f-uniq', 'U0000000000000000000000000000009', 'Uniq User',
+               '2024-01-01T00:00:00.000', '2024-01-01T00:00:00.000')`,
+    );
+    db.exec(
+      `INSERT INTO affiliates (id, name, code, is_active, created_at, friend_id)
+       VALUES ('aff-u1', 'A1', 'UCODE1', 1, '2024-01-01T00:00:00.000', 'f-uniq')`,
+    );
+    // A second affiliate for the same friend must be rejected.
+    expect(() =>
+      db.exec(
+        `INSERT INTO affiliates (id, name, code, is_active, created_at, friend_id)
+         VALUES ('aff-u2', 'A2', 'UCODE2', 1, '2024-01-01T00:00:00.000', 'f-uniq')`,
+      ),
+    ).toThrow(/UNIQUE constraint failed/);
+    // But multiple affiliates with NULL friend_id (admin-created) are allowed.
+    expect(() => {
+      db.exec(
+        `INSERT INTO affiliates (id, name, code, is_active, created_at)
+         VALUES ('aff-n1', 'N1', 'NCODE1', 1, '2024-01-01T00:00:00.000')`,
+      );
+      db.exec(
+        `INSERT INTO affiliates (id, name, code, is_active, created_at)
+         VALUES ('aff-n2', 'N2', 'NCODE2', 1, '2024-01-01T00:00:00.000')`,
+      );
+    }).not.toThrow();
+  });
+
+  test('affiliate_links default values are correct', () => {
+    db.exec(
+      `INSERT INTO friends (id, line_user_id, display_name, created_at, updated_at)
+       VALUES ('f-2', 'U0000000000000000000000000000002', 'Test User 2',
+               '2024-01-01T00:00:00.000', '2024-01-01T00:00:00.000')`,
+    );
+    db.exec(
+      `INSERT INTO affiliates (id, name, code, is_active, created_at)
+       VALUES ('aff-2', 'Affiliate 2', 'CODE002', 1, '2024-01-01T00:00:00.000')`,
+    );
+    db.exec(
+      `INSERT INTO affiliate_links (id, affiliate_id, ref_code, created_at)
+       VALUES ('al-3', 'aff-2', 'REF002', '2024-01-01T00:00:00.000')`,
+    );
+    const row = db
+      .prepare(`SELECT is_active, click_count FROM affiliate_links WHERE id = 'al-3'`)
+      .get() as { is_active: number; click_count: number };
+    expect(row.is_active).toBe(1);
+    expect(row.click_count).toBe(0);
+  });
+});

--- a/packages/db/test/affiliate-attribution.test.ts
+++ b/packages/db/test/affiliate-attribution.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  resolveAffiliateAttribution,
+  ATTRIBUTION_WINDOW_DAYS,
+} from '../src/affiliate-attribution.js';
+import { trackConversion, type ConversionEvent } from '../src/conversions.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = join(__dirname, '..');
+const MIGRATIONS_DIR = join(PKG_ROOT, 'migrations');
+
+const BENIGN = /duplicate column name|already exists/i;
+
+function execSafe(db: Database.Database, sql: string): void {
+  for (const stmt of sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    try {
+      db.exec(stmt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!BENIGN.test(msg)) throw err;
+    }
+  }
+}
+
+function setupDb(): Database.Database {
+  const db = new Database(':memory:');
+  execSafe(db, readFileSync(join(PKG_ROOT, 'schema.sql'), 'utf8'));
+  const migrationFiles = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  for (const file of migrationFiles) {
+    execSafe(db, readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+  }
+  return db;
+}
+
+function asD1(sqlite: Database.Database): D1Database {
+  return {
+    prepare(query: string) {
+      return {
+        bind(...params: unknown[]) {
+          const stmt = sqlite.prepare(query);
+          return {
+            async run() {
+              stmt.run(...params);
+              return { results: [], success: true, meta: {} };
+            },
+            async first<T>() {
+              return (stmt.get(...params) as T) ?? null;
+            },
+            async all<T>() {
+              return { results: stmt.all(...params) as T[], success: true, meta: {} };
+            },
+          };
+        },
+        async run() {
+          sqlite.prepare(query).run();
+          return { results: [], success: true, meta: {} };
+        },
+        async first<T>() {
+          return (sqlite.prepare(query).get() as T) ?? null;
+        },
+        async all<T>() {
+          return { results: sqlite.prepare(query).all() as T[], success: true, meta: {} };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+// ── Fixture helpers ──────────────────────────────────────────────────────────
+
+function insertFriend(sqlite: Database.Database, id: string): void {
+  sqlite
+    .prepare(
+      `INSERT INTO friends (id, line_user_id, display_name, created_at, updated_at)
+       VALUES (?, ?, 'Test User', '2024-01-01T00:00:00.000+09:00', '2024-01-01T00:00:00.000+09:00')`,
+    )
+    .run(id, `U${id.replace(/[^0-9a-f]/gi, '').padEnd(32, '0').slice(0, 32)}`);
+}
+
+let affiliateSeq = 0;
+function insertAffiliate(
+  sqlite: Database.Database,
+  id: string,
+  opts: { friendId?: string | null } = {},
+): void {
+  affiliateSeq++;
+  sqlite
+    .prepare(
+      `INSERT INTO affiliates (id, name, code, commission_rate, is_active, created_at, friend_id)
+       VALUES (?, ?, ?, 0, 1, '2024-01-01T00:00:00.000+09:00', ?)`,
+    )
+    .run(id, `Aff ${id}`, `code-${id}-${affiliateSeq}`, opts.friendId ?? null);
+}
+
+function insertLink(
+  sqlite: Database.Database,
+  opts: { id: string; affiliateId: string; refCode: string; isActive?: number },
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO affiliate_links (id, affiliate_id, ref_code, label, line_account_id, is_active, created_at, click_count)
+       VALUES (?, ?, ?, NULL, NULL, ?, '2024-01-01T00:00:00.000+09:00', 0)`,
+    )
+    .run(opts.id, opts.affiliateId, opts.refCode, opts.isActive ?? 1);
+}
+
+/** Insert a raw ref_tracking touch row with an explicit created_at. */
+function insertTouch(
+  sqlite: Database.Database,
+  opts: { id: string; refCode: string; friendId: string; createdAt: string },
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO ref_tracking (id, ref_code, friend_id, created_at)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .run(opts.id, opts.refCode, opts.friendId, opts.createdAt);
+}
+
+// JST ISO timestamp `daysAgo` days before `NOW`.
+const NOW = '2026-07-07T12:00:00.000+09:00';
+function jstDaysAgo(days: number, opts: { minutes?: number } = {}): string {
+  const base = new Date(NOW).getTime();
+  const ms = base - days * 86_400_000 + (opts.minutes ?? 0) * 60_000;
+  const jst = new Date(ms + 9 * 60 * 60_000);
+  return jst.toISOString().slice(0, -1) + '+09:00';
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('resolveAffiliateAttribution', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+  });
+
+  test('constant window is 90 days', () => {
+    expect(ATTRIBUTION_WINDOW_DAYS).toBe(90);
+  });
+
+  test('(a) multiple touches within 90 days -> latest affiliate link wins', async () => {
+    insertFriend(sqlite, 'friend-a');
+    insertAffiliate(sqlite, 'aff-1');
+    insertAffiliate(sqlite, 'aff-2');
+    insertLink(sqlite, { id: 'link-1', affiliateId: 'aff-1', refCode: 'ref1' });
+    insertLink(sqlite, { id: 'link-2', affiliateId: 'aff-2', refCode: 'ref2' });
+
+    insertTouch(sqlite, {
+      id: 't1',
+      refCode: 'ref1',
+      friendId: 'friend-a',
+      createdAt: jstDaysAgo(30),
+    });
+    insertTouch(sqlite, {
+      id: 't2',
+      refCode: 'ref2',
+      friendId: 'friend-a',
+      createdAt: jstDaysAgo(5),
+    });
+
+    const attr = await resolveAffiliateAttribution(db, 'friend-a', NOW);
+    expect(attr).toEqual({ affiliateId: 'aff-2', refCode: 'ref2' });
+  });
+
+  test('(b) a later non-affiliate ref touch does not override the latest affiliate touch', async () => {
+    insertFriend(sqlite, 'friend-b');
+    insertAffiliate(sqlite, 'aff-1');
+    insertLink(sqlite, { id: 'link-1', affiliateId: 'aff-1', refCode: 'ref1' });
+
+    // affiliate touch first
+    insertTouch(sqlite, {
+      id: 't1',
+      refCode: 'ref1',
+      friendId: 'friend-b',
+      createdAt: jstDaysAgo(10),
+    });
+    // later touch with a ref_code that has NO affiliate_link row
+    insertTouch(sqlite, {
+      id: 't2',
+      refCode: 'organic-ref',
+      friendId: 'friend-b',
+      createdAt: jstDaysAgo(1),
+    });
+
+    const attr = await resolveAffiliateAttribution(db, 'friend-b', NOW);
+    expect(attr).toEqual({ affiliateId: 'aff-1', refCode: 'ref1' });
+  });
+
+  test('(c) only a touch older than 90 days -> null', async () => {
+    insertFriend(sqlite, 'friend-c');
+    insertAffiliate(sqlite, 'aff-1');
+    insertLink(sqlite, { id: 'link-1', affiliateId: 'aff-1', refCode: 'ref1' });
+
+    insertTouch(sqlite, {
+      id: 't1',
+      refCode: 'ref1',
+      friendId: 'friend-c',
+      createdAt: jstDaysAgo(91),
+    });
+
+    const attr = await resolveAffiliateAttribution(db, 'friend-c', NOW);
+    expect(attr).toBeNull();
+  });
+
+  test('(c-boundary) a touch exactly at the 90-day edge is still attributed', async () => {
+    insertFriend(sqlite, 'friend-cb');
+    insertAffiliate(sqlite, 'aff-1');
+    insertLink(sqlite, { id: 'link-1', affiliateId: 'aff-1', refCode: 'ref1' });
+
+    // exactly 90 days ago (inside), plus just-over 90 days (outside)
+    insertTouch(sqlite, {
+      id: 't-edge',
+      refCode: 'ref1',
+      friendId: 'friend-cb',
+      createdAt: jstDaysAgo(90),
+    });
+    const attr = await resolveAffiliateAttribution(db, 'friend-cb', NOW);
+    expect(attr).toEqual({ affiliateId: 'aff-1', refCode: 'ref1' });
+
+    // A touch 1 minute past the 90-day window must be excluded.
+    insertTouch(sqlite, {
+      id: 't-over',
+      refCode: 'ref1',
+      friendId: 'friend-cb',
+      createdAt: jstDaysAgo(90, { minutes: -1 }), // one minute earlier than the edge
+    });
+    // still resolves to the in-window edge touch (not the out-of-window one)
+    const attr2 = await resolveAffiliateAttribution(db, 'friend-cb', NOW);
+    expect(attr2).toEqual({ affiliateId: 'aff-1', refCode: 'ref1' });
+  });
+
+  test('(d) self-click (friend is the affiliate owner) is excluded', async () => {
+    insertFriend(sqlite, 'friend-d');
+    // affiliate owned by friend-d themselves
+    insertAffiliate(sqlite, 'aff-self', { friendId: 'friend-d' });
+    insertLink(sqlite, { id: 'link-1', affiliateId: 'aff-self', refCode: 'refself' });
+
+    insertTouch(sqlite, {
+      id: 't1',
+      refCode: 'refself',
+      friendId: 'friend-d',
+      createdAt: jstDaysAgo(3),
+    });
+
+    const attr = await resolveAffiliateAttribution(db, 'friend-d', NOW);
+    expect(attr).toBeNull();
+  });
+
+  test('(d-2) self-click is skipped but an earlier non-self affiliate touch still wins', async () => {
+    insertFriend(sqlite, 'friend-d2');
+    insertAffiliate(sqlite, 'aff-other');
+    insertAffiliate(sqlite, 'aff-self', { friendId: 'friend-d2' });
+    insertLink(sqlite, { id: 'link-o', affiliateId: 'aff-other', refCode: 'refother' });
+    insertLink(sqlite, { id: 'link-s', affiliateId: 'aff-self', refCode: 'refselftouch' });
+
+    insertTouch(sqlite, {
+      id: 't1',
+      refCode: 'refother',
+      friendId: 'friend-d2',
+      createdAt: jstDaysAgo(10),
+    });
+    // most-recent touch is a self-click -> must be skipped
+    insertTouch(sqlite, {
+      id: 't2',
+      refCode: 'refselftouch',
+      friendId: 'friend-d2',
+      createdAt: jstDaysAgo(1),
+    });
+
+    const attr = await resolveAffiliateAttribution(db, 'friend-d2', NOW);
+    expect(attr).toEqual({ affiliateId: 'aff-other', refCode: 'refother' });
+  });
+
+  test('(e) touch on an inactive (is_active=0) link is still attributed', async () => {
+    insertFriend(sqlite, 'friend-e');
+    insertAffiliate(sqlite, 'aff-1');
+    insertLink(sqlite, {
+      id: 'link-1',
+      affiliateId: 'aff-1',
+      refCode: 'refinactive',
+      isActive: 0,
+    });
+
+    insertTouch(sqlite, {
+      id: 't1',
+      refCode: 'refinactive',
+      friendId: 'friend-e',
+      createdAt: jstDaysAgo(5),
+    });
+
+    const attr = await resolveAffiliateAttribution(db, 'friend-e', NOW);
+    expect(attr).toEqual({ affiliateId: 'aff-1', refCode: 'refinactive' });
+  });
+
+  test('no touches at all -> null', async () => {
+    insertFriend(sqlite, 'friend-none');
+    const attr = await resolveAffiliateAttribution(db, 'friend-none', NOW);
+    expect(attr).toBeNull();
+  });
+
+  test('(f) mixed timestamp formats: julianday ordering picks the truly newer touch', async () => {
+    // Scenario: two affiliate touches for the same friend.
+    //   - older touch (aff-1): stored as "+09:00" ISO format.
+    //     The textual value starts with "2026-06-" which sorts AFTER "2026-06-"
+    //     written as a space-separated UTC string, making it "win" under naive
+    //     string sort even though it is actually older in real time.
+    //   - newer touch (aff-2): stored as "YYYY-MM-DD HH:MM:SS" UTC space-separated
+    //     (as emitted by SQLite datetime('now')), which is actually 7 days later
+    //     in real time but would "lose" a naive text comparison.
+    //
+    // With ORDER BY julianday(rt.created_at) DESC, aff-2 must be returned.
+
+    insertFriend(sqlite, 'friend-f');
+    insertAffiliate(sqlite, 'aff-mixed-1');
+    insertAffiliate(sqlite, 'aff-mixed-2');
+    insertLink(sqlite, { id: 'link-f1', affiliateId: 'aff-mixed-1', refCode: 'ref-f1' });
+    insertLink(sqlite, { id: 'link-f2', affiliateId: 'aff-mixed-2', refCode: 'ref-f2' });
+
+    // Older touch: 20 days ago, stored in JST ISO "+09:00" format.
+    // julianday sees the true instant (2026-06-17T03:00:00Z ≈ JD 2461214.625).
+    const olderIso = '2026-06-17T12:00:00.000+09:00'; // JST noon = UTC 03:00
+
+    // Newer touch: 13 days ago, stored as UTC space-separated (SQLite datetime style).
+    // julianday sees the true instant (2026-06-24T03:00:00Z ≈ JD 2461221.625),
+    // which is 7 days later than the ISO touch.
+    // Naive text comparison: "2026-06-17T..." > "2026-06-24 ..." (ISO > space format
+    // because 'T' > ' ' in ASCII), so the older one would win under string sort.
+    const newerUtcSpace = '2026-06-24 03:00:00'; // UTC space-sep, same real instant as JST 12:00
+
+    sqlite
+      .prepare(`INSERT INTO ref_tracking (id, ref_code, friend_id, created_at) VALUES (?, ?, ?, ?)`)
+      .run('tf-old', 'ref-f1', 'friend-f', olderIso);
+    sqlite
+      .prepare(`INSERT INTO ref_tracking (id, ref_code, friend_id, created_at) VALUES (?, ?, ?, ?)`)
+      .run('tf-new', 'ref-f2', 'friend-f', newerUtcSpace);
+
+    const attr = await resolveAffiliateAttribution(db, 'friend-f', NOW);
+    // julianday ordering must select aff-mixed-2 (the genuinely newer touch).
+    expect(attr).toEqual({ affiliateId: 'aff-mixed-2', refCode: 'ref-f2' });
+  });
+});
+
+describe('trackConversion + attribution integration', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+    sqlite
+      .prepare(
+        `INSERT INTO conversion_points (id, name, event_type, value, created_at)
+         VALUES ('cp-1', 'Purchase', 'purchase', 1000, '2024-01-01T00:00:00.000+09:00')`,
+      )
+      .run();
+  });
+
+  test('trackConversion stamps affiliate_id + attributed_ref_code from last-touch', async () => {
+    insertFriend(sqlite, 'friend-x');
+    insertAffiliate(sqlite, 'aff-1');
+    insertLink(sqlite, { id: 'link-1', affiliateId: 'aff-1', refCode: 'refx' });
+    insertTouch(sqlite, {
+      id: 't1',
+      refCode: 'refx',
+      friendId: 'friend-x',
+      createdAt: jstDaysAgo(2),
+    });
+
+    const ev = (await trackConversion(db, {
+      conversionPointId: 'cp-1',
+      friendId: 'friend-x',
+    })) as ConversionEvent & {
+      affiliate_id: string | null;
+      attributed_ref_code: string | null;
+    };
+
+    expect(ev.affiliate_id).toBe('aff-1');
+    expect(ev.attributed_ref_code).toBe('refx');
+  });
+
+  test('trackConversion leaves attribution null when there is no eligible touch', async () => {
+    insertFriend(sqlite, 'friend-y');
+
+    const ev = (await trackConversion(db, {
+      conversionPointId: 'cp-1',
+      friendId: 'friend-y',
+    })) as ConversionEvent & {
+      affiliate_id: string | null;
+      attributed_ref_code: string | null;
+    };
+
+    expect(ev.affiliate_id).toBeNull();
+    expect(ev.attributed_ref_code).toBeNull();
+  });
+
+  test('existing affiliateCode argument behaviour is preserved', async () => {
+    insertFriend(sqlite, 'friend-z');
+
+    const ev = await trackConversion(db, {
+      conversionPointId: 'cp-1',
+      friendId: 'friend-z',
+      affiliateCode: 'legacy-code',
+    });
+
+    expect(ev.affiliate_code).toBe('legacy-code');
+  });
+});

--- a/packages/db/test/affiliate-links.test.ts
+++ b/packages/db/test/affiliate-links.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createAffiliateLink,
+  getAffiliateLinkByRefCode,
+  listAffiliateLinks,
+  countAffiliateLinks,
+  incrementAffiliateLinkClick,
+  getAffiliateByFriendId,
+  generateRefSlug,
+} from '../src/affiliate-links.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = join(__dirname, '..');
+const MIGRATIONS_DIR = join(PKG_ROOT, 'migrations');
+
+const BENIGN = /duplicate column name|already exists/i;
+
+function execSafe(db: Database.Database, sql: string): void {
+  for (const stmt of sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    try {
+      db.exec(stmt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!BENIGN.test(msg)) throw err;
+    }
+  }
+}
+
+function setupDb(): Database.Database {
+  const db = new Database(':memory:');
+  execSafe(db, readFileSync(join(PKG_ROOT, 'schema.sql'), 'utf8'));
+  const migrationFiles = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  for (const file of migrationFiles) {
+    execSafe(db, readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+  }
+  return db;
+}
+
+/**
+ * Wraps a better-sqlite3 Database to look like a D1Database (async API).
+ * Only implements prepare/bind/run/first/all needed by affiliate-links.ts.
+ */
+function asD1(sqlite: Database.Database): D1Database {
+  return {
+    prepare(query: string) {
+      return {
+        bind(...params: unknown[]) {
+          const stmt = sqlite.prepare(query);
+          return {
+            async run() {
+              stmt.run(...params);
+              return { results: [], success: true, meta: {} };
+            },
+            async first<T>() {
+              return (stmt.get(...params) as T) ?? null;
+            },
+            async all<T>() {
+              return { results: stmt.all(...params) as T[], success: true, meta: {} };
+            },
+          };
+        },
+        async run() {
+          sqlite.prepare(query).run();
+          return { results: [], success: true, meta: {} };
+        },
+        async first<T>() {
+          return (sqlite.prepare(query).get() as T) ?? null;
+        },
+        async all<T>() {
+          return { results: sqlite.prepare(query).all() as T[], success: true, meta: {} };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+function insertAffiliate(sqlite: Database.Database, id: string) {
+  sqlite
+    .prepare(
+      `INSERT INTO affiliates (id, name, code, is_active, created_at)
+       VALUES (?, ?, ?, 1, '2024-01-01T00:00:00.000')`,
+    )
+    .run(id, `Affiliate ${id}`, `CODE-${id}`);
+}
+
+function insertFriend(sqlite: Database.Database, id: string, lineUserId: string) {
+  sqlite
+    .prepare(
+      `INSERT INTO friends (id, line_user_id, display_name, created_at, updated_at)
+       VALUES (?, ?, 'Test User', '2024-01-01T00:00:00.000', '2024-01-01T00:00:00.000')`,
+    )
+    .run(id, lineUserId);
+}
+
+function insertLineAccount(sqlite: Database.Database, id: string) {
+  sqlite
+    .prepare(
+      `INSERT INTO line_accounts (id, channel_id, name, channel_secret, channel_access_token, created_at, updated_at)
+       VALUES (?, ?, ?, 'secret', 'token', '2024-01-01T00:00:00.000', '2024-01-01T00:00:00.000')`,
+    )
+    .run(id, `ch-${id}`, `Account ${id}`);
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+describe('affiliate-links CRUD', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+  const AFF_ID = 'aff-test-001';
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+    insertAffiliate(sqlite, AFF_ID);
+  });
+
+  // ── generateRefSlug ───────────────────────────────────────────────────────
+
+  test('generateRefSlug produces 6-char base62 string', () => {
+    const slug = generateRefSlug(6);
+    expect(slug).toMatch(/^[0-9A-Za-z]{6}$/);
+  });
+
+  test('generateRefSlug produces 8-char base62 string when length=8', () => {
+    const slug = generateRefSlug(8);
+    expect(slug).toMatch(/^[0-9A-Za-z]{8}$/);
+  });
+
+  test('generateRefSlug returns unique values', () => {
+    const set = new Set(Array.from({ length: 100 }, () => generateRefSlug(6)));
+    // At least 90 unique out of 100 — collision probability at 6 chars is negligible
+    expect(set.size).toBeGreaterThan(90);
+  });
+
+  // ── createAffiliateLink ──────────────────────────────────────────────────
+
+  test('createAffiliateLink generates unique 6-char base62 slug', async () => {
+    const link = await createAffiliateLink(db, { affiliateId: AFF_ID, label: 'X profile' });
+    expect(link.ref_code).toMatch(/^[0-9A-Za-z]{6}$/);
+    const again = await createAffiliateLink(db, { affiliateId: AFF_ID });
+    expect(again.ref_code).not.toBe(link.ref_code);
+  });
+
+  test('createAffiliateLink returns correct fields', async () => {
+    insertLineAccount(sqlite, 'la-001');
+    const link = await createAffiliateLink(db, {
+      affiliateId: AFF_ID,
+      label: 'Test Label',
+      lineAccountId: 'la-001',
+    });
+    expect(link.affiliate_id).toBe(AFF_ID);
+    expect(link.label).toBe('Test Label');
+    expect(link.line_account_id).toBe('la-001');
+    expect(link.is_active).toBe(1);
+    expect(link.click_count).toBe(0);
+    expect(link.id).toBeTruthy();
+    expect(link.created_at).toBeTruthy();
+  });
+
+  test('createAffiliateLink retries on collision using injected generator', async () => {
+    // Pre-insert a row with slug 'AAAAAA' to force collision on first attempt
+    const conflictSlug = 'AAAAAA';
+    sqlite
+      .prepare(
+        `INSERT INTO affiliate_links (id, affiliate_id, ref_code, is_active, created_at)
+         VALUES ('pre-001', ?, ?, 1, '2024-01-01T00:00:00.000')`,
+      )
+      .run(AFF_ID, conflictSlug);
+
+    // Generator that returns the conflicting slug first, then a valid one
+    let callCount = 0;
+    const deterministicGen = (len: number) => {
+      callCount += 1;
+      return callCount === 1 ? conflictSlug : `BBBBBB`.slice(0, len);
+    };
+
+    const link = await createAffiliateLink(
+      db,
+      { affiliateId: AFF_ID },
+      deterministicGen,
+    );
+    expect(callCount).toBe(2);
+    expect(link.ref_code).toBe('BBBBBB');
+  });
+
+  test('createAffiliateLink uses 8-char slug after 3 failed retries', async () => {
+    // Pre-insert 3 slugs to exhaust 6-char retries
+    const slugs = ['CCCCCC', 'DDDDDD', 'EEEEEE'];
+    for (const [i, s] of slugs.entries()) {
+      sqlite
+        .prepare(
+          `INSERT INTO affiliate_links (id, affiliate_id, ref_code, is_active, created_at)
+           VALUES (?, ?, ?, 1, '2024-01-01T00:00:00.000')`,
+        )
+        .run(`pre-${i}`, AFF_ID, s);
+    }
+
+    let callCount = 0;
+    const deterministicGen = (len: number) => {
+      callCount += 1;
+      if (len === 6) {
+        // Return the 3 conflicting slugs in order, then a new one (not reached)
+        return slugs[callCount - 1] ?? 'FFFFFF';
+      }
+      // len === 8 — should be reached on 4th attempt
+      return 'XXXXXXXX';
+    };
+
+    const link = await createAffiliateLink(
+      db,
+      { affiliateId: AFF_ID },
+      deterministicGen,
+    );
+    // callCount should be 4 (3 × 6-char failures + 1 × 8-char success)
+    expect(callCount).toBe(4);
+    expect(link.ref_code).toMatch(/^[0-9A-Za-z]{8}$/);
+    expect(link.ref_code).toBe('XXXXXXXX');
+  });
+
+  // ── getAffiliateLinkByRefCode ────────────────────────────────────────────
+
+  test('getAffiliateLinkByRefCode resolves existing link', async () => {
+    const link = await createAffiliateLink(db, { affiliateId: AFF_ID });
+    const found = await getAffiliateLinkByRefCode(db, link.ref_code);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(link.id);
+  });
+
+  test('getAffiliateLinkByRefCode returns null for unknown ref_code', async () => {
+    const result = await getAffiliateLinkByRefCode(db, 'zzzzzz');
+    expect(result).toBeNull();
+  });
+
+  // ── listAffiliateLinks ───────────────────────────────────────────────────
+
+  test('listAffiliateLinks returns links for the affiliate', async () => {
+    await createAffiliateLink(db, { affiliateId: AFF_ID, label: 'Link A' });
+    await createAffiliateLink(db, { affiliateId: AFF_ID, label: 'Link B' });
+
+    const AFF_ID_2 = 'aff-test-002';
+    insertAffiliate(sqlite, AFF_ID_2);
+    await createAffiliateLink(db, { affiliateId: AFF_ID_2, label: 'Other' });
+
+    const links = await listAffiliateLinks(db, AFF_ID);
+    expect(links).toHaveLength(2);
+    expect(links.every((l) => l.affiliate_id === AFF_ID)).toBe(true);
+  });
+
+  test('listAffiliateLinks returns empty array for unknown affiliate', async () => {
+    const links = await listAffiliateLinks(db, 'nonexistent');
+    expect(links).toEqual([]);
+  });
+
+  // ── countAffiliateLinks ──────────────────────────────────────────────────
+
+  test('countAffiliateLinks returns correct count', async () => {
+    expect(await countAffiliateLinks(db, AFF_ID)).toBe(0);
+    await createAffiliateLink(db, { affiliateId: AFF_ID });
+    await createAffiliateLink(db, { affiliateId: AFF_ID });
+    expect(await countAffiliateLinks(db, AFF_ID)).toBe(2);
+  });
+
+  // ── incrementAffiliateLinkClick ──────────────────────────────────────────
+
+  test('incrementAffiliateLinkClick increments click_count', async () => {
+    const link = await createAffiliateLink(db, { affiliateId: AFF_ID });
+    expect(link.click_count).toBe(0);
+
+    await incrementAffiliateLinkClick(db, link.ref_code);
+    await incrementAffiliateLinkClick(db, link.ref_code);
+
+    const updated = await getAffiliateLinkByRefCode(db, link.ref_code);
+    expect(updated!.click_count).toBe(2);
+  });
+
+  test('incrementAffiliateLinkClick on unknown ref_code is a no-op', async () => {
+    // Should not throw
+    await expect(incrementAffiliateLinkClick(db, 'zzzzzz')).resolves.toBeUndefined();
+  });
+
+  // ── getAffiliateByFriendId ───────────────────────────────────────────────
+
+  test('getAffiliateByFriendId returns null when no affiliate linked', async () => {
+    insertFriend(sqlite, 'friend-001', 'U0000000000000000000000000000099');
+    const result = await getAffiliateByFriendId(db, 'friend-001');
+    expect(result).toBeNull();
+  });
+
+  test('getAffiliateByFriendId returns affiliate when friend_id is set', async () => {
+    insertFriend(sqlite, 'friend-002', 'U0000000000000000000000000000098');
+    // Set friend_id on the affiliate
+    sqlite
+      .prepare(`UPDATE affiliates SET friend_id = ? WHERE id = ?`)
+      .run('friend-002', AFF_ID);
+
+    const aff = await getAffiliateByFriendId(db, 'friend-002');
+    expect(aff).not.toBeNull();
+    expect(aff!.id).toBe(AFF_ID);
+  });
+});

--- a/packages/db/test/affiliate-report.test.ts
+++ b/packages/db/test/affiliate-report.test.ts
@@ -1,0 +1,596 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  getAffiliateReportV2,
+  getFriendJourney,
+  getAffiliateJourneys,
+  getAffiliateLinkStats,
+} from '../src/affiliate-report.js';
+import { getAffiliateReport } from '../src/affiliates.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = join(__dirname, '..');
+const MIGRATIONS_DIR = join(PKG_ROOT, 'migrations');
+
+const BENIGN = /duplicate column name|already exists/i;
+
+// The canonical IDENTITY_KEY_SQL fragment (kept in sync with
+// apps/worker/src/lib/identity-key.ts). Passed into the report function so the
+// db layer stays decoupled from apps/worker while using the same expression.
+const IDENTITY_KEY_SQL = `
+  COALESCE(
+    CASE
+      WHEN friends.picture_url LIKE 'https://sprofile.line-scdn.net/%' THEN SUBSTR(friends.picture_url, 42, 80)
+      WHEN friends.picture_url LIKE 'https://profile.line-scdn.net/%' THEN SUBSTR(friends.picture_url, 41, 80)
+      ELSE NULL
+    END,
+    'uid:' || friends.user_id,
+    'solo:' || friends.id
+  )
+`;
+
+function execSafe(db: Database.Database, sql: string): void {
+  for (const stmt of sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    try {
+      db.exec(stmt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!BENIGN.test(msg)) throw err;
+    }
+  }
+}
+
+function setupDb(): Database.Database {
+  const db = new Database(':memory:');
+  execSafe(db, readFileSync(join(PKG_ROOT, 'schema.sql'), 'utf8'));
+  const migrationFiles = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  for (const file of migrationFiles) {
+    execSafe(db, readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+  }
+  return db;
+}
+
+function asD1(sqlite: Database.Database): D1Database {
+  return {
+    prepare(query: string) {
+      return {
+        bind(...params: unknown[]) {
+          const stmt = sqlite.prepare(query);
+          return {
+            async run() {
+              stmt.run(...params);
+              return { results: [], success: true, meta: {} };
+            },
+            async first<T>() {
+              return (stmt.get(...params) as T) ?? null;
+            },
+            async all<T>() {
+              return { results: stmt.all(...params) as T[], success: true, meta: {} };
+            },
+          };
+        },
+        async run() {
+          sqlite.prepare(query).run();
+          return { results: [], success: true, meta: {} };
+        },
+        async first<T>() {
+          return (sqlite.prepare(query).get() as T) ?? null;
+        },
+        async all<T>() {
+          return { results: sqlite.prepare(query).all() as T[], success: true, meta: {} };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+// ── Fixture helpers ──────────────────────────────────────────────────────────
+
+function insertFriend(
+  sqlite: Database.Database,
+  id: string,
+  opts: { createdAt: string; userId?: string | null; pictureUrl?: string | null; displayName?: string } = { createdAt: '2026-01-01T00:00:00.000+09:00' },
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO friends (id, line_user_id, display_name, picture_url, user_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      `U${id.replace(/[^0-9a-f]/gi, '').padEnd(32, '0').slice(0, 32)}`,
+      opts.displayName ?? 'Test User',
+      opts.pictureUrl ?? null,
+      opts.userId ?? null,
+      opts.createdAt,
+      opts.createdAt,
+    );
+}
+
+let affiliateSeq = 0;
+function insertAffiliate(
+  sqlite: Database.Database,
+  id: string,
+  opts: { friendId?: string | null; commissionRate?: number } = {},
+): void {
+  affiliateSeq++;
+  sqlite
+    .prepare(
+      `INSERT INTO affiliates (id, name, code, commission_rate, is_active, created_at, friend_id)
+       VALUES (?, ?, ?, ?, 1, '2024-01-01T00:00:00.000+09:00', ?)`,
+    )
+    .run(id, `Aff ${id}`, `code-${id}-${affiliateSeq}`, opts.commissionRate ?? 0, opts.friendId ?? null);
+}
+
+function insertLink(
+  sqlite: Database.Database,
+  opts: { id: string; affiliateId: string; refCode: string; clickCount?: number },
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO affiliate_links (id, affiliate_id, ref_code, label, line_account_id, is_active, created_at, click_count)
+       VALUES (?, ?, ?, NULL, NULL, 1, '2024-01-01T00:00:00.000+09:00', ?)`,
+    )
+    .run(opts.id, opts.affiliateId, opts.refCode, opts.clickCount ?? 0);
+}
+
+function insertTouch(
+  sqlite: Database.Database,
+  opts: { id: string; refCode: string; friendId: string; createdAt: string; sourceUrl?: string | null },
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO ref_tracking (id, ref_code, friend_id, source_url, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(opts.id, opts.refCode, opts.friendId, opts.sourceUrl ?? null, opts.createdAt);
+}
+
+function insertConversionPoint(
+  sqlite: Database.Database,
+  opts: { id: string; name: string; value: number },
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO conversion_points (id, name, event_type, value, created_at)
+       VALUES (?, ?, 'purchase', ?, '2024-01-01T00:00:00.000+09:00')`,
+    )
+    .run(opts.id, opts.name, opts.value);
+}
+
+function insertConversion(
+  sqlite: Database.Database,
+  opts: { id: string; pointId: string; friendId: string; affiliateId: string | null; refCode: string | null; createdAt: string },
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO conversion_events (id, conversion_point_id, friend_id, affiliate_id, attributed_ref_code, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run(opts.id, opts.pointId, opts.friendId, opts.affiliateId, opts.refCode, opts.createdAt);
+}
+
+function insertForm(sqlite: Database.Database, opts: { id: string; name: string }): void {
+  sqlite
+    .prepare(`INSERT INTO forms (id, name, created_at, updated_at) VALUES (?, ?, '2024-01-01T00:00:00.000+09:00', '2024-01-01T00:00:00.000+09:00')`)
+    .run(opts.id, opts.name);
+}
+
+function insertSubmission(
+  sqlite: Database.Database,
+  opts: { id: string; formId: string; friendId: string; createdAt: string },
+): void {
+  sqlite
+    .prepare(`INSERT INTO form_submissions (id, form_id, friend_id, data, created_at) VALUES (?, ?, ?, '{}', ?)`)
+    .run(opts.id, opts.formId, opts.friendId, opts.createdAt);
+}
+
+const NOW = '2026-07-07T12:00:00.000+09:00';
+function jstDaysAgo(days: number, opts: { minutes?: number } = {}): string {
+  const base = new Date(NOW).getTime();
+  const ms = base - days * 86_400_000 + (opts.minutes ?? 0) * 60_000;
+  const jst = new Date(ms + 9 * 60 * 60_000);
+  return jst.toISOString().slice(0, -1) + '+09:00';
+}
+
+// ── Journey + report scenario (brief) ────────────────────────────────────────
+// touch(A) -> friend_add -> touch(B, other affiliate) -> conversion.
+// The friend adds AFTER touch(A) but BEFORE touch(B), so add-time last-touch is
+// A. The conversion happens after touch(B), so its snapshot attribution is B.
+
+describe('journey + affiliate report v2 — canonical scenario', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+
+    insertAffiliate(sqlite, 'aff-A', { commissionRate: 0.2 });
+    insertAffiliate(sqlite, 'aff-B', { commissionRate: 0.5 });
+    insertLink(sqlite, { id: 'link-A', affiliateId: 'aff-A', refCode: 'refA', clickCount: 7 });
+    insertLink(sqlite, { id: 'link-B', affiliateId: 'aff-B', refCode: 'refB', clickCount: 3 });
+    insertConversionPoint(sqlite, { id: 'cp-1', name: 'Purchase', value: 1000 });
+
+    // friend added between touch A and touch B
+    insertFriend(sqlite, 'friend-1', { createdAt: jstDaysAgo(20) });
+    insertTouch(sqlite, { id: 't-a', refCode: 'refA', friendId: 'friend-1', createdAt: jstDaysAgo(25), sourceUrl: 'https://example.test/lp' });
+    insertTouch(sqlite, { id: 't-b', refCode: 'refB', friendId: 'friend-1', createdAt: jstDaysAgo(10) });
+    insertConversion(sqlite, {
+      id: 'cv-1', pointId: 'cp-1', friendId: 'friend-1',
+      affiliateId: 'aff-B', refCode: 'refB', createdAt: jstDaysAgo(5),
+    });
+  });
+
+  test('journey returns 4 events in ascending time order', async () => {
+    const journey = await getFriendJourney(db, 'friend-1');
+    expect(journey.map((e) => e.type)).toEqual([
+      'touch',      // touch A @ -25d
+      'friend_add', // add @ -20d
+      'touch',      // touch B @ -10d
+      'conversion', // cv @ -5d
+    ]);
+    expect(journey[0].refCode).toBe('refA');
+    expect(journey[0].affiliateId).toBe('aff-A');
+    expect(journey[2].refCode).toBe('refB');
+    expect(journey[2].affiliateId).toBe('aff-B');
+    expect(journey[3].refCode).toBe('refB');
+  });
+
+  test('affiliate A: friendAdds=1, conversions=0', async () => {
+    const report = await getAffiliateReportV2(db, 'aff-A', { identityKeySql: IDENTITY_KEY_SQL });
+    expect(report).not.toBeNull();
+    expect(report!.friendAdds).toBe(1);
+    expect(report!.conversions).toBe(0);
+    // A got 1 ref_tracking touch on its link
+    expect(report!.clicks).toBe(1);
+    expect(report!.linkClicks).toBe(7);
+    expect(report!.revenue).toBe(0);
+    expect(report!.estimatedCommission).toBe(0);
+  });
+
+  test('affiliate B: friendAdds=0, conversions=1', async () => {
+    const report = await getAffiliateReportV2(db, 'aff-B', { identityKeySql: IDENTITY_KEY_SQL });
+    expect(report!.friendAdds).toBe(0);
+    expect(report!.conversions).toBe(1);
+    expect(report!.clicks).toBe(1);
+    expect(report!.linkClicks).toBe(3);
+    expect(report!.conversionsByPoint).toEqual([
+      { conversionPointId: 'cp-1', name: 'Purchase', count: 1, value: 1000 },
+    ]);
+    expect(report!.revenue).toBe(1000);
+    expect(report!.estimatedCommission).toBe(500); // 1000 * 0.5
+  });
+
+  test('non-existent affiliate returns null', async () => {
+    expect(await getAffiliateReportV2(db, 'nope', { identityKeySql: IDENTITY_KEY_SQL })).toBeNull();
+  });
+});
+
+// ── friendAdds: self-click exclusion + window edge ───────────────────────────
+
+describe('getAffiliateReportV2 — friendAdds attribution rules', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+  });
+
+  test('self-click add is NOT counted as a friendAdd', async () => {
+    insertFriend(sqlite, 'friend-self', { createdAt: jstDaysAgo(1) });
+    insertAffiliate(sqlite, 'aff-self', { friendId: 'friend-self' });
+    insertLink(sqlite, { id: 'link-s', affiliateId: 'aff-self', refCode: 'refself' });
+    insertTouch(sqlite, { id: 't-s', refCode: 'refself', friendId: 'friend-self', createdAt: jstDaysAgo(3) });
+
+    const report = await getAffiliateReportV2(db, 'aff-self', { identityKeySql: IDENTITY_KEY_SQL });
+    expect(report!.friendAdds).toBe(0);
+  });
+
+  test('a touch strictly older than 90 days before add is not attributed', async () => {
+    insertFriend(sqlite, 'friend-old', { createdAt: NOW });
+    insertAffiliate(sqlite, 'aff-old');
+    insertLink(sqlite, { id: 'link-o', affiliateId: 'aff-old', refCode: 'refold' });
+    // touch 91 days before add
+    insertTouch(sqlite, { id: 't-o', refCode: 'refold', friendId: 'friend-old', createdAt: jstDaysAgo(91) });
+
+    const report = await getAffiliateReportV2(db, 'aff-old', { identityKeySql: IDENTITY_KEY_SQL });
+    expect(report!.friendAdds).toBe(0);
+  });
+
+  test('add-time last-touch: newest eligible touch before add wins', async () => {
+    insertAffiliate(sqlite, 'aff-x');
+    insertAffiliate(sqlite, 'aff-y');
+    insertLink(sqlite, { id: 'lx', affiliateId: 'aff-x', refCode: 'refx' });
+    insertLink(sqlite, { id: 'ly', affiliateId: 'aff-y', refCode: 'refy' });
+    // friend added at -10d: only touches before -10d count. refy(-12d) is newer than refx(-30d).
+    insertFriend(sqlite, 'friend-w', { createdAt: jstDaysAgo(10) });
+    insertTouch(sqlite, { id: 'tx', refCode: 'refx', friendId: 'friend-w', createdAt: jstDaysAgo(30) });
+    insertTouch(sqlite, { id: 'ty', refCode: 'refy', friendId: 'friend-w', createdAt: jstDaysAgo(12) });
+    // a later touch refx(-2d) is AFTER the add -> must not change add-time attribution
+    insertTouch(sqlite, { id: 'tx2', refCode: 'refx', friendId: 'friend-w', createdAt: jstDaysAgo(2) });
+
+    const rx = await getAffiliateReportV2(db, 'aff-x', { identityKeySql: IDENTITY_KEY_SQL });
+    const ry = await getAffiliateReportV2(db, 'aff-y', { identityKeySql: IDENTITY_KEY_SQL });
+    expect(rx!.friendAdds).toBe(0);
+    expect(ry!.friendAdds).toBe(1);
+  });
+});
+
+// ── duplicateFlags ───────────────────────────────────────────────────────────
+
+describe('getAffiliateReportV2 — duplicateFlags', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+    insertAffiliate(sqlite, 'aff-d');
+    insertLink(sqlite, { id: 'ld', affiliateId: 'aff-d', refCode: 'refd' });
+  });
+
+  test('two attributed friends sharing a user_id identity are flagged', async () => {
+    // Both friends attributed to aff-d, both share user_id 'same-uid' → dup.
+    insertFriend(sqlite, 'friend-d1', { createdAt: jstDaysAgo(10), userId: 'same-uid' });
+    insertFriend(sqlite, 'friend-d2', { createdAt: jstDaysAgo(9), userId: 'same-uid' });
+    // A third attributed friend with a unique identity → NOT flagged.
+    insertFriend(sqlite, 'friend-d3', { createdAt: jstDaysAgo(8), userId: 'other-uid' });
+    for (const fid of ['friend-d1', 'friend-d2', 'friend-d3']) {
+      insertTouch(sqlite, { id: `t-${fid}`, refCode: 'refd', friendId: fid, createdAt: jstDaysAgo(11) });
+    }
+
+    const report = await getAffiliateReportV2(db, 'aff-d', { identityKeySql: IDENTITY_KEY_SQL });
+    expect(report!.friendAdds).toBe(3);
+    const flagged = report!.duplicateFlags.map((f) => f.friendId).sort();
+    expect(flagged).toEqual(['friend-d1', 'friend-d2']);
+    expect(report!.duplicateFlags.every((f) => f.identityKey === 'uid:same-uid')).toBe(true);
+  });
+
+  test('no duplicates → empty array', async () => {
+    insertFriend(sqlite, 'friend-u1', { createdAt: jstDaysAgo(10), userId: 'u1' });
+    insertFriend(sqlite, 'friend-u2', { createdAt: jstDaysAgo(9), userId: 'u2' });
+    for (const fid of ['friend-u1', 'friend-u2']) {
+      insertTouch(sqlite, { id: `t-${fid}`, refCode: 'refd', friendId: fid, createdAt: jstDaysAgo(11) });
+    }
+    const report = await getAffiliateReportV2(db, 'aff-d', { identityKeySql: IDENTITY_KEY_SQL });
+    expect(report!.duplicateFlags).toEqual([]);
+  });
+});
+
+// ── journeys pagination ──────────────────────────────────────────────────────
+
+describe('getAffiliateJourneys — cursor pagination', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+    insertAffiliate(sqlite, 'aff-p');
+    insertLink(sqlite, { id: 'lp', affiliateId: 'aff-p', refCode: 'refp' });
+    insertForm(sqlite, { id: 'form-1', name: 'Signup' });
+    insertConversionPoint(sqlite, { id: 'cp-p', name: 'Buy', value: 500 });
+    // 3 attributed friends, added at -3d, -2d, -1d.
+    for (let i = 1; i <= 3; i++) {
+      const fid = `friend-p${i}`;
+      insertFriend(sqlite, fid, { createdAt: jstDaysAgo(4 - i), displayName: `P${i}` });
+      insertTouch(sqlite, { id: `tp${i}`, refCode: 'refp', friendId: fid, createdAt: jstDaysAgo(5) });
+    }
+    // friend-p1 also has a form submission and a conversion (later events)
+    insertSubmission(sqlite, { id: 'sub-1', formId: 'form-1', friendId: 'friend-p1', createdAt: jstDaysAgo(2) });
+    insertConversion(sqlite, { id: 'cv-p1', pointId: 'cp-p', friendId: 'friend-p1', affiliateId: 'aff-p', refCode: 'refp', createdAt: jstDaysAgo(1) });
+  });
+
+  test('newest-add first with per-friend counts', async () => {
+    const page = await getAffiliateJourneys(db, 'aff-p', {});
+    expect(page.items.map((i) => i.friendId)).toEqual(['friend-p3', 'friend-p2', 'friend-p1']);
+    const p1 = page.items.find((i) => i.friendId === 'friend-p1')!;
+    expect(p1.touchCount).toBe(1);
+    expect(p1.formCount).toBe(1);
+    expect(p1.conversionCount).toBe(1);
+    expect(p1.refCode).toBe('refp');
+    // last event for p1 is the conversion @ -1d, which is newer than its add @ -3d
+    expect(p1.lastEventAt).toBe(jstDaysAgo(1));
+    expect(page.nextCursor).toBeNull();
+  });
+
+  test('limit + cursor walks the whole set without gaps or repeats', async () => {
+    const first = await getAffiliateJourneys(db, 'aff-p', { limit: 2 });
+    expect(first.items.map((i) => i.friendId)).toEqual(['friend-p3', 'friend-p2']);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await getAffiliateJourneys(db, 'aff-p', {
+      limit: 2,
+      beforeAt: first.nextCursor!.beforeAt,
+      beforeId: first.nextCursor!.beforeId,
+    });
+    expect(second.items.map((i) => i.friendId)).toEqual(['friend-p1']);
+    expect(second.nextCursor).toBeNull();
+  });
+});
+
+// ── all-affiliates aggregate: linkCount + friendAdds (single pass) ────────────
+// getAffiliateReport backs the list view (GET /api/affiliates-report). Its
+// friend_adds column must match getAffiliateReportV2's friendAdds exactly, since
+// both resolve add-time last-touch via FRIEND_ADD_WINNER_SUBQUERY.
+
+describe('getAffiliateReport — linkCount + friendAdds aggregate', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+
+    // aff-A: 2 links, wins one attributed friend.
+    // aff-B: 1 link, wins zero attributed friends.
+    insertAffiliate(sqlite, 'aff-A', { commissionRate: 0.2 });
+    insertAffiliate(sqlite, 'aff-B', { commissionRate: 0.5 });
+    insertLink(sqlite, { id: 'link-A1', affiliateId: 'aff-A', refCode: 'refA1', clickCount: 4 });
+    insertLink(sqlite, { id: 'link-A2', affiliateId: 'aff-A', refCode: 'refA2', clickCount: 2 });
+    insertLink(sqlite, { id: 'link-B1', affiliateId: 'aff-B', refCode: 'refB1', clickCount: 3 });
+
+    // attributed friend: touch(refA1) before add → winner is aff-A.
+    insertFriend(sqlite, 'friend-1', { createdAt: jstDaysAgo(20) });
+    insertTouch(sqlite, { id: 't-a', refCode: 'refA1', friendId: 'friend-1', createdAt: jstDaysAgo(25) });
+
+    // non-attributed friend: its only touch is 91d before add → outside window.
+    insertFriend(sqlite, 'friend-2', { createdAt: NOW });
+    insertTouch(sqlite, { id: 't-b', refCode: 'refB1', friendId: 'friend-2', createdAt: jstDaysAgo(91) });
+  });
+
+  test('per-affiliate link_count and friend_adds are correct', async () => {
+    const rows = await getAffiliateReport(db);
+    const byId = new Map(rows.map((r) => [r.affiliateId, r]));
+
+    const a = byId.get('aff-A')!;
+    const b = byId.get('aff-B')!;
+    expect(a.linkCount).toBe(2);
+    expect(a.friendAdds).toBe(1);
+    expect(b.linkCount).toBe(1);
+    // friend-2's only touch is outside the 90d window → not attributed to anyone.
+    expect(b.friendAdds).toBe(0);
+  });
+
+  test('friend_adds matches per-affiliate getAffiliateReportV2 for the same input', async () => {
+    const all = await getAffiliateReport(db);
+    const allById = new Map(all.map((r) => [r.affiliateId, r.friendAdds]));
+
+    for (const affId of ['aff-A', 'aff-B']) {
+      const v2 = await getAffiliateReportV2(db, affId, { identityKeySql: IDENTITY_KEY_SQL });
+      expect(allById.get(affId)).toBe(v2!.friendAdds);
+    }
+  });
+});
+
+// ── per-link stats (self API) ────────────────────────────────────────────────
+// getAffiliateLinkStats backs the LIFF self endpoints. Per-link friendAdds must
+// sum to the per-affiliate friendAdds (same winner logic); per-link conversions
+// split by attributed_ref_code.
+
+describe('getAffiliateLinkStats — per-link friendAdds + conversions', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+
+    // One affiliate with two links (refA1, refA2). Each link wins its own
+    // friend at add-time, and each has its own conversion.
+    insertAffiliate(sqlite, 'aff-A', { commissionRate: 0.3 });
+    insertLink(sqlite, { id: 'link-A1', affiliateId: 'aff-A', refCode: 'refA1' });
+    insertLink(sqlite, { id: 'link-A2', affiliateId: 'aff-A', refCode: 'refA2' });
+    insertConversionPoint(sqlite, { id: 'cp-1', name: 'Purchase', value: 1000 });
+
+    // friend-1 won by refA1 (touch before add), + 1 conversion on refA1.
+    insertFriend(sqlite, 'friend-1', { createdAt: jstDaysAgo(20) });
+    insertTouch(sqlite, { id: 't-1', refCode: 'refA1', friendId: 'friend-1', createdAt: jstDaysAgo(25) });
+    insertConversion(sqlite, { id: 'cv-1', pointId: 'cp-1', friendId: 'friend-1', affiliateId: 'aff-A', refCode: 'refA1', createdAt: jstDaysAgo(5) });
+
+    // friend-2 won by refA2, + 2 conversions on refA2.
+    insertFriend(sqlite, 'friend-2', { createdAt: jstDaysAgo(15) });
+    insertTouch(sqlite, { id: 't-2', refCode: 'refA2', friendId: 'friend-2', createdAt: jstDaysAgo(18) });
+    insertConversion(sqlite, { id: 'cv-2', pointId: 'cp-1', friendId: 'friend-2', affiliateId: 'aff-A', refCode: 'refA2', createdAt: jstDaysAgo(4) });
+    insertConversion(sqlite, { id: 'cv-3', pointId: 'cp-1', friendId: 'friend-2', affiliateId: 'aff-A', refCode: 'refA2', createdAt: jstDaysAgo(3) });
+  });
+
+  test('friendAdds + conversions split correctly across two links', async () => {
+    const stats = await getAffiliateLinkStats(db, 'aff-A');
+    expect(stats.get('refA1')).toEqual({ friendAdds: 1, conversions: 1 });
+    expect(stats.get('refA2')).toEqual({ friendAdds: 1, conversions: 2 });
+  });
+
+  test('per-link friendAdds sum equals the per-affiliate friendAdds', async () => {
+    const stats = await getAffiliateLinkStats(db, 'aff-A');
+    const perLinkSum = [...stats.values()].reduce((s, v) => s + v.friendAdds, 0);
+    const v2 = await getAffiliateReportV2(db, 'aff-A', { identityKeySql: IDENTITY_KEY_SQL });
+    expect(perLinkSum).toBe(v2!.friendAdds);
+    expect(perLinkSum).toBe(2);
+  });
+
+  test('per-link conversions sum equals the per-affiliate conversions', async () => {
+    const stats = await getAffiliateLinkStats(db, 'aff-A');
+    const perLinkSum = [...stats.values()].reduce((s, v) => s + v.conversions, 0);
+    const v2 = await getAffiliateReportV2(db, 'aff-A', { identityKeySql: IDENTITY_KEY_SQL });
+    expect(perLinkSum).toBe(v2!.conversions);
+    expect(perLinkSum).toBe(3);
+  });
+
+  test('a link with no activity is absent from the map (caller defaults to 0)', async () => {
+    insertLink(sqlite, { id: 'link-A3', affiliateId: 'aff-A', refCode: 'refA3' });
+    const stats = await getAffiliateLinkStats(db, 'aff-A');
+    expect(stats.has('refA3')).toBe(false);
+  });
+});
+
+// ── list aggregate: ASP affiliate_id + legacy affiliate_code CV ───────────────
+// getAffiliateReport (list view) must surface conversions attributed by EITHER
+// the affiliate_id snapshot (ASP ref-code path) OR the legacy affiliate_code
+// match, without double-counting a row that satisfies both.
+
+describe('getAffiliateReport — CV via affiliate_id OR affiliate_code', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+    insertAffiliate(sqlite, 'aff-A', { commissionRate: 0.2 });
+    insertLink(sqlite, { id: 'link-A1', affiliateId: 'aff-A', refCode: 'refA1' });
+    insertConversionPoint(sqlite, { id: 'cp-1', name: 'Purchase', value: 1000 });
+  });
+
+  test('affiliate_id-only snapshot CV appears in the list aggregate', async () => {
+    insertFriend(sqlite, 'friend-1', { createdAt: jstDaysAgo(10) });
+    // affiliate_id set, affiliate_code NULL (ASP ref-code path).
+    insertConversion(sqlite, { id: 'cv-1', pointId: 'cp-1', friendId: 'friend-1', affiliateId: 'aff-A', refCode: 'refA1', createdAt: jstDaysAgo(2) });
+
+    const rows = await getAffiliateReport(db, 'aff-A');
+    expect(rows[0].totalConversions).toBe(1);
+    expect(rows[0].totalRevenue).toBe(1000);
+  });
+
+  test('legacy affiliate_code CV still appears', async () => {
+    const code = sqlite.prepare(`SELECT code FROM affiliates WHERE id = 'aff-A'`).get() as { code: string };
+    insertFriend(sqlite, 'friend-2', { createdAt: jstDaysAgo(10) });
+    // affiliate_code set (legacy), affiliate_id NULL.
+    sqlite
+      .prepare(
+        `INSERT INTO conversion_events (id, conversion_point_id, friend_id, affiliate_id, affiliate_code, attributed_ref_code, created_at)
+         VALUES ('cv-legacy', 'cp-1', 'friend-2', NULL, ?, NULL, ?)`,
+      )
+      .run(code.code, jstDaysAgo(2));
+
+    const rows = await getAffiliateReport(db, 'aff-A');
+    expect(rows[0].totalConversions).toBe(1);
+    expect(rows[0].totalRevenue).toBe(1000);
+  });
+
+  test('a row matching BOTH affiliate_id and affiliate_code is counted once', async () => {
+    const code = sqlite.prepare(`SELECT code FROM affiliates WHERE id = 'aff-A'`).get() as { code: string };
+    insertFriend(sqlite, 'friend-3', { createdAt: jstDaysAgo(10) });
+    // BOTH affiliate_id AND affiliate_code point at aff-A → must NOT double-count.
+    sqlite
+      .prepare(
+        `INSERT INTO conversion_events (id, conversion_point_id, friend_id, affiliate_id, affiliate_code, attributed_ref_code, created_at)
+         VALUES ('cv-both', 'cp-1', 'friend-3', 'aff-A', ?, 'refA1', ?)`,
+      )
+      .run(code.code, jstDaysAgo(2));
+
+    const rows = await getAffiliateReport(db, 'aff-A');
+    expect(rows[0].totalConversions).toBe(1);
+    expect(rows[0].totalRevenue).toBe(1000);
+  });
+});

--- a/packages/db/test/ref-tracking-last-touch.test.ts
+++ b/packages/db/test/ref-tracking-last-touch.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { recordRefTracking } from '../src/entry-routes.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = join(__dirname, '..');
+const MIGRATIONS_DIR = join(PKG_ROOT, 'migrations');
+
+const BENIGN = /duplicate column name|already exists/i;
+
+function execSafe(db: Database.Database, sql: string): void {
+  for (const stmt of sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    try {
+      db.exec(stmt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!BENIGN.test(msg)) throw err;
+    }
+  }
+}
+
+function setupDb(): Database.Database {
+  const db = new Database(':memory:');
+  execSafe(db, readFileSync(join(PKG_ROOT, 'schema.sql'), 'utf8'));
+  const migrationFiles = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  for (const file of migrationFiles) {
+    execSafe(db, readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+  }
+  return db;
+}
+
+function asD1(sqlite: Database.Database): D1Database {
+  return {
+    prepare(query: string) {
+      return {
+        bind(...params: unknown[]) {
+          const stmt = sqlite.prepare(query);
+          return {
+            async run() {
+              stmt.run(...params);
+              return { results: [], success: true, meta: {} };
+            },
+            async first<T>() {
+              return (stmt.get(...params) as T) ?? null;
+            },
+            async all<T>() {
+              return { results: stmt.all(...params) as T[], success: true, meta: {} };
+            },
+          };
+        },
+        async run() {
+          sqlite.prepare(query).run();
+          return { results: [], success: true, meta: {} };
+        },
+        async first<T>() {
+          return (sqlite.prepare(query).get() as T) ?? null;
+        },
+        async all<T>() {
+          return { results: sqlite.prepare(query).all() as T[], success: true, meta: {} };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function insertFriend(sqlite: Database.Database, id: string, lineUserId: string) {
+  sqlite
+    .prepare(
+      `INSERT INTO friends (id, line_user_id, display_name, created_at, updated_at)
+       VALUES (?, ?, 'Test User', '2024-01-01T00:00:00.000', '2024-01-01T00:00:00.000')`,
+    )
+    .run(id, lineUserId);
+}
+
+describe('recordRefTracking: last-touch update', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+  });
+
+  test('last_ref_code and last_ref_at are updated on each call with friendId', async () => {
+    insertFriend(sqlite, 'friend-lt-001', 'U0000000000000000000000000000001');
+
+    // First call with ref code 'aaa111'
+    await recordRefTracking(db, {
+      refCode: 'aaa111',
+      friendId: 'friend-lt-001',
+    });
+
+    const after1 = sqlite
+      .prepare(`SELECT last_ref_code, last_ref_at FROM friends WHERE id = 'friend-lt-001'`)
+      .get() as { last_ref_code: string | null; last_ref_at: string | null };
+
+    expect(after1.last_ref_code).toBe('aaa111');
+    expect(after1.last_ref_at).not.toBeNull();
+    const at1 = after1.last_ref_at!;
+
+    // Second call with ref code 'bbb222'
+    await recordRefTracking(db, {
+      refCode: 'bbb222',
+      friendId: 'friend-lt-001',
+    });
+
+    const after2 = sqlite
+      .prepare(`SELECT last_ref_code, last_ref_at FROM friends WHERE id = 'friend-lt-001'`)
+      .get() as { last_ref_code: string | null; last_ref_at: string | null };
+
+    // last-touch should be overwritten with the second ref code
+    expect(after2.last_ref_code).toBe('bbb222');
+    expect(after2.last_ref_at).not.toBeNull();
+    // last_ref_at should be >= the first timestamp (last-touch semantics)
+    expect(after2.last_ref_at! >= at1).toBe(true);
+  });
+
+  test('friends row is NOT changed when friendId is absent', async () => {
+    insertFriend(sqlite, 'friend-lt-002', 'U0000000000000000000000000000002');
+
+    const before = sqlite
+      .prepare(`SELECT last_ref_code, last_ref_at FROM friends WHERE id = 'friend-lt-002'`)
+      .get() as { last_ref_code: string | null; last_ref_at: string | null };
+
+    // Call without friendId
+    await recordRefTracking(db, {
+      refCode: 'ccc333',
+    });
+
+    const after = sqlite
+      .prepare(`SELECT last_ref_code, last_ref_at FROM friends WHERE id = 'friend-lt-002'`)
+      .get() as { last_ref_code: string | null; last_ref_at: string | null };
+
+    expect(after.last_ref_code).toBe(before.last_ref_code);
+    expect(after.last_ref_at).toBe(before.last_ref_at);
+  });
+});


### PR DESCRIPTION
Private main からの同期。セルフサーブ型アフィリエイト計測 (リンク発行 → クリック → 友だち追加 → CV の last-touch 帰属 + 時系列ジャーニー)。ドキュメント: docs/wiki/27-Affiliate-ASP.md。migration 046 は追加専用。