### PR TITLE
sync: アフィリ成果通知 + MCP resolved 除外

### DIFF
--- a/apps/worker/src/routes/conversations.ts
+++ b/apps/worker/src/routes/conversations.ts
@@ -20,6 +20,19 @@ conversations.get('/api/conversations', async (c) => {
         ? `AND ((strftime('%s', 'now') - strftime('%s', li.at)) / 3600.0) <= ?`
         : '';
 
+    // friend ごとの最新 chats 行の status (bare-column + 単一 MAX の argmax)。
+    // unanswered-inbox.ts の CANDIDATES_SQL と同じ resolved 除外。管理画面で
+    // 「解決済」にした会話が MCP (list_conversations) 側だけ要対応で残ると
+    // 判定が乖離するため、こちらにも同条件を入れる。main / count の両クエリで
+    // 共有し、片方だけ編集されて total と items が食い違うのを防ぐ。
+    const latestChatCte = `
+      latest_chat AS (
+        SELECT friend_id, status, MAX(created_at) AS created_at
+        FROM chats
+        GROUP BY friend_id
+      )`;
+    const whereNotResolved = `AND COALESCE(lc.status, 'unread') != 'resolved'`;
+
     const sql = `
       -- conversations queue (要対応の自発メッセージ) は postback (rich menu tap) を除外する。
       -- postback は button 押下で「人間の返信を要する自発メッセージ」ではないため。
@@ -48,7 +61,8 @@ conversations.get('/api/conversations', async (c) => {
         ) lm ON lm.friend_id = ml.friend_id AND lm.mx = ml.created_at
         WHERE ml.direction = 'incoming'
           AND (ml.source IS NULL OR ml.source != 'postback')
-      )
+      ),
+      ${latestChatCte}
       SELECT
         f.id AS friend_id,
         f.line_user_id,
@@ -64,8 +78,10 @@ conversations.get('/api/conversations', async (c) => {
       INNER JOIN last_incoming li ON li.friend_id = f.id
       LEFT JOIN last_human lh ON lh.friend_id = f.id
       LEFT JOIN latest_msg lm ON lm.friend_id = f.id
+      LEFT JOIN latest_chat lc ON lc.friend_id = f.id
       WHERE f.is_following = 1
         AND (lh.at IS NULL OR lh.at < li.at)
+        ${whereNotResolved}
         AND ((strftime('%s', 'now') - strftime('%s', li.at)) / 3600.0) >= ?
         ${whereMaxHours}
         ${whereAccount}
@@ -93,12 +109,15 @@ conversations.get('/api/conversations', async (c) => {
       last_human AS (
         SELECT friend_id, MAX(created_at) AS at FROM messages_log
         WHERE direction = 'outgoing' AND source = 'manual' GROUP BY friend_id
-      )
+      ),
+      ${latestChatCte}
       SELECT COUNT(*) AS total FROM friends f
       INNER JOIN last_incoming li ON li.friend_id = f.id
       LEFT JOIN last_human lh ON lh.friend_id = f.id
+      LEFT JOIN latest_chat lc ON lc.friend_id = f.id
       WHERE f.is_following = 1
         AND (lh.at IS NULL OR lh.at < li.at)
+        ${whereNotResolved}
         AND ((strftime('%s', 'now') - strftime('%s', li.at)) / 3600.0) >= ?
         ${whereMaxHours}
         ${whereAccount}

--- a/apps/worker/src/routes/conversions-approval.test.ts
+++ b/apps/worker/src/routes/conversions-approval.test.ts
@@ -21,8 +21,14 @@ const dbMocks = {
   getConversionReport: vi.fn(),
   getConversionApprovalQueue: vi.fn(),
   setConversionApproval: vi.fn(),
+  getConversionApprovalNotifyInfo: vi.fn(),
 };
 vi.mock('@line-crm/db', () => dbMocks);
+
+// Mock the affiliate notifier so the approval route's push is observable
+// without touching LINE / the DB resolution chain.
+const notifyAffiliateApproval = vi.fn().mockResolvedValue(undefined);
+vi.mock('../services/affiliate-notifier.js', () => ({ notifyAffiliateApproval }));
 
 const worker = (await import('../index.js')).default;
 
@@ -119,6 +125,11 @@ describe('GET /api/conversions/approvals', () => {
 describe('PATCH /api/conversions/events/:id/approval', () => {
   it('approves an attributed event', async () => {
     dbMocks.setConversionApproval.mockResolvedValue(true);
+    dbMocks.getConversionApprovalNotifyInfo.mockResolvedValue({
+      affiliateId: 'aff-1',
+      offerName: '案件X',
+      rewardAmount: 5000,
+    });
     const res = await req('PATCH', '/api/conversions/events/ev-1/approval', {
       status: 'approved',
     });
@@ -130,6 +141,43 @@ describe('PATCH /api/conversions/events/:id/approval', () => {
       'ev-1',
       'approved',
     );
+  });
+
+  it('notifies the affiliate on approval', async () => {
+    dbMocks.setConversionApproval.mockResolvedValue(true);
+    dbMocks.getConversionApprovalNotifyInfo.mockResolvedValue({
+      affiliateId: 'aff-1',
+      offerName: '案件X',
+      rewardAmount: 5000,
+    });
+    await req('PATCH', '/api/conversions/events/ev-1/approval', { status: 'approved' });
+    expect(notifyAffiliateApproval).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'aff-1',
+      '案件X',
+      5000,
+    );
+  });
+
+  it('does NOT notify the affiliate on rejection', async () => {
+    dbMocks.setConversionApproval.mockResolvedValue(true);
+    const res = await req('PATCH', '/api/conversions/events/ev-1/approval', {
+      status: 'rejected',
+    });
+    expect(res.status).toBe(200);
+    expect(dbMocks.getConversionApprovalNotifyInfo).not.toHaveBeenCalled();
+    expect(notifyAffiliateApproval).not.toHaveBeenCalled();
+  });
+
+  it('still returns 200 when the notify lookup finds nothing', async () => {
+    dbMocks.setConversionApproval.mockResolvedValue(true);
+    dbMocks.getConversionApprovalNotifyInfo.mockResolvedValue(null);
+    const res = await req('PATCH', '/api/conversions/events/ev-1/approval', {
+      status: 'approved',
+    });
+    expect(res.status).toBe(200);
+    expect(notifyAffiliateApproval).not.toHaveBeenCalled();
   });
 
   it('rejects an unknown status with 400', async () => {
@@ -151,5 +199,18 @@ describe('PATCH /api/conversions/events/:id/approval', () => {
       status: 'rejected',
     });
     expect(res.status).toBe(404);
+  });
+
+  it('returns 200 without calling notifyAffiliate when status is already_set (double-click guard)', async () => {
+    dbMocks.setConversionApproval.mockResolvedValue('already_set');
+    const res = await req('PATCH', '/api/conversions/events/ev-dup/approval', {
+      status: 'approved',
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { approvalStatus: string } };
+    expect(body.data.approvalStatus).toBe('approved');
+    // Critical: notify must NOT be called for an idempotent no-op
+    expect(notifyAffiliateApproval).not.toHaveBeenCalled();
+    expect(dbMocks.getConversionApprovalNotifyInfo).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/routes/conversions.ts
+++ b/apps/worker/src/routes/conversions.ts
@@ -9,8 +9,10 @@ import {
   getConversionReport,
   getConversionApprovalQueue,
   setConversionApproval,
+  getConversionApprovalNotifyInfo,
 } from '@line-crm/db';
 import { IDENTITY_KEY_SQL } from '../lib/identity-key.js';
+import { notifyAffiliateApproval } from '../services/affiliate-notifier.js';
 import type { Env } from '../index.js';
 
 const conversions = new Hono<Env>();
@@ -223,7 +225,7 @@ conversions.patch('/api/conversions/events/:id/approval', async (c) => {
       c.req.param('id'),
       body.status,
     );
-    if (!updated) {
+    if (updated === false) {
       // Missing event OR non-attributed CV (approval flow only applies to
       // affiliate-attributed rows) — both surface as 404.
       return c.json(
@@ -231,6 +233,35 @@ conversions.patch('/api/conversions/events/:id/approval', async (c) => {
         404,
       );
     }
+    if (updated === 'already_set') {
+      // Idempotent re-click: the status is already set to the requested value.
+      // Return 200 so the UI does not show an error to the operator.
+      return c.json({
+        success: true,
+        data: { id: c.req.param('id'), approvalStatus: body.status },
+      });
+    }
+
+    // ASP: notify the attributed affiliate on approval only (never on reject).
+    // Best-effort — notifyAffiliateApproval swallows its own errors, but guard
+    // the info lookup too so a push failure can never fail the approval request.
+    if (body.status === 'approved') {
+      try {
+        const info = await getConversionApprovalNotifyInfo(c.env.DB, c.req.param('id'));
+        if (info) {
+          await notifyAffiliateApproval(
+            c.env.DB,
+            c.env,
+            info.affiliateId,
+            info.offerName,
+            info.rewardAmount,
+          );
+        }
+      } catch (err) {
+        console.error('Affiliate approval notify failed (non-blocking):', err);
+      }
+    }
+
     return c.json({ success: true, data: { id: c.req.param('id'), approvalStatus: body.status } });
   } catch (err) {
     console.error('PATCH /api/conversions/events/:id/approval error:', err);

--- a/apps/worker/src/routes/liff-affiliate-friend-add.test.ts
+++ b/apps/worker/src/routes/liff-affiliate-friend-add.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ASP — friend-add push to the affiliate on a NEW friend arriving via an
+// affiliate link. Drives GET /auth/callback (the genuine new-friend entry
+// point). The db layer + notifier are mocked; a stubbed fetch answers the LINE
+// OAuth token / verify / profile / bot-info calls.
+//
+// Cases:
+//   - new friend via affiliate link → notifies
+//   - self-click (affiliate adds own bot) → does NOT notify
+//   - existing-friend re-touch → does NOT notify
+
+const dbMocks = {
+  // eager module-load deps
+  getLineAccounts: vi.fn().mockResolvedValue([]),
+  getStaffByApiKey: vi.fn(),
+  recoverStalledBroadcasts: vi.fn(),
+  recoverStuckDeliveries: vi.fn(),
+  // /auth/callback deps
+  getFriendByLineUserId: vi.fn(),
+  upsertFriend: vi.fn(),
+  createUser: vi.fn().mockResolvedValue({ id: 'U-uuid' }),
+  getUserByEmail: vi.fn().mockResolvedValue(null),
+  linkFriendToUser: vi.fn().mockResolvedValue(undefined),
+  getEntryRouteByRefCode: vi.fn().mockResolvedValue(null),
+  recordRefTracking: vi.fn().mockResolvedValue(undefined),
+  getTrackedLinkById: vi.fn().mockResolvedValue(null),
+  getMessageTemplateById: vi.fn().mockResolvedValue(null),
+  getAffiliateLinkByRefCode: vi.fn().mockResolvedValue(null),
+  getAffiliateOfferById: vi.fn().mockResolvedValue(null),
+  getAffiliateById: vi.fn().mockResolvedValue(null),
+  addTagToFriend: vi.fn().mockResolvedValue(undefined),
+  getLineAccountByChannelId: vi.fn().mockResolvedValue(null),
+  getLineAccountById: vi.fn().mockResolvedValue(null),
+  getScenarios: vi.fn().mockResolvedValue([]),
+  enrollFriendInScenario: vi.fn().mockResolvedValue(null),
+  getScenarioSteps: vi.fn().mockResolvedValue([]),
+  getTrafficPoolBySlug: vi.fn().mockResolvedValue(null),
+  getTrafficPoolById: vi.fn().mockResolvedValue(null),
+  getRandomPoolAccount: vi.fn().mockResolvedValue(null),
+  getPoolAccounts: vi.fn().mockResolvedValue([]),
+  jstNow: () => '2026-07-07 00:00:00',
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+const notifyAffiliateFriendAdd = vi.fn().mockResolvedValue(undefined);
+vi.mock('../services/affiliate-notifier.js', () => ({ notifyAffiliateFriendAdd }));
+
+const worker = (await import('../index.js')).default;
+
+// No-op prepared statement chain; the callback's raw UPDATE/SELECT statements
+// don't matter for the notification assertions.
+const DB = {
+  prepare: () => ({
+    bind: () => ({
+      run: async () => ({ meta: { changes: 0 } }),
+      first: async () => null,
+      all: async () => ({ results: [] }),
+    }),
+  }),
+} as unknown as D1Database;
+
+const env = {
+  DB,
+  LIFF_URL: 'https://liff.line.me/1000000000-DefaultAA',
+  WORKER_URL: 'https://worker.example.com',
+  LINE_LOGIN_CHANNEL_ID: '2000000000',
+  LINE_LOGIN_CHANNEL_SECRET: 'secret',
+  LINE_CHANNEL_ACCESS_TOKEN: 'env-token',
+} as unknown as import('../index.js').Env['Bindings'];
+
+function installFetchMock() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url === 'https://api.line.me/oauth2/v2.1/token') {
+        return new Response(
+          JSON.stringify({ access_token: 'at', id_token: 'idt', token_type: 'Bearer' }),
+          { status: 200 },
+        );
+      }
+      if (url === 'https://api.line.me/oauth2/v2.1/verify') {
+        return new Response(JSON.stringify({ sub: 'U-new-friend', name: 'Tester' }), {
+          status: 200,
+        });
+      }
+      if (url === 'https://api.line.me/v2/profile') {
+        return new Response(
+          JSON.stringify({ userId: 'U-new-friend', displayName: 'Tester' }),
+          { status: 200 },
+        );
+      }
+      // bot/info etc → 404 so the handler falls through to the completion page
+      return new Response('not found', { status: 404 });
+    }),
+  );
+}
+
+function callback(ref: string) {
+  const state = btoa(JSON.stringify({ ref }));
+  return worker.fetch(
+    new Request(
+      `https://worker.example.com/auth/callback?code=abc&state=${encodeURIComponent(state)}`,
+    ),
+    env,
+    { waitUntil() {}, passThroughOnException() {} } as unknown as ExecutionContext,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  installFetchMock();
+  dbMocks.createUser.mockResolvedValue({ id: 'U-uuid' });
+  dbMocks.upsertFriend.mockResolvedValue({
+    id: 'F-new',
+    line_user_id: 'U-new-friend',
+    line_account_id: null,
+    user_id: null,
+  });
+});
+
+describe('GET /auth/callback — affiliate friend-add notification', () => {
+  it('notifies the affiliate for a new friend via an offer affiliate link', async () => {
+    dbMocks.getFriendByLineUserId.mockResolvedValue(null); // brand-new friend
+    dbMocks.getAffiliateLinkByRefCode.mockResolvedValue({
+      id: 'AL-1',
+      affiliate_id: 'AFF-1',
+      ref_code: 'aff-ref',
+      offer_id: 'OFF-1',
+    });
+    dbMocks.getAffiliateOfferById.mockResolvedValue({
+      id: 'OFF-1',
+      name: '案件A',
+      tag_id: null,
+      scenario_id: null,
+      is_active: 1,
+    });
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'AFF-1', friend_id: 'F-owner' });
+
+    await callback('aff-ref');
+
+    expect(notifyAffiliateFriendAdd).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'AFF-1',
+      '案件A',
+    );
+  });
+
+  it('notifies with null offer name for a generic (offer-less) affiliate link', async () => {
+    dbMocks.getFriendByLineUserId.mockResolvedValue(null);
+    dbMocks.getAffiliateLinkByRefCode.mockResolvedValue({
+      id: 'AL-2',
+      affiliate_id: 'AFF-1',
+      ref_code: 'aff-generic',
+      offer_id: null,
+    });
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'AFF-1', friend_id: 'F-owner' });
+
+    await callback('aff-generic');
+
+    expect(notifyAffiliateFriendAdd).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'AFF-1',
+      null,
+    );
+  });
+
+  it('does NOT notify on a self-click (affiliate adds their own bot)', async () => {
+    dbMocks.getFriendByLineUserId.mockResolvedValue(null);
+    dbMocks.getAffiliateLinkByRefCode.mockResolvedValue({
+      id: 'AL-3',
+      affiliate_id: 'AFF-1',
+      ref_code: 'aff-self',
+      offer_id: 'OFF-1',
+    });
+    dbMocks.getAffiliateOfferById.mockResolvedValue({
+      id: 'OFF-1',
+      name: '案件A',
+      tag_id: null,
+      scenario_id: null,
+      is_active: 1,
+    });
+    // affiliate's own friend_id == the friend being added
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'AFF-1', friend_id: 'F-new' });
+
+    await callback('aff-self');
+
+    expect(notifyAffiliateFriendAdd).not.toHaveBeenCalled();
+  });
+
+  it('does NOT notify when the friend already existed (re-touch)', async () => {
+    // Pre-existing friend → isNewFriend is false.
+    dbMocks.getFriendByLineUserId.mockResolvedValue({
+      id: 'F-new',
+      line_user_id: 'U-new-friend',
+      line_account_id: null,
+      user_id: 'U-uuid',
+    });
+    dbMocks.getAffiliateLinkByRefCode.mockResolvedValue({
+      id: 'AL-4',
+      affiliate_id: 'AFF-1',
+      ref_code: 'aff-ref',
+      offer_id: 'OFF-1',
+    });
+    dbMocks.getAffiliateOfferById.mockResolvedValue({
+      id: 'OFF-1',
+      name: '案件A',
+      tag_id: null,
+      scenario_id: null,
+      is_active: 1,
+    });
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'AFF-1', friend_id: 'F-owner' });
+
+    await callback('aff-ref');
+
+    expect(notifyAffiliateFriendAdd).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/routes/liff-offer-attribution.test.ts
+++ b/apps/worker/src/routes/liff-offer-attribution.test.ts
@@ -20,12 +20,18 @@ const dbMocks = {
   getTrackedLinkById: vi.fn().mockResolvedValue(null),
   getAffiliateLinkByRefCode: vi.fn().mockResolvedValue(null),
   getAffiliateOfferById: vi.fn().mockResolvedValue(null),
+  getAffiliateById: vi.fn().mockResolvedValue(null),
   addTagToFriend: vi.fn().mockResolvedValue(undefined),
   recordRefTracking: vi.fn().mockResolvedValue(undefined),
   getLineAccountByChannelId: vi.fn().mockResolvedValue(null),
   getLineAccountById: vi.fn().mockResolvedValue(null),
 };
 vi.mock('@line-crm/db', () => dbMocks);
+
+// Notifier is mocked so we can assert the friend-add push is NOT fired on the
+// existing-friend re-touch path (/api/liff/link never sets isNewFriend).
+const notifyAffiliateFriendAdd = vi.fn().mockResolvedValue(undefined);
+vi.mock('../services/affiliate-notifier.js', () => ({ notifyAffiliateFriendAdd }));
 
 // Import after the mock so index.ts binds the mocked helpers.
 const worker = (await import('../index.js')).default;
@@ -161,6 +167,29 @@ describe('POST /api/liff/link — offer tag/scenario on affiliate-link friend ad
       'OFF-2',
     );
     expect(dbMocks.addTagToFriend).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire the friend-add notification on an existing-friend re-touch', async () => {
+    // /api/liff/link is a re-touch entry point (friend already exists), so the
+    // affiliate must never be notified — even for an affiliate offer link.
+    dbMocks.getAffiliateLinkByRefCode.mockResolvedValue({
+      id: 'AL-1',
+      affiliate_id: 'AFF-1',
+      ref_code: 'aff-offer',
+      offer_id: 'OFF-1',
+    });
+    dbMocks.getAffiliateOfferById.mockResolvedValue({
+      id: 'OFF-1',
+      name: '案件A',
+      tag_id: null,
+      scenario_id: null,
+      is_active: 1,
+    });
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'AFF-1', friend_id: 'F-other' });
+
+    const res = await link('aff-offer');
+    expect(res.status).toBe(200);
+    expect(notifyAffiliateFriendAdd).not.toHaveBeenCalled();
   });
 
   it('keeps entry_route behavior: offer is never consulted on an entry_route hit', async () => {

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -19,9 +19,11 @@ import {
   getMessageTemplateById,
   getAffiliateLinkByRefCode,
   getAffiliateOfferById,
+  getAffiliateById,
   jstNow,
 } from '@line-crm/db';
 import { buildIntroMessage } from '../services/intro-message.js';
+import { notifyAffiliateFriendAdd } from '../services/affiliate-notifier.js';
 import { safeRedirectTarget } from '../lib/safe-redirect.js';
 import type { Env } from '../index.js';
 
@@ -164,7 +166,7 @@ async function applyRefAttribution(
   ref: string,
   friend: { id: string; line_account_id?: string | null },
   lineUserId: string,
-  options?: { accountChannelId?: string | null },
+  options?: { accountChannelId?: string | null; isNewFriend?: boolean },
 ): Promise<void> {
   if (!ref || ref.startsWith('xh:')) return;
   const db = c.env.DB;
@@ -184,14 +186,37 @@ async function applyRefAttribution(
   let offer: Awaited<ReturnType<typeof getAffiliateOfferById>> = null;
   if (!route && !trackedLink) {
     const affiliateLink = await getAffiliateLinkByRefCode(db, ref);
-    if (affiliateLink?.offer_id) {
-      const fetchedOffer = await getAffiliateOfferById(db, affiliateLink.offer_id);
-      // Inactive offers (is_active = 0) are treated as null: stop the automatic
-      // flow (tag / scenario) so a paused campaign does not enroll new friends.
-      // Attribution recording (ref_tracking / ref_code on the friend row) is
-      // unaffected — it runs before this function and always persists the click.
-      if (fetchedOffer?.is_active) {
-        offer = fetchedOffer;
+    if (affiliateLink) {
+      // ASP friend-add notification: only for a brand-new friend arriving via an
+      // affiliate link (existing-friend re-touches would spam the affiliate).
+      // Self-clicks (the affiliate adding their own bot) are suppressed. Runs
+      // even for a 汎用リンク (offer_id NULL) — offerName is then null.
+      // Wrapped so a notify failure can never break attribution.
+      if (options?.isNewFriend) {
+        try {
+          const affiliate = await getAffiliateById(db, affiliateLink.affiliate_id);
+          if (affiliate && affiliate.friend_id !== friend.id) {
+            let offerName: string | null = null;
+            if (affiliateLink.offer_id) {
+              const linkOffer = await getAffiliateOfferById(db, affiliateLink.offer_id);
+              offerName = linkOffer?.name ?? null;
+            }
+            await notifyAffiliateFriendAdd(db, c.env, affiliate.id, offerName);
+          }
+        } catch (err) {
+          console.error('Affiliate friend-add notify failed (non-blocking):', err);
+        }
+      }
+
+      if (affiliateLink.offer_id) {
+        const fetchedOffer = await getAffiliateOfferById(db, affiliateLink.offer_id);
+        // Inactive offers (is_active = 0) are treated as null: stop the automatic
+        // flow (tag / scenario) so a paused campaign does not enroll new friends.
+        // Attribution recording (ref_tracking / ref_code on the friend row) is
+        // unaffected — it runs before this function and always persists the click.
+        if (fetchedOffer?.is_active) {
+          offer = fetchedOffer;
+        }
       }
     }
   }
@@ -799,6 +824,12 @@ liffRoutes.get('/auth/callback', async (c) => {
     const db = c.env.DB;
     const lineUserId = verified.sub;
 
+    // Detect a brand-new friend BEFORE upsertFriend creates the row, so the ASP
+    // affiliate friend-add notification fires once per genuinely-new add (a
+    // re-touch of an existing friend must not re-notify the affiliate).
+    const preExistingFriend = await getFriendByLineUserId(db, lineUserId);
+    const isNewFriend = !preExistingFriend;
+
     // Upsert friend (may not exist yet if webhook hasn't fired)
     const friend = await upsertFriend(db, {
       lineUserId,
@@ -876,6 +907,7 @@ liffRoutes.get('/auth/callback', async (c) => {
 
       await applyRefAttribution(c, ref, friend, lineUserId, {
         accountChannelId: accountParam || null,
+        isNewFriend,
       });
     }
 

--- a/apps/worker/src/services/affiliate-notifier.test.ts
+++ b/apps/worker/src/services/affiliate-notifier.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the LINE SDK so we can assert exactly what gets pushed without hitting
+// the network. pushMessage is a shared spy across all LineClient instances.
+const pushMessage = vi.fn().mockResolvedValue({});
+const LineClientMock = vi.fn().mockImplementation((token: string) => ({
+  __token: token,
+  pushMessage,
+}));
+vi.mock('@line-crm/line-sdk', () => ({ LineClient: LineClientMock }));
+
+// Mock the db helpers the notifier resolves through.
+const dbMocks = {
+  getAffiliateById: vi.fn(),
+  getFriendById: vi.fn(),
+  getLineAccountById: vi.fn(),
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+const {
+  notifyAffiliate,
+  notifyAffiliateFriendAdd,
+  notifyAffiliateApproval,
+} = await import('./affiliate-notifier.js');
+
+const DB = {} as D1Database;
+const env = { LINE_CHANNEL_ACCESS_TOKEN: 'env-token' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pushMessage.mockResolvedValue({});
+});
+
+describe('notifyAffiliate', () => {
+  it('pushes to the affiliate friend via the account token', async () => {
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'aff-1', friend_id: 'fr-1' });
+    dbMocks.getFriendById.mockResolvedValue({
+      id: 'fr-1',
+      line_user_id: 'Uaaa',
+      line_account_id: 'acct-1',
+    });
+    dbMocks.getLineAccountById.mockResolvedValue({ channel_access_token: 'acct-token' });
+
+    await notifyAffiliate(DB, env, 'aff-1', 'hello');
+
+    expect(LineClientMock).toHaveBeenCalledWith('acct-token');
+    expect(pushMessage).toHaveBeenCalledWith('Uaaa', [{ type: 'text', text: 'hello' }]);
+  });
+
+  it('falls back to env token when the account has no token', async () => {
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'aff-1', friend_id: 'fr-1' });
+    dbMocks.getFriendById.mockResolvedValue({
+      id: 'fr-1',
+      line_user_id: 'Uaaa',
+      line_account_id: null,
+    });
+
+    await notifyAffiliate(DB, env, 'aff-1', 'hello');
+
+    expect(dbMocks.getLineAccountById).not.toHaveBeenCalled();
+    expect(LineClientMock).toHaveBeenCalledWith('env-token');
+    expect(pushMessage).toHaveBeenCalledWith('Uaaa', [{ type: 'text', text: 'hello' }]);
+  });
+
+  it('skips silently when the affiliate has no bound friend', async () => {
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'aff-1', friend_id: null });
+
+    await notifyAffiliate(DB, env, 'aff-1', 'hello');
+
+    expect(dbMocks.getFriendById).not.toHaveBeenCalled();
+    expect(pushMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips silently when the affiliate does not exist', async () => {
+    dbMocks.getAffiliateById.mockResolvedValue(null);
+
+    await notifyAffiliate(DB, env, 'nope', 'hello');
+
+    expect(pushMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips silently when the bound friend has no line_user_id', async () => {
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'aff-1', friend_id: 'fr-1' });
+    dbMocks.getFriendById.mockResolvedValue({ id: 'fr-1', line_user_id: '', line_account_id: null });
+
+    await notifyAffiliate(DB, env, 'aff-1', 'hello');
+
+    expect(pushMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when pushMessage rejects (best-effort)', async () => {
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'aff-1', friend_id: 'fr-1' });
+    dbMocks.getFriendById.mockResolvedValue({
+      id: 'fr-1',
+      line_user_id: 'Uaaa',
+      line_account_id: null,
+    });
+    pushMessage.mockRejectedValue(new Error('LINE 500'));
+
+    await expect(notifyAffiliate(DB, env, 'aff-1', 'hello')).resolves.toBeUndefined();
+  });
+
+  it('does not throw when a db lookup rejects (best-effort)', async () => {
+    dbMocks.getAffiliateById.mockRejectedValue(new Error('db down'));
+    await expect(notifyAffiliate(DB, env, 'aff-1', 'hello')).resolves.toBeUndefined();
+    expect(pushMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('notifyAffiliateFriendAdd', () => {
+  beforeEach(() => {
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'aff-1', friend_id: 'fr-1' });
+    dbMocks.getFriendById.mockResolvedValue({
+      id: 'fr-1',
+      line_user_id: 'Uaaa',
+      line_account_id: null,
+    });
+  });
+
+  it('includes the offer name when present', async () => {
+    await notifyAffiliateFriendAdd(DB, env, 'aff-1', 'キャンペーンA');
+    const text = pushMessage.mock.calls[0][1][0].text as string;
+    expect(text).toContain('🎉 あなたの紹介リンクから友だち追加がありました！');
+    expect(text).toContain('案件: キャンペーンA');
+    expect(text).toContain('『アフィリ』と送るとマイページで実績を確認できます');
+  });
+
+  it('uses 汎用リンク when offer name is null', async () => {
+    await notifyAffiliateFriendAdd(DB, env, 'aff-1', null);
+    const text = pushMessage.mock.calls[0][1][0].text as string;
+    expect(text).toContain('案件: 汎用リンク');
+  });
+});
+
+describe('notifyAffiliateApproval', () => {
+  beforeEach(() => {
+    dbMocks.getAffiliateById.mockResolvedValue({ id: 'aff-1', friend_id: 'fr-1' });
+    dbMocks.getFriendById.mockResolvedValue({
+      id: 'fr-1',
+      line_user_id: 'Uaaa',
+      line_account_id: null,
+    });
+  });
+
+  it('includes the offer + formatted reward when the offer is present', async () => {
+    await notifyAffiliateApproval(DB, env, 'aff-1', '案件X', 12345);
+    const text = pushMessage.mock.calls[0][1][0].text as string;
+    expect(text).toContain('✅ 成果が承認されました！');
+    expect(text).toContain('案件: 案件X');
+    expect(text).toContain('確定報酬: ¥12,345');
+    expect(text).toContain('『アフィリ』と送るとマイページで確認できます');
+  });
+
+  it('omits the reward line for an offer-less attribution', async () => {
+    await notifyAffiliateApproval(DB, env, 'aff-1', null, 0);
+    const text = pushMessage.mock.calls[0][1][0].text as string;
+    expect(text).toContain('✅ 成果が承認されました！');
+    expect(text).not.toContain('案件:');
+    expect(text).not.toContain('確定報酬');
+  });
+});

--- a/apps/worker/src/services/affiliate-notifier.ts
+++ b/apps/worker/src/services/affiliate-notifier.ts
@@ -1,0 +1,125 @@
+import { LineClient } from '@line-crm/line-sdk';
+import {
+  getAffiliateById,
+  getFriendById,
+  getLineAccountById,
+} from '@line-crm/db';
+
+/**
+ * Affiliate push notifications (ASP).
+ *
+ * Two operator-facing events push a LINE message to the affiliate (the person
+ * who owns the referral link), not to the friend who converted:
+ *   A) friend-add via an affiliate link  → notifyAffiliateFriendAdd
+ *   B) conversion approved               → notifyAffiliateApproval
+ *
+ * Both flow through notifyAffiliate, which resolves:
+ *   affiliates.friend_id → friends(line_user_id, line_account_id)
+ *   → line_accounts.channel_access_token (fallback: env.LINE_CHANNEL_ACCESS_TOKEN)
+ *   → LINE push.
+ *
+ * Best-effort by contract: any failure is swallowed (try/catch + console.error)
+ * so it can never break the caller's primary flow (friend attribution / CV
+ * approval). Callers should still `await` it — Workers keeps the isolate alive
+ * for an awaited promise — but must not let a rejection escape (this never
+ * rejects).
+ */
+
+/** Minimal env surface needed to resolve the fallback push token. */
+export interface AffiliateNotifierEnv {
+  LINE_CHANNEL_ACCESS_TOKEN: string;
+}
+
+/**
+ * Push a plain-text LINE message to the affiliate identified by `affiliateId`.
+ *
+ * Silently no-ops (returns without throwing) when:
+ *   - the affiliate does not exist,
+ *   - the affiliate has no bound friend (admin-created affiliate with no LIFF
+ *     self-register — friend_id NULL),
+ *   - the bound friend row is missing or has no line_user_id,
+ *   - no push token can be resolved.
+ *
+ * Never throws. All errors are logged and swallowed.
+ */
+export async function notifyAffiliate(
+  db: D1Database,
+  env: AffiliateNotifierEnv,
+  affiliateId: string,
+  text: string,
+): Promise<void> {
+  try {
+    const affiliate = await getAffiliateById(db, affiliateId);
+    if (!affiliate?.friend_id) return; // unbound affiliate — nothing to push to
+
+    const friend = await getFriendById(db, affiliate.friend_id);
+    if (!friend?.line_user_id) return;
+
+    // Resolve the push token from the friend's LINE account, falling back to
+    // the env default when the account row / token is absent.
+    let accessToken = env.LINE_CHANNEL_ACCESS_TOKEN;
+    if (friend.line_account_id) {
+      const account = await getLineAccountById(db, friend.line_account_id);
+      if (account?.channel_access_token) accessToken = account.channel_access_token;
+    }
+    if (!accessToken) return;
+
+    const client = new LineClient(accessToken);
+    await client.pushMessage(friend.line_user_id, [{ type: 'text', text }]);
+  } catch (err) {
+    console.error('notifyAffiliate failed (non-blocking):', err);
+  }
+}
+
+/** Format the reward line with a thousands separator, e.g. 12345 → "12,345". */
+function formatYen(amount: number): string {
+  return new Intl.NumberFormat('en-US').format(amount);
+}
+
+/**
+ * A) 友だち追加通知 — a new friend was added through this affiliate's link.
+ *
+ * `offerName` is the offer (案件) name, or null for a 汎用リンク (generic link).
+ */
+export async function notifyAffiliateFriendAdd(
+  db: D1Database,
+  env: AffiliateNotifierEnv,
+  affiliateId: string,
+  offerName: string | null,
+): Promise<void> {
+  const offerLine = offerName && offerName.trim() ? offerName : '汎用リンク';
+  const text =
+    `🎉 あなたの紹介リンクから友だち追加がありました！\n` +
+    `案件: ${offerLine}\n` +
+    `『アフィリ』と送るとマイページで実績を確認できます`;
+  await notifyAffiliate(db, env, affiliateId, text);
+}
+
+/**
+ * B) 成果承認通知 — a conversion attributed to this affiliate was approved.
+ *
+ * When `offerName` is set the message includes the fixed reward line. For an
+ * offer-less attribution (offerName null) the reward line is omitted and only
+ * a generic approval message is sent.
+ */
+export async function notifyAffiliateApproval(
+  db: D1Database,
+  env: AffiliateNotifierEnv,
+  affiliateId: string,
+  offerName: string | null,
+  rewardAmount: number,
+): Promise<void> {
+  let text: string;
+  if (offerName && offerName.trim()) {
+    text =
+      `✅ 成果が承認されました！\n` +
+      `案件: ${offerName}\n` +
+      `確定報酬: ¥${formatYen(rewardAmount)}\n` +
+      `『アフィリ』と送るとマイページで確認できます`;
+  } else {
+    text =
+      `✅ 成果が承認されました！\n` +
+      `『アフィリ』と送るとマイページで確認できます`;
+  }
+  await notifyAffiliate(db, env, affiliateId, text);
+}

--- a/packages/db/src/affiliate-offers.ts
+++ b/packages/db/src/affiliate-offers.ts
@@ -198,21 +198,84 @@ async function findOfferLink(
  * UPDATE is guarded on that so non-attributed rows never gain a status. Stamps
  * approved_at with the decision time (for both approve and reject).
  *
- * @returns true if a row was updated, false otherwise (missing or non-attributed).
+ * The WHERE clause includes `approval_status IS NULL OR approval_status != ?`
+ * so re-setting the same status is a no-op (changes = 0) — this prevents
+ * double-approval notifications when an admin double-clicks.
+ *
+ * @returns
+ *   - `true`          — row was updated (status changed)
+ *   - `'already_set'` — row exists and attributed but status was already this value
+ *   - `false`         — row not found or not affiliate-attributed
  */
 export async function setConversionApproval(
   db: D1Database,
   eventId: string,
   status: 'approved' | 'rejected',
-): Promise<boolean> {
+): Promise<boolean | 'already_set'> {
   const now = jstNow();
   const result = await db
     .prepare(
       `UPDATE conversion_events
           SET approval_status = ?, approved_at = ?
-        WHERE id = ? AND affiliate_id IS NOT NULL`,
+        WHERE id = ? AND affiliate_id IS NOT NULL
+          AND (approval_status IS NULL OR approval_status != ?)`,
     )
-    .bind(status, now, eventId)
+    .bind(status, now, eventId, status)
     .run();
-  return (result.meta?.changes ?? 0) > 0;
+  if ((result.meta?.changes ?? 0) > 0) return true;
+
+  // Distinguish no-op (same status already set) from truly missing/non-attributed.
+  const existing = await db
+    .prepare(
+      `SELECT 1 FROM conversion_events WHERE id = ? AND affiliate_id IS NOT NULL AND approval_status = ?`,
+    )
+    .bind(eventId, status)
+    .first<{ 1: number }>();
+  return existing ? 'already_set' : false;
+}
+
+/** Resolved attribution detail for an affiliate-attributed conversion event. */
+export interface ConversionApprovalNotifyInfo {
+  affiliateId: string;
+  /** Offer name resolved via attributed_ref_code → link.offer_id, or null. */
+  offerName: string | null;
+  /** Fixed reward for the offer (0 when offer-less). */
+  rewardAmount: number;
+}
+
+/**
+ * Fetch the info needed to push an approval notification to the attributed
+ * affiliate: the affiliate id, and (via attributed_ref_code → affiliate_link →
+ * offer) the offer name + fixed reward amount.
+ *
+ * Returns null when the event is missing or not affiliate-attributed. When the
+ * attribution is offer-less (generic link), `offerName` is null and
+ * `rewardAmount` is 0.
+ */
+export async function getConversionApprovalNotifyInfo(
+  db: D1Database,
+  eventId: string,
+): Promise<ConversionApprovalNotifyInfo | null> {
+  const row = await db
+    .prepare(
+      `SELECT ce.affiliate_id AS affiliate_id,
+              off.name AS offer_name,
+              off.reward_amount AS reward_amount
+         FROM conversion_events ce
+         LEFT JOIN affiliate_links al ON al.ref_code = ce.attributed_ref_code
+         LEFT JOIN affiliate_offers off ON off.id = al.offer_id
+        WHERE ce.id = ? AND ce.affiliate_id IS NOT NULL`,
+    )
+    .bind(eventId)
+    .first<{
+      affiliate_id: string;
+      offer_name: string | null;
+      reward_amount: number | null;
+    }>();
+  if (!row) return null;
+  return {
+    affiliateId: row.affiliate_id,
+    offerName: row.offer_name,
+    rewardAmount: row.reward_amount ?? 0,
+  };
 }

--- a/packages/db/test/affiliate-offers.test.ts
+++ b/packages/db/test/affiliate-offers.test.ts
@@ -11,6 +11,7 @@ import {
   getAffiliateOfferById,
   enrollAffiliateInOffer,
   setConversionApproval,
+  getConversionApprovalNotifyInfo,
 } from '../src/affiliate-offers.js';
 import { trackConversion } from '../src/conversions.js';
 
@@ -301,6 +302,55 @@ describe('setConversionApproval', () => {
     expect(row.approved_at).toBeTruthy();
   });
 
+  test('returns already_set when setting the same status again (approved → approved)', async () => {
+    sqlite
+      .prepare(
+        `INSERT INTO affiliates (id, name, code, is_active, created_at)
+         VALUES ('aff-idem', 'A', 'CIDEM', 1, '2024-01-01T00:00:00.000')`,
+      )
+      .run();
+    sqlite
+      .prepare(
+        `INSERT INTO conversion_events (id, conversion_point_id, friend_id, created_at, affiliate_id, approval_status)
+         VALUES ('ce-idem', 'cp-1', 'f-1', '2024-01-01T00:00:00.000', 'aff-idem', 'pending')`,
+      )
+      .run();
+    // First approval — changes row
+    const first = await setConversionApproval(db, 'ce-idem', 'approved');
+    expect(first).toBe(true);
+    // Second approval with same status — no-op
+    const second = await setConversionApproval(db, 'ce-idem', 'approved');
+    expect(second).toBe('already_set');
+    // Verify DB row is unchanged (still approved, approved_at set by first call)
+    const row = sqlite
+      .prepare(`SELECT approval_status FROM conversion_events WHERE id = 'ce-idem'`)
+      .get() as { approval_status: string };
+    expect(row.approval_status).toBe('approved');
+  });
+
+  test('approved → rejected returns true (status change still works)', async () => {
+    sqlite
+      .prepare(
+        `INSERT INTO affiliates (id, name, code, is_active, created_at)
+         VALUES ('aff-chg', 'A', 'CCHG', 1, '2024-01-01T00:00:00.000')`,
+      )
+      .run();
+    sqlite
+      .prepare(
+        `INSERT INTO conversion_events (id, conversion_point_id, friend_id, created_at, affiliate_id, approval_status)
+         VALUES ('ce-chg', 'cp-1', 'f-1', '2024-01-01T00:00:00.000', 'aff-chg', 'pending')`,
+      )
+      .run();
+    const first = await setConversionApproval(db, 'ce-chg', 'approved');
+    expect(first).toBe(true);
+    const second = await setConversionApproval(db, 'ce-chg', 'rejected');
+    expect(second).toBe(true);
+    const row = sqlite
+      .prepare(`SELECT approval_status FROM conversion_events WHERE id = 'ce-chg'`)
+      .get() as { approval_status: string };
+    expect(row.approval_status).toBe('rejected');
+  });
+
   test('returns false for a non-attributed (affiliate_id NULL) event', async () => {
     sqlite
       .prepare(
@@ -318,6 +368,77 @@ describe('setConversionApproval', () => {
 
   test('returns false for a missing event', async () => {
     expect(await setConversionApproval(db, 'nope', 'approved')).toBe(false);
+  });
+});
+
+// ── getConversionApprovalNotifyInfo ─────────────────────────────────────────
+
+describe('getConversionApprovalNotifyInfo', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+    db = asD1(sqlite);
+    insertFriend(sqlite, 'f-1', 'U0000000000000000000000000000001');
+    insertConversionPoint(sqlite, 'cp-1');
+    insertAffiliate(sqlite, 'aff-1');
+  });
+
+  test('resolves affiliate + offer name + reward via attributed_ref_code', async () => {
+    sqlite
+      .prepare(
+        `INSERT INTO affiliate_offers (id, name, reward_amount, is_active, created_at)
+         VALUES ('off-1', '案件A', 5000, 1, '2024-01-01T00:00:00.000')`,
+      )
+      .run();
+    sqlite
+      .prepare(
+        `INSERT INTO affiliate_links (id, affiliate_id, ref_code, offer_id, is_active, created_at)
+         VALUES ('al-1', 'aff-1', 'ref-1', 'off-1', 1, '2024-01-01T00:00:00.000')`,
+      )
+      .run();
+    sqlite
+      .prepare(
+        `INSERT INTO conversion_events (id, conversion_point_id, friend_id, created_at, affiliate_id, attributed_ref_code, approval_status)
+         VALUES ('ce-1', 'cp-1', 'f-1', '2024-01-01T00:00:00.000', 'aff-1', 'ref-1', 'approved')`,
+      )
+      .run();
+
+    const info = await getConversionApprovalNotifyInfo(db, 'ce-1');
+    expect(info).toEqual({ affiliateId: 'aff-1', offerName: '案件A', rewardAmount: 5000 });
+  });
+
+  test('offer-less (generic link) attribution → null offer name, 0 reward', async () => {
+    sqlite
+      .prepare(
+        `INSERT INTO affiliate_links (id, affiliate_id, ref_code, offer_id, is_active, created_at)
+         VALUES ('al-2', 'aff-1', 'ref-2', NULL, 1, '2024-01-01T00:00:00.000')`,
+      )
+      .run();
+    sqlite
+      .prepare(
+        `INSERT INTO conversion_events (id, conversion_point_id, friend_id, created_at, affiliate_id, attributed_ref_code, approval_status)
+         VALUES ('ce-2', 'cp-1', 'f-1', '2024-01-01T00:00:00.000', 'aff-1', 'ref-2', 'approved')`,
+      )
+      .run();
+
+    const info = await getConversionApprovalNotifyInfo(db, 'ce-2');
+    expect(info).toEqual({ affiliateId: 'aff-1', offerName: null, rewardAmount: 0 });
+  });
+
+  test('returns null for a non-attributed (affiliate_id NULL) event', async () => {
+    sqlite
+      .prepare(
+        `INSERT INTO conversion_events (id, conversion_point_id, friend_id, created_at)
+         VALUES ('ce-null', 'cp-1', 'f-1', '2024-01-01T00:00:00.000')`,
+      )
+      .run();
+    expect(await getConversionApprovalNotifyInfo(db, 'ce-null')).toBeNull();
+  });
+
+  test('returns null for a missing event', async () => {
+    expect(await getConversionApprovalNotifyInfo(db, 'nope')).toBeNull();
   });
 });
 

--- a/packages/mcp-server/src/tools/list-conversations.ts
+++ b/packages/mcp-server/src/tools/list-conversations.ts
@@ -5,7 +5,7 @@ import { getClient } from "../client.js";
 export function registerListConversations(server: McpServer): void {
   server.tool(
     "list_conversations",
-    "List unreplied conversations (friends who sent an incoming message with no subsequent human reply). Excludes automated outgoing (broadcast/scenario/auto_reply/reminder). Results sorted by longest wait first.",
+    "List unreplied conversations (friends who sent an incoming message with no subsequent human reply). Excludes automated outgoing (broadcast/scenario/auto_reply/reminder) and conversations marked resolved in the admin UI. Results sorted by longest wait first.",
     {
       lineAccountId: z
         .string()


### PR DESCRIPTION
友だち追加/承認確定のアフィリエイター push 通知 (#89 相当)、/api/conversations の resolved 除外 (#87 相当)。