### PR TITLE
sync: v0.17.0 — installer/self-update overhaul

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/worker/src/routes/admin-update.ts
+++ b/apps/worker/src/routes/admin-update.ts
@@ -196,11 +196,16 @@ app.post('/start', async (c) => {
         current,
         target,
         manifestUrl: c.env.MANIFEST_URL,
+        // Enables admin-bundle placeholder materialization in the apply
+        // phase — without it the deployed admin calls __LH_WORKER_URL__.
+        workerPublicUrl: c.env.WORKER_PUBLIC_URL,
       },
       d1,
       workerHealthUrl: `${c.env.WORKER_PUBLIC_URL}/api/health`,
       adminUrl: c.env.ADMIN_PUBLIC_URL,
-      liffUrl: c.env.LIFF_PUBLIC_URL,
+      // Empty for worker-assets installs (LIFF_PAGES_PROJECT="") — the
+      // engine skips the LIFF probe in that topology.
+      liffUrl: c.env.LIFF_PAGES_PROJECT ? c.env.LIFF_PUBLIC_URL : '',
       currentWorkerBundleUrl: currentRelease.bundle_url,
     });
   } catch (err) {

--- a/docs/wiki/26-Manual-Update.md
+++ b/docs/wiki/26-Manual-Update.md
@@ -6,7 +6,6 @@ LINE Harness を手動で最新版に更新する手順です。
 
 - コードをカスタマイズしている（フォーク運用）
 - 自前の CI/CD（GitHub Actions 等）でデプロイしている
-- ビルドにバージョン情報が埋め込まれていない（`v0.0.0-dev` 表示）
 
 > カスタマイズ版であること自体は問題ではありません。自動更新が「勝手にあなたの変更を上書きしない」ための安全装置として無効になるだけです。
 
@@ -16,7 +15,16 @@ LINE Harness を手動で最新版に更新する手順です。
 npx create-line-harness@latest update
 ```
 
-vanilla ビルドであれば、バックアップ（ロールバック用スナップショット）付きで自動更新されます。
+vanilla ビルドであれば自動更新されます。
+
+### バージョンが `v0.0.0-dev` と表示される場合（旧 CLI インストール）
+
+旧バージョンの CLI でセットアップした環境は、公式リリースと同一でもバージョン情報が埋め込まれておらず `v0.0.0-dev` と表示されます。この場合も上記コマンドを実行してください — **公式リリースへの引き上げ（導入）を提案するプロンプト**が表示されます。
+
+- 承認すると、最新の公式リリースを導入し、以後は通常の自動アップデートが使えるようになります
+- DB のデータ・管理画面上の設定・シークレットはそのまま残ります
+- **Worker / 管理画面のソースコードをカスタマイズしている場合は上書きされる**ため、承認せず方法 3 で更新してください
+- マイグレーションは全件を再確認します。適用済みのものは「スキップ」と表示されます（正常です）
 
 ## 方法 2: git クローンして運用している場合
 
@@ -27,14 +35,26 @@ git pull origin main
 # 2. 依存を更新
 pnpm install
 
-# 3. DB マイグレーションを適用（未適用分のみ）
+# 3. DB マイグレーションを適用
+#    packages/db/migrations/ の SQL を番号順に 1 ファイルずつ適用します。
+#    適用済みのファイルは "already exists" / "duplicate column" エラーに
+#    なりますが、これは「適用済み」の意味なので無視して次に進んで構いません。
 cd apps/worker
-npx wrangler d1 migrations apply <your-database> --remote
+for f in ../../packages/db/migrations/*.sql; do
+  npx wrangler d1 execute <your-database> --remote --file "$f" || true
+done
 
 # 4. デプロイ
 npx wrangler deploy                      # Worker
 pnpm --filter web build                  # 管理画面（Pages にデプロイ）
 ```
+
+> **注意:** 以前このガイドに記載していた `wrangler d1 migrations apply` は、
+> `create-line-harness` でセットアップした環境では機能しません（wrangler の
+> マイグレーション管理テーブルを使わずにセットアップされるため、全マイグレー
+> ションが「未適用」扱いになります）。上記の `d1 execute --file` 方式を使って
+> ください。LINE Harness のマイグレーションは追加専用（additive-only）+
+> `INSERT OR IGNORE` 方針のため、適用済みファイルの再実行は安全です。
 
 自前の CI/CD がある場合は main を pull / merge して push すれば通常のデプロイフローで反映されます。
 

--- a/docs/wiki/Release-Notes.md
+++ b/docs/wiki/Release-Notes.md
@@ -1,5 +1,24 @@
 # Release Notes
 
+## v0.17.0 (2026-07-08)
+
+### Added — Link-tracking controls
+
+- **Per-account LIFF resolution for /t links** — new `tracked_links.line_account_id` (migration 046). The identify-redirect for /t links opened inside the LINE app now uses the LIFF of the account that owns the link (previously the global `LIFF_URL`, which could show another account's consent screen). Fallback order: `line_account_id` → the linked scenario's account → `env.LIFF_URL`. OGP resolution follows the same order.
+- **Per-broadcast link shortening toggle** — `broadcasts.track_links` (default ON). A checkbox on the broadcast form and draft/schedule detail lets you turn click tracking off per message; when off, URLs are sent as-is (no /t/ conversion, no text→flex rewrite).
+- **API / MCP support** — `trackLinks` on `POST/PUT /api/broadcasts` and `POST /api/friends/:id/messages`; MCP `broadcast` / `send_message` gain `trackLinks`, `create_tracked_link` / `manage_tracked_links` gain `accountId`.
+- Auto-tracked links now record the sending account; friends API returns `lineAccountId`.
+
+### Added — Installer / self-update overhaul
+
+`npx create-line-harness` installs are now version-stamped official releases, and automatic updates actually work. This is the first release built with the new pipeline.
+
+- **Setup deploys from the official release bundle** — the Worker ships the release artifact byte-for-byte (so `/admin/version` reports the real version and fork detection recognizes the install as vanilla), and the admin UI is unpacked from the bundle instead of a local Next.js build (much faster setup). The clone is pinned to the release tag so schema/migrations always match the deployed code. A `--from-source` flag keeps the old behaviour for development.
+- **Adoption path for older CLI installs (`v0.0.0-dev`)** — running `npx create-line-harness@latest update` now offers, with an explicit confirmation prompt, to move the install onto the latest official release. Database contents, settings, and secrets are preserved.
+- **Update-flow fixes** — the admin bundle's `__LH_WORKER_URL__` placeholder is now materialized before deploy (previously an update would break the dashboard), `nodejs_compat` is preserved on Worker uploads, Workers Assets survive script updates, LIFF-Pages-less installs are supported, and already-applied migrations are skipped instead of aborting the update. The dashboard's self-update flow receives the same fixes.
+- **Deployable release bundles** — previous bundles shipped a worker stub without its actual code, and the manifest hash could never match the bundled bytes. The release pipeline now builds the worker with wrangler (the same path every real deployment uses) and publishes a detached `worker_bundle_hash` for download verification. Bundles from older releases are explicitly rejected.
+- **Docs** — the manual update guide (26-Manual-Update) now covers CLI installs; `wrangler d1 migrations apply` (which does not work for CLI installs) was replaced with a per-file `d1 execute --file` procedure.
+
 ## v0.16.0 (2026-07-07)
 
 ### Added — Affiliate tracking (ASP)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "line-oss-crm",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "description": "Open-source LINE Official Account CRM/marketing automation",
   "scripts": {

--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-line-harness",
-  "version": "0.1.28",
-  "description": "Set up LINE Harness \u2014 AI-operated LINE CRM \u2014 with one command",
+  "version": "0.2.0",
+  "description": "Set up LINE Harness — AI-operated LINE CRM — with one command",
   "type": "module",
   "bin": {
     "create-line-harness": "./dist/index.js"
@@ -12,7 +12,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "prepublishOnly": "node ./scripts/guard-source-publish.mjs"
+    "prepublishOnly": "node ./scripts/guard-source-publish.mjs",
+    "test": "vitest run"
   },
   "keywords": [
     "line",
@@ -31,14 +32,15 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@line-harness/update-engine": "workspace:^0.0.2",
+    "@line-harness/update-engine": "workspace:^0.0.3",
     "execa": "^9.5.2",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "tsup": "^8.4.0",
     "typescript": "^5.9.3",
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "vitest": "^2.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/create-line-harness/src/commands/setup.ts
+++ b/packages/create-line-harness/src/commands/setup.ts
@@ -10,6 +10,8 @@ import { promptLineCredentials } from "../steps/prompt.js";
 import { createDatabase } from "../steps/database.js";
 import { deployWorker, syncInstalledWorkerConfig } from "../steps/deploy-worker.js";
 import { deployAdmin } from "../steps/deploy-admin.js";
+import { fetchLatestRelease, type FetchedRelease } from "../steps/release-bundle.js";
+import { pinRepoToTag } from "../steps/clone-repo.js";
 import { setSecrets } from "../steps/secrets.js";
 import { configureAdminAuth } from "../steps/admin-auth.js";
 import { generateMcpConfig } from "../steps/mcp-config.js";
@@ -21,6 +23,9 @@ import {
   WranglerError,
   type CloudflareAccount,
 } from "../lib/wrangler.js";
+
+const MANIFEST_URL =
+  "https://github.com/Shudesu/line-harness-oss/releases/latest/download/release-manifest.json";
 
 interface SetupState {
   projectName?: string;
@@ -38,6 +43,12 @@ interface SetupState {
   botBasicId?: string;
   workerUrl?: string;
   adminUrl?: string;
+  /**
+   * Release version selected on the FIRST run of this setup. Resumed runs
+   * re-pin to it (never float to a newer `latest`) so every step —
+   * schema/migrations, Worker bundle, admin files — comes from one release.
+   */
+  releaseVersion?: string;
   /**
    * Pristine apps/worker/wrangler.toml content captured before we started
    * substituting account/database IDs. Restored on exit so the cloned repo
@@ -286,7 +297,19 @@ async function verifyAccount(
   p.log.success("アカウント依存ステップをリセットしました。新しいアカウントで再構築します。");
 }
 
-export async function runSetup(repoDir: string): Promise<void> {
+export interface SetupOptions {
+  /**
+   * Deploy the Worker/Admin from a local source build instead of the
+   * official release bundle. Development escape hatch: the install reports
+   * 0.0.0-dev and automatic updates never apply to it.
+   */
+  fromSource?: boolean;
+}
+
+export async function runSetup(
+  repoDir: string,
+  options: SetupOptions = {},
+): Promise<void> {
   p.intro(pc.bgCyan(pc.black(" LINE Harness セットアップ ")));
 
   const state = loadState(repoDir);
@@ -336,7 +359,7 @@ export async function runSetup(repoDir: string): Promise<void> {
   process.once("SIGTERM", onSignal);
 
   try {
-    await runSetupInner(state, repoDir);
+    await runSetupInner(state, repoDir, options);
     cleanupSuccess();
   } catch (error) {
     cleanupFailure();
@@ -362,9 +385,34 @@ export async function runSetup(repoDir: string): Promise<void> {
 async function runSetupInner(
   state: SetupState,
   repoDir: string,
+  options: SetupOptions,
 ): Promise<void> {
   // Step 1: Check dependencies
   await checkDeps();
+
+  // Step 1.5: Resolve + download the official release, and pin the clone
+  // to its tag so schema/migrations/client assets match the Worker we
+  // deploy. Runs before auth (network-only) and re-runs on resume — the
+  // bundle is small and re-verifying beats trusting a stale download.
+  // Resumes re-pin to the release the first run selected (persisted in
+  // state) so completed steps and remaining steps never mix releases.
+  let release: FetchedRelease | null = null;
+  if (!options.fromSource) {
+    release = await fetchLatestRelease(MANIFEST_URL, state.releaseVersion);
+    if (state.releaseVersion !== release.release.version) {
+      state.releaseVersion = release.release.version;
+      saveState(repoDir, state);
+    }
+    await pinRepoToTag(repoDir, release.release.version);
+  } else {
+    p.log.warn(
+      [
+        "--from-source: ソースからビルドしてデプロイします。",
+        "この構成はバージョン情報が焼き込まれず (0.0.0-dev)、自動アップデート",
+        "(`npx create-line-harness update`) の対象外になります。開発用途向けです。",
+      ].join("\n"),
+    );
+  }
 
   // Step 2: Authenticate with Cloudflare
   await ensureAuth();
@@ -557,7 +605,10 @@ async function runSetupInner(
     }
   }
 
-  // Step 10: Deploy Worker (includes LIFF build via @cloudflare/vite-plugin)
+  // Step 10: Deploy Worker (includes LIFF build via @cloudflare/vite-plugin).
+  // The Worker script itself ships from the official release bundle so its
+  // version stamp matches the manifest; only the client assets are built
+  // locally.
   state.workerName = state.projectName!;
   if (!isDone(state, "worker")) {
     const { workerUrl } = await deployWorker({
@@ -569,6 +620,7 @@ async function runSetupInner(
       liffId: state.liffId!,
       r2BucketName: state.r2BucketName!,
       botBasicId: state.botBasicId || "",
+      bundleWorkerJs: release?.bundle.workerJs,
     });
     state.workerUrl = workerUrl;
     markDone(state, "worker");
@@ -700,6 +752,7 @@ ON CONFLICT(channel_id) DO UPDATE SET
       workerUrl: state.workerUrl!,
       apiKey: state.apiKey!,
       projectName: adminProjectName,
+      adminFiles: release?.bundle.adminFiles,
     });
     state.adminUrl = adminUrl;
     markDone(state, "admin");
@@ -733,10 +786,14 @@ ON CONFLICT(channel_id) DO UPDATE SET
       workerPublicUrl: state.workerUrl!,
       adminPagesProject: adminProjectName,
       adminPublicUrl: state.adminUrl!,
-      liffPagesProject: `${state.workerName}-liff`,
+      // Worker-assets install: the LIFF SPA is served by the Worker, no
+      // LIFF Pages project exists. '' makes the worker-side self-update
+      // skip LIFF Pages steps instead of failing on a missing project.
+      liffPagesProject: "",
       liffPublicUrl: state.workerUrl!,
-      manifestUrl:
-        "https://github.com/Shudesu/line-harness-oss/releases/latest/download/release-manifest.json",
+      manifestUrl: MANIFEST_URL,
+      workerDeployMode: release ? "bundle" : "source",
+      bundleWorkerJs: release?.bundle.workerJs,
     });
     markDone(state, "workerConfig");
     saveState(repoDir, state);
@@ -823,12 +880,20 @@ ON CONFLICT(channel_id) DO UPDATE SET
     adminProject: adminProjectName,
     adminPublicUrl,
     liffPublicUrl: state.workerUrl,
-    // liffProject is intentionally omitted — current setup serves LIFF
-    // from the Worker via [assets], not a separate Pages project.
-    manifestUrl:
-      "https://github.com/Shudesu/line-harness-oss/releases/latest/download/release-manifest.json",
+    // '' = worker-assets install: LIFF is served by the Worker via
+    // [assets], no separate Pages project exists.
+    liffProject: "",
+    manifestUrl: MANIFEST_URL,
+    workerDeployMode: release ? "bundle" : "source",
+    ...(release ? { installedVersion: release.release.version } : {}),
   };
   writeFileSync(configPath, JSON.stringify(fullConfig, null, 2) + "\n");
 
-  p.outro(pc.green("LINE Harness を使い始めましょう 🎉"));
+  p.outro(
+    pc.green(
+      release
+        ? `LINE Harness v${release.release.version} を使い始めましょう 🎉（更新: npx create-line-harness update）`
+        : "LINE Harness を使い始めましょう 🎉",
+    ),
+  );
 }

--- a/packages/create-line-harness/src/commands/update.ts
+++ b/packages/create-line-harness/src/commands/update.ts
@@ -1,7 +1,7 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { Readable } from "node:stream";
 import {
   fetchManifest,
@@ -10,14 +10,31 @@ import {
   compareSemver,
   parseBundleStream,
   verifyBundleHashes,
-  assertHashesMatch,
+  verifyBundleIntegrity,
   executeD1Query,
   putWorkerScript,
   listWorkerBindings,
   deployPagesProject,
+  materializeAdminFiles,
+  findResidualPlaceholders,
+  isBenignSchemaErrorText,
+  type CfApiCreds,
   type CurrentVersion,
+  type ParsedBundle,
+  type ReleaseEntry,
+  type WorkerBinding,
 } from "@line-harness/update-engine";
 import { configureAdminAuth } from "../steps/admin-auth.js";
+import {
+  isGeneratedInstalledWranglerToml,
+  renderInstalledWranglerToml,
+  resolveInstalledWranglerConfig,
+  type SavedInstallConfig,
+} from "../lib/installed-wrangler.js";
+
+/** Must mirror apps/worker/wrangler.toml — the script upload API replaces
+ *  metadata wholesale, so omitting this would strip nodejs_compat. */
+const WORKER_COMPATIBILITY_FLAGS = ["nodejs_compat"];
 
 /**
  * Shape of `.line-harness-config.json` written by `setup.ts` after
@@ -60,38 +77,45 @@ export function loadState(repoDir: string): SetupState | null {
 }
 
 /**
+ * Fully-resolved update configuration.
+ *
+ * `liffProject`/`liffPublicUrl` are '' for worker-assets installs — current
+ * CLI setups serve the LIFF SPA from the Worker's own assets and never
+ * create a LIFF Pages project. All LIFF Pages steps are skipped for them.
+ */
+interface ResolvedUpdateConfig {
+  workerName: string;
+  adminProject: string;
+  liffProject: string;
+  d1DatabaseId: string;
+  cfAccountId: string;
+  cfApiToken: string;
+  manifestUrl: string;
+  workerPublicUrl: string;
+  adminPublicUrl: string;
+  liffPublicUrl: string;
+}
+
+/**
  * Normalize the on-disk config into the strict shape the update flow needs.
  *
- * Two layers of fallback:
+ * Fallback layers:
  *   - `cfAccountId` may be stored as legacy `accountId`.
  *   - `workerPublicUrl` may be derivable from legacy `workerUrl`.
  *   - `adminProject` may be derivable from legacy `adminUrl` hostname.
+ *   - `liffProject` absent + `liffPublicUrl` absent-or-equal-to-workerUrl
+ *     means a worker-assets install (setup.ts intentionally omits the
+ *     field) → resolved as '' (no LIFF Pages project). Only the ambiguous
+ *     case (a distinct liffPublicUrl with no project name) still prompts.
  *
- * Returns `null` (with diagnostic message via caller) if a non-recoverable
- * field is missing. We never *guess* the API token — that has to be supplied
- * via env var if absent from config.
+ * Returns `{ ok: false }` (with diagnostic message via caller) if a
+ * non-recoverable field is missing. We never *guess* the API token — that
+ * has to be supplied via env var if absent from config.
  */
-function resolveState(
+export function resolveState(
   state: SetupState,
   envApiToken: string | undefined,
-): {
-  ok: true;
-  value: Required<
-    Pick<
-      SetupState,
-      | "workerName"
-      | "adminProject"
-      | "liffProject"
-      | "d1DatabaseId"
-      | "cfAccountId"
-      | "cfApiToken"
-      | "manifestUrl"
-      | "workerPublicUrl"
-      | "adminPublicUrl"
-      | "liffPublicUrl"
-    >
-  >;
-} | { ok: false; missing: string[] } {
+): { ok: true; value: ResolvedUpdateConfig } | { ok: false; missing: string[] } {
   const missing: string[] = [];
 
   const workerName = state.workerName ?? state.projectName;
@@ -119,9 +143,6 @@ function resolveState(
   }
   if (!adminProject) missing.push("adminProject");
 
-  // No legacy field for liffProject — must be present or prompt later.
-  if (!state.liffProject) missing.push("liffProject");
-
   // Worker public URL — prefer explicit, else legacy workerUrl.
   const workerPublicUrl = state.workerPublicUrl ?? state.workerUrl;
   if (!workerPublicUrl) missing.push("workerPublicUrl");
@@ -129,8 +150,21 @@ function resolveState(
   const adminPublicUrl = state.adminPublicUrl ?? state.adminUrl;
   if (!adminPublicUrl) missing.push("adminPublicUrl");
 
-  // No legacy field for liffPublicUrl; require explicit value.
-  if (!state.liffPublicUrl) missing.push("liffPublicUrl");
+  // LIFF topology resolution. '' (empty string) is a valid persisted value
+  // meaning "no LIFF Pages project".
+  let liffProject = state.liffProject;
+  if (liffProject === undefined) {
+    if (!state.liffPublicUrl || state.liffPublicUrl === workerPublicUrl) {
+      // Worker-assets install: LIFF is served by the Worker itself.
+      liffProject = "";
+    } else {
+      // A separate LIFF URL exists but its Pages project name is unknown —
+      // legacy 3-artifact install with an incomplete config. Prompt.
+      missing.push("liffProject");
+    }
+  }
+  const liffPublicUrl = liffProject ? state.liffPublicUrl : "";
+  if (liffProject && !state.liffPublicUrl) missing.push("liffPublicUrl");
 
   if (missing.length > 0) {
     return { ok: false, missing };
@@ -141,14 +175,14 @@ function resolveState(
     value: {
       workerName: workerName!,
       adminProject: adminProject!,
-      liffProject: state.liffProject!,
+      liffProject: liffProject!,
       d1DatabaseId: state.d1DatabaseId!,
       cfAccountId: cfAccountId!,
       cfApiToken: cfApiToken!,
       manifestUrl: state.manifestUrl ?? DEFAULT_MANIFEST_URL,
       workerPublicUrl: workerPublicUrl!,
       adminPublicUrl: adminPublicUrl!,
-      liffPublicUrl: state.liffPublicUrl!,
+      liffPublicUrl: liffPublicUrl ?? "",
     },
   };
 }
@@ -270,10 +304,10 @@ async function promptForMissingFields(
       case "liffProject": {
         const v = await p.text({
           message:
-            "LIFF Pages プロジェクト名 (例: lh-liff-abc123 — CF ダッシュボードで確認)",
+            "LIFF Pages プロジェクト名 (例: lh-liff-abc123 — CF ダッシュボードで確認。LIFF Pages を使っていない場合は空 Enter でスキップ)",
+          defaultValue: "",
           validate(value) {
-            if (!value) return "必須";
-            if (!/^[a-z0-9][a-z0-9-]*$/i.test(value.trim())) {
+            if (value && !/^[a-z0-9][a-z0-9-]*$/i.test(value.trim())) {
               return "英数字とハイフンのみ";
             }
           },
@@ -282,7 +316,9 @@ async function promptForMissingFields(
           p.cancel("aborted");
           process.exit(0);
         }
-        updated.liffProject = (v as string).trim();
+        // '' is persisted intentionally: it means "no LIFF Pages project"
+        // (worker-assets install) and stops future prompts.
+        updated.liffProject = ((v as string) || "").trim();
         break;
       }
       case "workerPublicUrl": {
@@ -463,9 +499,21 @@ export async function runUpdate(repoDir: string): Promise<void> {
   }
   s.stop(`最新: v${manifest.latest}`);
 
-  // 3) Fork detection — block automatic update if hashes don't match
+  // 3) Fork detection — block automatic update if hashes don't match.
+  //
+  // Two distinct fork classes get different treatment:
+  //   - "unknown version" (e.g. 0.0.0-dev): every CLI install before the
+  //     bundle-deploy fix shipped an unstamped Worker, so this is almost
+  //     always a vanilla install that simply never got version-stamped.
+  //     Offer the adoption path (explicit opt-in) instead of a dead end.
+  //   - hash mismatch on a KNOWN version: a genuinely modified build.
+  //     Never auto-update; point to the manual guide.
   const fork = detectFork(current, manifest);
   if (fork.kind === "fork") {
+    if (fork.reason.startsWith("unknown version")) {
+      await runAdoption({ repoDir, cfg, manifest, current });
+      return;
+    }
     p.log.info(pc.yellow(`カスタマイズ版を検出しました (${fork.reason})`));
     p.log.info(
       `カスタマイズされたインストールを上書きしないよう、自動アップデートは適用しません。\nそのままご利用いただけます。更新したい場合は手動アップデートガイドをご覧ください:\n  https://github.com/Shudesu/line-harness-oss/blob/main/docs/wiki/26-Manual-Update.md`,
@@ -503,112 +551,35 @@ export async function runUpdate(repoDir: string): Promise<void> {
     process.exit(0);
   }
 
-  const creds = { accountId: cfg.cfAccountId, apiToken: cfg.cfApiToken };
+  const creds: CfApiCreds = { accountId: cfg.cfAccountId, apiToken: cfg.cfApiToken };
 
   // 7) Download + verify bundle
-  s.start(
-    `Bundle ダウンロード中 (${(upgrade.bundle_size_bytes / 1024 / 1024).toFixed(1)} MB)`,
-  );
-  let bundle;
-  try {
-    const bRes = await fetch(upgrade.bundle_url);
-    if (!bRes.ok) throw new Error(`bundle fetch HTTP ${bRes.status}`);
-    if (!bRes.body) throw new Error("bundle response has no body");
-    bundle = await parseBundleStream(
-      Readable.fromWeb(bRes.body as Parameters<typeof Readable.fromWeb>[0]),
-    );
-    const hashes = verifyBundleHashes(bundle);
-    assertHashesMatch(hashes, upgrade);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    s.stop(pc.red(`Bundle 検証失敗: ${msg}`));
-    p.cancel("bundle が壊れているか、改ざんされている可能性があります。");
-    process.exit(1);
-  }
-  s.stop("Bundle 取得 + ハッシュ検証 OK");
+  const bundle = await downloadAndVerifyBundle(upgrade, s);
 
-  // 8) Apply migrations (in manifest order)
-  for (const name of upgrade.migrations) {
-    const sql = bundle.migrations.get(name);
-    if (!sql) {
-      p.cancel(`migration ${name} が bundle にありません`);
-      process.exit(1);
-    }
-    s.start(`Migration ${name} 実行中`);
-    try {
-      await executeD1Query({
-        creds,
-        databaseId: cfg.d1DatabaseId,
-        sql: sql.toString("utf-8"),
-      });
-      s.stop(`Migration ${name} 完了`);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      s.stop(pc.red(`Migration ${name} 失敗: ${msg}`));
-      p.cancel(
-        "先に手動で migration を確認してください。Worker/Pages はまだ更新されていません。",
-      );
-      process.exit(1);
-    }
-  }
+  // 8) Apply migrations (in manifest order). Duplicate-object errors are
+  // benign — CLI installs applied every migration available at install
+  // time, so the DB can legitimately be ahead of `upgrade.migrations`.
+  applyMigrationsGuard(bundle, upgrade.migrations);
+  await applyMigrations({
+    creds,
+    d1DatabaseId: cfg.d1DatabaseId,
+    names: upgrade.migrations,
+    bundle,
+    s,
+  });
 
-  // 9) Worker — preserve existing bindings
-  s.start("Worker デプロイ中");
-  try {
-    const bindings = await listWorkerBindings({
-      creds,
-      scriptName: cfg.workerName,
-    });
-    await putWorkerScript({
-      creds,
-      scriptName: cfg.workerName,
-      scriptContent: bundle.workerJs,
-      bindings,
-    });
-    s.stop("Worker デプロイ完了");
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    s.stop(pc.red(`Worker デプロイ失敗: ${msg}`));
-    p.cancel(
-      "migration は適用されています。手動で Worker を rollback してください。",
-    );
-    process.exit(1);
-  }
+  // 9) Worker — preserve existing bindings + assets
+  await deployWorkerFromBundle(creds, cfg, bundle, s);
 
-  // 10) Admin Pages
-  s.start("Admin Pages デプロイ中");
-  try {
-    const r = await deployPagesProject({
-      creds,
-      projectName: cfg.adminProject,
-      files: bundle.adminFiles,
-    });
-    s.stop(`Admin デプロイ完了 (${r.deploymentId.slice(0, 8)})`);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    s.stop(pc.red(`Admin デプロイ失敗: ${msg}`));
-    p.cancel(
-      "Worker は新バージョンが動いていますが、Admin は前バージョンのままです。",
-    );
-    process.exit(1);
-  }
+  // 10) Admin Pages — materialize the placeholder API origin first
+  await deployAdminFromBundle(creds, cfg, bundle, s);
 
-  // 11) LIFF Pages
-  s.start("LIFF Pages デプロイ中");
-  try {
-    const r = await deployPagesProject({
-      creds,
-      projectName: cfg.liffProject,
-      files: bundle.liffFiles,
-    });
-    s.stop(`LIFF デプロイ完了 (${r.deploymentId.slice(0, 8)})`);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    s.stop(pc.red(`LIFF デプロイ失敗: ${msg}`));
-    p.cancel(
-      "Worker + Admin は新バージョンですが、LIFF は前バージョンのままです。",
-    );
-    process.exit(1);
+  // 11) LIFF Pages — only for legacy 3-artifact installs. Worker-assets
+  // installs serve the LIFF SPA from the Worker deployed in step 9.
+  if (cfg.liffProject) {
+    await deployLiffFromBundle(creds, cfg, bundle, s);
+  } else {
+    p.log.info("LIFF は Worker アセット配信のためスキップ（Worker 更新に含まれています）");
   }
 
   // 12) Ensure cookie-based admin auth is configured. Installs created before
@@ -637,5 +608,398 @@ export async function runUpdate(repoDir: string): Promise<void> {
     );
   }
 
+  // 14) Refresh the local release artifact + record bundle mode so a later
+  // manual `wrangler deploy` from the clone re-deploys THIS version instead
+  // of silently downgrading to whatever was on disk. Best-effort.
+  writeLocalWorkerArtifact(repoDir, bundle);
+  persistBundleMode(repoDir, upgrade.version);
+
   p.outro(pc.green(`🎉 v${upgrade.version} にアップデート完了`));
+}
+
+// ─── Shared deploy steps (normal update + adoption) ──────────────────────────
+
+type Spinner = ReturnType<typeof p.spinner>;
+
+/**
+ * Pre-download gate: releases without `worker_bundle_hash` shipped a broken
+ * worker artifact (re-export stub) and can never be deployed from. Exits
+ * with actionable guidance instead of failing mid-flow.
+ */
+function assertReleaseDeployable(release: ReleaseEntry): void {
+  if (release.worker_bundle_hash) return;
+  p.log.error(
+    [
+      `リリース v${release.version} はこのアップデーターに対応していません`,
+      "（bundle にデプロイ可能な Worker が含まれていない旧形式のリリースです）。",
+      "対応済みリリースの公開をお待ちください。",
+    ].join("\n"),
+  );
+  p.cancel("アップデート中止（インストールはそのまま動作します）");
+  process.exit(1);
+}
+
+async function downloadAndVerifyBundle(
+  release: ReleaseEntry,
+  s: Spinner,
+): Promise<ParsedBundle> {
+  assertReleaseDeployable(release);
+  s.start(
+    `Bundle ダウンロード中 (${(release.bundle_size_bytes / 1024 / 1024).toFixed(1)} MB)`,
+  );
+  try {
+    const bRes = await fetch(release.bundle_url);
+    if (!bRes.ok) throw new Error(`bundle fetch HTTP ${bRes.status}`);
+    if (!bRes.body) throw new Error("bundle response has no body");
+    const bundle = await parseBundleStream(
+      Readable.fromWeb(bRes.body as Parameters<typeof Readable.fromWeb>[0]),
+    );
+    const hashes = verifyBundleHashes(bundle);
+    verifyBundleIntegrity(hashes, release);
+    s.stop("Bundle 取得 + ハッシュ検証 OK");
+    return bundle;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    s.stop(pc.red(`Bundle 検証失敗: ${msg}`));
+    p.cancel("bundle が壊れているか、改ざんされている可能性があります。");
+    process.exit(1);
+  }
+}
+
+/** Fail fast (before any D1 write) if a listed migration is absent from the bundle. */
+function applyMigrationsGuard(bundle: ParsedBundle, names: string[]): void {
+  for (const name of names) {
+    if (!bundle.migrations.has(name)) {
+      p.cancel(`migration ${name} が bundle にありません`);
+      process.exit(1);
+    }
+  }
+}
+
+/**
+ * Apply migrations one file at a time, in the given order.
+ *
+ * Duplicate-object errors ("already exists" / "duplicate column") are benign
+ * and logged as skips: migrations are additive-only + INSERT OR IGNORE by
+ * repo policy (scripts/check-migrations.ts), and CLI installs apply every
+ * migration shipped at install time, so re-encountering one is expected.
+ * Any other error aborts BEFORE the Worker/Pages deploys run.
+ */
+async function applyMigrations(opts: {
+  creds: CfApiCreds;
+  d1DatabaseId: string;
+  names: string[];
+  bundle: ParsedBundle;
+  s: Spinner;
+}): Promise<void> {
+  const { creds, d1DatabaseId, names, bundle, s } = opts;
+  for (const name of names) {
+    const sql = bundle.migrations.get(name);
+    if (!sql) {
+      p.cancel(`migration ${name} が bundle にありません`);
+      process.exit(1);
+    }
+    s.start(`Migration ${name} 実行中`);
+    try {
+      await executeD1Query({
+        creds,
+        databaseId: d1DatabaseId,
+        sql: sql.toString("utf-8"),
+      });
+      s.stop(`Migration ${name} 完了`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (isBenignSchemaErrorText(msg)) {
+        s.stop(pc.dim(`Migration ${name}: 適用済みのためスキップ`));
+        continue;
+      }
+      s.stop(pc.red(`Migration ${name} 失敗: ${msg}`));
+      p.cancel(
+        "先に手動で migration を確認してください。Worker/Pages はまだ更新されていません。",
+      );
+      process.exit(1);
+    }
+  }
+}
+
+/**
+ * Correct the LIFF_PAGES_PROJECT plain-text binding to match the resolved
+ * topology. Installs created before the worker-assets fix were deployed
+ * with `LIFF_PAGES_PROJECT=<worker>-liff` even though that Pages project
+ * never existed; re-uploading the binding verbatim would keep the
+ * worker-side self-update pointed at the missing project instead of
+ * taking the worker-assets skip path.
+ */
+export function normalizeLiffBindings(
+  bindings: WorkerBinding[],
+  liffProject: string,
+): WorkerBinding[] {
+  return bindings.map((b) =>
+    b.type === "plain_text" && b.name === "LIFF_PAGES_PROJECT"
+      ? { ...b, text: liffProject }
+      : b,
+  );
+}
+
+async function deployWorkerFromBundle(
+  creds: CfApiCreds,
+  cfg: ResolvedUpdateConfig,
+  bundle: ParsedBundle,
+  s: Spinner,
+): Promise<void> {
+  s.start("Worker デプロイ中");
+  try {
+    const bindings = await listWorkerBindings({
+      creds,
+      scriptName: cfg.workerName,
+    });
+    await putWorkerScript({
+      creds,
+      scriptName: cfg.workerName,
+      scriptContent: bundle.workerJs,
+      bindings: normalizeLiffBindings(bindings, cfg.liffProject),
+      compatibilityFlags: WORKER_COMPATIBILITY_FLAGS,
+      // Bundle carries no Worker assets — keep the ones deployed at setup
+      // (they serve the LIFF SPA on worker-assets installs).
+      keepAssets: true,
+    });
+    s.stop("Worker デプロイ完了");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    s.stop(pc.red(`Worker デプロイ失敗: ${msg}`));
+    p.cancel(
+      "migration は適用されています。手動で Worker を rollback してください。",
+    );
+    process.exit(1);
+  }
+}
+
+async function deployAdminFromBundle(
+  creds: CfApiCreds,
+  cfg: ResolvedUpdateConfig,
+  bundle: ParsedBundle,
+  s: Spinner,
+): Promise<void> {
+  s.start("Admin Pages デプロイ中");
+  try {
+    // The release admin build points at https://__LH_WORKER_URL__ —
+    // rewrite it to this install's Worker before uploading.
+    const files = materializeAdminFiles(bundle.adminFiles, cfg.workerPublicUrl);
+    const residual = findResidualPlaceholders(files);
+    const r = await deployPagesProject({
+      creds,
+      projectName: cfg.adminProject,
+      files,
+    });
+    s.stop(`Admin デプロイ完了 (${r.deploymentId.slice(0, 8)})`);
+    if (residual.length > 0) {
+      p.log.warn(
+        `未知のプレースホルダーが残っています（動作に影響する可能性）: ${residual.slice(0, 5).join(", ")}${residual.length > 5 ? " …" : ""}`,
+      );
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    s.stop(pc.red(`Admin デプロイ失敗: ${msg}`));
+    p.cancel(
+      "Worker は新バージョンが動いていますが、Admin は前バージョンのままです。",
+    );
+    process.exit(1);
+  }
+}
+
+async function deployLiffFromBundle(
+  creds: CfApiCreds,
+  cfg: ResolvedUpdateConfig,
+  bundle: ParsedBundle,
+  s: Spinner,
+): Promise<void> {
+  s.start("LIFF Pages デプロイ中");
+  try {
+    const r = await deployPagesProject({
+      creds,
+      projectName: cfg.liffProject,
+      files: bundle.liffFiles,
+    });
+    s.stop(`LIFF デプロイ完了 (${r.deploymentId.slice(0, 8)})`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    s.stop(pc.red(`LIFF デプロイ失敗: ${msg}`));
+    p.cancel(
+      "Worker + Admin は新バージョンですが、LIFF は前バージョンのままです。",
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * Write the deployed Worker bundle to the local clone's release-artifact
+ * path (`apps/worker/dist/release/index.js`) — the path the generated
+ * wrangler.toml points at. Keeps a later manual `wrangler deploy` from
+ * downgrading/unstamping the install. Best-effort: `repoDir` may be a bare
+ * config directory (no clone), in which case this is a silent no-op.
+ */
+function writeLocalWorkerArtifact(repoDir: string, bundle: ParsedBundle): void {
+  const workerDir = join(repoDir, "apps/worker");
+  if (!existsSync(workerDir)) return;
+  try {
+    const artifactPath = join(workerDir, "dist/release/index.js");
+    mkdirSync(dirname(artifactPath), { recursive: true });
+    writeFileSync(artifactPath, bundle.workerJs);
+  } catch {
+    // Non-critical — the next update/setup run rewrites it.
+  }
+}
+
+/**
+ * After a successful bundle deploy (update or adoption), record the install
+ * as bundle-mode: `.line-harness-config.json` gains
+ * `workerDeployMode: "bundle"` + `installedVersion`, and the clone's
+ * generated wrangler.toml is re-rendered so `main` points at the release
+ * artifact. Without this, an adopted source-mode install would keep
+ * `main = "src/index.ts"` and a later manual `wrangler deploy` would
+ * redeploy an unstamped source build, undoing the adoption. Best-effort.
+ */
+function persistBundleMode(repoDir: string, version: string): void {
+  const configPath = join(repoDir, ".line-harness-config.json");
+  if (!existsSync(configPath)) return;
+  try {
+    const config = JSON.parse(
+      readFileSync(configPath, "utf-8"),
+    ) as SavedInstallConfig & Record<string, unknown>;
+    config.workerDeployMode = "bundle";
+    config.installedVersion = version;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+
+    // Re-render the clone's wrangler.toml only when it is CLI-generated
+    // (or absent) — never clobber a hand-edited config.
+    const workerDir = join(repoDir, "apps/worker");
+    const tomlPath = join(workerDir, "wrangler.toml");
+    if (!existsSync(workerDir)) return;
+    if (
+      existsSync(tomlPath) &&
+      !isGeneratedInstalledWranglerToml(readFileSync(tomlPath, "utf-8"))
+    ) {
+      return;
+    }
+    const resolved = resolveInstalledWranglerConfig(config);
+    if (resolved) {
+      writeFileSync(tomlPath, renderInstalledWranglerToml(resolved));
+    }
+  } catch {
+    // Non-critical — setup/update reruns repair it.
+  }
+}
+
+// ─── Adoption path (unstamped CLI installs) ──────────────────────────────────
+
+/**
+ * Adopt an unstamped install (`/admin/version` reports a version the
+ * manifest doesn't know — 0.0.0-dev for every pre-fix CLI install) onto the
+ * latest official release so future updates work normally.
+ *
+ * Differences from a normal update:
+ *   - Explicit opt-in prompt (default: No) — a genuinely customized source
+ *     build would be overwritten by this operation.
+ *   - Applies ALL migrations in the bundle (benign-swallowed) instead of a
+ *     manifest diff: with an unknown starting version there is no reliable
+ *     "already applied" set, and re-application is safe by repo policy.
+ *   - Skips the min_from_version gate — it is meaningless for an unknown
+ *     starting version, and full-migration replay is the compensating
+ *     control.
+ */
+async function runAdoption(opts: {
+  repoDir: string;
+  cfg: ResolvedUpdateConfig;
+  manifest: Awaited<ReturnType<typeof fetchManifest>>;
+  current: CurrentVersion;
+}): Promise<void> {
+  const { repoDir, cfg, manifest, current } = opts;
+
+  const target = manifest.releases.find((r) => r.version === manifest.latest);
+  if (!target) {
+    p.cancel(
+      `manifest が壊れています (latest=${manifest.latest} が releases にありません)`,
+    );
+    process.exit(1);
+  }
+
+  p.log.warn(
+    [
+      `バージョン未スタンプのインストールを検出しました (現在: v${current.version})。`,
+      "旧バージョンの CLI でセットアップした環境は、公式リリースと同一でもバージョン情報が",
+      "埋め込まれておらず、自動アップデートが適用できない状態です。",
+      "",
+      `公式リリース v${target.version} を導入すると、以後の自動アップデートが使えるようになります。`,
+      "",
+      pc.bold("注意: Worker / 管理画面をソースコードレベルでカスタマイズしている場合、"),
+      pc.bold("この操作でカスタマイズは上書きされ失われます。"),
+      "（管理画面上の設定・DB データ・シークレットはそのまま残ります）",
+    ].join("\n"),
+  );
+
+  const confirm = await p.confirm({
+    message: `公式リリース v${target.version} を導入しますか?`,
+    initialValue: false,
+  });
+  if (p.isCancel(confirm) || !confirm) {
+    p.log.info(
+      `そのままご利用いただけます。手動での更新手順:\n  https://github.com/Shudesu/line-harness-oss/blob/main/docs/wiki/26-Manual-Update.md`,
+    );
+    p.outro(pc.yellow("導入をスキップしました (インストールはそのまま動作します)"));
+    process.exit(0);
+  }
+
+  const creds: CfApiCreds = { accountId: cfg.cfAccountId, apiToken: cfg.cfApiToken };
+  const s = p.spinner();
+
+  const bundle = await downloadAndVerifyBundle(target, s);
+
+  // Replay every migration in the bundle, oldest first. Duplicates are
+  // skipped via the benign-error policy inside applyMigrations.
+  const allMigrations = Array.from(bundle.migrations.keys()).sort();
+  p.log.info(
+    `全 ${allMigrations.length} migration を確認します（適用済みはスキップされます）`,
+  );
+  await applyMigrations({
+    creds,
+    d1DatabaseId: cfg.d1DatabaseId,
+    names: allMigrations,
+    bundle,
+    s,
+  });
+
+  await deployWorkerFromBundle(creds, cfg, bundle, s);
+  await deployAdminFromBundle(creds, cfg, bundle, s);
+  if (cfg.liffProject) {
+    await deployLiffFromBundle(creds, cfg, bundle, s);
+  } else {
+    p.log.info("LIFF は Worker アセット配信のためスキップ（Worker 更新に含まれています）");
+  }
+
+  // Older installs may pre-date cookie-based admin auth — same step the
+  // normal update path runs.
+  await configureAdminAuth({
+    workerName: cfg.workerName,
+    workerUrl: cfg.workerPublicUrl,
+    adminUrl: cfg.adminPublicUrl,
+  });
+
+  s.start("Health チェック中");
+  try {
+    const hRes = await fetch(`${cfg.workerPublicUrl.replace(/\/$/, "")}/health`);
+    if (!hRes.ok) throw new Error(`HTTP ${hRes.status}`);
+    s.stop("Health OK");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    s.stop(pc.yellow(`Health 確認失敗: ${msg} (導入自体は完了しています)`));
+  }
+
+  writeLocalWorkerArtifact(repoDir, bundle);
+  persistBundleMode(repoDir, target.version);
+
+  p.outro(
+    pc.green(
+      `🎉 v${target.version} を導入しました — 以後 \`npx create-line-harness update\` で自動アップデートできます`,
+    ),
+  );
 }

--- a/packages/create-line-harness/src/index.ts
+++ b/packages/create-line-harness/src/index.ts
@@ -7,20 +7,30 @@ import { ensureRepo } from "./steps/clone-repo.js";
 
 const args = process.argv.slice(2);
 
-function parseArgs(): { command: string; repoDir: string | null } {
+function parseArgs(): {
+  command: string;
+  repoDir: string | null;
+  fromSource: boolean;
+} {
   let command = "setup";
   let repoDir: string | null = null;
+  let fromSource = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--repo-dir" && args[i + 1]) {
       repoDir = resolve(args[i + 1]);
       i++;
+    } else if (args[i] === "--from-source") {
+      // Dev escape hatch: build + deploy from the cloned source instead of
+      // the official release bundle. The install reports 0.0.0-dev and is
+      // excluded from automatic updates.
+      fromSource = true;
     } else if (!args[i].startsWith("-")) {
       command = args[i];
     }
   }
 
-  return { command, repoDir };
+  return { command, repoDir, fromSource };
 }
 
 /**
@@ -50,7 +60,7 @@ function getConfigDir(explicitRepoDir: string | null): string {
 }
 
 async function main(): Promise<void> {
-  const { command, repoDir: explicitRepoDir } = parseArgs();
+  const { command, repoDir: explicitRepoDir, fromSource } = parseArgs();
 
   let repoDir: string;
   if (command === "update") {
@@ -64,12 +74,14 @@ async function main(): Promise<void> {
   }
 
   if (command === "setup") {
-    await runSetup(repoDir);
+    await runSetup(repoDir, { fromSource });
   } else if (command === "update") {
     await runUpdate(repoDir);
   } else {
     console.error(`Unknown command: ${command}`);
-    console.error("Usage: create-line-harness [setup|update] [--repo-dir <path>]");
+    console.error(
+      "Usage: create-line-harness [setup|update] [--repo-dir <path>] [--from-source]",
+    );
     process.exit(1);
   }
 }

--- a/packages/create-line-harness/src/lib/installed-wrangler.ts
+++ b/packages/create-line-harness/src/lib/installed-wrangler.ts
@@ -20,6 +20,14 @@ export interface SavedInstallConfig {
   adminPublicUrl?: string;
   liffProject?: string;
   liffPublicUrl?: string;
+  /**
+   * 'bundle' — Worker deployed from the official release bundle
+   * (main = dist/release/index.js + no_bundle, version-stamped).
+   * 'source' / absent — legacy install built from src/index.ts.
+   */
+  workerDeployMode?: "bundle" | "source";
+  /** Release version deployed by setup/adoption (informational). */
+  installedVersion?: string;
 }
 
 export interface InstalledWranglerConfig {
@@ -31,9 +39,11 @@ export interface InstalledWranglerConfig {
   workerPublicUrl: string;
   adminPagesProject: string;
   adminPublicUrl: string;
+  /** '' = worker-assets install (no LIFF Pages project). */
   liffPagesProject: string;
   liffPublicUrl: string;
   manifestUrl: string;
+  workerDeployMode: "bundle" | "source";
 }
 
 export function isGeneratedInstalledWranglerToml(content: string): boolean {
@@ -65,7 +75,11 @@ export function resolveInstalledWranglerConfig(
   }
 
   const adminPublicUrl = config.adminPublicUrl ?? config.adminUrl;
-  const liffPagesProject = config.liffProject ?? `${workerName ?? "line-harness"}-liff`;
+  // Worker-assets installs have no LIFF Pages project — '' tells the
+  // worker-side self-update to skip every LIFF Pages step. (The old
+  // `${workerName}-liff` fallback pointed self-update at a project that
+  // was never created and made its LIFF deploy step fail.)
+  const liffPagesProject = config.liffProject ?? "";
   const liffPublicUrl = config.liffPublicUrl ?? workerPublicUrl;
 
   if (
@@ -94,23 +108,36 @@ export function resolveInstalledWranglerConfig(
     liffPagesProject,
     liffPublicUrl,
     manifestUrl: config.manifestUrl ?? DEFAULT_MANIFEST_URL,
+    workerDeployMode: config.workerDeployMode === "bundle" ? "bundle" : "source",
   };
 }
 
 export function renderInstalledWranglerToml(
   config: InstalledWranglerConfig,
 ): string {
+  // Bundle installs deploy the official release artifact byte-for-byte:
+  // `no_bundle` stops wrangler from re-bundling (which would invalidate the
+  // version stamp's honesty), and the artifact path is refreshed by
+  // setup/update so a manual `wrangler deploy` re-ships the same release.
+  const mainSection =
+    config.workerDeployMode === "bundle"
+      ? `main = "dist/release/index.js"\nno_bundle = true`
+      : `main = "src/index.ts"`;
+
   return `${GENERATED_MARKER}
 name = "${config.workerName}"
-main = "src/index.ts"
+${mainSection}
 compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 account_id = "${config.accountId}"
 
+# Worker runs before static assets so bot UAs get OGP HTML injection;
+# normal UAs fall through to the SPA via env.ASSETS.fetch().
 [assets]
 directory = "dist/client"
 binding = "ASSETS"
+run_worker_first = true
 
 [[d1_databases]]
 binding = "DB"

--- a/packages/create-line-harness/src/steps/clone-repo.ts
+++ b/packages/create-line-harness/src/steps/clone-repo.ts
@@ -16,6 +16,72 @@ const REPO_URL =
   "https://github.com/Shudesu/line-harness-oss.git";
 
 /**
+ * Pin the cloned repo to the release tag for `version` (e.g. `0.16.0` →
+ * `v0.16.0`).
+ *
+ * Setup deploys the Worker from the official release bundle; pinning the
+ * clone to the SAME release keeps everything else sourced from the repo —
+ * schema.sql, migrations, the vite-built client assets — consistent with
+ * the deployed Worker. Installing from main HEAD instead would apply
+ * migrations newer than the release, leaving the database "ahead" of what
+ * the manifest expects on the next update.
+ *
+ * The clone is CLI-managed (`~/.line-harness`): apps/worker/wrangler.toml
+ * is force-restored before checkout because setup itself patches/generates
+ * it and a dirty copy would block `git checkout`.
+ */
+export async function pinRepoToTag(
+  repoDir: string,
+  version: string,
+): Promise<void> {
+  const tag = `v${version}`;
+  const s = p.spinner();
+  s.start(`リリース ${tag} のソースに固定中...`);
+
+  // Drop CLI-authored wrangler.toml changes so the checkout can't conflict.
+  // The file is regenerated later in setup (applyPatchedConfig /
+  // syncInstalledWorkerConfig), so nothing user-authored is lost.
+  try {
+    await execa("git", ["checkout", "--", "apps/worker/wrangler.toml"], {
+      cwd: repoDir,
+    });
+  } catch {
+    // File may be untracked / repo pristine — fine.
+  }
+
+  try {
+    await execa(
+      "git",
+      ["fetch", "--depth", "1", "origin", "tag", tag, "--no-tags"],
+      { cwd: repoDir },
+    );
+    await execa("git", ["checkout", "--quiet", tag], { cwd: repoDir });
+  } catch (error: any) {
+    s.stop(`リリースタグ ${tag} への切り替えに失敗`);
+    throw new Error(
+      [
+        `リリースタグ ${tag} を取得できませんでした: ${error.message}`,
+        "ネットワークを確認して再実行してください。",
+        "（タグの無い開発用リポジトリの場合は --from-source を使ってください）",
+      ].join("\n"),
+    );
+  }
+  s.stop(`リリース ${tag} のソースに固定しました`);
+
+  // The tag may pin different dependency versions than the previously
+  // installed main HEAD — reinstall to match its lockfile.
+  s.start("依存関係インストール中...");
+  try {
+    await repoPnpm(repoDir, ["install", "--frozen-lockfile"], {
+      cwd: repoDir,
+    });
+  } catch {
+    await repoPnpm(repoDir, ["install"], { cwd: repoDir });
+  }
+  s.stop("依存関係インストール完了");
+}
+
+/**
  * Clone the LINE Harness repo and install dependencies.
  * Returns the path to the cloned repo.
  */

--- a/packages/create-line-harness/src/steps/deploy-admin.ts
+++ b/packages/create-line-harness/src/steps/deploy-admin.ts
@@ -1,6 +1,11 @@
 import * as p from "@clack/prompts";
-import { writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  materializeAdminFiles,
+  findResidualPlaceholders,
+} from "@line-harness/update-engine";
 import { wrangler, WranglerError } from "../lib/wrangler.js";
 import { repoPnpm } from "../lib/pnpm.js";
 
@@ -12,10 +17,43 @@ interface DeployAdminOptions {
   workerUrl: string;
   apiKey?: string; // Deprecated: no longer embedded in client bundle
   projectName: string;
+  /**
+   * Admin static files from the official release bundle (path → content).
+   * When set, these are deployed (after `__LH_WORKER_URL__` placeholder
+   * materialization) instead of building apps/web from source — much
+   * faster, and pixel-identical to the released admin. Absent only in
+   * `--from-source` mode.
+   */
+  adminFiles?: Map<string, Buffer>;
 }
 
 interface DeployAdminResult {
   adminUrl: string;
+}
+
+/**
+ * Write the materialized admin files into a fresh temp dir that
+ * `wrangler pages deploy` can consume. Returns the dir path; caller cleans
+ * it up.
+ */
+function stageAdminFiles(
+  adminFiles: Map<string, Buffer>,
+  workerUrl: string,
+): string {
+  const stageDir = mkdtempSync(join(tmpdir(), "clh-admin-"));
+  const files = materializeAdminFiles(adminFiles, workerUrl);
+  const residual = findResidualPlaceholders(files);
+  if (residual.length > 0) {
+    p.log.warn(
+      `未知のプレースホルダーが残っています（動作に影響する可能性）: ${residual.slice(0, 5).join(", ")}${residual.length > 5 ? " …" : ""}`,
+    );
+  }
+  for (const [relPath, buf] of files) {
+    const dest = join(stageDir, relPath);
+    mkdirSync(dirname(dest), { recursive: true });
+    writeFileSync(dest, buf);
+  }
+  return stageDir;
 }
 
 export async function deployAdmin(
@@ -23,70 +61,97 @@ export async function deployAdmin(
 ): Promise<DeployAdminResult> {
   const webDir = join(options.repoDir, "apps/web");
 
-  // Write .env.production with the Worker URL and API key
-  const buildSpinner = p.spinner();
-  buildSpinner.start("Admin UI ビルド中...");
-  // Only set the API URL — API key is entered via login page (never embedded in client bundle)
-  const envContent = `NEXT_PUBLIC_API_URL=${options.workerUrl}\n`;
-  writeFileSync(join(webDir, ".env.production"), envContent);
+  // Resolve the directory to deploy: staged release-bundle files
+  // (placeholder-materialized), or a local Next.js build in --from-source
+  // mode.
+  let deployDir: string;
+  let deployCwd: string | undefined;
+  let stageDir: string | null = null;
 
-  // Build Next.js
-  try {
-    await repoPnpm(options.repoDir, ["run", "build"], { cwd: webDir });
-  } catch (error: any) {
-    buildSpinner.stop("Admin UI ビルド失敗");
-    throw new Error(`Admin UI のビルドに失敗しました: ${error.message}`);
-  }
-  buildSpinner.stop("Admin UI ビルド完了");
+  if (options.adminFiles) {
+    const s = p.spinner();
+    s.start("Admin UI 準備中（リリース bundle から展開）...");
+    stageDir = stageAdminFiles(options.adminFiles, options.workerUrl);
+    s.stop("Admin UI 準備完了");
+    deployDir = stageDir;
+    deployCwd = undefined;
+  } else {
+    // Write .env.production with the Worker URL and build from source.
+    const buildSpinner = p.spinner();
+    buildSpinner.start("Admin UI ビルド中...");
+    // Only set the API URL — API key is entered via login page (never embedded in client bundle)
+    const envContent = `NEXT_PUBLIC_API_URL=${options.workerUrl}\n`;
+    writeFileSync(join(webDir, ".env.production"), envContent);
 
-  // Create Pages project first (ignore error if already exists) — silent step
-  const projectSpinner = p.spinner();
-  projectSpinner.start("Pages プロジェクト準備中...");
-  try {
-    await wrangler(["pages", "project", "create", options.projectName, "--production-branch", "main"]);
-  } catch (error) {
-    if (
-      error instanceof WranglerError &&
-      TTY_REQUIRED.test(`${error.message}\n${error.stderr}`)
-    ) {
-      projectSpinner.stop("Pages プロジェクト認証を更新します");
-      await wrangler(
-        ["pages", "project", "create", options.projectName, "--production-branch", "main"],
-        { tty: true },
-      );
-      projectSpinner.start("Pages プロジェクト準備中...");
-    } else {
-    // Already exists, that's fine
-    }
-  }
-  projectSpinner.stop("Pages プロジェクト準備完了");
-
-  // Deploy to CF Pages — hand TTY over to wrangler
-  p.log.info("Admin UI をデプロイしています（wrangler の出力が表示されます）...");
-  try {
-    await wrangler(
-      ["pages", "deploy", "out", "--project-name", options.projectName, "--commit-dirty=true"],
-      { cwd: webDir, tty: true },
-    );
-
-    // Parse the actual subdomain from project list (deploy output is captured-or-not depending on TTY)
-    let adminUrl = `https://${options.projectName}.pages.dev`;
     try {
-      const projectList = await wrangler(["pages", "project", "list"]);
-      const subdomainMatch = projectList.match(
-        new RegExp(`${options.projectName}\\s+│\\s+(\\S+\\.pages\\.dev)`),
-      );
-      if (subdomainMatch) {
-        adminUrl = `https://${subdomainMatch[1]}`;
-      }
-    } catch {
-      // Fall back to project name
+      await repoPnpm(options.repoDir, ["run", "build"], { cwd: webDir });
+    } catch (error: any) {
+      buildSpinner.stop("Admin UI ビルド失敗");
+      throw new Error(`Admin UI のビルドに失敗しました: ${error.message}`);
     }
+    buildSpinner.stop("Admin UI ビルド完了");
+    deployDir = "out";
+    deployCwd = webDir;
+  }
 
-    p.log.success(`Admin UI デプロイ完了: ${adminUrl}`);
-    return { adminUrl };
-  } catch (error: any) {
-    p.log.error("Admin UI デプロイ失敗");
-    throw new Error(`Admin UI のデプロイに失敗しました: ${error.message}`);
+  try {
+    // Create Pages project first (ignore error if already exists) — silent step
+    const projectSpinner = p.spinner();
+    projectSpinner.start("Pages プロジェクト準備中...");
+    try {
+      await wrangler(["pages", "project", "create", options.projectName, "--production-branch", "main"]);
+    } catch (error) {
+      if (
+        error instanceof WranglerError &&
+        TTY_REQUIRED.test(`${error.message}\n${error.stderr}`)
+      ) {
+        projectSpinner.stop("Pages プロジェクト認証を更新します");
+        await wrangler(
+          ["pages", "project", "create", options.projectName, "--production-branch", "main"],
+          { tty: true },
+        );
+        projectSpinner.start("Pages プロジェクト準備中...");
+      } else {
+        // Already exists, that's fine
+      }
+    }
+    projectSpinner.stop("Pages プロジェクト準備完了");
+
+    // Deploy to CF Pages — hand TTY over to wrangler
+    p.log.info("Admin UI をデプロイしています（wrangler の出力が表示されます）...");
+    try {
+      await wrangler(
+        ["pages", "deploy", deployDir, "--project-name", options.projectName, "--commit-dirty=true"],
+        { cwd: deployCwd, tty: true },
+      );
+
+      // Parse the actual subdomain from project list (deploy output is captured-or-not depending on TTY)
+      let adminUrl = `https://${options.projectName}.pages.dev`;
+      try {
+        const projectList = await wrangler(["pages", "project", "list"]);
+        const subdomainMatch = projectList.match(
+          new RegExp(`${options.projectName}\\s+│\\s+(\\S+\\.pages\\.dev)`),
+        );
+        if (subdomainMatch) {
+          adminUrl = `https://${subdomainMatch[1]}`;
+        }
+      } catch {
+        // Fall back to project name
+      }
+
+      p.log.success(`Admin UI デプロイ完了: ${adminUrl}`);
+      return { adminUrl };
+    } catch (error: any) {
+      p.log.error("Admin UI デプロイ失敗");
+      throw new Error(`Admin UI のデプロイに失敗しました: ${error.message}`);
+    }
+  } finally {
+    if (stageDir) {
+      try {
+        rmSync(stageDir, { recursive: true, force: true });
+      } catch {
+        // Temp dir — the OS cleans it up eventually.
+      }
+    }
   }
 }

--- a/packages/create-line-harness/src/steps/deploy-worker.ts
+++ b/packages/create-line-harness/src/steps/deploy-worker.ts
@@ -1,6 +1,12 @@
 import * as p from "@clack/prompts";
-import { writeFileSync, existsSync, readFileSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
+import {
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  unlinkSync,
+  mkdirSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import { execa } from "execa";
 import { wrangler, WranglerError } from "../lib/wrangler.js";
 import {
@@ -15,6 +21,10 @@ const RETRYABLE_NETWORK_ERROR =
   /fetch failed|connectivity issue|network connectivity|connection reset|socket hang up/i;
 const MAX_DEPLOY_ATTEMPTS = 3;
 
+/** Path (relative to apps/worker) where the official release Worker
+ *  artifact is placed. The generated wrangler.toml points main at it. */
+export const RELEASE_ARTIFACT_RELPATH = "dist/release/index.js";
+
 interface DeployWorkerOptions {
   repoDir: string;
   d1DatabaseId: string;
@@ -24,6 +34,13 @@ interface DeployWorkerOptions {
   liffId: string;
   botBasicId: string;
   r2BucketName: string;
+  /**
+   * Official release Worker bytes (bundle.tar.gz → worker/index.js).
+   * When set, the deploy ships THESE bytes via `no_bundle` so the Worker's
+   * baked-in version stamp matches the release manifest and `update` works.
+   * Absent only in `--from-source` mode (deploys 0.0.0-dev, no updates).
+   */
+  bundleWorkerJs?: Buffer;
 }
 
 interface DeployWorkerResult {
@@ -32,6 +49,18 @@ interface DeployWorkerResult {
 
 interface SyncInstalledWorkerConfigOptions extends InstalledWranglerConfig {
   repoDir: string;
+  /** See DeployWorkerOptions.bundleWorkerJs — refreshed before the final deploy. */
+  bundleWorkerJs?: Buffer;
+}
+
+/** Write the release Worker artifact into the clone. */
+export function writeReleaseArtifact(
+  workerDir: string,
+  bundleWorkerJs: Buffer,
+): void {
+  const artifactPath = join(workerDir, RELEASE_ARTIFACT_RELPATH);
+  mkdirSync(dirname(artifactPath), { recursive: true });
+  writeFileSync(artifactPath, bundleWorkerJs);
 }
 
 async function deployWorkerBundle(
@@ -129,18 +158,24 @@ export async function deployWorker(
     ? readFileSync(tomlPath, "utf-8")
     : null;
 
-  // Write deploy wrangler.toml
-  const deployToml = `name = "${options.workerName}"
-main = "src/index.ts"
-compatibility_date = "2024-12-01"
+  // Deploy config template. `main` differs between the build pass (the
+  // @cloudflare/vite-plugin needs the source entry to produce dist/client)
+  // and the bundle deploy pass (ships the official release artifact
+  // verbatim via no_bundle).
+  const renderDeployToml = (main: string, noBundle: boolean) => `name = "${options.workerName}"
+main = "${main}"
+${noBundle ? 'no_bundle = true\n' : ""}compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 account_id = "${options.accountId}"
 
-# Static assets (LIFF pages) served by Workers Assets
-# SPA fallback ensures all non-API paths serve index.html
+# Static assets (LIFF pages) served by Workers Assets.
+# Worker runs first so bot UAs get OGP HTML injection; normal UAs are
+# served the SPA via env.ASSETS.fetch() in the Worker's notFound handler.
 [assets]
-not_found_handling = "single-page-application"
+directory = "dist/client"
+binding = "ASSETS"
+run_worker_first = true
 
 [[d1_databases]]
 binding = "DB"
@@ -152,9 +187,11 @@ binding = "IMAGES"
 bucket_name = "${options.r2BucketName}"
 
 [triggers]
-crons = ["*/5 * * * *"]
+crons = ["*/5 * * * *", "0 */6 * * *"]
 `;
-  writeFileSync(tomlPath, deployToml);
+
+  // Build pass config: vite needs the source entrypoint.
+  writeFileSync(tomlPath, renderDeployToml("src/index.ts", false));
 
   // Write .env for Vite build (LIFF client env vars)
   const envPath = join(workerDir, ".env");
@@ -183,6 +220,15 @@ crons = ["*/5 * * * *"]
     );
     await execa("npx", ["vite", "build"], { cwd: workerDir });
     buildSpinner.stop("Worker ビルド完了");
+
+    if (options.bundleWorkerJs) {
+      // Deploy the OFFICIAL release Worker bytes (not the local build).
+      // Their baked-in _version.ts stamp matches the release manifest, so
+      // `update`'s fork detection sees a vanilla install. The local vite
+      // build above still provides dist/client (the LIFF SPA assets).
+      writeReleaseArtifact(workerDir, options.bundleWorkerJs);
+      writeFileSync(tomlPath, renderDeployToml(RELEASE_ARTIFACT_RELPATH, true));
+    }
 
     // Pipe-first: capture deploy output so we can parse the real URL
     // (Cloudflare serves Workers at https://<worker>.<account-subdomain>.workers.dev,
@@ -217,6 +263,17 @@ export async function syncInstalledWorkerConfig(
 ): Promise<void> {
   const workerDir = join(options.repoDir, "apps/worker");
   const tomlPath = join(workerDir, "wrangler.toml");
+  if (options.workerDeployMode === "bundle") {
+    if (!options.bundleWorkerJs) {
+      throw new Error(
+        "internal: workerDeployMode=bundle なのに bundleWorkerJs がありません",
+      );
+    }
+    // This is the FINAL deploy of setup — make sure the artifact the
+    // generated toml points at is the release bytes (a resumed run may
+    // have a stale/absent dist/release/index.js).
+    writeReleaseArtifact(workerDir, options.bundleWorkerJs);
+  }
   writeFileSync(tomlPath, renderInstalledWranglerToml(options));
 
   const s = p.spinner();

--- a/packages/create-line-harness/src/steps/release-bundle.ts
+++ b/packages/create-line-harness/src/steps/release-bundle.ts
@@ -1,0 +1,120 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import { Readable } from "node:stream";
+import {
+  fetchManifest,
+  findRelease,
+  parseBundleStream,
+  verifyBundleHashes,
+  verifyBundleIntegrity,
+  type Manifest,
+  type ParsedBundle,
+  type ReleaseEntry,
+} from "@line-harness/update-engine";
+
+export interface FetchedRelease {
+  manifest: Manifest;
+  release: ReleaseEntry;
+  bundle: ParsedBundle;
+}
+
+/**
+ * Fetch the release manifest and download + verify an official bundle.
+ *
+ * Setup deploys the Worker from this bundle (instead of building from
+ * source) so the shipped `_version.ts` stamp — version + component hashes —
+ * matches a manifest entry and `update`'s fork detection recognizes the
+ * install as vanilla. A source build would report 0.0.0-dev and lock the
+ * install out of automatic updates permanently.
+ *
+ * `pinVersion` re-selects the release a previous (resumed) setup run chose.
+ * A resume must NOT float to a newer `latest`: earlier completed steps
+ * (schema/migrations, deployed artifacts) belong to the pinned release, and
+ * mixing releases would leave the Worker running against a mismatched
+ * schema. Run `update` after setup completes to move to the newest release.
+ *
+ * Fail-fast by design: no silent fallback to a source deploy. An installer
+ * who can't reach GitHub Releases should see why and decide (retry, or use
+ * `--from-source` knowing updates won't apply).
+ */
+export async function fetchLatestRelease(
+  manifestUrl: string,
+  pinVersion?: string,
+): Promise<FetchedRelease> {
+  const s = p.spinner();
+
+  s.start("リリース情報取得中...");
+  let manifest: Manifest;
+  try {
+    manifest = await fetchManifest(manifestUrl);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    s.stop(pc.red(`リリース情報の取得に失敗: ${msg}`));
+    throw new Error(
+      [
+        "公式リリース情報 (release-manifest.json) を取得できませんでした。",
+        `  URL: ${manifestUrl}`,
+        "ネットワークを確認して再実行してください。",
+        "（開発用にソースからデプロイする場合は --from-source を付けてください。",
+        "  その場合、自動アップデートは利用できません）",
+      ].join("\n"),
+    );
+  }
+
+  const targetVersion = pinVersion ?? manifest.latest;
+  const release = findRelease(manifest, targetVersion);
+  if (!release) {
+    s.stop(pc.red("リリース情報を解決できません"));
+    throw new Error(
+      pinVersion
+        ? [
+            `前回のセットアップで選択したリリース v${pinVersion} が manifest に見つかりません。`,
+            "最初からやり直すには、インストールディレクトリの .line-harness-setup.json を削除して再実行してください。",
+          ].join("\n")
+        : `manifest が壊れています (latest=${manifest.latest} が releases にありません)`,
+    );
+  }
+  if (pinVersion && pinVersion !== manifest.latest) {
+    p.log.info(
+      `再開のため前回選択したリリース v${pinVersion} を継続します（最新: v${manifest.latest}。セットアップ完了後に \`npx create-line-harness update\` で更新できます）`,
+    );
+  }
+  if (!release.worker_bundle_hash) {
+    // Old-pipeline release: its bundle ships a broken worker stub. Deploying
+    // it would produce a dead install, so fail before touching anything.
+    s.stop(pc.red(`最新リリース v${release.version} は新しいインストーラーに未対応`));
+    throw new Error(
+      [
+        `最新リリース v${release.version} の bundle にはデプロイ可能な Worker が含まれていません`,
+        "（新リリースパイプライン対応前の形式です）。対応リリースの公開をお待ちください。",
+        "（開発用途では --from-source でソースからデプロイできます。",
+        "  その場合、自動アップデートは利用できません）",
+      ].join("\n"),
+    );
+  }
+  s.stop(`最新リリース: v${release.version}`);
+
+  s.start(
+    `Bundle ダウンロード中 (${(release.bundle_size_bytes / 1024 / 1024).toFixed(1)} MB)...`,
+  );
+  let bundle: ParsedBundle;
+  try {
+    const res = await fetch(release.bundle_url);
+    if (!res.ok) throw new Error(`bundle fetch HTTP ${res.status}`);
+    if (!res.body) throw new Error("bundle response has no body");
+    bundle = await parseBundleStream(
+      Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]),
+    );
+    const hashes = verifyBundleHashes(bundle);
+    verifyBundleIntegrity(hashes, release);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    s.stop(pc.red(`Bundle 検証失敗: ${msg}`));
+    throw new Error(
+      "リリース bundle のダウンロードまたはハッシュ検証に失敗しました。再実行してください。",
+    );
+  }
+  s.stop(`Bundle 取得 + ハッシュ検証 OK (v${release.version})`);
+
+  return { manifest, release, bundle };
+}

--- a/packages/create-line-harness/test/resolve-state.test.ts
+++ b/packages/create-line-harness/test/resolve-state.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { resolveState } from '../src/commands/update.js';
+
+const WORKER_URL = 'https://line-harness.acc.workers.dev';
+
+/** A complete config as written by current setup.ts (worker-assets install). */
+function workerAssetsConfig() {
+  return {
+    projectName: 'line-harness',
+    workerName: 'line-harness',
+    cfAccountId: 'a'.repeat(32),
+    cfApiToken: 'tok',
+    d1DatabaseId: 'd1id',
+    adminProject: 'line-harness-admin-abc123',
+    adminPublicUrl: 'https://line-harness-admin-abc123.pages.dev',
+    workerPublicUrl: WORKER_URL,
+    // setup.ts intentionally omits liffProject and points liffPublicUrl at
+    // the Worker (LIFF is served from Worker assets).
+    liffPublicUrl: WORKER_URL,
+  };
+}
+
+describe('resolveState — LIFF topology', () => {
+  it('resolves a worker-assets install (no liffProject, liffPublicUrl == workerPublicUrl) without prompting', () => {
+    const r = resolveState(workerAssetsConfig(), undefined);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.liffProject).toBe('');
+    expect(r.value.liffPublicUrl).toBe('');
+  });
+
+  it('resolves a worker-assets install when liffPublicUrl is absent entirely', () => {
+    const cfg = workerAssetsConfig() as Record<string, unknown>;
+    delete cfg.liffPublicUrl;
+    const r = resolveState(cfg, undefined);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.liffProject).toBe('');
+  });
+
+  it('treats an explicitly-empty liffProject as "no LIFF Pages" (persisted prompt answer)', () => {
+    const r = resolveState({ ...workerAssetsConfig(), liffProject: '' }, undefined);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.liffProject).toBe('');
+    expect(r.value.liffPublicUrl).toBe('');
+  });
+
+  it('keeps the legacy 3-artifact topology when liffProject is present', () => {
+    const r = resolveState(
+      {
+        ...workerAssetsConfig(),
+        liffProject: 'lh-liff-abc123',
+        liffPublicUrl: 'https://lh-liff-abc123.pages.dev',
+      },
+      undefined,
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.liffProject).toBe('lh-liff-abc123');
+    expect(r.value.liffPublicUrl).toBe('https://lh-liff-abc123.pages.dev');
+  });
+
+  it('still asks for liffProject when a distinct LIFF URL exists without a project name', () => {
+    const r = resolveState(
+      {
+        ...workerAssetsConfig(),
+        liffPublicUrl: 'https://lh-liff-abc123.pages.dev',
+      },
+      undefined,
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.missing).toContain('liffProject');
+  });
+});
+
+describe('resolveState — credentials and legacy fallbacks', () => {
+  it('falls back to the CLOUDFLARE_API_TOKEN env var', () => {
+    const cfg = workerAssetsConfig() as Record<string, unknown>;
+    delete cfg.cfApiToken;
+    const withoutEnv = resolveState(cfg, undefined);
+    expect(withoutEnv.ok).toBe(false);
+    const withEnv = resolveState(cfg, 'env-token');
+    expect(withEnv.ok).toBe(true);
+    if (withEnv.ok) expect(withEnv.value.cfApiToken).toBe('env-token');
+  });
+
+  it('derives workerName / accountId / adminProject from legacy fields', () => {
+    const r = resolveState(
+      {
+        projectName: 'line-harness',
+        accountId: 'b'.repeat(32),
+        cfApiToken: 'tok',
+        d1DatabaseId: 'd1id',
+        adminUrl: 'https://legacy-admin.pages.dev',
+        workerUrl: WORKER_URL,
+      },
+      undefined,
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.workerName).toBe('line-harness');
+    expect(r.value.cfAccountId).toBe('b'.repeat(32));
+    expect(r.value.adminProject).toBe('legacy-admin');
+    expect(r.value.workerPublicUrl).toBe(WORKER_URL);
+    // No liffPublicUrl at all → worker-assets resolution.
+    expect(r.value.liffProject).toBe('');
+  });
+});
+
+// ─── normalizeLiffBindings ────────────────────────────────────────────────────
+
+import { normalizeLiffBindings } from '../src/commands/update.js';
+
+describe('normalizeLiffBindings', () => {
+  const bindings = [
+    { type: 'd1' as const, name: 'DB', database_id: 'd1id' },
+    { type: 'plain_text' as const, name: 'LIFF_PAGES_PROJECT', text: 'line-harness-liff' },
+    { type: 'plain_text' as const, name: 'WORKER_NAME', text: 'line-harness' },
+    { type: 'assets' as const, name: 'ASSETS' },
+  ];
+
+  it('clears the stale LIFF_PAGES_PROJECT binding for worker-assets installs', () => {
+    const out = normalizeLiffBindings(bindings, '');
+    const liff = out.find((b) => b.name === 'LIFF_PAGES_PROJECT');
+    expect(liff?.text).toBe('');
+    // Everything else passes through untouched.
+    expect(out.find((b) => b.name === 'WORKER_NAME')?.text).toBe('line-harness');
+    expect(out.find((b) => b.name === 'ASSETS')?.type).toBe('assets');
+  });
+
+  it('sets the binding to the real project name for legacy Pages-LIFF installs', () => {
+    const out = normalizeLiffBindings(bindings, 'lh-liff-abc123');
+    expect(out.find((b) => b.name === 'LIFF_PAGES_PROJECT')?.text).toBe('lh-liff-abc123');
+  });
+
+  it('does not mutate the input array', () => {
+    normalizeLiffBindings(bindings, '');
+    expect(bindings.find((b) => b.name === 'LIFF_PAGES_PROJECT')?.text).toBe('line-harness-liff');
+  });
+});

--- a/packages/create-line-harness/vitest.config.ts
+++ b/packages/create-line-harness/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/update-engine",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Self-update engine for LINE Harness — shared between Worker (cloud-side self-update) and CLI (npx create-line-harness update)",
   "type": "module",
   "exports": {

--- a/packages/update-engine/src/bundle.ts
+++ b/packages/update-engine/src/bundle.ts
@@ -180,9 +180,11 @@ function hashContentMap(map: Map<string, Buffer>): string {
  * hashes. Throws a descriptive error on mismatch; returns `undefined` when all
  * three match.
  *
- * The worker error embeds both hex hashes so operators can quickly identify
- * whether the bundle was tampered with (e.g. CDN replaced the artifact) or
- * the manifest itself drifted.
+ * DEPRECATED for bundle downloads: `worker_hash` is the first-pass identity
+ * hash baked INTO the worker (see ReleaseEntry.worker_hash) and can never
+ * equal the byte hash of the final artifact. Use
+ * {@link verifyBundleIntegrity} instead; this remains only for callers that
+ * compare two same-pass hash sets.
  */
 export function assertHashesMatch(
   computed: BundleHashes,
@@ -197,6 +199,58 @@ export function assertHashesMatch(
     throw new Error('bundle admin hash mismatch');
   }
   if (computed.liff !== expected.liff_hash) {
+    throw new Error('bundle liff hash mismatch');
+  }
+}
+
+/**
+ * Marker error: the release predates the deployable-worker pipeline (no
+ * `worker_bundle_hash`), so its bundle cannot be deployed. Callers show a
+ * "wait for the next release / use --from-source" message on this.
+ */
+export class BundleNotDeployableError extends Error {
+  constructor(version: string) {
+    super(
+      `release v${version} has no worker_bundle_hash — its bundle predates the ` +
+        'deployable-worker release pipeline and cannot be installed or updated from',
+    );
+    this.name = 'BundleNotDeployableError';
+  }
+}
+
+/**
+ * Verify a downloaded bundle against its manifest entry.
+ *
+ * - admin / liff: byte hashes must equal the manifest values (these are
+ *   hashed AFTER their final build, so equality is exact).
+ * - worker: compared against `worker_bundle_hash`, the detached hash of the
+ *   final artifact. `worker_hash` is NOT used here — it is the first-pass
+ *   identity stamp baked into the worker, definitionally different from the
+ *   final bytes. Entries without `worker_bundle_hash` are rejected with
+ *   {@link BundleNotDeployableError}: those bundles shipped a broken
+ *   re-export stub as worker/index.js and must not be deployed.
+ */
+export function verifyBundleIntegrity(
+  computed: BundleHashes,
+  entry: {
+    version: string;
+    admin_hash: string;
+    liff_hash: string;
+    worker_bundle_hash?: string;
+  },
+): void {
+  if (!entry.worker_bundle_hash) {
+    throw new BundleNotDeployableError(entry.version);
+  }
+  if (computed.worker !== entry.worker_bundle_hash) {
+    throw new Error(
+      `bundle worker hash mismatch (tampered? ${computed.worker} vs ${entry.worker_bundle_hash})`,
+    );
+  }
+  if (computed.admin !== entry.admin_hash) {
+    throw new Error('bundle admin hash mismatch');
+  }
+  if (computed.liff !== entry.liff_hash) {
     throw new Error('bundle liff hash mismatch');
   }
 }

--- a/packages/update-engine/src/cf-api/workers.ts
+++ b/packages/update-engine/src/cf-api/workers.ts
@@ -5,14 +5,15 @@ import { authHeader, throwHttpError, workersApiBase } from './_shared.js';
  * Cloudflare Workers binding shape used by the Workers Scripts API.
  *
  * Only the binding types we care about for the LINE Harness Worker are
- * modelled here: env-style plain text, secrets, and resource bindings for
- * D1, R2, and KV. Other types (`service`, `queue`, `analytics_engine`, …)
- * are intentionally left unsupported in v1 — callers should fail loudly if
- * the deployed Worker uses an unsupported binding type so we don't silently
- * drop it on update.
+ * modelled here: env-style plain text, secrets, resource bindings for
+ * D1, R2, and KV, and the Workers Assets binding (CLI installs serve the
+ * LIFF SPA from Worker assets). Other types (`service`, `queue`,
+ * `analytics_engine`, …) are intentionally left unsupported in v1 —
+ * callers should fail loudly if the deployed Worker uses an unsupported
+ * binding type so we don't silently drop it on update.
  */
 export interface WorkerBinding {
-  type: 'plain_text' | 'secret_text' | 'd1' | 'r2_bucket' | 'kv_namespace';
+  type: 'plain_text' | 'secret_text' | 'd1' | 'r2_bucket' | 'kv_namespace' | 'assets';
   name: string;
   database_id?: string;
   bucket_name?: string;
@@ -33,6 +34,15 @@ const DEFAULT_COMPATIBILITY_DATE = '2024-12-01';
  *
  * Throws on non-2xx with a body excerpt so caller logs include the API's
  * error reason.
+ *
+ * `keepAssets: true` sets the API's `keep_assets` flag so a script-only
+ * update retains the assets of the previous version — required for CLI
+ * installs, where the Worker serves the LIFF SPA via Workers Assets and the
+ * release bundle carries no asset files.
+ *
+ * `compatibilityFlags` must include every flag the current deployment uses
+ * (the upload REPLACES metadata; omitting `nodejs_compat` would strip it
+ * and break every `node:*` import in the Worker).
  */
 export async function putWorkerScript(opts: {
   creds: CfApiCreds;
@@ -40,15 +50,23 @@ export async function putWorkerScript(opts: {
   scriptContent: Buffer;
   bindings: WorkerBinding[];
   compatibilityDate?: string;
+  compatibilityFlags?: string[];
+  keepAssets?: boolean;
 }): Promise<void> {
   const { creds, scriptName, scriptContent, bindings } = opts;
   const compatibility_date = opts.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE;
 
-  const metadata = {
+  const metadata: Record<string, unknown> = {
     main_module: 'worker.js',
     bindings,
     compatibility_date,
   };
+  if (opts.compatibilityFlags && opts.compatibilityFlags.length > 0) {
+    metadata.compatibility_flags = opts.compatibilityFlags;
+  }
+  if (opts.keepAssets) {
+    metadata.keep_assets = true;
+  }
 
   const fd = new FormData();
   fd.set(

--- a/packages/update-engine/src/index.ts
+++ b/packages/update-engine/src/index.ts
@@ -3,7 +3,7 @@ import type { UpdateContext, UpdateEvent } from './types.js';
 import {
   parseBundleStream,
   verifyBundleHashes,
-  assertHashesMatch,
+  verifyBundleIntegrity,
 } from './bundle.js';
 import { getLatestDeployment } from './cf-api/pages.js';
 import {
@@ -24,6 +24,7 @@ export * from './types.js';
 export * from './manifest.js';
 export * from './fork-detect.js';
 export * from './bundle.js';
+export * from './materialize.js';
 export * from './snapshot.js';
 export * from './cf-api/workers.js';
 export * from './cf-api/pages.js';
@@ -133,9 +134,14 @@ export async function runUpdate(opts: RunUpdateOpts): Promise<UpdateHandle> {
   //
   // Failures here reject the OUTER promise — no snapshot row exists yet,
   // so the caller's catch is the only place that learns about the error.
+  // Worker-assets installs have no LIFF Pages project (empty string) —
+  // their LIFF is served by the Worker script, whose pre-update bytes are
+  // already captured via currentWorkerBundleUrl.
   const [adminLatest, liffLatest] = await Promise.all([
     getLatestDeployment({ creds: ctx.creds, projectName: ctx.adminPagesProject }),
-    getLatestDeployment({ creds: ctx.creds, projectName: ctx.liffPagesProject }),
+    ctx.liffPagesProject
+      ? getLatestDeployment({ creds: ctx.creds, projectName: ctx.liffPagesProject })
+      : Promise.resolve({ id: '' }),
   ]);
 
   // Step 2: create the snapshot row. From here every failure path is
@@ -185,7 +191,10 @@ export async function runUpdate(opts: RunUpdateOpts): Promise<UpdateHandle> {
         Readable.fromWeb(res.body as any),
       );
       const computed = verifyBundleHashes(bundle);
-      assertHashesMatch(computed, ctx.target);
+      // Byte-verify against worker_bundle_hash (detached final-artifact
+      // hash). Releases without it shipped undeployable worker stubs and
+      // are rejected here before any destructive step.
+      verifyBundleIntegrity(computed, ctx.target);
 
       // Step 6: apply (destructive).
       await runApply(ctx, bundle, ev);
@@ -212,17 +221,19 @@ export async function runUpdate(opts: RunUpdateOpts): Promise<UpdateHandle> {
       });
       try {
         const snap = await getSnapshot(d1, updateId);
+        // snapshot_liff_deployment is intentionally NOT required — it is
+        // empty for worker-assets installs, whose LIFF is restored by the
+        // Worker script rollback itself.
         if (
           snap?.snapshot_worker_url &&
-          snap.snapshot_admin_deployment &&
-          snap.snapshot_liff_deployment
+          snap.snapshot_admin_deployment
         ) {
           await runRollback(
             ctx,
             {
               snapshotWorkerBundleUrl: snap.snapshot_worker_url,
               snapshotAdminDeployment: snap.snapshot_admin_deployment,
-              snapshotLiffDeployment: snap.snapshot_liff_deployment,
+              snapshotLiffDeployment: snap.snapshot_liff_deployment ?? '',
             },
             ev,
           );

--- a/packages/update-engine/src/materialize.ts
+++ b/packages/update-engine/src/materialize.ts
@@ -1,0 +1,107 @@
+/**
+ * Install-time materialization of release-bundle artifacts.
+ *
+ * The release pipeline bakes a placeholder origin
+ * (`https://__LH_WORKER_URL__`) into the admin bundle because the real
+ * Worker URL only exists once a customer installs. Every deploy path that
+ * ships bundle admin files to Pages (CLI setup, CLI update, worker-side
+ * self-update) MUST rewrite that placeholder to the install's Worker URL
+ * first — deploying the files verbatim produces an admin UI that calls
+ * `https://__LH_WORKER_URL__/api/...` and breaks on arrival.
+ */
+
+/** Placeholder origin baked into release admin builds by release.yml. */
+export const ADMIN_URL_PLACEHOLDER = 'https://__LH_WORKER_URL__';
+
+/**
+ * Extensions we treat as text for placeholder substitution. Everything else
+ * (images, fonts, wasm) is passed through byte-for-byte — running a string
+ * replace over binary content would corrupt it.
+ */
+const TEXT_EXTENSIONS = new Set([
+  'js',
+  'mjs',
+  'cjs',
+  'css',
+  'html',
+  'htm',
+  'json',
+  'map',
+  'svg',
+  'txt',
+  'webmanifest',
+  'xml',
+]);
+
+export function isTextAssetPath(path: string): boolean {
+  const dot = path.lastIndexOf('.');
+  if (dot === -1) return false;
+  return TEXT_EXTENSIONS.has(path.slice(dot + 1).toLowerCase());
+}
+
+/**
+ * Rewrite the admin bundle for a concrete install: replaces every
+ * occurrence of {@link ADMIN_URL_PLACEHOLDER} with the install's Worker
+ * origin. Returns a NEW map; input buffers are never mutated.
+ *
+ * `workerUrl` is normalized to a bare origin (no trailing slash) because
+ * the admin client concatenates paths as `${API_URL}${path}`.
+ */
+export function materializeAdminFiles(
+  files: Map<string, Buffer>,
+  workerUrl: string,
+): Map<string, Buffer> {
+  const origin = workerUrl.replace(/\/+$/, '');
+  const out = new Map<string, Buffer>();
+  for (const [path, buf] of files) {
+    if (!isTextAssetPath(path)) {
+      out.set(path, buf);
+      continue;
+    }
+    const text = buf.toString('utf8');
+    if (!text.includes(ADMIN_URL_PLACEHOLDER)) {
+      out.set(path, buf);
+      continue;
+    }
+    out.set(path, Buffer.from(text.split(ADMIN_URL_PLACEHOLDER).join(origin), 'utf8'));
+  }
+  return out;
+}
+
+/**
+ * Post-materialization safety net: list text files that still contain a
+ * `__LH_` marker (an unknown placeholder this version of the tooling does
+ * not know how to fill). Callers surface these as warnings — the deploy
+ * still proceeds, but the operator learns which files may misbehave.
+ */
+export function findResidualPlaceholders(files: Map<string, Buffer>): string[] {
+  const residual: string[] = [];
+  for (const [path, buf] of files) {
+    if (!isTextAssetPath(path)) continue;
+    if (buf.toString('utf8').includes('__LH_')) {
+      residual.push(path);
+    }
+  }
+  return residual.sort();
+}
+
+/**
+ * Classify a D1 / SQLite error message as "schema object already exists".
+ *
+ * LINE Harness migrations are additive-only (enforced by
+ * scripts/check-migrations.ts) and use INSERT OR IGNORE for seed data, so
+ * re-applying a migration against a database that already has it fails ONLY
+ * with duplicate-object errors. Setup has always swallowed these
+ * (`packages/create-line-harness/src/steps/database.ts`); the update and
+ * adoption flows reuse the same policy via this predicate.
+ *
+ * Matches both wrangler CLI stderr and the D1 REST API error text.
+ */
+export function isBenignSchemaErrorText(text: string): boolean {
+  const t = text.toLowerCase();
+  return (
+    t.includes('duplicate column') ||
+    t.includes('already exists') ||
+    (t.includes('table') && t.includes('already'))
+  );
+}

--- a/packages/update-engine/src/phases/apply.ts
+++ b/packages/update-engine/src/phases/apply.ts
@@ -4,6 +4,15 @@ import type { ParsedBundle } from '../bundle.js';
 import { executeD1Query } from '../cf-api/d1.js';
 import { listWorkerBindings, putWorkerScript } from '../cf-api/workers.js';
 import { deployPagesProject } from '../cf-api/pages.js';
+import { materializeAdminFiles } from '../materialize.js';
+
+/**
+ * Compatibility flags the LINE Harness Worker requires. The script upload
+ * API replaces metadata wholesale, so these must be re-sent on every PUT —
+ * omitting them would strip `nodejs_compat` and break `node:*` imports.
+ * Kept in lockstep with apps/worker/wrangler.toml.
+ */
+const WORKER_COMPATIBILITY_FLAGS = ['nodejs_compat'];
 
 /**
  * Result of a successful apply phase.
@@ -77,6 +86,11 @@ export async function runApply(
     scriptName: ctx.workerName,
     scriptContent: bundle.workerJs,
     bindings,
+    compatibilityFlags: WORKER_COMPATIBILITY_FLAGS,
+    // The release bundle carries no Worker asset files. CLI installs serve
+    // the LIFF SPA from Workers Assets, so the previous version's assets
+    // must survive this script upload. No-op for installs without assets.
+    keepAssets: true,
   });
   await ev.emit({
     step: 'worker',
@@ -86,11 +100,16 @@ export async function runApply(
 
   // Step 3: Admin Pages. Done before LIFF because admin is internal-only
   // and any breakage here is contained — LIFF is what customers see.
+  // The bundle's admin build has `https://__LH_WORKER_URL__` baked in as
+  // its API origin; rewrite it to this install's Worker URL first.
   await ev.emit({ step: 'admin', status: 'running' });
+  const adminFiles = ctx.workerPublicUrl
+    ? materializeAdminFiles(bundle.adminFiles, ctx.workerPublicUrl)
+    : bundle.adminFiles;
   const adminResult = await deployPagesProject({
     creds: ctx.creds,
     projectName: ctx.adminPagesProject,
-    files: bundle.adminFiles,
+    files: adminFiles,
   });
   await ev.emit({
     step: 'admin',
@@ -100,7 +119,17 @@ export async function runApply(
 
   // Step 4: LIFF Pages. Last so the customer-facing UI swap only happens
   // once everything beneath it (schema + Worker + admin) is already
-  // live on the new version.
+  // live on the new version. Skipped entirely for CLI installs
+  // (liffPagesProject === ''), where the LIFF SPA is served by the Worker's
+  // own assets and there is no Pages project to deploy to.
+  if (!ctx.liffPagesProject) {
+    await ev.emit({ step: 'liff', status: 'done', name: 'skipped (worker-assets install)' });
+    return {
+      adminDeploymentId: adminResult.deploymentId,
+      liffDeploymentId: '',
+    };
+  }
+
   await ev.emit({ step: 'liff', status: 'running' });
   const liffResult = await deployPagesProject({
     creds: ctx.creds,

--- a/packages/update-engine/src/phases/preflight.ts
+++ b/packages/update-engine/src/phases/preflight.ts
@@ -43,9 +43,13 @@ export async function runPreflight(
   await verifyToken(ctx.creds);
 
   // 3. Verify each CF resource the update will touch actually exists.
+  //    The LIFF Pages project is optional — CLI installs serve the LIFF
+  //    SPA from Worker assets and set liffPagesProject to ''.
   await verifyWorker(ctx.creds, ctx.workerName);
   await verifyPagesProject(ctx.creds, ctx.adminPagesProject);
-  await verifyPagesProject(ctx.creds, ctx.liffPagesProject);
+  if (ctx.liffPagesProject) {
+    await verifyPagesProject(ctx.creds, ctx.liffPagesProject);
+  }
 
   // 4. D1 reachability — a trivial SELECT 1 confirms the database is
   //    online AND our token has query rights. Failure mentions the D1

--- a/packages/update-engine/src/phases/rollback.ts
+++ b/packages/update-engine/src/phases/rollback.ts
@@ -85,6 +85,8 @@ export async function runRollback(
     scriptName: ctx.workerName,
     scriptContent: bytes,
     bindings,
+    compatibilityFlags: ['nodejs_compat'],
+    keepAssets: true,
   });
 
   // Step 4: admin Pages rollback. Done before liff so a failure here
@@ -100,12 +102,15 @@ export async function runRollback(
 
   // Step 5: liff Pages rollback. Customer-facing, done last so the swap
   // back happens only after the admin console is already on the old
-  // version.
-  await rollbackPagesDeployment({
-    creds: ctx.creds,
-    projectName: ctx.liffPagesProject,
-    deploymentId: snap.snapshotLiffDeployment,
-  });
+  // version. Skipped for worker-assets installs (no LIFF Pages project —
+  // the Worker script rollback in step 3 already restored their LIFF).
+  if (ctx.liffPagesProject && snap.snapshotLiffDeployment) {
+    await rollbackPagesDeployment({
+      creds: ctx.creds,
+      projectName: ctx.liffPagesProject,
+      deploymentId: snap.snapshotLiffDeployment,
+    });
+  }
 
   await ev.emit({ step: 'rollback', status: 'done' });
 }

--- a/packages/update-engine/src/phases/verify.ts
+++ b/packages/update-engine/src/phases/verify.ts
@@ -13,7 +13,11 @@ export interface VerifyUrls {
   workerHealthUrl: string;
   /** Admin Pages root URL (e.g. `https://admin.example.pages.dev/`). */
   adminUrl: string;
-  /** LIFF Pages root URL (e.g. `https://liff.example.pages.dev/`). */
+  /**
+   * LIFF Pages root URL (e.g. `https://liff.example.pages.dev/`), or ''
+   * for worker-assets installs — the LIFF probe is skipped when empty
+   * (the Worker /health probe already covers the serving script).
+   */
   liffUrl: string;
 }
 
@@ -80,12 +84,15 @@ export async function runVerify(
 
   // 4. LIFF Pages — customer-facing UI. Last because a failure here is
   //    the most "user visible" and we want the other probes to have
-  //    succeeded before we even report this one missing.
-  try {
-    await fetchWithRetry(urls.liffUrl);
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    throw new Error(`LIFF URL failed: ${reason} (${urls.liffUrl})`);
+  //    succeeded before we even report this one missing. Skipped for
+  //    worker-assets installs (no separate LIFF deployment to probe).
+  if (urls.liffUrl) {
+    try {
+      await fetchWithRetry(urls.liffUrl);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(`LIFF URL failed: ${reason} (${urls.liffUrl})`);
+    }
   }
 
   await ev.emit({ step: 'verify', status: 'done' });

--- a/packages/update-engine/src/types.ts
+++ b/packages/update-engine/src/types.ts
@@ -1,9 +1,23 @@
 export interface ReleaseEntry {
   version: string;
   released_at: string;
+  /**
+   * Identity hash of the Worker: computed on the FIRST-pass build (before
+   * `_version.ts` is embedded) and baked into the shipped Worker, which
+   * self-reports it via /admin/version. detectFork compares against this.
+   * NOT the byte hash of the bundle's worker/index.js — an artifact cannot
+   * contain its own hash.
+   */
   worker_hash: string;
   admin_hash: string;
   liff_hash: string;
+  /**
+   * Byte hash (sha256:<hex>) of the FINAL worker/index.js inside
+   * bundle.tar.gz — the detached integrity hash download verification
+   * uses. Absent on releases predating the deployable-worker pipeline;
+   * those bundles ship a broken worker stub and cannot be installed from.
+   */
+  worker_bundle_hash?: string;
   bundle_url: string;
   bundle_size_bytes: number;
   required_secrets: string[];
@@ -59,10 +73,23 @@ export interface UpdateContext {
   creds: CfApiCreds;
   workerName: string;
   adminPagesProject: string;
+  /**
+   * LIFF Pages project name, or '' for CLI installs that serve the LIFF SPA
+   * from Worker assets instead of a separate Pages project. When empty, the
+   * LIFF snapshot / deploy / verify / rollback steps are skipped.
+   */
   liffPagesProject: string;
   d1DatabaseId: string;
   current: CurrentVersion;
   target: ReleaseEntry;
   manifestUrl: string;
   bundleStoragePath?: string;
+  /**
+   * Public origin of the deployed Worker (e.g. `https://x.workers.dev`).
+   * Used to materialize the admin bundle's `__LH_WORKER_URL__` placeholder
+   * before the admin Pages deploy. Optional only for backwards
+   * compatibility — callers should always set it; when absent the admin
+   * files ship with the placeholder still baked in (pre-fix behaviour).
+   */
+  workerPublicUrl?: string;
 }

--- a/packages/update-engine/test/materialize.test.ts
+++ b/packages/update-engine/test/materialize.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ADMIN_URL_PLACEHOLDER,
+  isTextAssetPath,
+  materializeAdminFiles,
+  findResidualPlaceholders,
+  isBenignSchemaErrorText,
+} from '../src/materialize.js';
+
+const WORKER_URL = 'https://my-harness.example.workers.dev';
+
+describe('isTextAssetPath', () => {
+  it('classifies common Next.js export outputs', () => {
+    expect(isTextAssetPath('index.html')).toBe(true);
+    expect(isTextAssetPath('_next/static/chunks/main-abc123.js')).toBe(true);
+    expect(isTextAssetPath('_next/static/css/app.css')).toBe(true);
+    expect(isTextAssetPath('manifest.webmanifest')).toBe(true);
+    expect(isTextAssetPath('chunks/page.js.map')).toBe(true);
+  });
+
+  it('treats binary and extension-less paths as non-text', () => {
+    expect(isTextAssetPath('favicon.ico')).toBe(false);
+    expect(isTextAssetPath('images/logo.png')).toBe(false);
+    expect(isTextAssetPath('fonts/inter.woff2')).toBe(false);
+    expect(isTextAssetPath('LICENSE')).toBe(false);
+  });
+});
+
+describe('materializeAdminFiles', () => {
+  it('replaces every occurrence of the placeholder in text files', () => {
+    const js = `fetch("${ADMIN_URL_PLACEHOLDER}/api/friends");const base="${ADMIN_URL_PLACEHOLDER}";`;
+    const files = new Map([['chunk.js', Buffer.from(js)]]);
+
+    const out = materializeAdminFiles(files, WORKER_URL);
+
+    const text = out.get('chunk.js')!.toString('utf8');
+    expect(text).toBe(
+      `fetch("${WORKER_URL}/api/friends");const base="${WORKER_URL}";`,
+    );
+    expect(text).not.toContain('__LH_');
+  });
+
+  it('strips trailing slashes from the worker URL (admin concatenates paths)', () => {
+    const files = new Map([
+      ['a.js', Buffer.from(`"${ADMIN_URL_PLACEHOLDER}/api"`)],
+    ]);
+    const out = materializeAdminFiles(files, `${WORKER_URL}/`);
+    expect(out.get('a.js')!.toString('utf8')).toBe(`"${WORKER_URL}/api"`);
+  });
+
+  it('passes binary files through byte-for-byte even if bytes match the placeholder', () => {
+    const png = Buffer.from(`\x89PNG${ADMIN_URL_PLACEHOLDER}`, 'latin1');
+    const files = new Map([['logo.png', png]]);
+    const out = materializeAdminFiles(files, WORKER_URL);
+    expect(out.get('logo.png')).toBe(png);
+  });
+
+  it('does not mutate the input map or its buffers', () => {
+    const original = Buffer.from(`x="${ADMIN_URL_PLACEHOLDER}"`);
+    const files = new Map([['a.js', original]]);
+    materializeAdminFiles(files, WORKER_URL);
+    expect(files.get('a.js')!.toString('utf8')).toContain(ADMIN_URL_PLACEHOLDER);
+  });
+
+  it('reuses untouched buffers for text files without the placeholder', () => {
+    const clean = Buffer.from('console.log(1)');
+    const files = new Map([['a.js', clean]]);
+    const out = materializeAdminFiles(files, WORKER_URL);
+    expect(out.get('a.js')).toBe(clean);
+  });
+});
+
+describe('findResidualPlaceholders', () => {
+  it('reports text files that still contain a __LH_ marker, sorted', () => {
+    const files = new Map([
+      ['z.js', Buffer.from('const x = "__LH_FUTURE_THING__";')],
+      ['a.html', Buffer.from('<a href="__LH_OTHER__">x</a>')],
+      ['ok.js', Buffer.from('nothing here')],
+      ['bin.png', Buffer.from('__LH_IN_BINARY__')],
+    ]);
+    expect(findResidualPlaceholders(files)).toEqual(['a.html', 'z.js']);
+  });
+
+  it('returns empty after a full materialization', () => {
+    const files = new Map([
+      ['a.js', Buffer.from(`"${ADMIN_URL_PLACEHOLDER}/api"`)],
+    ]);
+    const out = materializeAdminFiles(files, WORKER_URL);
+    expect(findResidualPlaceholders(out)).toEqual([]);
+  });
+});
+
+describe('isBenignSchemaErrorText', () => {
+  it('matches duplicate-object errors from wrangler and the D1 REST API', () => {
+    expect(isBenignSchemaErrorText('duplicate column name: score')).toBe(true);
+    expect(isBenignSchemaErrorText('table "friends" already exists')).toBe(true);
+    expect(
+      isBenignSchemaErrorText('D1_ERROR: index idx_chats_friend already exists: SQLITE_ERROR'),
+    ).toBe(true);
+    expect(isBenignSchemaErrorText('Error: table friends already defined? ALREADY exists')).toBe(
+      true,
+    );
+  });
+
+  it('rejects real failures', () => {
+    expect(isBenignSchemaErrorText('no such table: friends')).toBe(false);
+    expect(isBenignSchemaErrorText('near "FRM": syntax error')).toBe(false);
+    expect(isBenignSchemaErrorText('D1_ERROR: too many SQL variables')).toBe(false);
+    expect(isBenignSchemaErrorText('')).toBe(false);
+  });
+});

--- a/packages/update-engine/test/orchestrator.test.ts
+++ b/packages/update-engine/test/orchestrator.test.ts
@@ -160,6 +160,9 @@ const sampleRelease = (
   version: '0.8.0',
   released_at: '2026-05-01T00:00:00Z',
   worker_hash: fixture.workerHash,
+  // In fixtures the identity hash and the final-artifact byte hash coincide
+  // (no two-pass rebuild); real manifests carry distinct values.
+  worker_bundle_hash: fixture.workerHash,
   admin_hash: fixture.adminHash,
   liff_hash: fixture.liffHash,
   bundle_url: BUNDLE_URL,
@@ -644,13 +647,13 @@ describe('runUpdate orchestrator', () => {
     expect(row.error).toMatch(/rollback:/);
   });
 
-  it('bundle hash mismatch (tampered) → throws via assertHashesMatch, rollback runs', async () => {
-    // Build a release with WRONG hashes — assertHashesMatch should reject.
+  it('bundle hash mismatch (tampered) → throws via verifyBundleIntegrity, rollback runs', async () => {
+    // Build a release with a WRONG byte hash — verifyBundleIntegrity should reject.
     globalThis.fetch = makeFetch(fixture) as unknown as typeof fetch;
 
     const ctx = sampleCtx(fixture, {
       target: sampleRelease(fixture, {
-        worker_hash: 'sha256:tampered',
+        worker_bundle_hash: 'sha256:tampered',
       }),
     });
 

--- a/packages/update-engine/test/phases/apply-topology.test.ts
+++ b/packages/update-engine/test/phases/apply-topology.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Apply-phase behaviour that varies by install topology.
+ *
+ * Uses module mocks (instead of the fetch router in apply.test.ts) so the
+ * assertions can inspect the exact arguments handed to the CF API layer:
+ *   - admin files must be materialized (placeholder → real Worker URL)
+ *   - worker-assets installs (liffPagesProject === '') skip the LIFF deploy
+ *   - the Worker upload preserves assets + compatibility flags
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { runApply } from '../../src/phases/apply.js';
+import { createEventEmitter } from '../../src/events.js';
+import { ADMIN_URL_PLACEHOLDER } from '../../src/materialize.js';
+import type { ParsedBundle } from '../../src/bundle.js';
+import type { UpdateContext, UpdateEvent } from '../../src/types.js';
+
+vi.mock('../../src/cf-api/d1.js', () => ({
+  executeD1Query: vi.fn(async () => ({})),
+}));
+vi.mock('../../src/cf-api/workers.js', () => ({
+  listWorkerBindings: vi.fn(async () => [
+    { type: 'd1', name: 'DB', database_id: 'd1id' },
+    { type: 'assets', name: 'ASSETS' },
+  ]),
+  putWorkerScript: vi.fn(async () => undefined),
+}));
+vi.mock('../../src/cf-api/pages.js', () => ({
+  deployPagesProject: vi.fn(async ({ projectName }: { projectName: string }) => ({
+    deploymentId: `${projectName}-dep`,
+    url: `https://${projectName}.pages.dev`,
+  })),
+}));
+
+import { putWorkerScript } from '../../src/cf-api/workers.js';
+import { deployPagesProject } from '../../src/cf-api/pages.js';
+
+const WORKER_URL = 'https://w.acc.workers.dev';
+
+function ctx(overrides: Partial<UpdateContext> = {}): UpdateContext {
+  return {
+    creds: { accountId: 'acc', apiToken: 'tok' },
+    workerName: 'w',
+    adminPagesProject: 'admin-proj',
+    liffPagesProject: 'liff-proj',
+    d1DatabaseId: 'd1id',
+    current: { version: '0.15.0', worker_hash: '', admin_hash: '', liff_hash: '' },
+    target: {
+      version: '0.16.0',
+      released_at: '',
+      worker_hash: 'sha256:w',
+      admin_hash: 'sha256:a',
+      liff_hash: 'sha256:l',
+      bundle_url: '',
+      bundle_size_bytes: 0,
+      required_secrets: [],
+      new_required_secrets: [],
+      migrations: [],
+      changelog_url: '',
+      min_from_version: '0.0.0',
+    },
+    manifestUrl: '',
+    workerPublicUrl: WORKER_URL,
+    ...overrides,
+  };
+}
+
+function bundle(): ParsedBundle {
+  return {
+    workerJs: Buffer.from('export default {}'),
+    adminFiles: new Map([
+      ['chunk.js', Buffer.from(`fetch("${ADMIN_URL_PLACEHOLDER}/api")`)],
+      ['logo.png', Buffer.from('binarydata')],
+    ]),
+    liffFiles: new Map([['index.html', Buffer.from('<html>l</html>')]]),
+    migrations: new Map(),
+  };
+}
+
+function emitter(): { events: UpdateEvent[]; ev: ReturnType<typeof createEventEmitter> } {
+  const events: UpdateEvent[] = [];
+  const ev = createEventEmitter({ persist: async (e) => void events.push(e) });
+  return { events, ev };
+}
+
+beforeEach(() => {
+  vi.mocked(putWorkerScript).mockClear();
+  vi.mocked(deployPagesProject).mockClear();
+});
+
+describe('runApply — install topologies', () => {
+  it('materializes the admin placeholder before the Pages deploy', async () => {
+    const { ev } = emitter();
+    await runApply(ctx(), bundle(), ev);
+
+    const adminCall = vi
+      .mocked(deployPagesProject)
+      .mock.calls.find(([args]) => args.projectName === 'admin-proj');
+    expect(adminCall).toBeDefined();
+    const files = adminCall![0].files as Map<string, Buffer>;
+    expect(files.get('chunk.js')!.toString('utf8')).toBe(`fetch("${WORKER_URL}/api")`);
+    // Binary passthrough.
+    expect(files.get('logo.png')!.toString('utf8')).toBe('binarydata');
+  });
+
+  it('deploys admin files as-is when workerPublicUrl is not provided (legacy ctx)', async () => {
+    const { ev } = emitter();
+    await runApply(ctx({ workerPublicUrl: undefined }), bundle(), ev);
+
+    const adminCall = vi
+      .mocked(deployPagesProject)
+      .mock.calls.find(([args]) => args.projectName === 'admin-proj');
+    const files = adminCall![0].files as Map<string, Buffer>;
+    expect(files.get('chunk.js')!.toString('utf8')).toContain(ADMIN_URL_PLACEHOLDER);
+  });
+
+  it('skips the LIFF Pages deploy for worker-assets installs', async () => {
+    const { events, ev } = emitter();
+    const result = await runApply(ctx({ liffPagesProject: '' }), bundle(), ev);
+
+    expect(result.liffDeploymentId).toBe('');
+    expect(result.adminDeploymentId).toBe('admin-proj-dep');
+    const projects = vi.mocked(deployPagesProject).mock.calls.map(([a]) => a.projectName);
+    expect(projects).toEqual(['admin-proj']);
+    const liffEvents = events.filter((e) => e.step === 'liff');
+    expect(liffEvents).toHaveLength(1);
+    expect(liffEvents[0].status).toBe('done');
+  });
+
+  it('still deploys LIFF Pages for the legacy 3-artifact topology', async () => {
+    const { ev } = emitter();
+    const result = await runApply(ctx(), bundle(), ev);
+
+    expect(result.liffDeploymentId).toBe('liff-proj-dep');
+    const projects = vi.mocked(deployPagesProject).mock.calls.map(([a]) => a.projectName);
+    expect(projects).toEqual(['admin-proj', 'liff-proj']);
+  });
+
+  it('uploads the Worker with keep_assets + nodejs_compat and preserved bindings', async () => {
+    const { ev } = emitter();
+    await runApply(ctx(), bundle(), ev);
+
+    expect(putWorkerScript).toHaveBeenCalledTimes(1);
+    const args = vi.mocked(putWorkerScript).mock.calls[0][0];
+    expect(args.keepAssets).toBe(true);
+    expect(args.compatibilityFlags).toEqual(['nodejs_compat']);
+    expect(args.bindings).toEqual([
+      { type: 'd1', name: 'DB', database_id: 'd1id' },
+      { type: 'assets', name: 'ASSETS' },
+    ]);
+  });
+});

--- a/packages/update-engine/test/verify-integrity.test.ts
+++ b/packages/update-engine/test/verify-integrity.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  verifyBundleIntegrity,
+  BundleNotDeployableError,
+  type BundleHashes,
+} from '../src/bundle.js';
+
+const computed: BundleHashes = {
+  worker: 'sha256:workerbytes',
+  admin: 'sha256:adminbytes',
+  liff: 'sha256:liffbytes',
+};
+
+const entry = {
+  version: '0.17.0',
+  admin_hash: 'sha256:adminbytes',
+  liff_hash: 'sha256:liffbytes',
+  worker_bundle_hash: 'sha256:workerbytes',
+};
+
+describe('verifyBundleIntegrity', () => {
+  it('passes when worker bytes match worker_bundle_hash and admin/liff match', () => {
+    expect(() => verifyBundleIntegrity(computed, entry)).not.toThrow();
+  });
+
+  it('rejects releases without worker_bundle_hash (pre-pipeline bundles are undeployable)', () => {
+    const legacy = { ...entry, worker_bundle_hash: undefined };
+    expect(() => verifyBundleIntegrity(computed, legacy)).toThrow(
+      BundleNotDeployableError,
+    );
+    expect(() => verifyBundleIntegrity(computed, legacy)).toThrow(/0\.17\.0/);
+  });
+
+  it('rejects a tampered worker artifact', () => {
+    expect(() =>
+      verifyBundleIntegrity(computed, {
+        ...entry,
+        worker_bundle_hash: 'sha256:other',
+      }),
+    ).toThrow(/worker hash mismatch/);
+  });
+
+  it('rejects tampered admin / liff files', () => {
+    expect(() =>
+      verifyBundleIntegrity(
+        { ...computed, admin: 'sha256:evil' },
+        entry,
+      ),
+    ).toThrow(/admin hash mismatch/);
+    expect(() =>
+      verifyBundleIntegrity(
+        { ...computed, liff: 'sha256:evil' },
+        entry,
+      ),
+    ).toThrow(/liff hash mismatch/);
+  });
+});

--- a/packages/update-engine/test/workers-put.test.ts
+++ b/packages/update-engine/test/workers-put.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { putWorkerScript, type WorkerBinding } from '../src/cf-api/workers.js';
+
+const creds = { accountId: 'acc', apiToken: 'tok' };
+
+const BINDINGS: WorkerBinding[] = [
+  { type: 'd1', name: 'DB', database_id: 'd1id' },
+  { type: 'assets', name: 'ASSETS' },
+];
+
+/** Capture the metadata part of the multipart PUT body as parsed JSON. */
+async function capturedMetadata(
+  fetchMock: ReturnType<typeof vi.fn>,
+): Promise<Record<string, unknown>> {
+  const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+  const fd = init.body as FormData;
+  const blob = fd.get('metadata') as Blob;
+  return JSON.parse(await blob.text()) as Record<string, unknown>;
+}
+
+describe('putWorkerScript metadata', () => {
+  const originalFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({ ok: true, status: 200, text: async () => '' }) as unknown as Response);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('omits keep_assets and compatibility_flags by default (legacy call shape)', async () => {
+    await putWorkerScript({
+      creds,
+      scriptName: 'w',
+      scriptContent: Buffer.from('export default {}'),
+      bindings: BINDINGS,
+    });
+
+    const metadata = await capturedMetadata(fetchMock);
+    expect(metadata.main_module).toBe('worker.js');
+    expect(metadata.compatibility_date).toBe('2024-12-01');
+    expect(metadata.bindings).toEqual(BINDINGS);
+    expect(metadata).not.toHaveProperty('keep_assets');
+    expect(metadata).not.toHaveProperty('compatibility_flags');
+  });
+
+  it('sends keep_assets + compatibility_flags when requested', async () => {
+    await putWorkerScript({
+      creds,
+      scriptName: 'w',
+      scriptContent: Buffer.from('export default {}'),
+      bindings: BINDINGS,
+      keepAssets: true,
+      compatibilityFlags: ['nodejs_compat'],
+    });
+
+    const metadata = await capturedMetadata(fetchMock);
+    expect(metadata.keep_assets).toBe(true);
+    expect(metadata.compatibility_flags).toEqual(['nodejs_compat']);
+  });
+
+  it('omits compatibility_flags when the list is empty', async () => {
+    await putWorkerScript({
+      creds,
+      scriptName: 'w',
+      scriptContent: Buffer.from('export default {}'),
+      bindings: [],
+      compatibilityFlags: [],
+    });
+
+    const metadata = await capturedMetadata(fetchMock);
+    expect(metadata).not.toHaveProperty('compatibility_flags');
+  });
+
+  it('uploads the script bytes unchanged as the worker.js module part', async () => {
+    const script = Buffer.from('export default {fetch(){}}');
+    await putWorkerScript({
+      creds,
+      scriptName: 'w',
+      scriptContent: script,
+      bindings: [],
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const fd = init.body as FormData;
+    const blob = fd.get('worker.js') as Blob;
+    expect(Buffer.from(await blob.arrayBuffer())).toEqual(script);
+    expect(blob.type).toBe('application/javascript+module');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@line-harness/update-engine':
-        specifier: workspace:^0.0.2
+        specifier: workspace:^0.0.3
         version: link:../update-engine
       execa:
         specifier: ^9.5.2
@@ -198,6 +198,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.15)(lightningcss@1.32.0)
 
   packages/db:
     devDependencies:
@@ -7183,6 +7186,24 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@2.1.9(@types/node@22.19.15)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.15)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@2.1.9(@types/node@25.5.0)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
@@ -7200,6 +7221,16 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite@5.4.21(@types/node@22.19.15)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.8
+      rollup: 4.59.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
 
   vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0):
     dependencies:
@@ -7225,6 +7256,41 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       tsx: 4.23.0
+
+  vitest@2.1.9(@types/node@22.19.15)(lightningcss@1.32.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.15)(lightningcss@1.32.0)
+      vite-node: 2.1.9(@types/node@22.19.15)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@2.1.9(@types/node@25.5.0)(lightningcss@1.32.0):
     dependencies:


### PR DESCRIPTION
Upstream sync for the v0.17.0 release (installer/bundle-deploy + update-engine fixes). See CHANGELOG v0.17.0. Pairs with #206 (release pipeline); merge this first, then #206, then tag v0.17.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)