### PR TITLE
fix(auto-track): Flexメッセージの画像URLを計測リンクに書き換えない

### DIFF
--- a/apps/worker/src/services/auto-track.ts
+++ b/apps/worker/src/services/auto-track.ts
@@ -196,15 +196,60 @@ export async function autoTrackContent(
     return { messageType: 'text', content: result };
   }
 
-  // Flex messages → replace URLs inline in the JSON
-  // For app-link domains, also inject openExternalBrowser=1 into the URI action
-  const urlMap = await createTrackingMap(db, urls, workerUrl);
-  let result = content;
-  for (const [original, { trackingUrl, originalUrl }] of urlMap) {
-    const finalUrl = isAppLinkDomain(originalUrl)
-      ? appendOpenExternalBrowser(trackingUrl)
-      : trackingUrl;
-    result = result.split(original).join(finalUrl);
+  // Flex messages → rewrite ONLY uri actions (action / defaultAction).
+  // Never rewrite the `url` field of image/video/icon components: LINE's image
+  // loader fetches that URL directly, and the tracking endpoint returns an HTML
+  // interstitial (not an image), which renders hero/body images as blank space.
+  let tree: unknown;
+  try {
+    tree = JSON.parse(content);
+  } catch {
+    // Not valid JSON — leave untouched rather than risk corrupting the payload
+    return { messageType, content };
   }
-  return { messageType, content: result };
+  const actionUris = new Set<string>();
+  collectActionUris(tree, actionUris);
+  const trackableUris = new Set([...actionUris].filter((u) => !shouldSkip(u)));
+  if (trackableUris.size === 0) return { messageType, content };
+  const uriMap = await createTrackingMap(db, trackableUris, workerUrl);
+  rewriteActionUris(tree, (u) => {
+    const tracked = uriMap.get(u);
+    if (!tracked) return u;
+    return isAppLinkDomain(u)
+      ? appendOpenExternalBrowser(tracked.trackingUrl)
+      : tracked.trackingUrl;
+  });
+  return { messageType, content: JSON.stringify(tree) };
+}
+
+/** Collect every action/defaultAction uri in a Flex JSON tree */
+function collectActionUris(node: unknown, out: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const child of node) collectActionUris(child, out);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  for (const key of ['action', 'defaultAction']) {
+    const a = obj[key] as Record<string, unknown> | undefined;
+    if (a && a.type === 'uri' && typeof a.uri === 'string') out.add(a.uri);
+  }
+  for (const value of Object.values(obj)) collectActionUris(value, out);
+}
+
+/** Rewrite every action/defaultAction uri in a Flex JSON tree */
+function rewriteActionUris(node: unknown, fn: (u: string) => string): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const child of node) rewriteActionUris(child, fn);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  for (const key of ['action', 'defaultAction']) {
+    const a = obj[key] as Record<string, unknown> | undefined;
+    if (a && a.type === 'uri' && typeof a.uri === 'string') {
+      a.uri = fn(a.uri as string);
+    }
+  }
+  for (const value of Object.values(obj)) rewriteActionUris(value, fn);
 }


### PR DESCRIPTION
## 問題

`autoTrackContent` はFlexメッセージのJSON文字列に含まれる全URLを文字列置換でトラッキングリンク（`/t/:id`）に書き換えますが、この際 **hero/body の image コンポーネントの `url` フィールドまで書き換えて**しまいます。

LINEクライアントの画像ローダーは書き換えられたURLへ画像を取りに行き、トラッキングエンドポイントのHTML（クリック計測用）を受け取るため、**画像領域が空白でレンダリングされます**（iOS・PC版の両方で再現）。

## 再現手順

1. 外部画像をheroに持つFlexバブルを `POST /api/friends/:id/messages`（またはシナリオステップ）で送信
2. 受信すると画像領域が空白になる（テキスト・ボタンは正常）
3. 同じJSONをLINE Messaging APIへ直接送ると正常に表示される

※ YouTube等の「アプリリンクドメイン」の画像だけ表示されるのは、`/t/` がそれらに対しリダイレクトを返すためで、通常URLはHTML interstitialが返るため空白になります。

## 修正

Flexメッセージについては、JSONをパースして **`action` / `defaultAction` の `type: "uri"` の `uri` のみ**をトラッキングリンク化し、image等の `url` フィールドには触れないようにしました。

- ボタンのクリック計測は従来通り機能します
- appリンクドメインへの `openExternalBrowser=1` 付与も維持
- JSONパースに失敗した場合は安全側（書き換えなし）に倒します

## 動作確認

- 修正前: hero画像が空白（スマホ/PC両方）
- 修正後: hero画像表示・ボタンは `/t/` 経由でクリック計測されることを実機で確認（シナリオエンジン経由の自動配信でも確認済み）