### PR TITLE
sync: v0.18.0 — branded short domain + short codes for tracked links

### DIFF
--- a/apps/web/src/components/accounts/link-base-url-setting.tsx
+++ b/apps/web/src/components/accounts/link-base-url-setting.tsx
@@ -4,15 +4,25 @@ import { useState, useEffect } from 'react'
 import { api } from '@/lib/api'
 
 /**
- * Global short-link base URL setting.
+ * Global short-link domain settings (deployment-wide, not per-account).
  *
- * When set, affiliate click-through links use this domain instead of the
- * built-in Worker redirect route.  The operator must configure a Redirect
- * Rule on that domain to forward requests to the Worker's /r/ path.
- *
- * This is a deployment-wide setting — not per-account.
+ * 1. link_base_url — affiliate click-through links. The operator configures a
+ *    Redirect Rule that forwards the domain's root paths to the Worker's /r/.
+ * 2. tracked_link_base_url — message tracked links (/t/<code>) created by
+ *    auto-shortening. The domain must route /t/* to the Worker as-is
+ *    (path-preserving Redirect Rule or Custom Domain). Kept separate from
+ *    link_base_url because existing affiliate domains map everything to /r/.
  */
-export default function LinkBaseUrlSetting() {
+
+interface UrlSettingCardProps {
+  title: string
+  description: React.ReactNode
+  placeholder: string
+  load: () => Promise<{ success: boolean; data: string | null }>
+  save: (value: string) => Promise<{ success: boolean; error?: string }>
+}
+
+function UrlSettingCard({ title, description, placeholder, load, save }: UrlSettingCardProps) {
   const [value, setValue] = useState('')
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -23,7 +33,7 @@ export default function LinkBaseUrlSetting() {
     let cancelled = false
     ;(async () => {
       try {
-        const res = await api.accountSettings.getLinkBaseUrl()
+        const res = await load()
         if (!cancelled && res.success) {
           setValue(res.data ?? '')
         }
@@ -31,6 +41,7 @@ export default function LinkBaseUrlSetting() {
       finally { if (!cancelled) setLoading(false) }
     })()
     return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleSave = async () => {
@@ -38,7 +49,7 @@ export default function LinkBaseUrlSetting() {
     setError('')
     setSaved(false)
     try {
-      const res = await api.accountSettings.updateLinkBaseUrl(value.trim())
+      const res = await save(value.trim())
       if (res.success) {
         // Normalise stored value: strip trailing slash to match server behaviour.
         setValue(value.trim().replace(/\/$/, ''))
@@ -60,18 +71,15 @@ export default function LinkBaseUrlSetting() {
 
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-      <h3 className="text-sm font-semibold text-gray-800 mb-1">短縮リンクドメイン（全アカウント共通）</h3>
-      <p className="text-xs text-gray-500 mb-3">
-        短縮ドメインを使う場合に設定。例: <code className="bg-gray-100 px-1 rounded">https://go.example.com</code>
-        （そのドメインから Worker の /r/ へ転送する Redirect Rule が必要）
-      </p>
+      <h3 className="text-sm font-semibold text-gray-800 mb-1">{title}</h3>
+      <p className="text-xs text-gray-500 mb-3">{description}</p>
       <div className="flex gap-2 items-start">
         <div className="flex-1">
           <input
             type="url"
             value={value}
             onChange={(e) => setValue(e.target.value)}
-            placeholder="https://go.example.com（空欄でデフォルト /r/ を使用）"
+            placeholder={placeholder}
             className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-400"
           />
           {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
@@ -86,5 +94,39 @@ export default function LinkBaseUrlSetting() {
         </button>
       </div>
     </div>
+  )
+}
+
+export default function LinkBaseUrlSetting() {
+  return (
+    <>
+      <UrlSettingCard
+        title="アフィリリンクドメイン（全アカウント共通）"
+        description={
+          <>
+            アフィリエイト配布リンクに短縮ドメインを使う場合に設定。例:{' '}
+            <code className="bg-gray-100 px-1 rounded">https://go.example.com</code>
+            （そのドメインから Worker の /r/ へ転送する Redirect Rule が必要）
+          </>
+        }
+        placeholder="https://go.example.com（空欄でデフォルト /r/ を使用）"
+        load={api.accountSettings.getLinkBaseUrl}
+        save={api.accountSettings.updateLinkBaseUrl}
+      />
+      <UrlSettingCard
+        title="メッセージ内リンクの短縮ドメイン（全アカウント共通）"
+        description={
+          <>
+            配信メッセージの自動短縮リンク（/t/…）に使うドメイン。例:{' '}
+            <code className="bg-gray-100 px-1 rounded">https://go.example.com</code>
+            {' '}→ リンクは <code className="bg-gray-100 px-1 rounded">https://go.example.com/t/Ab3xY9k</code> 形式に。
+            そのドメインの <code className="bg-gray-100 px-1 rounded">/t/*</code> をパスそのまま Worker へ転送する設定（Redirect Rule 等）が必要。詳細は wiki「Tracked Links」参照
+          </>
+        }
+        placeholder="https://go.example.com（空欄で Worker URL を使用）"
+        load={api.accountSettings.getTrackedLinkBaseUrl}
+        save={api.accountSettings.updateTrackedLinkBaseUrl}
+      />
+    </>
   )
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -426,6 +426,13 @@ export const api = {
         method: 'PUT',
         body: JSON.stringify({ value }),
       }),
+    getTrackedLinkBaseUrl: () =>
+      fetchApi<{ success: boolean; data: string | null }>('/api/account-settings/tracked-link-base-url'),
+    updateTrackedLinkBaseUrl: (value: string) =>
+      fetchApi<{ success: boolean; error?: string }>('/api/account-settings/tracked-link-base-url', {
+        method: 'PUT',
+        body: JSON.stringify({ value }),
+      }),
   },
 
   // ── Round 2 APIs ─────────────────────────────────────────────────────────

--- a/apps/worker/src/lib/link-base-url.ts
+++ b/apps/worker/src/lib/link-base-url.ts
@@ -1,4 +1,4 @@
-import { getLinkBaseUrl } from '@line-crm/db';
+import { getLinkBaseUrl, getTrackedLinkBaseUrl } from '@line-crm/db';
 
 /**
  * Resolve the base URL used to build affiliate link click URLs.
@@ -41,4 +41,25 @@ export async function resolveLinkBaseUrl(
     );
   }
   return workerUrl.replace(/\/$/, '') + '/r';
+}
+
+/**
+ * Resolve the base URL used to build message tracked-link URLs (/t/<code>).
+ *
+ * Priority:
+ *  1. DB-configured `tracked_link_base_url` global setting — a short branded
+ *     domain that routes /t/* to the Worker (Redirect Rule or Custom Domain).
+ *  2. `fallback` — the Worker's own URL (WORKER_URL or request origin).
+ *
+ * Unlike the affiliate base above, no path segment is appended here: callers
+ * always build `${base}/t/${code}` themselves so both branches produce the
+ * same URL shape.
+ */
+export async function resolveTrackedLinkBaseUrl(
+  db: D1Database,
+  fallback: string,
+): Promise<string> {
+  const stored = await getTrackedLinkBaseUrl(db, '__global__');
+  if (stored) return stored;
+  return fallback.replace(/\/$/, '');
 }

--- a/apps/worker/src/routes/account-settings.ts
+++ b/apps/worker/src/routes/account-settings.ts
@@ -1,5 +1,10 @@
 import { Hono } from 'hono';
-import { getLinkBaseUrl, setLinkBaseUrl } from '@line-crm/db';
+import {
+  getLinkBaseUrl,
+  setLinkBaseUrl,
+  getTrackedLinkBaseUrl,
+  setTrackedLinkBaseUrl,
+} from '@line-crm/db';
 import type { Env } from '../index.js';
 
 const accountSettings = new Hono<Env>();
@@ -79,6 +84,30 @@ accountSettings.put('/api/account-settings/link-base-url', async (c) => {
 
   try {
     await setLinkBaseUrl(c.env.DB, '__global__', value);
+    return c.json({ success: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Validation error';
+    return c.json({ success: false, error: message }, 400);
+  }
+});
+
+// ── tracked_link_base_url (global setting) ────────────────────────────────────
+// Base domain for message tracked links (/t/<code>). The domain must route
+// /t/* to the Worker (Redirect Rule or Custom Domain). Unset → WORKER_URL.
+
+accountSettings.get('/api/account-settings/tracked-link-base-url', async (c) => {
+  const value = await getTrackedLinkBaseUrl(c.env.DB, '__global__');
+  return c.json({ success: true, data: value });
+});
+
+accountSettings.put('/api/account-settings/tracked-link-base-url', async (c) => {
+  const body = await c.req
+    .json<{ value?: string }>()
+    .catch((): { value?: string } => ({}));
+  const value = typeof body.value === 'string' ? body.value : '';
+
+  try {
+    await setTrackedLinkBaseUrl(c.env.DB, '__global__', value);
     return c.json({ success: true });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Validation error';

--- a/apps/worker/src/routes/tracked-links.test.ts
+++ b/apps/worker/src/routes/tracked-links.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test, beforeEach, vi } from 'vitest';
 const dbMocks = {
   getTrackedLinks: vi.fn(),
   getTrackedLinkById: vi.fn(),
+  getTrackedLinkByIdOrShortCode: vi.fn(),
   createTrackedLink: vi.fn(),
   updateTrackedLink: vi.fn(),
   deleteTrackedLink: vi.fn(),
@@ -13,6 +14,8 @@ const dbMocks = {
   getFriendByLineUserId: vi.fn(),
   addTagToFriend: vi.fn(),
   enrollFriendInScenario: vi.fn(),
+  getTrackedLinkBaseUrl: vi.fn(),
+  getLinkBaseUrl: vi.fn(),
 };
 vi.mock('@line-crm/db', () => dbMocks);
 
@@ -75,6 +78,7 @@ function makeLink(overrides: Record<string, unknown> = {}) {
     intro_template_id: null,
     reward_template_id: null,
     line_account_id: null,
+    short_code: null,
     is_active: 1,
     click_count: 0,
     og_title: null,
@@ -91,9 +95,9 @@ const executionCtx = {
   passThroughOnException: () => {},
 } as unknown as ExecutionContext;
 
-function request(env: Record<string, unknown>, ua: string) {
+function request(env: Record<string, unknown>, ua: string, path = '/t/link-1') {
   return trackedLinks.request(
-    'https://worker.example.com/t/link-1',
+    `https://worker.example.com${path}`,
     { headers: { 'user-agent': ua }, redirect: 'manual' },
     env,
     executionCtx,
@@ -103,11 +107,12 @@ function request(env: Record<string, unknown>, ua: string) {
 beforeEach(() => {
   vi.clearAllMocks();
   dbMocks.recordLinkClick.mockResolvedValue({});
+  dbMocks.getTrackedLinkBaseUrl.mockResolvedValue(null);
 });
 
 describe('GET /t/:linkId — per-account LIFF resolution', () => {
   test('link owned by an account redirects LINE in-app clicks to that account LIFF', async () => {
-    dbMocks.getTrackedLinkById.mockResolvedValue(makeLink({ line_account_id: 'acc-1b' }));
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(makeLink({ line_account_id: 'acc-1b' }));
     const env = {
       DB: makeDb({ accounts: [{ id: 'acc-1b', liff_id: '2009668520-YghzbHx9' }] }),
       LIFF_URL: 'https://liff.line.me/2009554425-4IMBmLQ9',
@@ -121,7 +126,7 @@ describe('GET /t/:linkId — per-account LIFF resolution', () => {
   });
 
   test('falls back to scenario account when link has no line_account_id', async () => {
-    dbMocks.getTrackedLinkById.mockResolvedValue(makeLink({ scenario_id: 'scn-1' }));
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(makeLink({ scenario_id: 'scn-1' }));
     const env = {
       DB: makeDb({
         scenarios: [{ id: 'scn-1', line_account_id: 'acc-2' }],
@@ -136,7 +141,7 @@ describe('GET /t/:linkId — per-account LIFF resolution', () => {
   });
 
   test('falls back to env.LIFF_URL when no owning account is resolvable', async () => {
-    dbMocks.getTrackedLinkById.mockResolvedValue(makeLink());
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(makeLink());
     const env = {
       DB: makeDb({}),
       LIFF_URL: 'https://liff.line.me/2009554425-4IMBmLQ9',
@@ -148,7 +153,7 @@ describe('GET /t/:linkId — per-account LIFF resolution', () => {
   });
 
   test('account without liff_id falls back to env.LIFF_URL', async () => {
-    dbMocks.getTrackedLinkById.mockResolvedValue(makeLink({ line_account_id: 'acc-x' }));
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(makeLink({ line_account_id: 'acc-x' }));
     const env = {
       DB: makeDb({ accounts: [{ id: 'acc-x', liff_id: null }] }),
       LIFF_URL: 'https://liff.line.me/2009554425-4IMBmLQ9',
@@ -160,7 +165,7 @@ describe('GET /t/:linkId — per-account LIFF resolution', () => {
   });
 
   test('non-LINE browsers redirect straight to the original URL', async () => {
-    dbMocks.getTrackedLinkById.mockResolvedValue(makeLink({ line_account_id: 'acc-1b' }));
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(makeLink({ line_account_id: 'acc-1b' }));
     const env = {
       DB: makeDb({ accounts: [{ id: 'acc-1b', liff_id: '2009668520-YghzbHx9' }] }),
       LIFF_URL: 'https://liff.line.me/2009554425-4IMBmLQ9',
@@ -169,5 +174,51 @@ describe('GET /t/:linkId — per-account LIFF resolution', () => {
     const res = await request(env, 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15');
     expect(res.status).toBe(302);
     expect(res.headers.get('location')).toBe('https://example.com/lp');
+  });
+});
+
+describe('GET /t/:linkId — short codes', () => {
+  test('short-code URLs resolve and record the click against the link UUID', async () => {
+    const waits: Promise<unknown>[] = [];
+    const collectingCtx = {
+      waitUntil: (p: Promise<unknown>) => waits.push(p),
+      passThroughOnException: () => {},
+    } as unknown as ExecutionContext;
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(
+      makeLink({ id: 'uuid-link-1', short_code: 'Ab3xY9k' }),
+    );
+    const env = {
+      DB: makeDb({}),
+      LIFF_URL: 'https://liff.line.me/2009554425-4IMBmLQ9',
+      WORKER_URL: 'https://worker.example.com',
+    };
+    const res = await trackedLinks.request(
+      'https://worker.example.com/t/Ab3xY9k',
+      { headers: { 'user-agent': 'Mozilla/5.0 Safari/605.1.15' }, redirect: 'manual' },
+      env,
+      collectingCtx,
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://example.com/lp');
+    expect(dbMocks.getTrackedLinkByIdOrShortCode).toHaveBeenCalledWith(env.DB, 'Ab3xY9k');
+    await Promise.allSettled(waits);
+    // Click must be recorded against the UUID, not the short code
+    expect(dbMocks.recordLinkClick).toHaveBeenCalledWith(env.DB, 'uuid-link-1', null);
+  });
+
+  test('LINE in-app LIFF round-trip keeps the same /t identifier', async () => {
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(
+      makeLink({ id: 'uuid-link-1', short_code: 'Ab3xY9k', line_account_id: 'acc-1b' }),
+    );
+    const env = {
+      DB: makeDb({ accounts: [{ id: 'acc-1b', liff_id: '2009668520-YghzbHx9' }] }),
+      LIFF_URL: 'https://liff.line.me/2009554425-4IMBmLQ9',
+      WORKER_URL: 'https://worker.example.com',
+    };
+    const res = await request(env, LINE_UA, '/t/Ab3xY9k');
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain(
+      encodeURIComponent('https://worker.example.com/t/Ab3xY9k'),
+    );
   });
 });

--- a/apps/worker/src/routes/tracked-links.ts
+++ b/apps/worker/src/routes/tracked-links.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import {
   getTrackedLinks,
   getTrackedLinkById,
+  getTrackedLinkByIdOrShortCode,
   createTrackedLink,
   updateTrackedLink,
   deleteTrackedLink,
@@ -15,16 +16,19 @@ import type { Env } from '../index.js';
 import { isLinkPreviewBot } from '../lib/og-bot.js';
 import { buildOgHtml } from '../lib/og-html.js';
 import { resolveOgForTrackedLink } from '../lib/og-resolver.js';
+import { resolveTrackedLinkBaseUrl } from '../lib/link-base-url.js';
 
 const trackedLinks = new Hono<Env>();
 
 function serializeTrackedLink(row: TrackedLink, baseUrl: string) {
-  const trackingUrl = `${baseUrl}/t/${row.id}`;
+  // Prefer the short code (baseUrl may be a branded short domain).
+  const trackingUrl = `${baseUrl}/t/${row.short_code ?? row.id}`;
   return {
     id: row.id,
     name: row.name,
     originalUrl: row.original_url,
     trackingUrl,
+    shortCode: row.short_code,
     tagId: row.tag_id,
     scenarioId: row.scenario_id,
     introTemplateId: row.intro_template_id,
@@ -43,6 +47,11 @@ function serializeTrackedLink(row: TrackedLink, baseUrl: string) {
 function getBaseUrl(c: { req: { url: string } }): string {
   const url = new URL(c.req.url);
   return `${url.protocol}//${url.host}`;
+}
+
+/** Base for admin-facing trackingUrl: branded short domain or the request origin. */
+async function resolveApiLinkBase(c: { env: { DB: D1Database }; req: { url: string } }): Promise<string> {
+  return resolveTrackedLinkBaseUrl(c.env.DB, getBaseUrl(c));
 }
 
 /**
@@ -73,7 +82,7 @@ async function resolveLinkAccount(
 trackedLinks.get('/api/tracked-links', async (c) => {
   try {
     const items = await getTrackedLinks(c.env.DB);
-    const base = getBaseUrl(c);
+    const base = await resolveApiLinkBase(c);
     return c.json({ success: true, data: items.map((item) => serializeTrackedLink(item, base)) });
   } catch (err) {
     console.error('GET /api/tracked-links error:', err);
@@ -90,7 +99,7 @@ trackedLinks.get('/api/tracked-links/:id', async (c) => {
       return c.json({ success: false, error: 'Tracked link not found' }, 404);
     }
     const clicks = await getLinkClicks(c.env.DB, id);
-    const base = getBaseUrl(c);
+    const base = await resolveApiLinkBase(c);
     return c.json({
       success: true,
       data: {
@@ -142,7 +151,7 @@ trackedLinks.post('/api/tracked-links', async (c) => {
       ogImageUrl: body.ogImageUrl ?? null,
     });
 
-    const base = getBaseUrl(c);
+    const base = await resolveApiLinkBase(c);
     return c.json({ success: true, data: serializeTrackedLink(link, base) }, 201);
   } catch (err) {
     console.error('POST /api/tracked-links error:', err);
@@ -171,7 +180,7 @@ trackedLinks.patch('/api/tracked-links/:id', async (c) => {
     if (!link) {
       return c.json({ success: false, error: 'Tracked link not found' }, 404);
     }
-    const base = getBaseUrl(c);
+    const base = await resolveApiLinkBase(c);
     return c.json({ success: true, data: serializeTrackedLink(link, base) });
   } catch (err) {
     console.error('PATCH /api/tracked-links/:id error:', err);
@@ -269,13 +278,14 @@ function buildAppRedirectHtml(destinationUrl: string): string {
 }
 
 // GET /t/:linkId — click tracking redirect (no auth, fast redirect)
+// :linkId accepts both the legacy UUID and the 7-char short code.
 trackedLinks.get('/t/:linkId', async (c) => {
   const linkId = c.req.param('linkId');
   const lineUserId = c.req.query('lu') ?? null;
   let friendId = c.req.query('f') ?? null;
 
   // Look up the link first
-  const link = await getTrackedLinkById(c.env.DB, linkId);
+  const link = await getTrackedLinkByIdOrShortCode(c.env.DB, linkId);
 
   if (!link || !link.is_active) {
     return c.json({ success: false, error: 'Link not found' }, 404);
@@ -327,8 +337,8 @@ trackedLinks.get('/t/:linkId', async (c) => {
   ctx.waitUntil(
     (async () => {
       try {
-        // Record the click
-        await recordLinkClick(c.env.DB, linkId, friendId);
+        // Record the click (link.id, not the raw param — it may be a short code)
+        await recordLinkClick(c.env.DB, link.id, friendId);
 
         // Run automatic actions if a friend is identified
         if (friendId) {

--- a/apps/worker/src/services/auto-track.ts
+++ b/apps/worker/src/services/auto-track.ts
@@ -1,4 +1,5 @@
 import { createTrackedLink } from '@line-crm/db';
+import { resolveTrackedLinkBaseUrl } from '../lib/link-base-url.js';
 
 // Domains where Universal Links / App Links should be used
 const APP_LINK_DOMAINS = new Set([
@@ -45,22 +46,25 @@ const URL_REGEX = /https?:\/\/[^\s"'<>\])}]+/g;
 
 // URLs that should NOT be wrapped (internal/system URLs)
 const SKIP_PATTERNS = [
-  /\/t\/[0-9a-f-]{36}/,       // already a tracking link
+  /\/t\/[0-9a-f-]{36}/,       // already a tracking link (legacy UUID form)
   /liff\.line\.me/,            // LIFF URLs
   /line\.me\/R\//,             // LINE deep links
   /your-worker-name/,           // our own worker
 ];
 
-function shouldSkip(url: string): boolean {
-  return SKIP_PATTERNS.some((p) => p.test(url));
+function shouldSkip(url: string, skipPrefixes: string[]): boolean {
+  if (SKIP_PATTERNS.some((p) => p.test(url))) return true;
+  // Short-code tracking links (/t/Ab3xY9k) don't match the UUID pattern, so
+  // skip anything under our own worker or the configured short domain.
+  return skipPrefixes.some((prefix) => prefix && url.startsWith(`${prefix}/t/`));
 }
 
 /** Extract trackable URLs from content string */
-function extractUrls(content: string): Set<string> {
+function extractUrls(content: string, skipPrefixes: string[]): Set<string> {
   const urls = new Set<string>();
   for (const match of content.matchAll(URL_REGEX)) {
     const url = match[0].replace(/[.,;:!?)]+$/, '');
-    if (!shouldSkip(url)) urls.add(url);
+    if (!shouldSkip(url, skipPrefixes)) urls.add(url);
   }
   return urls;
 }
@@ -69,7 +73,7 @@ function extractUrls(content: string): Set<string> {
 async function createTrackingMap(
   db: D1Database,
   urls: Set<string>,
-  workerUrl: string,
+  linkBase: string,
   lineAccountId?: string | null,
 ): Promise<Map<string, { trackingUrl: string; originalUrl: string; label: string }>> {
   const urlMap = new Map<string, { trackingUrl: string; originalUrl: string; label: string }>();
@@ -79,8 +83,9 @@ async function createTrackingMap(
       originalUrl: url,
       lineAccountId: lineAccountId ?? null,
     });
-    // Use direct /t/ URL — Worker handles LINE app detection and LIFF redirect server-side
-    const trackingUrl = `${workerUrl}/t/${link.id}`;
+    // /t/ URL — Worker handles LINE app detection and LIFF redirect server-side.
+    // Prefer the short code (linkBase may be a branded short domain).
+    const trackingUrl = `${linkBase}/t/${link.short_code ?? link.id}`;
     const hostname = new URL(url).hostname.replace('www.', '');
     const label = hostname.length > 20 ? hostname.slice(0, 20) + '…' : hostname;
     urlMap.set(url, { trackingUrl, originalUrl: url, label });
@@ -178,8 +183,19 @@ export async function autoTrackContent(
 ): Promise<AutoTrackResult> {
   if (messageType === 'image') return { messageType, content };
 
-  const urls = extractUrls(content);
+  // Extract first so URL-free messages (the common case in per-friend
+  // delivery loops) skip the settings lookup entirely.
+  const workerBase = workerUrl.replace(/\/$/, '');
+  let urls = extractUrls(content, [workerBase]);
   if (urls.size === 0) return { messageType, content };
+
+  // Branded short domain (tracked_link_base_url) when configured, else workerUrl.
+  // Re-filter: short-domain /t links are already tracked — never re-wrap them.
+  const linkBase = await resolveTrackedLinkBaseUrl(db, workerUrl);
+  if (linkBase !== workerBase) {
+    urls = new Set([...urls].filter((u) => !u.startsWith(`${linkBase}/t/`)));
+    if (urls.size === 0) return { messageType, content };
+  }
 
   // Text messages: app-link domain (YouTube / X / TikTok 等) は raw URL を残して
   //   `?openExternalBrowser=1` だけ付ける。LINE 上で rich preview (YT サムネ等) が
@@ -192,7 +208,7 @@ export async function autoTrackContent(
     // (無駄な link_clicks レコード防止)。
     const trackable = new Set([...urls].filter((u) => !isAppLinkDomain(u)));
     const urlMap = trackable.size > 0
-      ? await createTrackingMap(db, trackable, workerUrl, options?.lineAccountId)
+      ? await createTrackingMap(db, trackable, linkBase, options?.lineAccountId)
       : new Map<string, { trackingUrl: string; originalUrl: string; label: string }>();
 
     let result = content;
@@ -211,7 +227,7 @@ export async function autoTrackContent(
 
   // Flex messages → replace URLs inline in the JSON
   // For app-link domains, also inject openExternalBrowser=1 into the URI action
-  const urlMap = await createTrackingMap(db, urls, workerUrl, options?.lineAccountId);
+  const urlMap = await createTrackingMap(db, urls, linkBase, options?.lineAccountId);
   let result = content;
   for (const [original, { trackingUrl, originalUrl }] of urlMap) {
     const finalUrl = isAppLinkDomain(originalUrl)

--- a/docs/wiki/10-Tracked-Links.md
+++ b/docs/wiki/10-Tracked-Links.md
@@ -52,6 +52,15 @@ CREATE TABLE tracked_links (
 );
 ```
 
+後続マイグレーションで追加された主なカラム:
+
+| カラム | 追加 | 用途 |
+|--------|------|------|
+| `intro_template_id` / `reward_template_id` | 020/021 | キャンペーン intro / 特典メッセージ |
+| `og_title` / `og_description` / `og_image_url` | 042 | リンクプレビュー OGP 上書き |
+| `line_account_id` | 046 | リンク所有アカウント（/t の LIFF 解決・OGP に使用） |
+| `short_code` | 049 | 7文字ショートコード（短縮ドメイン用、UNIQUE） |
+
 ### link_clicks テーブル
 
 ```sql
@@ -71,11 +80,13 @@ CREATE INDEX idx_link_clicks_friend ON link_clicks (friend_id);
 ### トラッキングURL形式
 
 ```
-https://your-worker.your-subdomain.workers.dev/t/{linkId}?f={friendId}
+https://<your-worker>/t/{code}?f={friendId}
+https://go.example.com/t/{code}          ← 短縮ドメイン設定時（v0.18.0+）
 ```
 
-- `linkId`: tracked_linksのID（UUID）
+- `code`: 7文字のショートコード（`short_code`、v0.18.0以降の新規リンク）または tracked_links の ID（UUID、旧リンク）。`/t/:linkId` は両方を解決する
 - `f`: friendsテーブルのID（オプション。メッセージ内で動的に埋め込む）
+- 過去に配信済みの UUID 形式 URL は短縮ドメイン設定後もそのまま有効
 
 ### 処理フロー
 
@@ -96,6 +107,55 @@ https://your-worker.your-subdomain.workers.dev/t/{linkId}?f={friendId}
 |---|---|---|---|---|
 | 匿名 | なし | `friend_id=NULL` で記録 | なし | なし |
 | 友だち特定 | あり | `friend_id` 付きで記録 | 実行 | 実行 |
+
+## 短縮ドメイン設定（メッセージ内リンク）
+
+自動短縮で生成される `/t/` リンクを、Worker のデフォルト URL ではなく独自の短いドメインで配信できる。
+
+```
+未設定:  https://<your-worker>.workers.dev/t/<36文字UUID>   （約90文字）
+設定後:  https://go.example.com/t/Ab3xY9k                   （約35文字）
+```
+
+### 設定方法
+
+管理画面 → アカウント管理 → 「メッセージ内リンクの短縮ドメイン」に `https://go.example.com` を入力して保存。API では:
+
+```
+PUT /api/account-settings/tracked-link-base-url
+{ "value": "https://go.example.com" }
+```
+
+グローバル設定（`account_settings` の `tracked_link_base_url`、accountId=`'__global__'`）。空文字で解除（Worker URL に戻る）。
+
+**アフィリリンク用の `link_base_url` とは別の設定**。既存環境がアフィリ用に設定しているドメインは全パスを `/r/` に転送しているため、同じ値を流用すると /t リンクが壊れる。同じドメインを両方に使いたい場合は下のパターンAで Redirect Rule を追加する。
+
+### ドメイン側の設定パターン
+
+ドメインの `/t/*` を**パスそのまま** Worker に届ける必要がある。
+
+**パターンA: アフィリリンクと同一ドメインで同居**
+
+Cloudflare Redirect Rules を2本、この順序で設定（ゾーンと Worker のアカウントが違ってもよい）:
+
+| 順序 | If (条件) | Then (転送先) | 備考 |
+|------|-----------|---------------|------|
+| 1 | URI Path starts with `/t/` | `concat("https://<your-worker>", http.request.uri.path)` | **「Preserve query string」を必ず ON**（`openExternalBrowser=1` 等が消えると挙動が壊れる） |
+| 2 | URI Path matches `/*` | `https://<your-worker>/r/${path}` | 既存のアフィリ用ルール |
+
+**パターンB: 専用サブドメインを新設**
+
+`t.example.com` 等を用意し、Redirect Rule 1本: `/*` → `concat("https://<your-worker>", http.request.uri.path)`（クエリ保持 ON）。アフィリ設定には触れない。
+
+**パターンC: Custom Domain 直結（ゾーンと Worker が同一 CF アカウントの場合のみ）**
+
+ドメインを Worker の Custom Domain として直接アタッチ。転送ホップが無くなり最速。ただし Workers の Custom Domain は同一アカウントのゾーンにしか張れない。
+
+### 挙動の詳細
+
+- ショートコードは作成時に自動生成される7文字の base62（62^7 ≈ 3.5兆通り、UNIQUE 制約 + 衝突時リトライ）
+- 管理画面・API の `trackingUrl` も短縮ドメイン + ショートコードで返る
+- LINE アプリ内クリック時の LIFF 識別リダイレクトや OGP 生成は従来どおり Worker 側で処理（短縮ドメインは入り口だけ）
 
 ## APIレスポンス形式
 
@@ -380,4 +440,4 @@ manage_tracked_links action=update linkId=<id> introTemplateId=<msg-template-id>
 - reward メッセージ生成 (Flex 描画): `apps/worker/src/services/reward-message.ts`
 - DB クエリ: `packages/db/src/tracked-links.ts`
 - SDK リソース: `packages/sdk/src/resources/tracked-links.ts`
-- マイグレーション: `packages/db/migrations/006_tracked_links.sql`, `020_tracked_link_intro.sql`, `021_tracked_link_reward.sql`, `022_friend_first_tracked_link.sql`
+- マイグレーション: `packages/db/migrations/006_tracked_links.sql`, `020_tracked_link_intro.sql`, `021_tracked_link_reward.sql`, `022_friend_first_tracked_link.sql`, `046_link_tracking_controls.sql`, `049_tracked_links_short_code.sql`

--- a/packages/db/bootstrap-meta.json
+++ b/packages/db/bootstrap-meta.json
@@ -54,7 +54,8 @@
     "046_affiliate_links.sql",
     "046_link_tracking_controls.sql",
     "047_affiliate_offers.sql",
-    "048_chats_friend_unique.sql"
+    "048_chats_friend_unique.sql",
+    "049_tracked_links_short_code.sql"
   ],
-  "migrationCount": 55
+  "migrationCount": 56
 }

--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -800,7 +800,7 @@ CREATE TABLE tracked_links (
   click_count INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-, intro_template_id TEXT REFERENCES message_templates (id) ON DELETE SET NULL, reward_template_id TEXT REFERENCES message_templates (id) ON DELETE SET NULL, og_title TEXT, og_description TEXT, og_image_url TEXT, line_account_id TEXT REFERENCES line_accounts(id) ON DELETE SET NULL);
+, intro_template_id TEXT REFERENCES message_templates (id) ON DELETE SET NULL, reward_template_id TEXT REFERENCES message_templates (id) ON DELETE SET NULL, og_title TEXT, og_description TEXT, og_image_url TEXT, line_account_id TEXT REFERENCES line_accounts(id) ON DELETE SET NULL, short_code TEXT);
 
 CREATE TABLE traffic_pools (
   id TEXT PRIMARY KEY,
@@ -999,6 +999,9 @@ CREATE INDEX idx_stripe_events_friend ON stripe_events (friend_id);
 CREATE INDEX idx_stripe_events_type ON stripe_events (event_type);
 
 CREATE INDEX idx_templates_category ON templates (category);
+
+CREATE UNIQUE INDEX idx_tracked_links_short_code
+  ON tracked_links (short_code) WHERE short_code IS NOT NULL;
 
 CREATE INDEX idx_update_history_started ON update_history(started_at DESC);
 

--- a/packages/db/migrations/049_tracked_links_short_code.sql
+++ b/packages/db/migrations/049_tracked_links_short_code.sql
@@ -1,0 +1,11 @@
+-- 049: Short codes for tracked links
+--
+-- tracked_links.short_code — 7-char base62 code so message links can be short:
+--   https://<short-domain>/t/Ab3xY9k   (instead of /t/<36-char-uuid>)
+-- /t/:linkId resolves both forms (UUID for legacy links, short_code for new ones).
+-- Codes are generated at creation time; existing rows keep NULL and continue to
+-- resolve by UUID only.
+
+ALTER TABLE tracked_links ADD COLUMN short_code TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tracked_links_short_code
+  ON tracked_links (short_code) WHERE short_code IS NOT NULL;

--- a/packages/db/src/account-settings.ts
+++ b/packages/db/src/account-settings.ts
@@ -45,20 +45,17 @@ export async function setAccountSetting(
     .run();
 }
 
-// ── link_base_url ─────────────────────────────────────────────────────────────
+// ── URL settings (link_base_url / tracked_link_base_url) ─────────────────────
 
 const LINK_BASE_URL_KEY = 'link_base_url';
+const TRACKED_LINK_BASE_URL_KEY = 'tracked_link_base_url';
 
-/**
- * Get the configured short-link base URL for an account.
- * Returns null when not set (caller should fall back to WORKER_URL/r).
- * The stored value has no trailing slash.
- */
-export async function getLinkBaseUrl(
+async function getUrlSetting(
   db: D1Database,
   accountId: string,
+  key: string,
 ): Promise<string | null> {
-  const raw = await getAccountSetting(db, accountId, LINK_BASE_URL_KEY);
+  const raw = await getAccountSetting(db, accountId, key);
   if (!raw) return null;
   try {
     return JSON.parse(raw) as string;
@@ -68,7 +65,7 @@ export async function getLinkBaseUrl(
 }
 
 /**
- * Validate and persist a link_base_url value for an account.
+ * Validate and persist an https URL setting.
  *
  * Rules:
  *  - Empty string clears the setting (returns without storing).
@@ -77,9 +74,10 @@ export async function getLinkBaseUrl(
  *
  * Throws a descriptive Error on validation failure.
  */
-export async function setLinkBaseUrl(
+async function setUrlSetting(
   db: D1Database,
   accountId: string,
+  key: string,
   value: string,
 ): Promise<void> {
   const trimmed = value.trim();
@@ -90,15 +88,60 @@ export async function setLinkBaseUrl(
       .prepare(
         `DELETE FROM account_settings WHERE line_account_id = ? AND key = ?`,
       )
-      .bind(accountId, LINK_BASE_URL_KEY)
+      .bind(accountId, key)
       .run();
     return;
   }
 
   if (!trimmed.startsWith('https://')) {
-    throw new Error('link_base_url must start with https://');
+    throw new Error(`${key} must start with https://`);
   }
 
   const normalized = trimmed.replace(/\/$/, '');
-  await setAccountSetting(db, accountId, LINK_BASE_URL_KEY, JSON.stringify(normalized));
+  await setAccountSetting(db, accountId, key, JSON.stringify(normalized));
+}
+
+/**
+ * Get the configured short-link base URL for an account (affiliate links).
+ * Returns null when not set (caller should fall back to WORKER_URL/r).
+ * The stored value has no trailing slash.
+ */
+export async function getLinkBaseUrl(
+  db: D1Database,
+  accountId: string,
+): Promise<string | null> {
+  return getUrlSetting(db, accountId, LINK_BASE_URL_KEY);
+}
+
+export async function setLinkBaseUrl(
+  db: D1Database,
+  accountId: string,
+  value: string,
+): Promise<void> {
+  return setUrlSetting(db, accountId, LINK_BASE_URL_KEY, value);
+}
+
+/**
+ * Get the configured base URL for message tracked links (/t/...).
+ * When set, auto-tracked message URLs are built as `${base}/t/<code>` instead
+ * of `${WORKER_URL}/t/<code>`. The domain must route /t/* to the Worker
+ * (Redirect Rule or Custom Domain). Returns null when not set.
+ *
+ * Kept separate from link_base_url on purpose: existing deployments map that
+ * domain's root paths to /r/ (affiliate), so silently reusing it for /t/
+ * would emit broken URLs on upgrade.
+ */
+export async function getTrackedLinkBaseUrl(
+  db: D1Database,
+  accountId: string,
+): Promise<string | null> {
+  return getUrlSetting(db, accountId, TRACKED_LINK_BASE_URL_KEY);
+}
+
+export async function setTrackedLinkBaseUrl(
+  db: D1Database,
+  accountId: string,
+  value: string,
+): Promise<void> {
+  return setUrlSetting(db, accountId, TRACKED_LINK_BASE_URL_KEY, value);
 }

--- a/packages/db/src/tracked-links.ts
+++ b/packages/db/src/tracked-links.ts
@@ -12,6 +12,7 @@ export interface TrackedLink {
   intro_template_id: string | null;
   reward_template_id: string | null;
   line_account_id: string | null;
+  short_code: string | null;
   is_active: number;
   click_count: number;
   og_title: string | null;
@@ -47,6 +48,48 @@ export async function getTrackedLinkById(
     .first<TrackedLink>();
 }
 
+/**
+ * Resolve a tracked link by either its UUID (legacy links) or its 7-char
+ * short code. UUIDs are 36 chars with dashes so the two namespaces never
+ * collide; try the cheap discriminator first, then fall back to the other
+ * column to be safe against unexpected identifier shapes.
+ */
+export async function getTrackedLinkByIdOrShortCode(
+  db: D1Database,
+  idOrCode: string,
+): Promise<TrackedLink | null> {
+  const looksLikeUuid = idOrCode.length === 36 && idOrCode.includes('-');
+  const first = looksLikeUuid
+    ? await getTrackedLinkById(db, idOrCode)
+    : await db
+        .prepare(`SELECT * FROM tracked_links WHERE short_code = ?`)
+        .bind(idOrCode)
+        .first<TrackedLink>();
+  if (first) return first;
+  return looksLikeUuid
+    ? db
+        .prepare(`SELECT * FROM tracked_links WHERE short_code = ?`)
+        .bind(idOrCode)
+        .first<TrackedLink>()
+    : getTrackedLinkById(db, idOrCode);
+}
+
+// Base62 alphabet — no ambiguity issues matter here (codes are copy-pasted,
+// not hand-typed), so keep the full 62-char space: 62^7 ≈ 3.5 trillion.
+const SHORT_CODE_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const SHORT_CODE_LENGTH = 7;
+
+export function generateShortCode(): string {
+  const bytes = new Uint8Array(SHORT_CODE_LENGTH);
+  crypto.getRandomValues(bytes);
+  let code = '';
+  for (const b of bytes) {
+    code += SHORT_CODE_ALPHABET[b % SHORT_CODE_ALPHABET.length];
+  }
+  return code;
+}
+
 export interface CreateTrackedLinkInput {
   name: string;
   originalUrl: string;
@@ -67,27 +110,40 @@ export async function createTrackedLink(
   const id = crypto.randomUUID();
   const now = jstNow();
 
-  await db
-    .prepare(
-      `INSERT INTO tracked_links (id, name, original_url, tag_id, scenario_id, intro_template_id, reward_template_id, line_account_id, is_active, click_count, og_title, og_description, og_image_url, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?, ?)`,
-    )
-    .bind(
-      id,
-      input.name,
-      input.originalUrl,
-      input.tagId ?? null,
-      input.scenarioId ?? null,
-      input.introTemplateId ?? null,
-      input.rewardTemplateId ?? null,
-      input.lineAccountId ?? null,
-      input.ogTitle ?? null,
-      input.ogDescription ?? null,
-      input.ogImageUrl ?? null,
-      now,
-      now,
-    )
-    .run();
+  // Retry on the (astronomically unlikely) short-code UNIQUE collision.
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; ; attempt++) {
+    const shortCode = generateShortCode();
+    try {
+      await db
+        .prepare(
+          `INSERT INTO tracked_links (id, name, original_url, tag_id, scenario_id, intro_template_id, reward_template_id, line_account_id, short_code, is_active, click_count, og_title, og_description, og_image_url, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?, ?)`,
+        )
+        .bind(
+          id,
+          input.name,
+          input.originalUrl,
+          input.tagId ?? null,
+          input.scenarioId ?? null,
+          input.introTemplateId ?? null,
+          input.rewardTemplateId ?? null,
+          input.lineAccountId ?? null,
+          shortCode,
+          input.ogTitle ?? null,
+          input.ogDescription ?? null,
+          input.ogImageUrl ?? null,
+          now,
+          now,
+        )
+        .run();
+      break;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (attempt < MAX_ATTEMPTS && /UNIQUE.*short_code/i.test(msg)) continue;
+      throw err;
+    }
+  }
 
   return (await getTrackedLinkById(db, id))!;
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/mcp-server",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "MCP server for LINE Harness — operate a LINE official account from AI agents over MCP",
   "type": "module",
   "bin": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/sdk",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "AI-native SDK for LINE Harness — programmatic LINE official account automation",
   "type": "module",
   "exports": {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -328,6 +328,8 @@ export interface TrackedLink {
   name: string
   originalUrl: string
   trackingUrl: string
+  /** 7文字の短縮コード（/t/<code>）。旧リンクは null（UUID URL のみ）。 */
+  shortCode?: string | null
   tagId: string | null
   scenarioId: string | null
   introTemplateId: string | null


### PR DESCRIPTION
Private → OSS sync for v0.18.0.

- `tracked_links.short_code` (7-char base62, migration 049). `/t/:linkId` resolves both short codes and legacy UUIDs; clicks recorded against the UUID.
- New global setting `tracked_link_base_url` (admin UI + `GET/PUT /api/account-settings/tracked-link-base-url`). Auto-tracked message URLs become `https://<short-domain>/t/<code>` (~35 chars). Kept separate from the affiliate `link_base_url`.
- auto-track: settings lookup skipped for URL-free messages; short-domain /t links never re-wrapped.
- wiki 10-Tracked-Links: short-domain setup guide (coexist-with-affiliate Redirect Rules / dedicated subdomain / same-account Custom Domain).
- SDK / MCP server 0.18.0.

Tests: worker 655 / db 114 passing, bootstrap regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)