### PR TITLE
sync: v0.18.1 — f=friendId on per-friend /t links (skip LIFF hop)

### DIFF
--- a/apps/worker/src/routes/booking-admin.test.ts
+++ b/apps/worker/src/routes/booking-admin.test.ts
@@ -124,11 +124,20 @@ const execCtx = {
 } as unknown as ExecutionContext;
 
 describe('POST /api/booking/admin/bookings', () => {
+  // Always 7 days in the future at 02:00Z (= JST 11:00, inside the mocked
+  // 10:00-19:00 shift). A fixed date here becomes a time bomb: the route
+  // rejects past slots with 422 once the calendar catches up.
+  const futureStartsAt = (() => {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() + 7);
+    d.setUTCHours(2, 0, 0, 0);
+    return d.toISOString();
+  })();
   const validBody = {
     friend_id: 'f1',
     menu_id: 'm1',
     staff_id: 's1',
-    starts_at: '2026-07-10T02:00:00.000Z', // JST 11:00
+    starts_at: futureStartsAt, // JST 11:00
   };
 
   function happyDb(insertChanges = 1) {
@@ -269,11 +278,19 @@ describe('POST /api/booking/admin/bookings', () => {
     availabilityMocks.computeSlots.mockReturnValue([{ start: '11:00', end: '12:00' }]);
     const db = happyDb();
     const { app, env } = makeApp(db);
+    // September exercises the old `.replace('-09', ...)` mangling bug, but the
+    // year must stay in the future (past slots are rejected with 422 before the
+    // window query runs) — pick this year's Sep 10 or next year's once passed.
+    const now = new Date();
+    const sepYear =
+      now.getTime() < Date.UTC(now.getUTCFullYear(), 8, 1) // before Sep 1
+        ? now.getUTCFullYear()
+        : now.getUTCFullYear() + 1;
     const res = await app.request(
       '/api/booking/admin/bookings?account_id=acc1',
       {
         method: 'POST',
-        body: JSON.stringify({ ...validBody, starts_at: '2026-09-10T02:00:00.000Z' }),
+        body: JSON.stringify({ ...validBody, starts_at: `${sepYear}-09-10T02:00:00.000Z` }),
         headers: { 'Content-Type': 'application/json' },
       },
       env,
@@ -286,8 +303,8 @@ describe('POST /api/booking/admin/bookings', () => {
       (c) => c.sql.includes('SELECT starts_at, block_ends_at FROM bookings'),
     );
     const [, endUtc, startUtc] = windowQuery!.params as [string, string, string];
-    expect(startUtc).toBe('2026-09-09T15:00:00.000Z'); // JST 2026-09-10 00:00 = prev-day 15:00Z
-    expect(endUtc).toBe('2026-09-10T15:00:00Z'); // JST 2026-09-11 00:00 = 2026-09-10 15:00Z
+    expect(startUtc).toBe(`${sepYear}-09-09T15:00:00.000Z`); // JST Sep 10 00:00 = prev-day 15:00Z
+    expect(endUtc).toBe(`${sepYear}-09-10T15:00:00Z`); // JST Sep 11 00:00 = Sep 10 15:00Z
   });
 });
 

--- a/apps/worker/src/routes/forms.ts
+++ b/apps/worker/src/routes/forms.ts
@@ -588,7 +588,10 @@ forms.post('/api/forms/:id/submit', async (c) => {
           } else if (form.on_submit_message_type && form.on_submit_message_content) {
             // Custom form message replaces default diagnostic result
             const expanded = expandVariables(form.on_submit_message_content, friendData, apiOrigin, form.on_submit_message_type);
-            messages.push(buildMessage(form.on_submit_message_type, expanded));
+            // 1:1 push → /t リンクに f=<friendId> を焼き込み (LIFF 識別ホップ回避)
+            const { appendFriendToTrackedLinks } = await import('../services/auto-track.js');
+            const decorated = await appendFriendToTrackedLinks(db, expanded, apiOrigin, friend.id);
+            messages.push(buildMessage(form.on_submit_message_type, decorated));
           } else {
             // Default: send diagnostic result Flex
             messages.push(buildMessage('flex', JSON.stringify(resultFlex)));

--- a/apps/worker/src/routes/friends.ts
+++ b/apps/worker/src/routes/friends.ts
@@ -571,14 +571,24 @@ friends.post('/api/friends/:id/messages', async (c) => {
 
     // Auto-wrap URLs with tracking links (text with URLs → Flex with button)
     // trackLinks=false で明示的に短縮 OFF (URL をそのまま送る)
+    const sendWorkerUrl = c.env.WORKER_URL || new URL(c.req.url).origin;
     let tracked = { messageType, content: body.content };
     if (body.trackLinks !== false) {
       const { autoTrackContent } = await import('../services/auto-track.js');
       tracked = await autoTrackContent(
         db, messageType, body.content,
-        c.env.WORKER_URL || new URL(c.req.url).origin,
+        sendWorkerUrl,
         { lineAccountId: friendAccountId },
       );
+    }
+    // 1:1 送信なので /t リンクに f=<friendId> を焼き込み、LIFF 識別ホップなしで
+    // クリック帰属できるようにする（既存 /t リンクにも効くので trackLinks に関わらず実施）
+    {
+      const { appendFriendToTrackedLinks } = await import('../services/auto-track.js');
+      tracked = {
+        ...tracked,
+        content: await appendFriendToTrackedLinks(db, tracked.content, sendWorkerUrl, friend.id),
+      };
     }
 
     const message = buildMessage(tracked.messageType, tracked.content, body.altText);

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -1019,7 +1019,12 @@ liffRoutes.get('/auth/callback', async (c) => {
                   c.env.WORKER_URL,
                   resolved.messageType,
                 );
-                const pushedMessage = buildMessage(resolved.messageType, expandedContent);
+                // 1:1 push → /t リンクに f=<friendId> を焼き込み (LIFF 識別ホップ回避)
+                const { appendFriendToTrackedLinks } = await import('../services/auto-track.js');
+                const decoratedContent = await appendFriendToTrackedLinks(
+                  db, expandedContent, c.env.WORKER_URL, friend.id,
+                );
+                const pushedMessage = buildMessage(resolved.messageType, decoratedContent);
                 await lineClient.pushMessage(lineUserId, [pushedMessage]);
 
                 // messages_log への記録 (到達率分母に含めるため)

--- a/apps/worker/src/services/auto-track.test.ts
+++ b/apps/worker/src/services/auto-track.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+
+const dbMocks = {
+  createTrackedLink: vi.fn(),
+  getTrackedLinkBaseUrl: vi.fn(),
+  getLinkBaseUrl: vi.fn(),
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+const { appendFriendToTrackedLinks } = await import('./auto-track.js');
+
+const DB = {} as D1Database;
+const WORKER = 'https://worker.example.com';
+const SHORT = 'https://go.example.com';
+const FRIEND = 'friend-uuid-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.getTrackedLinkBaseUrl.mockResolvedValue(SHORT);
+});
+
+describe('appendFriendToTrackedLinks', () => {
+  test('appends f= to short-domain /t links in flex JSON', async () => {
+    const content = `{"type":"uri","uri":"${SHORT}/t/Ab3xY9k"}`;
+    const out = await appendFriendToTrackedLinks(DB, content, WORKER, FRIEND);
+    expect(out).toBe(`{"type":"uri","uri":"${SHORT}/t/Ab3xY9k?f=${FRIEND}"}`);
+  });
+
+  test('appends with & when the link already has a query', async () => {
+    const content = `${SHORT}/t/Ab3xY9k?openExternalBrowser=1`;
+    const out = await appendFriendToTrackedLinks(DB, content, WORKER, FRIEND);
+    expect(out).toBe(`${SHORT}/t/Ab3xY9k?openExternalBrowser=1&f=${FRIEND}`);
+  });
+
+  test('appends to worker-domain legacy UUID links too', async () => {
+    const content = `${WORKER}/t/415bbb13-97bc-4a3c-a5bb-e5138af42737`;
+    const out = await appendFriendToTrackedLinks(DB, content, WORKER, FRIEND);
+    expect(out).toBe(`${WORKER}/t/415bbb13-97bc-4a3c-a5bb-e5138af42737?f=${FRIEND}`);
+  });
+
+  test('does not touch non-tracked URLs or existing f= params', async () => {
+    const content = `https://example.com/lp と ${SHORT}/t/abc1234?f=other`;
+    const out = await appendFriendToTrackedLinks(DB, content, WORKER, FRIEND);
+    expect(out).toBe(content);
+  });
+
+  test('keeps sentence punctuation outside the appended query', async () => {
+    const content = `詳しくはこちら ${SHORT}/t/Ab3xY9k。続きは ${SHORT}/t/xYz9876.`;
+    const out = await appendFriendToTrackedLinks(DB, content, WORKER, FRIEND);
+    expect(out).toBe(
+      `詳しくはこちら ${SHORT}/t/Ab3xY9k?f=${FRIEND}。続きは ${SHORT}/t/xYz9876?f=${FRIEND}.`,
+    );
+  });
+
+  test('no-op when friendId is missing', async () => {
+    const content = `${SHORT}/t/Ab3xY9k`;
+    expect(await appendFriendToTrackedLinks(DB, content, WORKER, null)).toBe(content);
+    expect(dbMocks.getTrackedLinkBaseUrl).not.toHaveBeenCalled();
+  });
+
+  test('falls back to worker base when no short domain is configured', async () => {
+    dbMocks.getTrackedLinkBaseUrl.mockResolvedValue(null);
+    const content = `${WORKER}/t/Ab3xY9k`;
+    const out = await appendFriendToTrackedLinks(DB, content, WORKER, FRIEND);
+    expect(out).toBe(`${WORKER}/t/Ab3xY9k?f=${FRIEND}`);
+  });
+});

--- a/apps/worker/src/services/auto-track.ts
+++ b/apps/worker/src/services/auto-track.ts
@@ -170,6 +170,45 @@ export interface AutoTrackOptions {
 }
 
 /**
+ * Append `f=<friendId>` to every /t/ tracked-link URL in per-friend message
+ * content. With f= present, /t skips the LIFF identification hop entirely
+ * (no consent screen, no extra tap) and still attributes the click — the
+ * friend is already known because the message was pushed 1:1.
+ *
+ * Only valid for per-friend sends (scenario step delivery, manual DM,
+ * OAuth immediate push). NEVER use for multicast/broadcast content: the same
+ * body goes to many users, so a baked f= would attribute everyone's clicks
+ * to one friend.
+ */
+export async function appendFriendToTrackedLinks(
+  db: D1Database,
+  content: string,
+  workerUrl: string,
+  friendId: string | null | undefined,
+): Promise<string> {
+  if (!friendId) return content;
+  const workerBase = workerUrl.replace(/\/$/, '');
+  const linkBase = await resolveTrackedLinkBaseUrl(db, workerUrl);
+  const bases = [...new Set([workerBase, linkBase])];
+  return content.replace(URL_REGEX, (match) => {
+    // URL_REGEX greedily captures trailing sentence punctuation and even
+    // full-width Japanese text glued to the URL (「…/t/abc。続き」等)。
+    // URL は ASCII のみなので、まず ASCII 境界で切り、さらに extractUrls と
+    // 同じ末尾記号を URL の外として扱う。f= はその手前に挿す。
+    const ascii = match.match(/^[\x21-\x7E]+/)?.[0] ?? '';
+    const punct = ascii.match(/[.,;:!?)]+$/)?.[0] ?? '';
+    const url = punct ? ascii.slice(0, -punct.length) : ascii;
+    const trailing = match.slice(url.length);
+    const isTrackedLink = bases.some((b) => url.startsWith(`${b}/t/`));
+    if (!isTrackedLink) return match;
+    if (/[?&]f=/.test(url)) return match;
+    // /t links never carry fragments, so appending at the end is safe.
+    const sep = url.includes('?') ? '&' : '?';
+    return `${url}${sep}f=${encodeURIComponent(friendId)}${trailing}`;
+  });
+}
+
+/**
  * Auto-wrap URLs in message content with tracking links.
  * For text messages with URLs, converts to Flex with button.
  * For flex messages, replaces URLs inline.

--- a/apps/worker/src/services/step-delivery.ts
+++ b/apps/worker/src/services/step-delivery.ts
@@ -229,12 +229,14 @@ async function processSingleDelivery(
   let trackedType: string = resolved.messageType;
   let trackedContent = expandedContent;
   if (workerUrl) {
-    const { autoTrackContent } = await import('./auto-track.js');
+    const { autoTrackContent, appendFriendToTrackedLinks } = await import('./auto-track.js');
     const tracked = await autoTrackContent(db, resolved.messageType, expandedContent, workerUrl, {
       lineAccountId: friendAccountId ?? null,
     });
     trackedType = tracked.messageType;
-    trackedContent = tracked.content;
+    // Per-friend push → bake f=<friendId> into /t links so clicks attribute
+    // without the LIFF identification hop (no consent screen on first tap).
+    trackedContent = await appendFriendToTrackedLinks(db, tracked.content, workerUrl, friend.id);
   }
   const message = buildMessage(trackedType, trackedContent);
   // Resolve the correct LINE client for this friend's account


### PR DESCRIPTION
Private → OSS sync for v0.18.1. Per-friend sends bake `f=<friendId>` into /t links: direct redirect + attribution without the LIFF identification hop (no first-time consent screen on cross-account funnels, no tap-twice). Broadcast/multicast unchanged. 7 new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)