### PR TITLE
sync: keep_bindings secret inheritance + public health endpoints

### DIFF
--- a/apps/worker/src/middleware/auth.ts
+++ b/apps/worker/src/middleware/auth.ts
@@ -178,7 +178,8 @@ export async function authMiddleware(c: Context<Env>, next: Next): Promise<Respo
     path.match(/^\/api\/forms\/[^/]+\/partial$/) ||
     path.match(/^\/api\/forms\/[^/]+$/) || // GET form definition (public for LIFF)
     path === '/api/meet-callback' || // Meet Harness completion callback
-    path === '/api/qr' // Public QR proxy — used by desktop landing pages
+    path === '/api/qr' || // Public QR proxy — used by desktop landing pages
+    path === '/api/health' // Liveness probe (update CLI / self-update verify)
   ) {
     return next();
   }

--- a/apps/worker/src/routes/health.test.ts
+++ b/apps/worker/src/routes/health.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test, vi } from 'vitest';
+import { Hono } from 'hono';
+import { authMiddleware } from '../middleware/auth.js';
+import { health } from './health.js';
+import type { Env } from '../index.js';
+
+vi.mock('@line-crm/db', () => ({
+  getStaffByApiKey: vi.fn(async () => null),
+  getAccountHealthLogs: vi.fn(async () => []),
+  getLatestRiskLevel: vi.fn(async () => null),
+  getAccountMigrations: vi.fn(async () => []),
+  getAccountMigrationById: vi.fn(async () => null),
+  createAccountMigration: vi.fn(),
+  updateAccountMigration: vi.fn(),
+}));
+
+function env(): Env['Bindings'] {
+  return {
+    DB: {} as D1Database,
+    IMAGES: {} as R2Bucket,
+    ASSETS: {} as Fetcher,
+    LINE_CHANNEL_SECRET: 'secret',
+    LINE_CHANNEL_ACCESS_TOKEN: 'line-token',
+    API_KEY: 'env-key',
+    LIFF_URL: 'https://liff.example.test',
+    LINE_CHANNEL_ID: 'line-channel',
+    LINE_LOGIN_CHANNEL_ID: 'login-channel',
+    LINE_LOGIN_CHANNEL_SECRET: 'login-secret',
+    WORKER_URL: 'https://worker.example.test',
+  };
+}
+
+function app() {
+  const a = new Hono<Env>();
+  a.use('*', authMiddleware);
+  a.route('/', health);
+  return a;
+}
+
+// The liveness endpoints are what `create-line-harness update` and the
+// self-update verify phase probe after a deploy — they must answer 200
+// with no credentials, or every update ends in a bogus health warning
+// (CLI) or rollback (self-update).
+describe('liveness endpoints are public', () => {
+  test.each(['/health', '/api/health'])('GET %s → 200 without credentials', async (path) => {
+    const res = await app().request(path, {}, env());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: { status: string } };
+    expect(body.success).toBe(true);
+    expect(body.data.status).toBe('ok');
+  });
+});
+
+describe('account health stays auth-guarded', () => {
+  test('GET /api/accounts/:id/health without credentials → 401', async () => {
+    const res = await app().request('/api/accounts/a1/health', {}, env());
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/worker/src/routes/health.ts
+++ b/apps/worker/src/routes/health.ts
@@ -11,6 +11,17 @@ import type { Env } from '../index.js';
 
 const health = new Hono<Env>();
 
+// ========== Liveness ==========
+// Public (no auth, see middleware/auth.ts skip list): probed by
+// `create-line-harness update` and by the self-update verify phase
+// (capabilities advertises `/api/health`). Deliberately dependency-free —
+// it exists only to prove the Worker booted and is routing requests.
+
+const LIVENESS_BODY = { success: true, data: { status: 'ok' } } as const;
+
+health.get('/health', (c) => c.json(LIVENESS_BODY));
+health.get('/api/health', (c) => c.json(LIVENESS_BODY));
+
 // ========== アカウントヘルス ==========
 
 health.get('/api/accounts/:id/health', async (c) => {

--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "Set up LINE Harness — AI-operated LINE CRM — with one command",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@line-harness/update-engine": "workspace:^0.0.3",
+    "@line-harness/update-engine": "workspace:^0.0.5",
     "execa": "^9.5.2",
     "picocolors": "^1.1.1"
   },

--- a/packages/create-line-harness/src/commands/update.ts
+++ b/packages/create-line-harness/src/commands/update.ts
@@ -592,21 +592,7 @@ export async function runUpdate(repoDir: string): Promise<void> {
   });
 
   // 13) Health check (non-fatal)
-  s.start("Health チェック中");
-  try {
-    const hRes = await fetch(
-      `${cfg.workerPublicUrl.replace(/\/$/, "")}/health`,
-    );
-    if (!hRes.ok) throw new Error(`HTTP ${hRes.status}`);
-    s.stop("Health OK");
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    s.stop(
-      pc.yellow(
-        `Health 確認失敗: ${msg} (アップデート自体は完了しています)`,
-      ),
-    );
-  }
+  await checkWorkerHealth(cfg.workerPublicUrl, s, "アップデート自体は完了しています");
 
   // 14) Refresh the local release artifact + record bundle mode so a later
   // manual `wrangler deploy` from the clone re-deploys THIS version instead
@@ -620,6 +606,33 @@ export async function runUpdate(repoDir: string): Promise<void> {
 // ─── Shared deploy steps (normal update + adoption) ──────────────────────────
 
 type Spinner = ReturnType<typeof p.spinner>;
+
+/**
+ * Post-deploy liveness check (non-fatal — the deploy already succeeded).
+ *
+ * Probes `/api/health` and treats ANY response below 500 as alive: worker
+ * bundles released before the public health route existed answer 401
+ * (auth middleware) or 404, and a Worker that routes a request to either
+ * has provably booted. Only network errors and 5xx are reported, with
+ * `doneNote` clarifying that the update itself still completed.
+ */
+export async function checkWorkerHealth(
+  workerPublicUrl: string,
+  s: Spinner,
+  doneNote: string,
+): Promise<void> {
+  s.start("Health チェック中");
+  try {
+    const hRes = await fetch(
+      `${workerPublicUrl.replace(/\/$/, "")}/api/health`,
+    );
+    if (hRes.status >= 500) throw new Error(`HTTP ${hRes.status}`);
+    s.stop("Health OK");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    s.stop(pc.yellow(`Health 確認失敗: ${msg} (${doneNote})`));
+  }
+}
 
 /**
  * Pre-download gate: releases without `worker_bundle_hash` shipped a broken
@@ -984,15 +997,7 @@ async function runAdoption(opts: {
     adminUrl: cfg.adminPublicUrl,
   });
 
-  s.start("Health チェック中");
-  try {
-    const hRes = await fetch(`${cfg.workerPublicUrl.replace(/\/$/, "")}/health`);
-    if (!hRes.ok) throw new Error(`HTTP ${hRes.status}`);
-    s.stop("Health OK");
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    s.stop(pc.yellow(`Health 確認失敗: ${msg} (導入自体は完了しています)`));
-  }
+  await checkWorkerHealth(cfg.workerPublicUrl, s, "導入自体は完了しています");
 
   writeLocalWorkerArtifact(repoDir, bundle);
   persistBundleMode(repoDir, target.version);

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/update-engine",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "Self-update engine for LINE Harness — shared between Worker (cloud-side self-update) and CLI (npx create-line-harness update)",
   "type": "module",
   "exports": {

--- a/packages/update-engine/src/cf-api/workers.ts
+++ b/packages/update-engine/src/cf-api/workers.ts
@@ -13,7 +13,7 @@ import { authHeader, throwHttpError, workersApiBase } from './_shared.js';
  * binding type so we don't silently drop it on update.
  */
 export interface WorkerBinding {
-  type: 'plain_text' | 'secret_text' | 'd1' | 'r2_bucket' | 'kv_namespace' | 'assets';
+  type: 'plain_text' | 'secret_text' | 'secret_key' | 'd1' | 'r2_bucket' | 'kv_namespace' | 'assets';
   name: string;
   database_id?: string;
   bucket_name?: string;
@@ -22,6 +22,14 @@ export interface WorkerBinding {
 }
 
 const DEFAULT_COMPATIBILITY_DATE = '2024-12-01';
+
+/**
+ * Binding types whose values can never be read back via the API. They are
+ * dropped from the upload's bindings array (re-sending them value-less
+ * fails with error 10021) and carried across uploads with
+ * `metadata.keep_bindings` instead.
+ */
+const SECRET_BINDING_TYPES: string[] = ['secret_text', 'secret_key'];
 
 /**
  * Upload (create or overwrite) a Worker script via the Cloudflare API.
@@ -56,10 +64,23 @@ export async function putWorkerScript(opts: {
   const { creds, scriptName, scriptContent, bindings } = opts;
   const compatibility_date = opts.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE;
 
+  // Secret-typed bindings come back from GET /bindings WITHOUT their
+  // values, and the upload API rejects a value-less secret binding with
+  // error 10021 ("invalid or missing text property for binding <NAME>").
+  // Drop them from the upload and carry the existing secrets over via
+  // `keep_bindings` instead (the same mechanism wrangler uses). A
+  // secret_text binding WITH a text value is a caller explicitly setting
+  // a new secret — sent as-is, and it takes precedence over the
+  // inherited one.
+  const sendableBindings = bindings.filter(
+    (b) => !SECRET_BINDING_TYPES.includes(b.type) || typeof b.text === 'string',
+  );
+
   const metadata: Record<string, unknown> = {
     main_module: 'worker.js',
-    bindings,
+    bindings: sendableBindings,
     compatibility_date,
+    keep_bindings: SECRET_BINDING_TYPES,
   };
   if (opts.compatibilityFlags && opts.compatibilityFlags.length > 0) {
     metadata.compatibility_flags = opts.compatibilityFlags;

--- a/packages/update-engine/src/phases/verify.ts
+++ b/packages/update-engine/src/phases/verify.ts
@@ -58,8 +58,12 @@ export async function runVerify(
 
   // 1. Worker /health — most common failure mode (new bundle crashed on
   //    boot), so probe first and surface the URL in the error message.
+  //    ANY response below 500 counts as alive: bundles released before the
+  //    public /api/health route answer 401 (auth middleware) or 404, and a
+  //    Worker that routes a request to either has provably booted. Only
+  //    5xx / network errors indicate a broken deploy worth rolling back.
   try {
-    await fetchWithRetry(urls.workerHealthUrl);
+    await fetchWithRetry(urls.workerHealthUrl, (r) => r.status < 500);
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     throw new Error(`Worker /health failed: ${reason} (${urls.workerHealthUrl})`);
@@ -101,12 +105,14 @@ export async function runVerify(
 /**
  * Fetch with retry — 3 attempts, 3s delay between attempts.
  *
- * Treats both rejected promises (network errors) and non-2xx responses as
- * retryable. The final error preserves the underlying cause so the caller
- * can wrap it with a URL-naming message.
+ * Treats both rejected promises (network errors) and non-accepted
+ * responses as retryable. `accept` decides what counts as success
+ * (default: 2xx). The final error preserves the underlying cause so the
+ * caller can wrap it with a URL-naming message.
  */
 async function fetchWithRetry(
   url: string,
+  accept: (r: Response) => boolean = (r) => r.ok,
   retries = RETRIES,
   delayMs = RETRY_DELAY_MS,
 ): Promise<Response> {
@@ -114,7 +120,7 @@ async function fetchWithRetry(
   for (let i = 0; i < retries; i++) {
     try {
       const r = await fetch(url);
-      if (r.ok) return r;
+      if (accept(r)) return r;
       last = new Error(`HTTP ${r.status}`);
     } catch (e) {
       last = e;

--- a/packages/update-engine/test/phases/apply.test.ts
+++ b/packages/update-engine/test/phases/apply.test.ts
@@ -519,6 +519,12 @@ describe('runApply', () => {
     const metadataBlob = fd.get('metadata') as Blob;
     const metadataText = await metadataBlob.text();
     const metadata = JSON.parse(metadataText);
-    expect(metadata.bindings).toEqual(existingBindings);
+    // Textless secret_text bindings can't be re-sent (CF rejects them with
+    // 10021) — they're carried over via keep_bindings instead.
+    expect(metadata.bindings).toEqual([
+      { type: 'd1', name: 'DB', database_id: D1_ID },
+      { type: 'plain_text', name: 'ENV', text: 'prod' },
+    ]);
+    expect(metadata.keep_bindings).toEqual(['secret_text', 'secret_key']);
   });
 });

--- a/packages/update-engine/test/phases/rollback.test.ts
+++ b/packages/update-engine/test/phases/rollback.test.ts
@@ -169,7 +169,12 @@ describe('runRollback', () => {
     const fd = putCall![1]!.body as FormData;
     const metadataBlob = fd.get('metadata') as Blob;
     const metadata = JSON.parse(await metadataBlob.text());
-    expect(metadata.bindings).toEqual(existingBindings);
+    // Textless secret_text bindings can't be re-sent (CF rejects them with
+    // 10021) — they're carried over via keep_bindings instead.
+    expect(metadata.bindings).toEqual([
+      { type: 'd1', name: 'DB', database_id: D1_ID },
+    ]);
+    expect(metadata.keep_bindings).toEqual(['secret_text', 'secret_key']);
 
     // Both Pages rollbacks were invoked.
     const adminRb = calls.find(([url]) =>

--- a/packages/update-engine/test/phases/verify.test.ts
+++ b/packages/update-engine/test/phases/verify.test.ts
@@ -169,6 +169,54 @@ describe('runVerify', () => {
     expect(fetchMock).toHaveBeenCalledTimes(6);
   });
 
+  // Regression: worker bundles released before the public /api/health
+  // route existed answer 401 (auth middleware) or 404 to the health probe.
+  // Any response below 500 proves the Worker booted and is routing — it
+  // must NOT fail verify (which would trigger a pointless rollback).
+  it.each([401, 404])(
+    'Worker health %i (pre-health-route bundle) — treated as alive, verify proceeds',
+    async (status) => {
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url === WORKER_HEALTH_URL) return notOk(status);
+        if (url.includes(D1_QUERY_SUBSTR)) return ok({ success: true, result: [] });
+        return ok();
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const { events, emitter } = collectEvents();
+      await runVerify(sampleCtx(), sampleUrls(), emitter);
+
+      expect(events).toEqual([
+        { step: 'verify', status: 'running' },
+        { step: 'verify', status: 'done' },
+      ]);
+      // No retries: the first sub-500 response settles the worker probe.
+      const callUrls = (fetchMock.mock.calls as Array<[string]>).map(([u]) => u);
+      expect(callUrls.filter((u) => u === WORKER_HEALTH_URL).length).toBe(1);
+    },
+  );
+
+  it('Admin URL 401 still fails — permissive check applies to the worker probe only', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === WORKER_HEALTH_URL) return ok();
+      if (url.includes(D1_QUERY_SUBSTR)) return ok({ success: true, result: [] });
+      if (url === ADMIN_URL) return notOk(401);
+      return ok();
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { emitter } = collectEvents();
+    const promise = runVerify(sampleCtx(), sampleUrls(), emitter);
+    const settled = promise.catch((e) => e);
+
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+
+    const err = (await settled) as Error;
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toMatch(/Admin/);
+  });
+
   it('Worker /health fails after 3 retries — throws, done event NOT emitted', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url === WORKER_HEALTH_URL) return notOk(500);

--- a/packages/update-engine/test/workers-put.test.ts
+++ b/packages/update-engine/test/workers-put.test.ts
@@ -75,6 +75,47 @@ describe('putWorkerScript metadata', () => {
     expect(metadata).not.toHaveProperty('compatibility_flags');
   });
 
+  // Regression: adoption/update flows re-send the bindings returned by
+  // GET /bindings verbatim. That list contains secret_text entries WITHOUT
+  // their values (CF never returns secret values), and the script upload
+  // API rejects a textless secret_text binding with error 10021
+  // "invalid or missing text property for binding <NAME>". Secrets must
+  // instead be carried over via metadata.keep_bindings.
+  it('drops textless secret_text bindings and inherits them via keep_bindings', async () => {
+    await putWorkerScript({
+      creds,
+      scriptName: 'w',
+      scriptContent: Buffer.from('export default {}'),
+      bindings: [
+        ...BINDINGS,
+        { type: 'secret_text', name: 'ADMIN_ORIGIN' },
+        { type: 'secret_text', name: 'WORKER_URL' },
+        { type: 'secret_key', name: 'SIGNING_KEY' },
+      ],
+    });
+
+    const metadata = await capturedMetadata(fetchMock);
+    expect(metadata.bindings).toEqual(BINDINGS);
+    expect(metadata.keep_bindings).toEqual(['secret_text', 'secret_key']);
+  });
+
+  it('keeps secret_text bindings that carry an explicit text value', async () => {
+    const withValue: WorkerBinding = {
+      type: 'secret_text',
+      name: 'NEW_SECRET',
+      text: 's3cret',
+    };
+    await putWorkerScript({
+      creds,
+      scriptName: 'w',
+      scriptContent: Buffer.from('export default {}'),
+      bindings: [withValue],
+    });
+
+    const metadata = await capturedMetadata(fetchMock);
+    expect(metadata.bindings).toEqual([withValue]);
+  });
+
   it('uploads the script bytes unchanged as the worker.js module part', async () => {
     const script = Buffer.from('export default {fetch(){}}');
     await putWorkerScript({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@line-harness/update-engine':
-        specifier: workspace:^0.0.3
+        specifier: workspace:^0.0.5
         version: link:../update-engine
       execa:
         specifier: ^9.5.2


### PR DESCRIPTION
Private リポからの手動 sync（[private #100](https://github.com/Shudesu/line-harness/pull/100) + [private #102](https://github.com/Shudesu/line-harness/pull/102)）。

## Fixes

1. **update が secret 環境で必ず 10021 で失敗する問題** — worker script upload で secret_text/secret_key を \`keep_bindings\` 継承に変更（GET /bindings は secret の値を返さないため、そのまま再送すると CF が拒否していた）
2. **self-update verify が毎回 rollback する問題** — capabilities が広告していた \`/api/health\` が実在せず 401 → verify 失敗。公開 liveness エンドポイント \`GET /health\` / \`GET /api/health\` を追加し、Worker probe を「500 未満 = alive」判定に変更
3. **CLI update の恒常的な Health 警告** — \`/api/health\` + 500 未満 OK 判定に修正

npm: @line-harness/update-engine 0.0.5 / create-line-harness 0.2.2（0.0.4/0.2.1 は published 済み、0.0.5/0.2.2 は次回 publish）

🤖 Generated with [Claude Code](https://claude.com/claude-code)