### PR TITLE
sync: workers.dev subdomain auto-registration (CLI 0.2.3 / update-engine 0.0.6)

### DIFF
--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Set up LINE Harness — AI-operated LINE CRM — with one command",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@line-harness/update-engine": "workspace:^0.0.5",
+    "@line-harness/update-engine": "workspace:^0.0.6",
     "execa": "^9.5.2",
     "picocolors": "^1.1.1"
   },

--- a/packages/create-line-harness/src/commands/setup.ts
+++ b/packages/create-line-harness/src/commands/setup.ts
@@ -9,6 +9,7 @@ import { ensureAuth, getAccountId } from "../steps/auth.js";
 import { promptLineCredentials } from "../steps/prompt.js";
 import { createDatabase } from "../steps/database.js";
 import { deployWorker, syncInstalledWorkerConfig } from "../steps/deploy-worker.js";
+import { ensureWorkersDevSubdomain } from "../steps/ensure-subdomain.js";
 import { deployAdmin } from "../steps/deploy-admin.js";
 import { fetchLatestRelease, type FetchedRelease } from "../steps/release-bundle.js";
 import { pinRepoToTag } from "../steps/clone-repo.js";
@@ -611,6 +612,14 @@ async function runSetupInner(
   // locally.
   state.workerName = state.projectName!;
   if (!isDone(state, "worker")) {
+    // New accounts have no workers.dev subdomain and `wrangler deploy` dies
+    // on it non-interactively — check + register (interactively) first.
+    // Not persisted as a step: the check is one cheap GET and re-running it
+    // covers account switches on resume.
+    await ensureWorkersDevSubdomain({
+      accountId: state.accountId!,
+      defaultName: state.projectName!,
+    });
     const { workerUrl } = await deployWorker({
       repoDir,
       d1DatabaseId: state.d1DatabaseId!,

--- a/packages/create-line-harness/src/commands/update.ts
+++ b/packages/create-line-harness/src/commands/update.ts
@@ -25,6 +25,8 @@ import {
   type WorkerBinding,
 } from "@line-harness/update-engine";
 import { configureAdminAuth } from "../steps/admin-auth.js";
+import { ensureWorkersDevSubdomain } from "../steps/ensure-subdomain.js";
+import { subdomainFromWorkersDevUrl } from "../lib/subdomain-name.js";
 import {
   isGeneratedInstalledWranglerToml,
   renderInstalledWranglerToml,
@@ -73,6 +75,35 @@ export function loadState(repoDir: string): SetupState | null {
     return JSON.parse(readFileSync(configPath, "utf-8")) as SetupState;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Persist a changed Worker public URL back to `.line-harness-config.json`
+ * after the workers.dev subdomain was re-registered under a new name.
+ * Updates the legacy `workerUrl` alias too, and `liffPublicUrl` when it
+ * pointed at the same origin — worker-assets installs rely on
+ * `liffPublicUrl === workerPublicUrl` to resolve as "no LIFF Pages project"
+ * (see resolveState), so leaving it stale would trigger a bogus liffProject
+ * prompt on the next run. Best-effort: on failure the next run simply
+ * re-detects the mismatch.
+ */
+function persistWorkerPublicUrl(
+  configPath: string,
+  oldUrl: string,
+  newUrl: string,
+): void {
+  try {
+    const config = JSON.parse(readFileSync(configPath, "utf-8")) as SetupState;
+    config.workerPublicUrl = newUrl;
+    if (config.workerUrl !== undefined) config.workerUrl = newUrl;
+    if (config.liffPublicUrl === oldUrl) config.liffPublicUrl = newUrl;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    p.log.success(`設定を保存しました: ${configPath}`);
+  } catch (e) {
+    p.log.warn(
+      `Worker URL の設定保存に失敗: ${e instanceof Error ? e.message : String(e)} — 続行します`,
+    );
   }
 }
 
@@ -466,6 +497,33 @@ export async function runUpdate(repoDir: string): Promise<void> {
 
   p.log.success(`プロジェクト: ${state.projectName ?? cfg.workerName}`);
 
+  // 0) workers.dev-hosted installs: if the account-level workers.dev
+  // subdomain has been deleted since install, EVERY Worker URL probe below
+  // (/admin/version, health check) fails — so check and repair it before
+  // the first probe. Skipped for custom-domain installs (no workers.dev
+  // hostname to repair).
+  let subdomainRegisteredNow = false;
+  let workerUrlRenamed = false;
+  const expectedSubdomain = subdomainFromWorkersDevUrl(cfg.workerPublicUrl);
+  if (expectedSubdomain) {
+    const ensured = await ensureWorkersDevSubdomain({
+      accountId: cfg.cfAccountId,
+      apiToken: cfg.cfApiToken,
+      defaultName: expectedSubdomain,
+    });
+    subdomainRegisteredNow = ensured.registeredNow;
+    if (ensured.subdomain && ensured.subdomain !== expectedSubdomain) {
+      // Registered/found under a different name — the saved Worker URL's
+      // hostname is dead. Point config + this run at the new one.
+      const workerLabel = new URL(cfg.workerPublicUrl).hostname.split(".")[0];
+      const newUrl = `https://${workerLabel}.${ensured.subdomain}.workers.dev`;
+      p.log.warn(`Worker URL を更新します: ${cfg.workerPublicUrl} → ${newUrl}`);
+      persistWorkerPublicUrl(configPath, cfg.workerPublicUrl, newUrl);
+      cfg.workerPublicUrl = newUrl;
+      workerUrlRenamed = true;
+    }
+  }
+
   // 1) Fetch current version from deployed Worker
   const s = p.spinner();
   s.start("現在バージョン取得中");
@@ -482,7 +540,11 @@ export async function runUpdate(repoDir: string): Promise<void> {
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     s.stop(pc.red(`Worker /admin/version 取得失敗: ${msg}`));
-    p.cancel("Worker が応答していません。デプロイ状態を確認してください。");
+    p.cancel(
+      subdomainRegisteredNow
+        ? "workers.dev サブドメイン登録直後のため DNS 反映待ちの可能性があります。数分待ってから同じコマンドを再実行してください。"
+        : "Worker が応答していません。デプロイ状態を確認してください。",
+    );
     process.exit(1);
   }
   s.stop(`現在: v${current.version}`);
@@ -511,7 +573,7 @@ export async function runUpdate(repoDir: string): Promise<void> {
   const fork = detectFork(current, manifest);
   if (fork.kind === "fork") {
     if (fork.reason.startsWith("unknown version")) {
-      await runAdoption({ repoDir, cfg, manifest, current });
+      await runAdoption({ repoDir, cfg, manifest, current, subdomainRegisteredNow });
       return;
     }
     p.log.info(pc.yellow(`カスタマイズ版を検出しました (${fork.reason})`));
@@ -525,6 +587,17 @@ export async function runUpdate(repoDir: string): Promise<void> {
   // 4) Find upgrade target
   const upgrade = findLatestUpgrade(manifest, current.version);
   if (!upgrade) {
+    if (workerUrlRenamed) {
+      // The config now points at the new hostname, but the running
+      // Worker's WORKER_PUBLIC_URL binding and the Admin bundle's baked-in
+      // API origin still reference the dead one — redeploy the CURRENT
+      // release so everything points at the new URL.
+      await redeployCurrentBundle({ repoDir, cfg, manifest, current });
+      p.outro(
+        pc.green(`既に最新版です (v${current.version}) — 新しい Worker URL で再デプロイしました`),
+      );
+      return;
+    }
     p.outro(pc.green(`既に最新版です (v${current.version})`));
     return;
   }
@@ -592,7 +665,13 @@ export async function runUpdate(repoDir: string): Promise<void> {
   });
 
   // 13) Health check (non-fatal)
-  await checkWorkerHealth(cfg.workerPublicUrl, s, "アップデート自体は完了しています");
+  await checkWorkerHealth(
+    cfg.workerPublicUrl,
+    s,
+    subdomainRegisteredNow
+      ? "アップデート自体は完了しています。workers.dev サブドメイン登録直後は DNS 反映に数分かかるため、数分待ってから同じコマンドを再実行してください"
+      : "アップデート自体は完了しています",
+  );
 
   // 14) Refresh the local release artifact + record bundle mode so a later
   // manual `wrangler deploy` from the clone re-deploys THIS version instead
@@ -736,22 +815,28 @@ async function applyMigrations(opts: {
 }
 
 /**
- * Correct the LIFF_PAGES_PROJECT plain-text binding to match the resolved
- * topology. Installs created before the worker-assets fix were deployed
- * with `LIFF_PAGES_PROJECT=<worker>-liff` even though that Pages project
- * never existed; re-uploading the binding verbatim would keep the
- * worker-side self-update pointed at the missing project instead of
- * taking the worker-assets skip path.
+ * Correct install-topology plain-text bindings to match the resolved config
+ * before re-uploading them:
+ *   - LIFF_PAGES_PROJECT: installs created before the worker-assets fix were
+ *     deployed with `LIFF_PAGES_PROJECT=<worker>-liff` even though that Pages
+ *     project never existed; re-uploading the binding verbatim would keep the
+ *     worker-side self-update pointed at the missing project instead of
+ *     taking the worker-assets skip path.
+ *   - WORKER_PUBLIC_URL: when the workers.dev subdomain was re-registered
+ *     under a new name this run, the deployed binding still carries the dead
+ *     hostname — the worker-side self-update health check would probe a URL
+ *     that never resolves again.
  */
-export function normalizeLiffBindings(
+export function normalizeInstallBindings(
   bindings: WorkerBinding[],
-  liffProject: string,
+  opts: { liffProject: string; workerPublicUrl: string },
 ): WorkerBinding[] {
-  return bindings.map((b) =>
-    b.type === "plain_text" && b.name === "LIFF_PAGES_PROJECT"
-      ? { ...b, text: liffProject }
-      : b,
-  );
+  return bindings.map((b) => {
+    if (b.type !== "plain_text") return b;
+    if (b.name === "LIFF_PAGES_PROJECT") return { ...b, text: opts.liffProject };
+    if (b.name === "WORKER_PUBLIC_URL") return { ...b, text: opts.workerPublicUrl };
+    return b;
+  });
 }
 
 async function deployWorkerFromBundle(
@@ -770,7 +855,10 @@ async function deployWorkerFromBundle(
       creds,
       scriptName: cfg.workerName,
       scriptContent: bundle.workerJs,
-      bindings: normalizeLiffBindings(bindings, cfg.liffProject),
+      bindings: normalizeInstallBindings(bindings, {
+        liffProject: cfg.liffProject,
+        workerPublicUrl: cfg.workerPublicUrl,
+      }),
       compatibilityFlags: WORKER_COMPATIBILITY_FLAGS,
       // Bundle carries no Worker assets — keep the ones deployed at setup
       // (they serve the LIFF SPA on worker-assets installs).
@@ -903,6 +991,60 @@ function persistBundleMode(repoDir: string, version: string): void {
   }
 }
 
+/**
+ * Same-version redeploy after a workers.dev subdomain rename with no
+ * pending upgrade: the deployed Admin bundle bakes in the Worker origin and
+ * the Worker carries a WORKER_PUBLIC_URL binding, so the URL change still
+ * needs the CURRENT release redeployed to point everything at the new
+ * hostname. No migrations run (same version, DB untouched).
+ */
+async function redeployCurrentBundle(opts: {
+  repoDir: string;
+  cfg: ResolvedUpdateConfig;
+  manifest: Awaited<ReturnType<typeof fetchManifest>>;
+  current: CurrentVersion;
+}): Promise<void> {
+  const { repoDir, cfg, manifest, current } = opts;
+
+  const release = manifest.releases.find((r) => r.version === current.version);
+  if (!release || !release.worker_bundle_hash) {
+    p.log.warn(
+      [
+        `現行バージョン v${current.version} の再デプロイ可能なリリースが見つからないため、`,
+        "Worker 内部と管理画面には旧 URL が残っている可能性があります。",
+        "次回のアップデート適用時に新 URL で自動的に再デプロイされます。",
+      ].join("\n"),
+    );
+    return;
+  }
+
+  const creds: CfApiCreds = { accountId: cfg.cfAccountId, apiToken: cfg.cfApiToken };
+  const s = p.spinner();
+  const bundle = await downloadAndVerifyBundle(release, s);
+
+  await deployWorkerFromBundle(creds, cfg, bundle, s);
+  await deployAdminFromBundle(creds, cfg, bundle, s);
+  if (cfg.liffProject) {
+    await deployLiffFromBundle(creds, cfg, bundle, s);
+  }
+
+  // Re-point the cookie-auth CORS allowlist / origins at the new Worker URL.
+  await configureAdminAuth({
+    workerName: cfg.workerName,
+    workerUrl: cfg.workerPublicUrl,
+    adminUrl: cfg.adminPublicUrl,
+  });
+
+  await checkWorkerHealth(
+    cfg.workerPublicUrl,
+    s,
+    "再デプロイ自体は完了しています。workers.dev サブドメイン登録直後は DNS 反映に数分かかるため、数分待ってから同じコマンドを再実行してください",
+  );
+
+  writeLocalWorkerArtifact(repoDir, bundle);
+  persistBundleMode(repoDir, current.version);
+}
+
 // ─── Adoption path (unstamped CLI installs) ──────────────────────────────────
 
 /**
@@ -925,8 +1067,10 @@ async function runAdoption(opts: {
   cfg: ResolvedUpdateConfig;
   manifest: Awaited<ReturnType<typeof fetchManifest>>;
   current: CurrentVersion;
+  /** True when runUpdate registered a workers.dev subdomain this run. */
+  subdomainRegisteredNow: boolean;
 }): Promise<void> {
-  const { repoDir, cfg, manifest, current } = opts;
+  const { repoDir, cfg, manifest, current, subdomainRegisteredNow } = opts;
 
   const target = manifest.releases.find((r) => r.version === manifest.latest);
   if (!target) {
@@ -997,7 +1141,13 @@ async function runAdoption(opts: {
     adminUrl: cfg.adminPublicUrl,
   });
 
-  await checkWorkerHealth(cfg.workerPublicUrl, s, "導入自体は完了しています");
+  await checkWorkerHealth(
+    cfg.workerPublicUrl,
+    s,
+    subdomainRegisteredNow
+      ? "導入自体は完了しています。workers.dev サブドメイン登録直後は DNS 反映に数分かかるため、数分待ってから同じコマンドを再実行してください"
+      : "導入自体は完了しています",
+  );
 
   writeLocalWorkerArtifact(repoDir, bundle);
   persistBundleMode(repoDir, target.version);

--- a/packages/create-line-harness/src/lib/subdomain-name.ts
+++ b/packages/create-line-harness/src/lib/subdomain-name.ts
@@ -1,0 +1,43 @@
+/**
+ * workers.dev subdomain name rules — the same pattern wrangler validates
+ * against before PUTting to the API (cloudflare/workers-sdk,
+ * packages/deploy-helpers/src/triggers/subdomain.ts): 1–63 chars, lowercase
+ * alphanumeric + hyphens, no leading/trailing hyphen.
+ */
+export const WORKERS_SUBDOMAIN_NAME_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export function isValidSubdomainName(name: string): boolean {
+  return WORKERS_SUBDOMAIN_NAME_RE.test(name);
+}
+
+/**
+ * Derive a valid workers.dev subdomain candidate from an arbitrary string
+ * (typically the project name). Returns null when nothing usable remains —
+ * callers then prompt without a default.
+ */
+export function sanitizeSubdomainCandidate(source: string): string | null {
+  const candidate = source
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 63)
+    .replace(/-+$/, "");
+  return isValidSubdomainName(candidate) ? candidate : null;
+}
+
+/**
+ * Extract the account subdomain from a `https://<worker>.<subdomain>.workers.dev`
+ * URL. Used by the update flow to suggest re-registering the same name the
+ * install originally had. Returns null for custom domains / unparsable URLs.
+ */
+export function subdomainFromWorkersDevUrl(url: string): string | null {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return null;
+  }
+  const match = hostname.match(/^[^.]+\.([^.]+)\.workers\.dev$/);
+  return match ? match[1] : null;
+}

--- a/packages/create-line-harness/src/lib/wrangler-oauth.ts
+++ b/packages/create-line-harness/src/lib/wrangler-oauth.ts
@@ -1,0 +1,113 @@
+import { readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Locate and read wrangler's own OAuth access token so setup can call the
+ * Cloudflare REST API directly (e.g. the workers.dev subdomain endpoints,
+ * which have no wrangler subcommand) with the same identity the user already
+ * authorized via `wrangler login`.
+ *
+ * The path resolution mirrors wrangler's `getGlobalConfigPath()`
+ * (cloudflare/workers-sdk, packages/workers-utils/src/global-wrangler-config-path.ts):
+ *   1. A pre-existing legacy `~/.wrangler` directory wins.
+ *   2. Otherwise the XDG-compliant config dir:
+ *        - macOS:   $XDG_CONFIG_HOME || ~/Library/Preferences
+ *        - Windows: $XDG_CONFIG_HOME || %APPDATA%/xdg.config
+ *        - other:   $XDG_CONFIG_HOME || ~/.config
+ *      each suffixed with `/.wrangler`.
+ * Credentials live at `<dir>/config/default.toml`.
+ */
+
+export interface WranglerOAuthEnv {
+  env?: Record<string, string | undefined>;
+  platform?: NodeJS.Platform;
+  home?: string;
+  /** Injectable for tests. Defaults to fs.statSync-based directory check. */
+  isDirectory?: (path: string) => boolean;
+}
+
+function defaultIsDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve wrangler's global config directory (the one holding `config/default.toml`). */
+export function getWranglerConfigDir(opts: WranglerOAuthEnv = {}): string {
+  const env = opts.env ?? process.env;
+  const platform = opts.platform ?? process.platform;
+  const home = opts.home ?? homedir();
+  const isDirectory = opts.isDirectory ?? defaultIsDirectory;
+
+  const legacyDir = join(home, ".wrangler");
+  if (isDirectory(legacyDir)) {
+    return legacyDir;
+  }
+
+  let xdgConfigBase: string;
+  if (env.XDG_CONFIG_HOME) {
+    xdgConfigBase = env.XDG_CONFIG_HOME;
+  } else if (platform === "darwin") {
+    xdgConfigBase = join(home, "Library", "Preferences");
+  } else if (platform === "win32") {
+    xdgConfigBase = join(env.APPDATA ?? join(home, "AppData", "Roaming"), "xdg.config");
+  } else {
+    xdgConfigBase = join(home, ".config");
+  }
+  return join(xdgConfigBase, ".wrangler");
+}
+
+/**
+ * Extract `oauth_token` / `expiration_time` from wrangler's credentials TOML
+ * without a TOML parser — wrangler writes flat `key = "value"` lines, which
+ * is all we need to match.
+ */
+export function parseWranglerAuthToml(content: string): {
+  oauthToken: string | null;
+  expirationTime: string | null;
+} {
+  const tokenMatch = content.match(/^\s*oauth_token\s*=\s*"([^"]+)"/m);
+  const expirationMatch = content.match(/^\s*expiration_time\s*=\s*"([^"]+)"/m);
+  return {
+    oauthToken: tokenMatch?.[1] ?? null,
+    expirationTime: expirationMatch?.[1] ?? null,
+  };
+}
+
+/**
+ * Read the current wrangler OAuth access token.
+ *
+ * Returns null when the credentials file is absent/unreadable, has no
+ * `oauth_token`, or the token is already expired (wrangler refreshes it on
+ * its own CLI runs — we can't, so an expired token is unusable). Callers
+ * treat null as "cannot pre-check via the API" and fall back to the plain
+ * deploy path.
+ */
+export function readWranglerOAuthToken(
+  opts: WranglerOAuthEnv & { now?: () => number } = {},
+): string | null {
+  const tomlPath = join(getWranglerConfigDir(opts), "config", "default.toml");
+
+  let content: string;
+  try {
+    content = readFileSync(tomlPath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const { oauthToken, expirationTime } = parseWranglerAuthToml(content);
+  if (!oauthToken) return null;
+
+  if (expirationTime) {
+    const expiresAt = Date.parse(expirationTime);
+    const now = (opts.now ?? Date.now)();
+    if (!Number.isNaN(expiresAt) && expiresAt <= now) {
+      return null;
+    }
+  }
+
+  return oauthToken;
+}

--- a/packages/create-line-harness/src/lib/wrangler.ts
+++ b/packages/create-line-harness/src/lib/wrangler.ts
@@ -17,6 +17,23 @@ export class WranglerError extends Error {
     const text = `${this.message}\n${this.stderr}`.toLowerCase();
     const hints: string[] = [];
 
+    // Deploying with `workers_dev = true` fails on accounts that never
+    // registered their workers.dev subdomain. Wrangler tries to prompt for
+    // registration, but our piped (non-TTY) invocation cannot answer it, so
+    // users only ever see the raw error — guide them to the dashboard.
+    const needsWorkersDevSubdomain = text.includes(
+      "register a workers.dev subdomain",
+    );
+    if (needsWorkersDevSubdomain) {
+      hints.push(
+        [
+          "workers.dev サブドメインが未登録です。ブラウザで以下の URL を開いてサブドメインを登録してください:",
+          `  ${workersOnboardingUrl(_accountId)}`,
+          "登録が終わったら、同じコマンドを再実行すれば途中から再開されます。",
+          "（登録直後は DNS 反映に数分かかる場合があります。デプロイが失敗する場合は少し待ってから再実行してください）",
+        ].join("\n"),
+      );
+    }
     if (text.includes("code: 10034") || text.includes("code:10034")) {
       hints.push(
         "Cloudflare アカウントのメール認証が完了していません。Cloudflare ダッシュボードに届く確認メールを開いて認証してください。",
@@ -34,13 +51,28 @@ export class WranglerError extends Error {
     if (text.includes("not authenticated") || text.includes("you are not authenticated")) {
       hints.push("OAuth トークンが切れています。`npx wrangler logout && npx wrangler login` で再ログインしてください。");
     }
-    if (text.includes("non-interactive") || text.includes("cloudflare_api_token")) {
+    if (
+      !needsWorkersDevSubdomain &&
+      (text.includes("non-interactive") || text.includes("cloudflare_api_token"))
+    ) {
+      // Skipped for the subdomain case: wrangler's registration prompt is
+      // what trips the non-interactive error there, and reporting it as a
+      // CLI bug would send users down the wrong path.
       hints.push(
         "wrangler が CI モード判定に陥っています（TTY 不在）。create-line-harness 側のバグの可能性が高いので、Issue で報告してください。",
       );
     }
     if (text.includes("d1_create_too_many_databases") || text.includes("too many databases")) {
       hints.push("D1 の無料枠を使い切っています。古い D1 を削除するか有料プランへ。");
+    }
+    if (text.includes("register a workers.dev subdomain")) {
+      hints.push(
+        [
+          "workers.dev サブドメインが未登録です。同じコマンドを再実行すると CLI 内で登録できます。",
+          "うまくいかない場合は Cloudflare ダッシュボード（https://dash.cloudflare.com/ → Workers & Pages）で登録してください。",
+          "登録直後は DNS 反映に数分かかるため、失敗する場合は数分待ってから再実行してください。",
+        ].join("\n"),
+      );
     }
 
     return hints.length > 0 ? hints.join("\n") : null;
@@ -55,6 +87,17 @@ let _accountId: string | undefined;
  */
 export function setAccountId(accountId: string): void {
   _accountId = accountId;
+}
+
+/**
+ * Dashboard page where the user registers their workers.dev subdomain.
+ * Without an account ID, `?to=/:account/...` lets the dashboard resolve the
+ * account (showing a picker if the user has several).
+ */
+export function workersOnboardingUrl(accountId?: string): string {
+  return accountId
+    ? `https://dash.cloudflare.com/${accountId}/workers/onboarding`
+    : "https://dash.cloudflare.com/?to=/:account/workers/onboarding";
 }
 
 export interface WranglerOptions {

--- a/packages/create-line-harness/src/steps/deploy-worker.ts
+++ b/packages/create-line-harness/src/steps/deploy-worker.ts
@@ -17,6 +17,11 @@ import { repoPnpm } from "../lib/pnpm.js";
 
 const WORKERS_DEV_URL = /(https:\/\/[^\s]+\.workers\.dev)/;
 const TTY_REQUIRED = /non[- ]?interactive|cloudflare_api_token|consent denied|authentication error|expired/i;
+// Unregistered workers.dev subdomain. Wrangler prints this alongside a
+// non-interactive-context error (its registration prompt cannot be answered
+// through our pipe), so it would otherwise take the TTY-retry path below and
+// lose the message getHelp() keys on — rethrow immediately instead.
+const WORKERS_DEV_SUBDOMAIN_UNREGISTERED = /register a workers\.dev subdomain/i;
 const RETRYABLE_NETWORK_ERROR =
   /fetch failed|connectivity issue|network connectivity|connection reset|socket hang up/i;
 const MAX_DEPLOY_ATTEMPTS = 3;
@@ -76,6 +81,10 @@ async function deployWorkerBundle(
     return match[1];
   };
 
+  const isSubdomainUnregisteredError = (error: unknown): boolean =>
+    error instanceof WranglerError &&
+    WORKERS_DEV_SUBDOMAIN_UNREGISTERED.test(`${error.message}\n${error.stderr}`);
+
   const isAuthError = (error: unknown): boolean =>
     error instanceof WranglerError &&
     TTY_REQUIRED.test(`${error.message}\n${error.stderr}`);
@@ -97,6 +106,13 @@ async function deployWorkerBundle(
     try {
       return await deployAndParseUrl();
     } catch (firstError) {
+      // No retry can fix an unregistered subdomain — surface the original
+      // WranglerError so setup's top-level catch renders the registration
+      // guidance (WranglerError.getHelp()).
+      if (isSubdomainUnregisteredError(firstError)) {
+        throw firstError;
+      }
+
       if (isAuthError(firstError)) {
         p.log.warn(
           "wrangler の認証を更新するため、対話モードで再実行します（出力が表示されます）...",
@@ -106,6 +122,9 @@ async function deployWorkerBundle(
         try {
           return await deployAndParseUrl();
         } catch (urlError) {
+          if (isSubdomainUnregisteredError(urlError)) {
+            throw urlError;
+          }
           if (
             isRetryableNetworkError(urlError) &&
             attempt < MAX_DEPLOY_ATTEMPTS

--- a/packages/create-line-harness/src/steps/ensure-subdomain.ts
+++ b/packages/create-line-harness/src/steps/ensure-subdomain.ts
@@ -1,0 +1,228 @@
+import * as p from "@clack/prompts";
+import pc from "picocolors";
+import {
+  getWorkersSubdomain,
+  putWorkersSubdomain,
+  SubdomainConflictError,
+  type CfApiCreds,
+} from "@line-harness/update-engine";
+import { readWranglerOAuthToken } from "../lib/wrangler-oauth.js";
+import {
+  isValidSubdomainName,
+  sanitizeSubdomainCandidate,
+} from "../lib/subdomain-name.js";
+
+/**
+ * Make sure the Cloudflare account has a workers.dev subdomain BEFORE the
+ * Worker deploy runs. Accounts that never deployed a Worker don't have one,
+ * and `wrangler deploy` then fails with "You need to register a workers.dev
+ * subdomain before publishing to workers.dev" — a dead end when wrangler
+ * runs non-interactively (community users ended up re-running the same
+ * command in a loop).
+ *
+ * Uses the same REST endpoints wrangler's own interactive prompt calls
+ * (GET/PUT accounts/{account_id}/workers/subdomain), authenticated with
+ * either a caller-supplied API token (update flow) or wrangler's OAuth
+ * token from `wrangler login` (setup flow).
+ */
+
+export interface EnsureSubdomainOptions {
+  accountId: string;
+  /** Source string for the suggested subdomain name (e.g. project name). */
+  defaultName: string;
+  /**
+   * CF API token to use (update flow). When absent, falls back to
+   * CLOUDFLARE_API_TOKEN and then wrangler's own OAuth token.
+   */
+  apiToken?: string;
+}
+
+export interface EnsureSubdomainResult {
+  /**
+   * True when a subdomain was registered during THIS run — callers add
+   * "DNS propagation takes a few minutes" guidance to any immediately
+   * following health check failure.
+   */
+  registeredNow: boolean;
+  /**
+   * The account's current subdomain when known (pre-existing or just
+   * registered); null when it could not be determined. The update flow
+   * compares this against the hostname in the saved Worker URL and
+   * rewrites the URL when the user registered a different name.
+   */
+  subdomain: string | null;
+}
+
+function onboardingUrl(accountId: string): string {
+  return `https://dash.cloudflare.com/${accountId}/workers/onboarding`;
+}
+
+/** DNS-propagation note shown right after a successful registration. */
+function dnsPropagationNote(): string {
+  return [
+    "登録直後は DNS 反映に数分かかることがあります。",
+    "この後のデプロイ確認やヘルスチェックが失敗した場合は、数分待ってから",
+    "同じコマンドを再実行してください（続きから再開されます）。",
+  ].join("\n");
+}
+
+function manualRegistrationGuide(accountId: string): string {
+  return [
+    "CLI からの自動登録ができなかったため、ブラウザで手動登録してください:",
+    "",
+    `  1. ${pc.cyan(onboardingUrl(accountId))} を開く`,
+    "  2. 「サブドメインの登録」（Register subdomain）で好きな名前を入力して登録",
+    "     （この名前はアカウント共通で、URL の一部になります）",
+  ].join("\n");
+}
+
+async function promptSubdomainName(defaultCandidate: string | null): Promise<string> {
+  const name = await p.text({
+    message:
+      "workers.dev サブドメイン名（Worker の URL が https://<Worker名>.<この名前>.workers.dev になります）",
+    placeholder: defaultCandidate ?? undefined,
+    defaultValue: defaultCandidate ?? undefined,
+    validate(value) {
+      const v = (value || defaultCandidate || "").trim();
+      if (!isValidSubdomainName(v)) {
+        return "英小文字・数字・ハイフンのみ、63文字以内、先頭と末尾は英数字にしてください";
+      }
+    },
+  });
+  if (p.isCancel(name)) {
+    p.cancel("セットアップをキャンセルしました");
+    process.exit(0);
+  }
+  return ((name as string) || defaultCandidate || "").trim();
+}
+
+/**
+ * Interactive registration loop: prompt a name → PUT → on conflict re-prompt.
+ * Returns the registered name, or null when the caller should fall back to
+ * the manual (dashboard) path.
+ */
+async function registerInteractively(
+  creds: CfApiCreds,
+  defaultName: string,
+): Promise<string | null> {
+  let candidate = sanitizeSubdomainCandidate(defaultName);
+  for (;;) {
+    const name = await promptSubdomainName(candidate);
+    // The suggested name conflicted once — don't suggest it again.
+    candidate = null;
+
+    const s = p.spinner();
+    s.start(`workers.dev サブドメイン "${name}" を登録中...`);
+    try {
+      await putWorkersSubdomain({ creds, subdomain: name });
+      s.stop(`workers.dev サブドメイン登録完了: ${name}.workers.dev`);
+      p.log.info(dnsPropagationNote());
+      return name;
+    } catch (error) {
+      if (error instanceof SubdomainConflictError) {
+        s.stop(pc.yellow(`"${name}" は既に使われています`));
+        p.log.warn(
+          "workers.dev サブドメインは全世界で早い者勝ちです。別の名前を入力してください。",
+        );
+        continue;
+      }
+      const msg = error instanceof Error ? error.message : String(error);
+      s.stop(pc.yellow(`自動登録に失敗しました: ${msg}`));
+      return null;
+    }
+  }
+}
+
+/**
+ * Manual fallback: show the dashboard guide, then poll the GET endpoint
+ * each time the user says they're done. The user can also choose to
+ * continue without verification (the deploy will surface the truth).
+ * Returns the verified name, or null when the user skipped verification.
+ */
+async function registerManually(creds: CfApiCreds): Promise<string | null> {
+  p.log.warn(manualRegistrationGuide(creds.accountId));
+
+  for (;;) {
+    const choice = await p.select({
+      message: "ダッシュボードでの登録が終わったら「確認する」を選んでください",
+      options: [
+        { value: "check", label: "確認する（登録済みかチェックします）" },
+        { value: "continue", label: "確認せずに続行する（未登録だとデプロイに失敗します）" },
+      ],
+    });
+    if (p.isCancel(choice)) {
+      p.cancel("セットアップをキャンセルしました");
+      process.exit(0);
+    }
+    if (choice === "continue") {
+      return null;
+    }
+
+    const s = p.spinner();
+    s.start("登録状態を確認中...");
+    try {
+      const subdomain = await getWorkersSubdomain({ creds });
+      if (subdomain) {
+        s.stop(`workers.dev サブドメイン確認完了: ${subdomain}.workers.dev`);
+        p.log.info(dnsPropagationNote());
+        return subdomain;
+      }
+      s.stop(pc.yellow("まだ登録が確認できません"));
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      s.stop(pc.yellow(`確認に失敗しました: ${msg}`));
+    }
+  }
+}
+
+export async function ensureWorkersDevSubdomain(
+  options: EnsureSubdomainOptions,
+): Promise<EnsureSubdomainResult> {
+  const apiToken =
+    options.apiToken ??
+    process.env.CLOUDFLARE_API_TOKEN ??
+    readWranglerOAuthToken() ??
+    undefined;
+
+  if (!apiToken) {
+    // Can't pre-check (no readable credential). Not fatal: wrangler deploy
+    // runs next with its own auth, and its error path points back here.
+    return { registeredNow: false, subdomain: null };
+  }
+
+  const creds: CfApiCreds = { accountId: options.accountId, apiToken };
+
+  const s = p.spinner();
+  s.start("workers.dev サブドメイン確認中...");
+  let existing: string | null;
+  try {
+    existing = await getWorkersSubdomain({ creds });
+  } catch {
+    // Auth scope/network issues etc. — the account may well have a
+    // subdomain, so don't drag the user into registration. Proceed and let
+    // the deploy tell the truth.
+    s.stop("workers.dev サブドメイン確認をスキップ（状態を取得できませんでした）");
+    return { registeredNow: false, subdomain: null };
+  }
+
+  if (existing) {
+    s.stop(`workers.dev サブドメイン: ${existing}.workers.dev`);
+    return { registeredNow: false, subdomain: existing };
+  }
+
+  s.stop(pc.yellow("workers.dev サブドメインが未登録です"));
+  p.log.info(
+    [
+      "この Cloudflare アカウントにはまだ workers.dev サブドメインがありません。",
+      "Worker を公開するために必要なので、ここで登録します（無料・1アカウント1回だけ）。",
+    ].join("\n"),
+  );
+
+  const registeredName = await registerInteractively(creds, options.defaultName);
+  if (registeredName) {
+    return { registeredNow: true, subdomain: registeredName };
+  }
+
+  const manualName = await registerManually(creds);
+  return { registeredNow: manualName !== null, subdomain: manualName };
+}

--- a/packages/create-line-harness/test/resolve-state.test.ts
+++ b/packages/create-line-harness/test/resolve-state.test.ts
@@ -109,20 +109,30 @@ describe('resolveState — credentials and legacy fallbacks', () => {
   });
 });
 
-// ─── normalizeLiffBindings ────────────────────────────────────────────────────
+// ─── normalizeInstallBindings ─────────────────────────────────────────────────
 
-import { normalizeLiffBindings } from '../src/commands/update.js';
+import { normalizeInstallBindings } from '../src/commands/update.js';
 
-describe('normalizeLiffBindings', () => {
+describe('normalizeInstallBindings', () => {
   const bindings = [
     { type: 'd1' as const, name: 'DB', database_id: 'd1id' },
     { type: 'plain_text' as const, name: 'LIFF_PAGES_PROJECT', text: 'line-harness-liff' },
     { type: 'plain_text' as const, name: 'WORKER_NAME', text: 'line-harness' },
+    {
+      type: 'plain_text' as const,
+      name: 'WORKER_PUBLIC_URL',
+      text: 'https://line-harness.old-sub.workers.dev',
+    },
     { type: 'assets' as const, name: 'ASSETS' },
   ];
 
+  const OPTS = {
+    liffProject: '',
+    workerPublicUrl: 'https://line-harness.old-sub.workers.dev',
+  };
+
   it('clears the stale LIFF_PAGES_PROJECT binding for worker-assets installs', () => {
-    const out = normalizeLiffBindings(bindings, '');
+    const out = normalizeInstallBindings(bindings, OPTS);
     const liff = out.find((b) => b.name === 'LIFF_PAGES_PROJECT');
     expect(liff?.text).toBe('');
     // Everything else passes through untouched.
@@ -131,12 +141,25 @@ describe('normalizeLiffBindings', () => {
   });
 
   it('sets the binding to the real project name for legacy Pages-LIFF installs', () => {
-    const out = normalizeLiffBindings(bindings, 'lh-liff-abc123');
+    const out = normalizeInstallBindings(bindings, {
+      ...OPTS,
+      liffProject: 'lh-liff-abc123',
+    });
     expect(out.find((b) => b.name === 'LIFF_PAGES_PROJECT')?.text).toBe('lh-liff-abc123');
   });
 
+  it('rewrites WORKER_PUBLIC_URL after a subdomain rename', () => {
+    const out = normalizeInstallBindings(bindings, {
+      ...OPTS,
+      workerPublicUrl: 'https://line-harness.new-sub.workers.dev',
+    });
+    expect(out.find((b) => b.name === 'WORKER_PUBLIC_URL')?.text).toBe(
+      'https://line-harness.new-sub.workers.dev',
+    );
+  });
+
   it('does not mutate the input array', () => {
-    normalizeLiffBindings(bindings, '');
+    normalizeInstallBindings(bindings, OPTS);
     expect(bindings.find((b) => b.name === 'LIFF_PAGES_PROJECT')?.text).toBe('line-harness-liff');
   });
 });

--- a/packages/create-line-harness/test/subdomain-name.test.ts
+++ b/packages/create-line-harness/test/subdomain-name.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidSubdomainName,
+  sanitizeSubdomainCandidate,
+  subdomainFromWorkersDevUrl,
+} from '../src/lib/subdomain-name.js';
+
+describe('isValidSubdomainName', () => {
+  it('accepts typical names', () => {
+    expect(isValidSubdomainName('line-harness')).toBe(true);
+    expect(isValidSubdomainName('a')).toBe(true);
+    expect(isValidSubdomainName('a1')).toBe(true);
+    expect(isValidSubdomainName('my-bot-2')).toBe(true);
+  });
+
+  it('rejects invalid names', () => {
+    expect(isValidSubdomainName('')).toBe(false);
+    expect(isValidSubdomainName('-leading')).toBe(false);
+    expect(isValidSubdomainName('trailing-')).toBe(false);
+    expect(isValidSubdomainName('UPPER')).toBe(false);
+    expect(isValidSubdomainName('has.dot')).toBe(false);
+    expect(isValidSubdomainName('a'.repeat(64))).toBe(false);
+    expect(isValidSubdomainName('a'.repeat(63))).toBe(true);
+  });
+});
+
+describe('sanitizeSubdomainCandidate', () => {
+  it('passes through already-valid project names', () => {
+    expect(sanitizeSubdomainCandidate('line-harness')).toBe('line-harness');
+  });
+
+  it('lowercases and replaces invalid characters', () => {
+    expect(sanitizeSubdomainCandidate('My_Cool Bot!')).toBe('my-cool-bot');
+  });
+
+  it('collapses runs of hyphens and trims edges', () => {
+    expect(sanitizeSubdomainCandidate('--a--b--')).toBe('a-b');
+  });
+
+  it('truncates to 63 chars without leaving a trailing hyphen', () => {
+    const long = 'ab-'.repeat(30); // 90 chars, position 63 lands after a hyphen
+    const out = sanitizeSubdomainCandidate(long);
+    expect(out).not.toBeNull();
+    expect(out!.length).toBeLessThanOrEqual(63);
+    expect(isValidSubdomainName(out!)).toBe(true);
+  });
+
+  it('returns null when nothing usable remains', () => {
+    expect(sanitizeSubdomainCandidate('---')).toBeNull();
+    expect(sanitizeSubdomainCandidate('日本語だけ')).toBeNull();
+    expect(sanitizeSubdomainCandidate('')).toBeNull();
+  });
+});
+
+describe('subdomainFromWorkersDevUrl', () => {
+  it('extracts the account subdomain from a workers.dev URL', () => {
+    expect(
+      subdomainFromWorkersDevUrl('https://line-harness.acc.workers.dev'),
+    ).toBe('acc');
+    expect(
+      subdomainFromWorkersDevUrl('https://my-bot.example-team.workers.dev/health'),
+    ).toBe('example-team');
+  });
+
+  it('returns null for custom domains and unparsable input', () => {
+    expect(subdomainFromWorkersDevUrl('https://bot.example.com')).toBeNull();
+    // Bare account-subdomain URL (no worker label) — nothing to extract.
+    expect(subdomainFromWorkersDevUrl('https://acc.workers.dev')).toBeNull();
+    expect(subdomainFromWorkersDevUrl('not a url')).toBeNull();
+  });
+});

--- a/packages/create-line-harness/test/wrangler-error.test.ts
+++ b/packages/create-line-harness/test/wrangler-error.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  WranglerError,
+  setAccountId,
+  workersOnboardingUrl,
+} from '../src/lib/wrangler.js';
+
+const ACCOUNT_ID = 'a'.repeat(32);
+const SUBDOMAIN_ERROR =
+  'wrangler deploy failed: ✘ [ERROR] You need to register a workers.dev subdomain before publishing to workers.dev';
+
+describe('workersOnboardingUrl', () => {
+  it('embeds the account ID when available', () => {
+    expect(workersOnboardingUrl(ACCOUNT_ID)).toBe(
+      `https://dash.cloudflare.com/${ACCOUNT_ID}/workers/onboarding`,
+    );
+  });
+
+  it('falls back to the account-resolving deep link without an account ID', () => {
+    expect(workersOnboardingUrl(undefined)).toBe(
+      'https://dash.cloudflare.com/?to=/:account/workers/onboarding',
+    );
+  });
+});
+
+describe('WranglerError.getHelp — workers.dev subdomain registration', () => {
+  beforeEach(() => {
+    // Reset module-level account ID (empty string is treated as unset).
+    setAccountId('');
+  });
+
+  it('maps the unregistered-subdomain error to registration guidance', () => {
+    const help = new WranglerError(SUBDOMAIN_ERROR, '').getHelp();
+    expect(help).toContain('workers.dev サブドメインが未登録です');
+    expect(help).toContain('/workers/onboarding');
+    expect(help).toContain('同じコマンドを再実行');
+    expect(help).toContain('DNS 反映に数分かかる');
+  });
+
+  it('detects the error when it only appears on stderr', () => {
+    const help = new WranglerError(
+      'wrangler deploy failed: exit code 1',
+      'You need to register a workers.dev subdomain before publishing to workers.dev',
+    ).getHelp();
+    expect(help).toContain('workers.dev サブドメインが未登録です');
+  });
+
+  it('embeds the account ID in the onboarding URL once setAccountId was called', () => {
+    setAccountId(ACCOUNT_ID);
+    const help = new WranglerError(SUBDOMAIN_ERROR, '').getHelp();
+    expect(help).toContain(
+      `https://dash.cloudflare.com/${ACCOUNT_ID}/workers/onboarding`,
+    );
+  });
+
+  it('links the generic dashboard deep link when no account ID is known', () => {
+    const help = new WranglerError(SUBDOMAIN_ERROR, '').getHelp();
+    expect(help).toContain(
+      'https://dash.cloudflare.com/?to=/:account/workers/onboarding',
+    );
+  });
+
+  it('suppresses the non-interactive "CLI bug" hint for the subdomain case', () => {
+    // Wrangler tries to prompt for registration and then fails with a
+    // non-interactive error — the subdomain guidance is the real fix.
+    const help = new WranglerError(
+      SUBDOMAIN_ERROR,
+      'This command cannot be run in a non-interactive context',
+    ).getHelp();
+    expect(help).toContain('workers.dev サブドメインが未登録です');
+    expect(help).not.toContain('Issue で報告');
+  });
+
+  it('keeps the non-interactive hint for unrelated non-interactive errors', () => {
+    const help = new WranglerError(
+      'wrangler deploy failed: This command cannot be run in a non-interactive context',
+      '',
+    ).getHelp();
+    expect(help).toContain('Issue で報告');
+  });
+
+  it('returns null for unrelated errors', () => {
+    const help = new WranglerError(
+      'wrangler deploy failed: something else entirely',
+      '',
+    ).getHelp();
+    expect(help).toBeNull();
+  });
+});

--- a/packages/create-line-harness/test/wrangler-oauth.test.ts
+++ b/packages/create-line-harness/test/wrangler-oauth.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  getWranglerConfigDir,
+  parseWranglerAuthToml,
+  readWranglerOAuthToken,
+} from '../src/lib/wrangler-oauth.js';
+
+describe('getWranglerConfigDir', () => {
+  const isDir = (dirs: string[]) => (p: string) => dirs.includes(p);
+
+  it('prefers a pre-existing legacy ~/.wrangler directory', () => {
+    const home = '/home/user';
+    expect(
+      getWranglerConfigDir({
+        env: {},
+        platform: 'linux',
+        home,
+        isDirectory: isDir([join(home, '.wrangler')]),
+      }),
+    ).toBe(join(home, '.wrangler'));
+  });
+
+  it('uses XDG_CONFIG_HOME when set (no legacy dir)', () => {
+    expect(
+      getWranglerConfigDir({
+        env: { XDG_CONFIG_HOME: '/custom/config' },
+        platform: 'linux',
+        home: '/home/user',
+        isDirectory: () => false,
+      }),
+    ).toBe(join('/custom/config', '.wrangler'));
+  });
+
+  it('falls back to ~/Library/Preferences on macOS', () => {
+    expect(
+      getWranglerConfigDir({
+        env: {},
+        platform: 'darwin',
+        home: '/Users/u',
+        isDirectory: () => false,
+      }),
+    ).toBe(join('/Users/u', 'Library', 'Preferences', '.wrangler'));
+  });
+
+  it('falls back to ~/.config on Linux', () => {
+    expect(
+      getWranglerConfigDir({
+        env: {},
+        platform: 'linux',
+        home: '/home/user',
+        isDirectory: () => false,
+      }),
+    ).toBe(join('/home/user', '.config', '.wrangler'));
+  });
+
+  it('uses %APPDATA%/xdg.config on Windows', () => {
+    expect(
+      getWranglerConfigDir({
+        env: { APPDATA: 'C:\\Users\\u\\AppData\\Roaming' },
+        platform: 'win32',
+        home: 'C:\\Users\\u',
+        isDirectory: () => false,
+      }),
+    ).toBe(join('C:\\Users\\u\\AppData\\Roaming', 'xdg.config', '.wrangler'));
+  });
+});
+
+describe('parseWranglerAuthToml', () => {
+  it('extracts oauth_token and expiration_time', () => {
+    const toml = [
+      'oauth_token = "tok_123"',
+      'refresh_token = "ref_456"',
+      'expiration_time = "2099-01-01T00:00:00.000Z"',
+      'scopes = ["account:read"]',
+    ].join('\n');
+    expect(parseWranglerAuthToml(toml)).toEqual({
+      oauthToken: 'tok_123',
+      expirationTime: '2099-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('returns nulls for an api-token-only or empty config', () => {
+    expect(parseWranglerAuthToml('api_token = "x"\n')).toEqual({
+      oauthToken: null,
+      expirationTime: null,
+    });
+    expect(parseWranglerAuthToml('')).toEqual({
+      oauthToken: null,
+      expirationTime: null,
+    });
+  });
+});
+
+describe('readWranglerOAuthToken', () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'clh-oauth-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeCredentials(content: string): void {
+    const configDir = join(home, '.wrangler', 'config');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'default.toml'), content);
+  }
+
+  const opts = () => ({ env: {}, platform: 'linux' as const, home });
+
+  it('reads a live token from the legacy ~/.wrangler location', () => {
+    writeCredentials(
+      'oauth_token = "tok_live"\nexpiration_time = "2099-01-01T00:00:00.000Z"\n',
+    );
+    expect(readWranglerOAuthToken(opts())).toBe('tok_live');
+  });
+
+  it('returns null when the token is expired', () => {
+    writeCredentials(
+      'oauth_token = "tok_old"\nexpiration_time = "2000-01-01T00:00:00.000Z"\n',
+    );
+    expect(readWranglerOAuthToken(opts())).toBeNull();
+  });
+
+  it('accepts a token without expiration_time', () => {
+    writeCredentials('oauth_token = "tok_noexp"\n');
+    expect(readWranglerOAuthToken(opts())).toBe('tok_noexp');
+  });
+
+  it('returns null when the credentials file is missing', () => {
+    expect(readWranglerOAuthToken(opts())).toBeNull();
+  });
+
+  it('returns null when the file has no oauth_token', () => {
+    writeCredentials('api_token = "not-oauth"\n');
+    expect(readWranglerOAuthToken(opts())).toBeNull();
+  });
+});

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/update-engine",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Self-update engine for LINE Harness — shared between Worker (cloud-side self-update) and CLI (npx create-line-harness update)",
   "type": "module",
   "exports": {

--- a/packages/update-engine/src/cf-api/subdomain.ts
+++ b/packages/update-engine/src/cf-api/subdomain.ts
@@ -1,0 +1,124 @@
+import type { CfApiCreds } from '../types.js';
+import { authHeader, readBodyExcerpt } from './_shared.js';
+
+/**
+ * Cloudflare error codes for the workers.dev subdomain endpoints, as used by
+ * wrangler itself (packages/deploy-helpers/src/triggers/subdomain.ts in
+ * cloudflare/workers-sdk):
+ *   - 10007: no subdomain registered on the account (GET "not found")
+ *   - 10031: subdomain name is unavailable / already taken (PUT)
+ */
+const CF_ERROR_SUBDOMAIN_NOT_FOUND = 10007;
+const CF_ERROR_SUBDOMAIN_UNAVAILABLE = 10031;
+
+/** Thrown by {@link putWorkersSubdomain} when the requested name is taken. */
+export class SubdomainConflictError extends Error {
+  constructor(subdomain: string) {
+    super(`workers.dev subdomain "${subdomain}" is unavailable (already taken)`);
+    this.name = 'SubdomainConflictError';
+  }
+}
+
+interface CfEnvelope {
+  success?: boolean;
+  errors?: Array<{ code?: number; message?: string }>;
+  result?: { subdomain?: string | null } | null;
+}
+
+function workersSubdomainApiUrl(accountId: string): string {
+  return `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/subdomain`;
+}
+
+/**
+ * Parse a CF API response body without assuming it is valid JSON — 5xx
+ * responses can be a wall-of-HTML error page. Returns null when unparsable.
+ */
+async function parseEnvelope(res: Response): Promise<{ envelope: CfEnvelope | null; raw: string }> {
+  let raw = '';
+  try {
+    raw = await res.text();
+  } catch {
+    return { envelope: null, raw: '' };
+  }
+  try {
+    return { envelope: JSON.parse(raw) as CfEnvelope, raw };
+  } catch {
+    return { envelope: null, raw };
+  }
+}
+
+function hasErrorCode(envelope: CfEnvelope | null, code: number): boolean {
+  return envelope?.errors?.some((e) => e.code === code) ?? false;
+}
+
+function excerpt(raw: string): string {
+  return raw.length > 500 ? raw.slice(0, 500) + '…' : raw;
+}
+
+/**
+ * Fetch the account-level workers.dev subdomain.
+ *
+ * Returns the bare subdomain name (`"example"` for
+ * `https://<worker>.example.workers.dev`) or `null` when the account has not
+ * registered one yet (CF answers 404 with error code 10007). Any other
+ * non-2xx — including auth failures — throws so callers can distinguish
+ * "definitely unregistered" from "could not check".
+ */
+export async function getWorkersSubdomain(opts: {
+  creds: CfApiCreds;
+}): Promise<string | null> {
+  const { creds } = opts;
+  const res = await fetch(workersSubdomainApiUrl(creds.accountId), {
+    method: 'GET',
+    headers: authHeader(creds.apiToken),
+  });
+
+  const { envelope, raw } = await parseEnvelope(res);
+
+  if (res.ok) {
+    const subdomain = envelope?.result?.subdomain;
+    return typeof subdomain === 'string' && subdomain.length > 0 ? subdomain : null;
+  }
+
+  if (hasErrorCode(envelope, CF_ERROR_SUBDOMAIN_NOT_FOUND)) {
+    return null;
+  }
+
+  throw new Error(`GET workers subdomain failed: HTTP ${res.status} ${excerpt(raw)}`);
+}
+
+/**
+ * Register the account-level workers.dev subdomain.
+ *
+ * workers.dev names are globally first-come-first-served: a taken name is
+ * reported via error code 10031 (or HTTP 409) and surfaces as
+ * {@link SubdomainConflictError} so callers can re-prompt for another name.
+ * Any other failure (permissions, network, 5xx) throws a plain Error.
+ */
+export async function putWorkersSubdomain(opts: {
+  creds: CfApiCreds;
+  subdomain: string;
+}): Promise<void> {
+  const { creds, subdomain } = opts;
+  const res = await fetch(workersSubdomainApiUrl(creds.accountId), {
+    method: 'PUT',
+    headers: {
+      ...authHeader(creds.apiToken),
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ subdomain }),
+  });
+
+  if (res.ok) {
+    // Drain the body so the connection can be reused.
+    await readBodyExcerpt(res);
+    return;
+  }
+
+  const { envelope, raw } = await parseEnvelope(res);
+  if (res.status === 409 || hasErrorCode(envelope, CF_ERROR_SUBDOMAIN_UNAVAILABLE)) {
+    throw new SubdomainConflictError(subdomain);
+  }
+
+  throw new Error(`PUT workers subdomain failed: HTTP ${res.status} ${excerpt(raw)}`);
+}

--- a/packages/update-engine/src/index.ts
+++ b/packages/update-engine/src/index.ts
@@ -29,6 +29,7 @@ export * from './snapshot.js';
 export * from './cf-api/workers.js';
 export * from './cf-api/pages.js';
 export * from './cf-api/d1.js';
+export * from './cf-api/subdomain.js';
 export * from './events.js';
 export * from './phases/preflight.js';
 export * from './phases/apply.js';

--- a/packages/update-engine/test/cf-api/subdomain.test.ts
+++ b/packages/update-engine/test/cf-api/subdomain.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getWorkersSubdomain,
+  putWorkersSubdomain,
+  SubdomainConflictError,
+} from '../../src/cf-api/subdomain.js';
+import type { CfApiCreds } from '../../src/types.js';
+
+const creds: CfApiCreds = {
+  accountId: 'acct123',
+  apiToken: 'tok_abc',
+};
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as Response;
+}
+
+describe('getWorkersSubdomain', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('returns the registered subdomain name', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockResponse(200, { success: true, result: { subdomain: 'example' } }),
+    );
+
+    await expect(getWorkersSubdomain({ creds })).resolves.toBe('example');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      'https://api.cloudflare.com/client/v4/accounts/acct123/workers/subdomain',
+    );
+    expect(init.method).toBe('GET');
+    expect(init.headers.Authorization).toBe('Bearer tok_abc');
+  });
+
+  it('returns null when the account has no subdomain (404 + code 10007)', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockResponse(404, {
+        success: false,
+        errors: [{ code: 10007, message: 'workers.api.error.subdomain_not_found' }],
+        result: null,
+      }),
+    );
+
+    await expect(getWorkersSubdomain({ creds })).resolves.toBeNull();
+  });
+
+  it('returns null when the API answers 200 with a null subdomain', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockResponse(200, { success: true, result: { subdomain: null } }),
+    );
+
+    await expect(getWorkersSubdomain({ creds })).resolves.toBeNull();
+  });
+
+  it('throws on auth errors instead of reporting "unregistered"', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockResponse(403, {
+        success: false,
+        errors: [{ code: 10000, message: 'Authentication error' }],
+      }),
+    );
+
+    await expect(getWorkersSubdomain({ creds })).rejects.toThrow(/HTTP 403/);
+  });
+
+  it('throws on a non-JSON 5xx body without crashing the parser', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(mockResponse(502, '<html>Bad Gateway</html>'));
+
+    await expect(getWorkersSubdomain({ creds })).rejects.toThrow(/HTTP 502/);
+  });
+});
+
+describe('putWorkersSubdomain', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('registers the subdomain with a JSON body', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockResponse(200, { success: true, result: { subdomain: 'example' } }),
+    );
+
+    await expect(
+      putWorkersSubdomain({ creds, subdomain: 'example' }),
+    ).resolves.toBeUndefined();
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      'https://api.cloudflare.com/client/v4/accounts/acct123/workers/subdomain',
+    );
+    expect(init.method).toBe('PUT');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init.body)).toEqual({ subdomain: 'example' });
+  });
+
+  it('throws SubdomainConflictError on code 10031 (name taken)', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockResponse(400, {
+        success: false,
+        errors: [{ code: 10031, message: 'workers.api.error.subdomain_unavailable' }],
+      }),
+    );
+
+    await expect(
+      putWorkersSubdomain({ creds, subdomain: 'taken' }),
+    ).rejects.toBeInstanceOf(SubdomainConflictError);
+  });
+
+  it('throws SubdomainConflictError on HTTP 409', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockResponse(409, { success: false, errors: [{ message: 'conflict' }] }),
+    );
+
+    await expect(
+      putWorkersSubdomain({ creds, subdomain: 'taken' }),
+    ).rejects.toBeInstanceOf(SubdomainConflictError);
+  });
+
+  it('throws a plain Error on other failures (e.g. missing permission)', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(
+      mockResponse(403, {
+        success: false,
+        errors: [{ code: 10000, message: 'Authentication error' }],
+      }),
+    );
+
+    const err = await putWorkersSubdomain({ creds, subdomain: 'x' }).catch(
+      (e) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(SubdomainConflictError);
+    expect(err.message).toMatch(/HTTP 403/);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@line-harness/update-engine':
-        specifier: workspace:^0.0.5
+        specifier: workspace:^0.0.6
         version: link:../update-engine
       execa:
         specifier: ^9.5.2


### PR DESCRIPTION
## Summary

Private からの定期 sync。新規 Cloudflare アカウントで `wrangler deploy` が「You need to register a workers.dev subdomain」で詰まる問題（コミュニティ報告）を解消。

- **setup/update とも、deploy 前にサブドメイン登録状態を確認し、未登録なら CLI 内の対話で名前を入力してもらい CF API で自動登録**（未登録 10007 / 名前衝突 10031 の判定は wrangler 本体と同一）
- update 経路はサブドメイン修復を最初の Worker 疎通前に実施。rename 後は現行バンドルを再デプロイして URL を確実に復旧
- API 登録に失敗した場合はダッシュボード登録ページの URL つきガイドを表示（フォールバック）

npm 公開済み: `create-line-harness@0.2.3` / `@line-harness/update-engine@0.0.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)