### PR TITLE
docs(contributing): migration numbering rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,10 @@ Small, focused PRs are easiest to review. A good PR includes:
 - A clear statement of what was not tested.
 - No production secrets, private configuration, generated build output, or
   unrelated formatting churn.
+- Migration files with a placeholder number (for example `NNN_add_feature.sql`).
+  The upstream migration chain moves fast, so final numbers are assigned by
+  maintainers at merge time. Do not pick the next free number yourself — it
+  will almost always conflict by the time the PR lands.
 
 ### PRs We Usually Do Not Merge As-Is
 


### PR DESCRIPTION
外部PRの migration 番号が upstream チェーンとほぼ必ず衝突する問題（直近では #211 / #214 / #152 すべてで発生）への予防策として、「番号は placeholder で提出、採番はマージ時に maintainer が行う」を Pull Request Rules に明記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)