### PR TITLE
sync: community fixes — flex image-safe auto-track (#208) + MCP default account (#182)

### DIFF
--- a/apps/worker/src/services/auto-track.test.ts
+++ b/apps/worker/src/services/auto-track.test.ts
@@ -7,7 +7,7 @@ const dbMocks = {
 };
 vi.mock('@line-crm/db', () => dbMocks);
 
-const { appendFriendToTrackedLinks } = await import('./auto-track.js');
+const { appendFriendToTrackedLinks, autoTrackContent } = await import('./auto-track.js');
 
 const DB = {} as D1Database;
 const WORKER = 'https://worker.example.com';
@@ -63,5 +63,107 @@ describe('appendFriendToTrackedLinks', () => {
     const content = `${WORKER}/t/Ab3xY9k`;
     const out = await appendFriendToTrackedLinks(DB, content, WORKER, FRIEND);
     expect(out).toBe(`${WORKER}/t/Ab3xY9k?f=${FRIEND}`);
+  });
+});
+
+describe('autoTrackContent (flex)', () => {
+  beforeEach(() => {
+    let n = 0;
+    dbMocks.createTrackedLink.mockImplementation(async () => {
+      n += 1;
+      return { id: `id-${n}`, short_code: `Code${n}` };
+    });
+  });
+
+  const flex = (obj: unknown) => JSON.stringify(obj);
+
+  test('rewrites action uri but never the image url (blank-image bug)', async () => {
+    const content = flex({
+      type: 'bubble',
+      hero: {
+        type: 'image',
+        url: 'https://cdn.example.com/hero.png',
+        action: { type: 'uri', uri: 'https://example.com/lp' },
+      },
+    });
+    const out = await autoTrackContent(DB, 'flex', content, WORKER);
+    const tree = JSON.parse(out.content);
+    expect(tree.hero.url).toBe('https://cdn.example.com/hero.png');
+    expect(tree.hero.action.uri).toBe(`${SHORT}/t/Code1`);
+  });
+
+  test('rewrites defaultAction and altUri.desktop', async () => {
+    const content = flex({
+      type: 'box',
+      defaultAction: {
+        type: 'uri',
+        uri: 'https://example.com/a',
+        altUri: { desktop: 'https://example.com/a' },
+      },
+    });
+    const out = await autoTrackContent(DB, 'flex', content, WORKER);
+    const tree = JSON.parse(out.content);
+    expect(tree.defaultAction.uri).toBe(`${SHORT}/t/Code1`);
+    expect(tree.defaultAction.altUri.desktop).toBe(`${SHORT}/t/Code1`);
+  });
+
+  test('adds openExternalBrowser=1 for app-link domains in actions', async () => {
+    const content = flex({
+      type: 'button',
+      action: { type: 'uri', uri: 'https://youtube.com/watch?v=abc' },
+    });
+    const out = await autoTrackContent(DB, 'flex', content, WORKER);
+    const tree = JSON.parse(out.content);
+    expect(tree.action.uri).toBe(`${SHORT}/t/Code1?openExternalBrowser=1`);
+  });
+
+  test('skips LIFF, tel: and already-tracked action uris', async () => {
+    const content = flex({
+      type: 'box',
+      contents: [
+        { type: 'button', action: { type: 'uri', uri: 'https://liff.line.me/123-abc' } },
+        { type: 'button', action: { type: 'uri', uri: 'tel:0312345678' } },
+        { type: 'button', action: { type: 'uri', uri: `${SHORT}/t/Existing1` } },
+      ],
+    });
+    const out = await autoTrackContent(DB, 'flex', content, WORKER);
+    expect(out.content).toBe(content);
+    expect(dbMocks.createTrackedLink).not.toHaveBeenCalled();
+  });
+
+  test('malformed action uris are skipped instead of crashing the delivery', async () => {
+    const content = flex({
+      type: 'box',
+      contents: [
+        { type: 'button', action: { type: 'uri', uri: 'https://' } },
+        { type: 'button', action: { type: 'uri', uri: 'https://exa mple.com/lp' } },
+        { type: 'button', action: { type: 'uri', uri: 'https://example.com/ok' } },
+      ],
+    });
+    const out = await autoTrackContent(DB, 'flex', content, WORKER);
+    const tree = JSON.parse(out.content);
+    expect(tree.contents[0].action.uri).toBe('https://');
+    expect(tree.contents[1].action.uri).toBe('https://exa mple.com/lp');
+    expect(tree.contents[2].action.uri).toBe(`${SHORT}/t/Code1`);
+    expect(dbMocks.createTrackedLink).toHaveBeenCalledTimes(1);
+  });
+
+  test('leaves invalid flex JSON untouched instead of corrupting it', async () => {
+    const content = 'not-json https://example.com/lp';
+    const out = await autoTrackContent(DB, 'flex', content, WORKER);
+    expect(out.content).toBe(content);
+    expect(dbMocks.createTrackedLink).not.toHaveBeenCalled();
+  });
+
+  test('passes lineAccountId through to created links', async () => {
+    const content = flex({
+      type: 'button',
+      action: { type: 'uri', uri: 'https://example.com/lp' },
+    });
+    await autoTrackContent(DB, 'flex', content, WORKER, { lineAccountId: 'acc-1' });
+    expect(dbMocks.createTrackedLink).toHaveBeenCalledWith(
+      DB,
+      expect.objectContaining({ lineAccountId: 'acc-1' }),
+    );
   });
 });

--- a/apps/worker/src/services/auto-track.ts
+++ b/apps/worker/src/services/auto-track.ts
@@ -76,21 +76,25 @@ async function createTrackingMap(
   linkBase: string,
   lineAccountId?: string | null,
 ): Promise<Map<string, { trackingUrl: string; originalUrl: string; label: string }>> {
-  const urlMap = new Map<string, { trackingUrl: string; originalUrl: string; label: string }>();
-  for (const url of urls) {
-    const link = await createTrackedLink(db, {
-      name: `auto: ${url.slice(0, 60)}`,
-      originalUrl: url,
-      lineAccountId: lineAccountId ?? null,
-    });
-    // /t/ URL — Worker handles LINE app detection and LIFF redirect server-side.
-    // Prefer the short code (linkBase may be a branded short domain).
-    const trackingUrl = `${linkBase}/t/${link.short_code ?? link.id}`;
-    const hostname = new URL(url).hostname.replace('www.', '');
-    const label = hostname.length > 20 ? hostname.slice(0, 20) + '…' : hostname;
-    urlMap.set(url, { trackingUrl, originalUrl: url, label });
-  }
-  return urlMap;
+  // Inserts are independent (each generates its own id/short_code), so run
+  // them concurrently — a carousel can hold 10+ URIs and sequential D1
+  // round-trips add up inside per-friend delivery loops.
+  const entries = await Promise.all(
+    [...urls].map(async (url) => {
+      const link = await createTrackedLink(db, {
+        name: `auto: ${url.slice(0, 60)}`,
+        originalUrl: url,
+        lineAccountId: lineAccountId ?? null,
+      });
+      // /t/ URL — Worker handles LINE app detection and LIFF redirect server-side.
+      // Prefer the short code (linkBase may be a branded short domain).
+      const trackingUrl = `${linkBase}/t/${link.short_code ?? link.id}`;
+      const hostname = new URL(url).hostname.replace('www.', '');
+      const label = hostname.length > 20 ? hostname.slice(0, 20) + '…' : hostname;
+      return [url, { trackingUrl, originalUrl: url, label }] as const;
+    }),
+  );
+  return new Map(entries);
 }
 
 /** Build a Flex bubble from text + tracked URLs */
@@ -264,15 +268,75 @@ export async function autoTrackContent(
     return { messageType: 'text', content: result };
   }
 
-  // Flex messages → replace URLs inline in the JSON
-  // For app-link domains, also inject openExternalBrowser=1 into the URI action
-  const urlMap = await createTrackingMap(db, urls, linkBase, options?.lineAccountId);
-  let result = content;
-  for (const [original, { trackingUrl, originalUrl }] of urlMap) {
-    const finalUrl = isAppLinkDomain(originalUrl)
-      ? appendOpenExternalBrowser(trackingUrl)
-      : trackingUrl;
-    result = result.split(original).join(finalUrl);
+  // Flex messages → rewrite ONLY uri actions (action / defaultAction / altUri.desktop).
+  // Never rewrite the `url` field of image/video/icon components: LINE's media
+  // loader fetches that URL directly, and /t returns an HTML interstitial (not
+  // an image), which renders hero/body images as blank space.
+  let tree: unknown;
+  try {
+    tree = JSON.parse(content);
+  } catch {
+    // Not valid JSON — leave untouched rather than risk corrupting the payload
+    return { messageType, content };
   }
-  return { messageType, content: result };
+  const skipPrefixes = linkBase !== workerBase ? [workerBase, linkBase] : [workerBase];
+  const actionUris = new Set<string>();
+  collectActionUris(tree, actionUris);
+  // Only valid http(s) URIs are trackable (uri actions also allow tel:,
+  // line://, etc., and hand-written JSON can hold malformed URLs like a bare
+  // "https://" — createTrackingMap calls `new URL()`, so an invalid URI here
+  // would throw and fail the whole delivery instead of one link).
+  const trackableUris = new Set(
+    [...actionUris].filter((u) => isTrackableHttpUrl(u) && !shouldSkip(u, skipPrefixes)),
+  );
+  if (trackableUris.size === 0) return { messageType, content };
+  const uriMap = await createTrackingMap(db, trackableUris, linkBase, options?.lineAccountId);
+  rewriteActionUris(tree, (u) => {
+    const tracked = uriMap.get(u);
+    if (!tracked) return u;
+    return isAppLinkDomain(u)
+      ? appendOpenExternalBrowser(tracked.trackingUrl)
+      : tracked.trackingUrl;
+  });
+  return { messageType, content: JSON.stringify(tree) };
+}
+
+/** Valid, parseable http(s) URL — safe to hand to `new URL()` downstream */
+function isTrackableHttpUrl(u: string): boolean {
+  try {
+    const parsed = new URL(u);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/** Walk a Flex JSON tree and visit every action/defaultAction uri (+ altUri.desktop) */
+function visitActionUris(node: unknown, visit: (holder: Record<string, unknown>, key: string) => void): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const child of node) visitActionUris(child, visit);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  for (const key of ['action', 'defaultAction']) {
+    const a = obj[key] as Record<string, unknown> | undefined;
+    if (a && a.type === 'uri') {
+      if (typeof a.uri === 'string') visit(a, 'uri');
+      // Desktop LINE uses altUri.desktop instead of uri — track it the same way
+      const alt = a.altUri as Record<string, unknown> | undefined;
+      if (alt && typeof alt.desktop === 'string') visit(alt, 'desktop');
+    }
+  }
+  for (const value of Object.values(obj)) visitActionUris(value, visit);
+}
+
+function collectActionUris(node: unknown, out: Set<string>): void {
+  visitActionUris(node, (holder, key) => out.add(holder[key] as string));
+}
+
+function rewriteActionUris(node: unknown, fn: (u: string) => string): void {
+  visitActionUris(node, (holder, key) => {
+    holder[key] = fn(holder[key] as string);
+  });
 }

--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Set up LINE Harness — AI-operated LINE CRM — with one command",
   "type": "module",
   "bin": {

--- a/packages/create-line-harness/src/commands/setup.ts
+++ b/packages/create-line-harness/src/commands/setup.ts
@@ -41,6 +41,8 @@ interface SetupState {
   r2BucketName?: string;
   workerName?: string;
   accountId?: string;
+  /** line_accounts.id of the row registered in Step 12 (NOT the CF account id) */
+  lineAccountId?: string;
   botBasicId?: string;
   workerUrl?: string;
   adminUrl?: string;
@@ -815,7 +817,39 @@ ON CONFLICT(channel_id) DO UPDATE SET
     message: "MCP 設定を .mcp.json に追加しますか？（Claude Code / Cursor 用）",
   });
   if (addMcp && !p.isCancel(addMcp)) {
-    generateMcpConfig({ workerUrl: state.workerUrl!, apiKey: state.apiKey! });
+    // Resolve the line_accounts.id via wrangler (same authenticated path as
+    // Step 12) so generateMcpConfig doesn't have to HTTP the fresh worker —
+    // new workers.dev subdomains can take minutes to DNS-resolve. The upsert
+    // in Step 12 is ON CONFLICT(channel_id), so a resumed install may keep a
+    // pre-existing row id — always SELECT instead of trusting a generated id.
+    if (!state.lineAccountId && state.d1DatabaseName && state.lineChannelId) {
+      try {
+        const q = (val: string) => `'${val.replace(/'/g, "''")}'`;
+        const out = await wrangler([
+          "d1",
+          "execute",
+          state.d1DatabaseName,
+          "--remote",
+          "--json",
+          "--command",
+          `SELECT id FROM line_accounts WHERE channel_id = ${q(state.lineChannelId)} LIMIT 1`,
+        ]);
+        const jsonStart = out.indexOf("[");
+        const parsed = jsonStart >= 0 ? JSON.parse(out.slice(jsonStart)) : null;
+        const id = parsed?.[0]?.results?.[0]?.id;
+        if (typeof id === "string" && id) {
+          state.lineAccountId = id;
+          saveState(repoDir, state);
+        }
+      } catch {
+        // best-effort — generateMcpConfig falls back to the worker API
+      }
+    }
+    await generateMcpConfig({
+      workerUrl: state.workerUrl!,
+      apiKey: state.apiKey!,
+      accountId: state.lineAccountId,
+    });
   }
 
   // Step 15: Show completion screen

--- a/packages/create-line-harness/src/steps/mcp-config.ts
+++ b/packages/create-line-harness/src/steps/mcp-config.ts
@@ -5,18 +5,78 @@ import { join } from "node:path";
 interface McpConfigOptions {
   workerUrl: string;
   apiKey: string;
+  /**
+   * LINE account id resolved by the caller (setup knows it from the D1 insert).
+   * When provided we skip the HTTP lookup entirely — fresh workers.dev
+   * subdomains can take minutes to DNS-resolve, so an install-time fetch to
+   * the worker is exactly the call most likely to fail on a fresh install.
+   */
+  accountId?: string;
 }
 
-export function generateMcpConfig(options: McpConfigOptions): void {
+interface LineAccount {
+  id: string;
+  name?: string;
+}
+
+/**
+ * Resolve the single LINE account id for a fresh install so the MCP server can
+ * be configured with a default account.
+ *
+ * Why this matters: the MCP server passes its `LINE_HARNESS_ACCOUNT_ID` to the
+ * SDK as `defaultAccountId`. The SDK only auto-fills `lineAccountId` on
+ * broadcast create/list/send when that default is present. Without it, every
+ * broadcast created via the MCP server is written with `line_account_id = NULL`
+ * and is therefore invisible in the account-scoped admin UI list (which filters
+ * on `line_account_id`). Single-account installs are the common case, so we set
+ * the default automatically. Multi-account setups are left unset on purpose —
+ * the operator should pick a default per server entry themselves.
+ *
+ * Best-effort: any failure (network, multi-account, unexpected shape) just
+ * skips the field and never breaks the install.
+ */
+async function resolveDefaultAccountId(
+  options: McpConfigOptions,
+): Promise<string | undefined> {
+  try {
+    const base = options.workerUrl.replace(/\/$/, "");
+    const res = await fetch(`${base}/api/line-accounts`, {
+      headers: { Authorization: `Bearer ${options.apiKey}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return undefined;
+    const json = (await res.json().catch(() => null)) as
+      | { success?: boolean; data?: LineAccount[] }
+      | null;
+    if (!json?.success || !Array.isArray(json.data)) return undefined;
+    if (json.data.length === 1) return json.data[0]?.id;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function generateMcpConfig(options: McpConfigOptions): Promise<void> {
   const mcpJsonPath = join(process.cwd(), ".mcp.json");
+
+  const env: Record<string, string> = {
+    LINE_HARNESS_API_URL: options.workerUrl,
+    LINE_HARNESS_API_KEY: options.apiKey,
+  };
+
+  // Set a default account for single-account installs so MCP-created
+  // broadcasts are tagged with line_account_id and show up in the admin UI.
+  // Prefer the caller-provided id; fall back to asking the worker API.
+  const defaultAccountId =
+    options.accountId ?? (await resolveDefaultAccountId(options));
+  if (defaultAccountId) {
+    env.LINE_HARNESS_ACCOUNT_ID = defaultAccountId;
+  }
 
   const newServerConfig = {
     command: "npx",
     args: ["-y", "@line-harness/mcp-server@latest"],
-    env: {
-      LINE_HARNESS_API_URL: options.workerUrl,
-      LINE_HARNESS_API_KEY: options.apiKey,
-    },
+    env,
   };
 
   let mcpConfig: Record<string, any> = {};

--- a/packages/create-line-harness/test/mcp-config.test.ts
+++ b/packages/create-line-harness/test/mcp-config.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { generateMcpConfig } from '../src/steps/mcp-config.js';
+
+const WORKER = 'https://worker.example.com';
+const API_KEY = 'test-api-key-12345678';
+
+function mockAccounts(data: unknown, ok = true) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok,
+      json: async () => ({ success: true, data }),
+    })),
+  );
+}
+
+describe('generateMcpConfig', () => {
+  let dir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'clh-mcp-test-'));
+    prevCwd = process.cwd();
+    process.chdir(dir);
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllGlobals();
+  });
+
+  const readConfig = () =>
+    JSON.parse(readFileSync(join(dir, '.mcp.json'), 'utf-8'));
+
+  it('sets LINE_HARNESS_ACCOUNT_ID for single-account installs', async () => {
+    mockAccounts([{ id: 'acc-1', name: 'Main' }]);
+    await generateMcpConfig({ workerUrl: WORKER, apiKey: API_KEY });
+    const env = readConfig().mcpServers['line-harness'].env;
+    expect(env.LINE_HARNESS_ACCOUNT_ID).toBe('acc-1');
+    expect(env.LINE_HARNESS_API_URL).toBe(WORKER);
+    expect(env.LINE_HARNESS_API_KEY).toBe(API_KEY);
+  });
+
+  it('uses the caller-provided accountId without calling the worker API', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    await generateMcpConfig({ workerUrl: WORKER, apiKey: API_KEY, accountId: 'acc-known' });
+    const env = readConfig().mcpServers['line-harness'].env;
+    expect(env.LINE_HARNESS_ACCOUNT_ID).toBe('acc-known');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('strips a trailing slash from workerUrl before calling the accounts API', async () => {
+    mockAccounts([{ id: 'acc-1' }]);
+    await generateMcpConfig({ workerUrl: `${WORKER}/`, apiKey: API_KEY });
+    expect(vi.mocked(fetch).mock.calls[0][0]).toBe(`${WORKER}/api/line-accounts`);
+    const env = readConfig().mcpServers['line-harness'].env;
+    expect(env.LINE_HARNESS_ACCOUNT_ID).toBe('acc-1');
+  });
+
+  it('leaves ACCOUNT_ID unset for multi-account installs', async () => {
+    mockAccounts([{ id: 'acc-1' }, { id: 'acc-2' }]);
+    await generateMcpConfig({ workerUrl: WORKER, apiKey: API_KEY });
+    const env = readConfig().mcpServers['line-harness'].env;
+    expect(env.LINE_HARNESS_ACCOUNT_ID).toBeUndefined();
+  });
+
+  it('still writes config when the accounts API fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+    await generateMcpConfig({ workerUrl: WORKER, apiKey: API_KEY });
+    const env = readConfig().mcpServers['line-harness'].env;
+    expect(env.LINE_HARNESS_ACCOUNT_ID).toBeUndefined();
+    expect(env.LINE_HARNESS_API_KEY).toBe(API_KEY);
+  });
+
+  it('does not overwrite an existing line-harness entry', async () => {
+    mockAccounts([{ id: 'acc-1' }]);
+    await generateMcpConfig({ workerUrl: WORKER, apiKey: API_KEY });
+    await generateMcpConfig({ workerUrl: WORKER, apiKey: 'second-key-87654321' });
+    const servers = readConfig().mcpServers;
+    expect(servers['line-harness'].env.LINE_HARNESS_API_KEY).toBe(API_KEY);
+    expect(servers['line-harness-second-k'].env.LINE_HARNESS_API_KEY).toBe(
+      'second-key-87654321',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

コミュニティ PR 2本を upstream (private) に移植し、レビュー・テスト・本番デプロイを経て sync するリリースです。

- **#208 port** (thanks @hakamadataira1229-cmyk): auto-track が Flex JSON の image/hero `url` まで計測リンク化して画像が空白になるバグを修正。action / defaultAction / altUri.desktop の uri のみ書き換える方式に変更。加えて不正な URI（bare `https://` 等）は追跡対象から除外し、配信全体を落とさないようにした
- **#182 port** (thanks @ex-takashima): setup が書く .mcp.json に `LINE_HARNESS_ACCOUNT_ID` が無く、MCP 作成の broadcast が `line_account_id = NULL` で管理画面に出ない問題を修正。単一アカウント install では自動設定（id は D1 から wrangler で直接解決し、新規 workers.dev の DNS 伝播レースを回避。worker API フォールバック付き）
- 計測リンク作成の並列化（多リンク flex の配信開始高速化）

Tests: worker auto-track 14件 / create-line-harness 47件 pass。private 本番デプロイ済み・ヘルス確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)