### PR TITLE
管理画面ダッシュボードをリデザイン（ヒーローKPI・グリーン統一・空状態ガイド）

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,1 +1,7 @@
 @import "tailwindcss";
+
+/* 文字をなめらかに描画（モダン SaaS 標準） */
+body {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -25,6 +25,10 @@ const ccPrompts = [
   },
 ]
 
+// ブランドカラー（LINE グリーン）。アイコンチップ・アクセントはこの1色に統一する。
+const BRAND = '#06C755'
+const BRAND_DARK = '#059212'
+
 interface DashboardStats {
   friendCount: number | null
   activeScenarioCount: number | null
@@ -34,42 +38,92 @@ interface DashboardStats {
   scoringRuleCount: number | null
 }
 
+// ─── アイコン（SVG パス定義） ───
+
+const iconPaths = {
+  friends:
+    'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z',
+  scenario:
+    'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2',
+  broadcast:
+    'M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z',
+  template:
+    'M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6z',
+  automation: 'M13 10V3L4 14h7v7l9-11h-7z',
+  scoring:
+    'M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z',
+  chat: 'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z',
+  health:
+    'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
+}
+
+function Icon({ d, className = 'w-5 h-5' }: { d: string; className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
+    </svg>
+  )
+}
+
+// ─── 統計カード ───
+// 値が 0 のときは「次の一歩」を促すヒントを表示する（空状態ガイダンス）
+
 interface StatCardProps {
   title: string
   value: number | null
   loading: boolean
-  icon: React.ReactNode
+  iconD: string
   href: string
-  accentColor?: string
+  emptyHint?: string
 }
 
-function StatCard({ title, value, loading, icon, href, accentColor = '#06C755' }: StatCardProps) {
+function StatCard({ title, value, loading, iconD, href, emptyHint }: StatCardProps) {
+  const showHint = !loading && value === 0 && !!emptyHint
   return (
-    <Link href={href} className="block bg-white rounded-lg shadow-sm border border-gray-200 p-6 hover:shadow-md transition-shadow group">
-      <div className="flex items-start justify-between">
-        <div>
-          <p className="text-sm font-medium text-gray-500 mb-2">{title}</p>
-          {loading ? (
-            <div className="h-8 w-20 bg-gray-100 rounded animate-pulse" />
-          ) : (
-            <p className="text-3xl font-bold text-gray-900">
-              {value !== null ? value.toLocaleString('ja-JP') : '-'}
-            </p>
-          )}
-        </div>
+    <Link
+      href={href}
+      className="group block bg-white rounded-2xl border border-gray-100 shadow-sm p-6 transition-all duration-200 hover:border-green-200 hover:shadow-md hover:-translate-y-0.5"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm font-medium text-gray-500">{title}</p>
         <div
-          className="w-10 h-10 rounded-lg flex items-center justify-center text-white shrink-0"
-          style={{ backgroundColor: accentColor }}
+          className="w-9 h-9 rounded-xl flex items-center justify-center shrink-0"
+          style={{ backgroundColor: 'rgba(6, 199, 85, 0.1)', color: BRAND_DARK }}
         >
-          {icon}
+          <Icon d={iconD} />
         </div>
       </div>
-      <p className="text-xs text-gray-400 mt-3 group-hover:text-green-600 transition-colors">
-        詳細を見る →
+      {loading ? (
+        <div className="h-10 w-24 bg-gray-100 rounded-lg animate-pulse mt-1" />
+      ) : (
+        <p className="text-4xl font-bold tracking-tight text-gray-900 tabular-nums mt-1">
+          {value !== null ? value.toLocaleString('ja-JP') : '–'}
+        </p>
+      )}
+      <p
+        className={`text-xs mt-3 transition-colors ${
+          showHint ? 'font-medium' : 'text-gray-400'
+        }`}
+        style={showHint ? { color: BRAND_DARK } : undefined}
+      >
+        <span className={showHint ? '' : 'group-hover:text-green-700 transition-colors'}>
+          {showHint ? `${emptyHint} →` : '詳細を見る →'}
+        </span>
       </p>
     </Link>
   )
 }
+
+// ─── クイックアクション ───
+
+const quickActions = [
+  { href: '/friends', label: '友だち管理', desc: '友だちの一覧・タグ管理', iconD: iconPaths.friends },
+  { href: '/scenarios', label: 'シナリオ配信', desc: '自動配信シナリオの作成・編集', iconD: iconPaths.scenario },
+  { href: '/broadcasts', label: '一斉配信', desc: 'メッセージの一斉送信・予約', iconD: iconPaths.broadcast },
+  { href: '/chats', label: 'チャット', desc: 'オペレーターチャット管理', iconD: iconPaths.chat },
+  { href: '/templates', label: 'テンプレート', desc: 'よく使う文面の管理', iconD: iconPaths.template },
+  { href: '/health', label: 'BAN検知', desc: 'アカウント健康度ダッシュボード', iconD: iconPaths.health },
+]
 
 export default function DashboardPage() {
   const { selectedAccountId, selectedAccount } = useAccount()
@@ -137,7 +191,7 @@ export default function DashboardPage() {
   return (
     <div>
       <div className="mb-6">
-        <h1 className="text-xl sm:text-2xl font-bold text-gray-900">ダッシュボード</h1>
+        <h1 className="text-xl sm:text-2xl font-bold text-gray-900 tracking-tight">ダッシュボード</h1>
         <p className="text-sm text-gray-500 mt-1">
           {selectedAccount
             ? `${selectedAccount.displayName || selectedAccount.name} の管理画面`
@@ -151,192 +205,132 @@ export default function DashboardPage() {
         </div>
       )}
 
-      {/* Demo banner */}
-      <a
-        href="https://your-worker.your-subdomain.workers.dev/auth/line?ref=dashboard"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block mb-6 p-4 rounded-xl border border-green-200 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 transition-colors"
+      {/* ヒーロー: 友だち数（主役 KPI）+ LINE 体験 CTA */}
+      <div
+        className="relative overflow-hidden rounded-2xl mb-6 text-white"
+        style={{ background: `linear-gradient(135deg, ${BRAND} 0%, #04a94a 55%, #059669 100%)` }}
       >
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm font-bold text-gray-900">LINE で体験する</p>
-            <p className="text-xs text-gray-500 mt-0.5">友だち追加でステップ配信・フォーム・自動返信を体験</p>
-          </div>
-          <span className="text-xs px-3 py-1.5 rounded-full text-white font-medium" style={{ backgroundColor: '#06C755' }}>
-            友だち追加
-          </span>
-        </div>
-      </a>
+        {/* 装飾円 */}
+        <div className="absolute -top-20 -right-16 w-72 h-72 rounded-full bg-white/10 pointer-events-none" />
+        <div className="absolute -bottom-28 -left-12 w-80 h-80 rounded-full bg-white/5 pointer-events-none" />
 
-      {/* Summary cards */}
+        <div className="relative p-6 sm:p-8 flex flex-col sm:flex-row sm:items-center gap-6">
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 rounded-xl bg-white/15 flex items-center justify-center">
+                <Icon d={iconPaths.friends} className="w-4 h-4" />
+              </div>
+              <p className="text-sm font-medium text-white/85">友だち数</p>
+            </div>
+            {loading ? (
+              <div className="h-12 w-32 bg-white/20 rounded-lg animate-pulse mt-3" />
+            ) : (
+              <p className="text-5xl font-bold tracking-tight tabular-nums mt-2">
+                {stats.friendCount !== null ? stats.friendCount.toLocaleString('ja-JP') : '–'}
+              </p>
+            )}
+            <Link
+              href="/friends"
+              className="inline-flex items-center gap-1 mt-3 text-sm font-medium text-white/85 hover:text-white transition-colors"
+            >
+              {!loading && stats.friendCount === 0 ? '友だち追加リンクを共有してみましょう →' : '友だち管理へ →'}
+            </Link>
+          </div>
+
+          <a
+            href="https://your-worker.your-subdomain.workers.dev/auth/line?ref=dashboard"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="sm:w-72 rounded-xl bg-white/10 border border-white/20 p-4 hover:bg-white/[0.16] transition-colors backdrop-blur-sm"
+          >
+            <p className="text-sm font-bold">LINE で体験する</p>
+            <p className="text-xs text-white/75 mt-1 leading-relaxed">
+              友だち追加でステップ配信・フォーム・自動返信を体験
+            </p>
+            <span
+              className="inline-block mt-3 text-xs font-bold bg-white px-3.5 py-1.5 rounded-full"
+              style={{ color: BRAND_DARK }}
+            >
+              友だち追加
+            </span>
+          </a>
+        </div>
+      </div>
+
+      {/* 統計カード */}
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 mb-8">
-        <StatCard
-          title="友だち数"
-          value={stats.friendCount}
-          loading={loading}
-          href="/friends"
-          icon={
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
-          }
-        />
         <StatCard
           title="アクティブシナリオ数"
           value={stats.activeScenarioCount}
           loading={loading}
           href="/scenarios"
-          accentColor="#3B82F6"
-          icon={
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-            </svg>
-          }
+          iconD={iconPaths.scenario}
+          emptyHint="最初のシナリオを作成しましょう"
         />
         <StatCard
           title="配信数 (合計)"
           value={stats.broadcastCount}
           loading={loading}
           href="/broadcasts"
-          accentColor="#8B5CF6"
-          icon={
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
-            </svg>
-          }
+          iconD={iconPaths.broadcast}
+          emptyHint="最初の一斉配信を作成しましょう"
         />
-      </div>
-
-      {/* Round 3 summary cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 mb-8">
         <StatCard
           title="テンプレート数"
           value={stats.templateCount}
           loading={loading}
           href="/templates"
-          accentColor="#F59E0B"
-          icon={
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6z" />
-            </svg>
-          }
+          iconD={iconPaths.template}
+          emptyHint="よく使う文面を登録しましょう"
         />
         <StatCard
           title="アクティブルール数"
           value={stats.automationCount}
           loading={loading}
           href="/automations"
-          accentColor="#EF4444"
-          icon={
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                d="M13 10V3L4 14h7v7l9-11h-7z" />
-            </svg>
-          }
+          iconD={iconPaths.automation}
+          emptyHint="オートメーションを設定しましょう"
         />
         <StatCard
           title="スコアリングルール数"
           value={stats.scoringRuleCount}
           loading={loading}
           href="/scoring"
-          accentColor="#10B981"
-          icon={
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-            </svg>
-          }
+          iconD={iconPaths.scoring}
+          emptyHint="見込み度を可視化しましょう"
         />
       </div>
 
-      {/* Quick links */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h2 className="text-sm font-semibold text-gray-800 mb-4">クイックアクション</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <Link
-            href="/friends"
-            className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 hover:border-green-300 hover:bg-green-50 transition-colors group"
-          >
-            <div className="w-8 h-8 rounded-lg flex items-center justify-center text-white shrink-0" style={{ backgroundColor: '#06C755' }}>
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+      {/* クイックアクション */}
+      <div>
+        <h2 className="text-sm font-semibold text-gray-800 mb-3">クイックアクション</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
+          {quickActions.map((action) => (
+            <Link
+              key={action.href}
+              href={action.href}
+              className="group flex items-center gap-3 p-4 bg-white rounded-2xl border border-gray-100 shadow-sm transition-all duration-200 hover:border-green-200 hover:shadow-md hover:-translate-y-0.5"
+            >
+              <div
+                className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+                style={{ backgroundColor: 'rgba(6, 199, 85, 0.1)', color: BRAND_DARK }}
+              >
+                <Icon d={action.iconD} className="w-5 h-5" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-semibold text-gray-900">{action.label}</p>
+                <p className="text-xs text-gray-400 mt-0.5 truncate">{action.desc}</p>
+              </div>
+              <svg
+                className="w-4 h-4 text-gray-300 shrink-0 transition-all duration-200 group-hover:text-green-600 group-hover:translate-x-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
-            </div>
-            <div>
-              <p className="text-sm font-medium text-gray-900 group-hover:text-green-700 transition-colors">友だち管理</p>
-              <p className="text-xs text-gray-400">友だちの一覧・タグ管理</p>
-            </div>
-          </Link>
-
-          <Link
-            href="/scenarios"
-            className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 hover:border-blue-300 hover:bg-blue-50 transition-colors group"
-          >
-            <div className="w-8 h-8 rounded-lg flex items-center justify-center text-white shrink-0 bg-blue-500">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-              </svg>
-            </div>
-            <div>
-              <p className="text-sm font-medium text-gray-900 group-hover:text-blue-700 transition-colors">シナリオ配信</p>
-              <p className="text-xs text-gray-400">自動配信シナリオの作成・編集</p>
-            </div>
-          </Link>
-
-          <Link
-            href="/broadcasts"
-            className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 hover:border-purple-300 hover:bg-purple-50 transition-colors group"
-          >
-            <div className="w-8 h-8 rounded-lg flex items-center justify-center text-white shrink-0 bg-purple-500">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                  d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
-              </svg>
-            </div>
-            <div>
-              <p className="text-sm font-medium text-gray-900 group-hover:text-purple-700 transition-colors">一斉配信</p>
-              <p className="text-xs text-gray-400">メッセージの一斉送信・予約</p>
-            </div>
-          </Link>
-
-          <Link
-            href="/chats"
-            className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 hover:border-green-300 hover:bg-green-50 transition-colors group"
-          >
-            <div className="w-8 h-8 rounded-lg flex items-center justify-center text-white shrink-0" style={{ backgroundColor: '#06C755' }}>
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                  d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-              </svg>
-            </div>
-            <div>
-              <p className="text-sm font-medium text-gray-900 group-hover:text-green-700 transition-colors">チャット</p>
-              <p className="text-xs text-gray-400">オペレーターチャット管理</p>
-            </div>
-          </Link>
-
-          <Link
-            href="/health"
-            className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 hover:border-red-300 hover:bg-red-50 transition-colors group"
-          >
-            <div className="w-8 h-8 rounded-lg flex items-center justify-center text-white shrink-0 bg-red-500">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                  d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-              </svg>
-            </div>
-            <div>
-              <p className="text-sm font-medium text-gray-900 group-hover:text-red-700 transition-colors">BAN検知</p>
-              <p className="text-xs text-gray-400">アカウント健康度ダッシュボード</p>
-            </div>
-          </Link>
+            </Link>
+          ))}
         </div>
       </div>
 

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -284,23 +284,27 @@ export default function Sidebar() {
                 <Link
                   key={item.href}
                   href={item.href}
-                  className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+                  className={`relative flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm transition-colors ${
                     active
-                      ? 'text-white'
+                      ? isDanger
+                        ? 'bg-red-50 text-red-600 font-semibold'
+                        : 'bg-green-50 font-semibold'
                       : isDanger
-                        ? 'text-red-500 hover:bg-red-50'
-                        : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+                        ? 'text-red-500 font-medium hover:bg-red-50'
+                        : 'text-gray-600 font-medium hover:bg-gray-100 hover:text-gray-900'
                   }`}
-                  style={active ? { backgroundColor: isDanger ? '#EF4444' : '#06C755' } : {}}
+                  style={active && !isDanger ? { color: '#059212' } : {}}
                 >
+                  {active && (
+                    <span
+                      className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-5 rounded-r-full"
+                      style={{ backgroundColor: isDanger ? '#EF4444' : '#06C755' }}
+                    />
+                  )}
                   <NavIcon d={item.icon} />
                   <span className="flex-1">{item.label}</span>
                   {item.href === '/notifications' && unansweredCount > 0 && (
-                    <span
-                      className={`rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums ${
-                        active ? 'bg-white text-rose-600' : 'bg-rose-500 text-white'
-                      }`}
-                    >
+                    <span className="rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums bg-rose-500 text-white">
                       {unansweredCount > 99 ? '99+' : unansweredCount}
                     </span>
                   )}


### PR DESCRIPTION
## Summary
- 友だち数を主役にしたヒーローエリアを新設（LINEグリーンのグラデーション背景）。「LINE で体験する」バナーをヒーロー内のCTAカードに統合
- 統計カードのアイコン色を5色バラバラ → LINEグリーン1色の淡いチップに統一。数字を大型化し、ホバーで浮き上がるアニメーションを追加
- 値が 0 のカードに「最初のシナリオを作成しましょう →」等の空状態ガイダンスを表示（オンボーディング導線）
- クイックアクションを独立カードのグリッドに刷新（6項目、ホバーで矢印アニメーション）
- サイドバーのアクティブ表示を緑ベタ塗り → 淡いグリーン背景＋左アクセントラインに変更
- フォント描画をアンチエイリアス化

## 影響範囲
- `apps/web/src/app/page.tsx`（ダッシュボード全面書き換え。データ取得ロジックは無変更）
- `apps/web/src/components/layout/sidebar.tsx`（アクティブ項目のスタイルのみ）
- `apps/web/src/app/globals.css`（font-smoothing 追加）

## Test plan
- [x] `pnpm --filter web test` 全8件パス
- [x] `tsc --noEmit` エラーなし
- [ ] デプロイプレビューでダッシュボードの表示確認（デスクトップ／モバイル）
- [ ] サイドバーのアクティブ表示・未対応バッジの表示確認
- [ ] 統計 0 件時の空状態ヒント表示確認

Generated with [Claude Code](https://claude.com/claude-code)