### PR TITLE
トラッキングリンクに時限失効機能を追加（絶対期限＋友だち別相対期限）

### DIFF
--- a/apps/worker/src/routes/tracked-links.test.ts
+++ b/apps/worker/src/routes/tracked-links.test.ts
@@ -16,6 +16,7 @@ const dbMocks = {
   enrollFriendInScenario: vi.fn(),
   getTrackedLinkBaseUrl: vi.fn(),
   getLinkBaseUrl: vi.fn(),
+  isTrackedLinkExpired: vi.fn(),
 };
 vi.mock('@line-crm/db', () => dbMocks);
 
@@ -84,6 +85,9 @@ function makeLink(overrides: Record<string, unknown> = {}) {
     og_title: null,
     og_description: null,
     og_image_url: null,
+    expires_at: null,
+    expires_minutes_after_send: null,
+    expired_redirect_url: null,
     created_at: '2026-01-01T00:00:00+09:00',
     updated_at: '2026-01-01T00:00:00+09:00',
     ...overrides,
@@ -220,5 +224,102 @@ describe('GET /t/:linkId — short codes', () => {
     expect(res.headers.get('location')).toContain(
       encodeURIComponent('https://worker.example.com/t/Ab3xY9k'),
     );
+  });
+});
+
+describe('GET /t/:linkId — expiration', () => {
+  const SAFARI_UA = 'Mozilla/5.0 Safari/605.1.15';
+
+  function collectingCtx(waits: Promise<unknown>[]): ExecutionContext {
+    return {
+      waitUntil: (p: Promise<unknown>) => waits.push(p),
+      passThroughOnException: () => {},
+    } as unknown as ExecutionContext;
+  }
+
+  test('expired link redirects to expired_redirect_url and skips tag/scenario actions', async () => {
+    const waits: Promise<unknown>[] = [];
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(
+      makeLink({
+        expires_at: '2026-01-01T00:00:00+09:00',
+        expired_redirect_url: 'https://example.com/closed',
+        tag_id: 'tag-1',
+        scenario_id: 'sc-1',
+      }),
+    );
+    dbMocks.isTrackedLinkExpired.mockResolvedValue(true);
+    const env = { DB: makeDb({}), WORKER_URL: 'https://worker.example.com' };
+    const res = await trackedLinks.request(
+      'https://worker.example.com/t/link-1?f=friend-1',
+      { headers: { 'user-agent': SAFARI_UA }, redirect: 'manual' },
+      env,
+      collectingCtx(waits),
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://example.com/closed');
+    await Promise.allSettled(waits);
+    // Click is still recorded for stats, but no automation side-effects fire.
+    expect(dbMocks.recordLinkClick).toHaveBeenCalledWith(env.DB, 'link-1', 'friend-1');
+    expect(dbMocks.addTagToFriend).not.toHaveBeenCalled();
+    expect(dbMocks.enrollFriendInScenario).not.toHaveBeenCalled();
+  });
+
+  test('expired link without redirect URL returns the 410 expired page', async () => {
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(
+      makeLink({ expires_at: '2026-01-01T00:00:00+09:00' }),
+    );
+    dbMocks.isTrackedLinkExpired.mockResolvedValue(true);
+    const env = { DB: makeDb({}), WORKER_URL: 'https://worker.example.com' };
+    const res = await request(env, SAFARI_UA);
+    expect(res.status).toBe(410);
+    expect(await res.text()).toContain('有効期限');
+  });
+
+  test('non-expired deadline link redirects normally and fires actions', async () => {
+    const waits: Promise<unknown>[] = [];
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(
+      makeLink({ expires_at: '2099-12-31T23:59:00+09:00', tag_id: 'tag-1' }),
+    );
+    dbMocks.isTrackedLinkExpired.mockResolvedValue(false);
+    const env = { DB: makeDb({}), WORKER_URL: 'https://worker.example.com' };
+    const res = await trackedLinks.request(
+      'https://worker.example.com/t/link-1?f=friend-1',
+      { headers: { 'user-agent': SAFARI_UA }, redirect: 'manual' },
+      env,
+      collectingCtx(waits),
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://example.com/lp');
+    await Promise.allSettled(waits);
+    expect(dbMocks.addTagToFriend).toHaveBeenCalledWith(env.DB, 'friend-1', 'tag-1');
+  });
+
+  test('links without deadlines never call the expiration check', async () => {
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(makeLink());
+    const env = { DB: makeDb({}), WORKER_URL: 'https://worker.example.com' };
+    const res = await request(env, SAFARI_UA);
+    expect(res.status).toBe(302);
+    expect(dbMocks.isTrackedLinkExpired).not.toHaveBeenCalled();
+  });
+
+  test('POST rejects a non-positive expiresMinutesAfterSend', async () => {
+    const env = { DB: makeDb({}), WORKER_URL: 'https://worker.example.com' };
+    const res = await trackedLinks.request(
+      'https://worker.example.com/api/tracked-links',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'x',
+          originalUrl: 'https://example.com',
+          expiresMinutesAfterSend: -5,
+        }),
+      },
+      env,
+      executionCtx,
+    );
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toContain('expiresMinutesAfterSend');
   });
 });

--- a/apps/worker/src/routes/tracked-links.ts
+++ b/apps/worker/src/routes/tracked-links.ts
@@ -9,6 +9,7 @@ import {
   recordLinkClick,
   getLinkClicks,
   getFriendByLineUserId,
+  isTrackedLinkExpired,
 } from '@line-crm/db';
 import { addTagToFriend, enrollFriendInScenario } from '@line-crm/db';
 import type { TrackedLink } from '@line-crm/db';
@@ -39,9 +40,59 @@ function serializeTrackedLink(row: TrackedLink, baseUrl: string) {
     ogTitle: row.og_title,
     ogDescription: row.og_description,
     ogImageUrl: row.og_image_url,
+    expiresAt: row.expires_at,
+    expiresMinutesAfterSend: row.expires_minutes_after_send,
+    expiredRedirectUrl: row.expired_redirect_url,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+/**
+ * Validate expiration fields shared by POST/PATCH.
+ * Returns an error message, or null when valid.
+ */
+function validateExpirationFields(body: {
+  expiresAt?: string | null;
+  expiresMinutesAfterSend?: number | null;
+  expiredRedirectUrl?: string | null;
+}): string | null {
+  if (body.expiresAt != null) {
+    if (typeof body.expiresAt !== 'string' || Number.isNaN(new Date(body.expiresAt).getTime())) {
+      return 'expiresAt must be an ISO-8601 datetime string (e.g. 2026-08-01T23:59:00+09:00)';
+    }
+  }
+  if (body.expiresMinutesAfterSend != null) {
+    if (
+      typeof body.expiresMinutesAfterSend !== 'number' ||
+      !Number.isInteger(body.expiresMinutesAfterSend) ||
+      body.expiresMinutesAfterSend <= 0
+    ) {
+      return 'expiresMinutesAfterSend must be a positive integer (minutes)';
+    }
+  }
+  if (body.expiredRedirectUrl != null) {
+    if (
+      typeof body.expiredRedirectUrl !== 'string' ||
+      !/^https?:\/\//.test(body.expiredRedirectUrl)
+    ) {
+      return 'expiredRedirectUrl must be an http(s) URL';
+    }
+  }
+  return null;
+}
+
+/** Plain fallback page for expired links without an expired_redirect_url. */
+function buildExpiredHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="ja"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>リンクの有効期限が切れています</title>
+<style>body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;font-family:system-ui;color:#334155;background:#f8fafc;text-align:center}p{font-size:15px;line-height:2}</style>
+</head><body>
+<p>このリンクの有効期限は終了しました。<br>お手数ですが、配信元のメッセージをご確認ください。</p>
+</body></html>`;
 }
 
 function getBaseUrl(c: { req: { url: string } }): string {
@@ -132,10 +183,18 @@ trackedLinks.post('/api/tracked-links', async (c) => {
       ogTitle?: string | null;
       ogDescription?: string | null;
       ogImageUrl?: string | null;
+      expiresAt?: string | null;
+      expiresMinutesAfterSend?: number | null;
+      expiredRedirectUrl?: string | null;
     }>();
 
     if (!body.name || !body.originalUrl) {
       return c.json({ success: false, error: 'name and originalUrl are required' }, 400);
+    }
+
+    const expirationError = validateExpirationFields(body);
+    if (expirationError) {
+      return c.json({ success: false, error: expirationError }, 400);
     }
 
     const link = await createTrackedLink(c.env.DB, {
@@ -149,6 +208,9 @@ trackedLinks.post('/api/tracked-links', async (c) => {
       ogTitle: body.ogTitle ?? null,
       ogDescription: body.ogDescription ?? null,
       ogImageUrl: body.ogImageUrl ?? null,
+      expiresAt: body.expiresAt ?? null,
+      expiresMinutesAfterSend: body.expiresMinutesAfterSend ?? null,
+      expiredRedirectUrl: body.expiredRedirectUrl ?? null,
     });
 
     const base = await resolveApiLinkBase(c);
@@ -174,7 +236,15 @@ trackedLinks.patch('/api/tracked-links/:id', async (c) => {
       ogTitle?: string | null;
       ogDescription?: string | null;
       ogImageUrl?: string | null;
+      expiresAt?: string | null;
+      expiresMinutesAfterSend?: number | null;
+      expiredRedirectUrl?: string | null;
     }>();
+
+    const expirationError = validateExpirationFields(body);
+    if (expirationError) {
+      return c.json({ success: false, error: expirationError }, 400);
+    }
 
     const link = await updateTrackedLink(c.env.DB, id, body);
     if (!link) {
@@ -329,6 +399,26 @@ trackedLinks.get('/t/:linkId', async (c) => {
     const friend = await getFriendByLineUserId(c.env.DB, lineUserId);
     if (friend) {
       friendId = friend.id;
+    }
+  }
+
+  // Expiration gate — evaluated after friend resolution so the per-friend
+  // relative deadline (expires_minutes_after_send) can be computed. Expired
+  // clicks are still recorded (for funnel stats) but never fire tag/scenario
+  // side-effects, and land on the expired redirect instead of the offer.
+  if (link.expires_at || link.expires_minutes_after_send != null) {
+    const expired = await isTrackedLinkExpired(c.env.DB, link, friendId);
+    if (expired) {
+      const ctx = c.executionCtx as ExecutionContext;
+      ctx.waitUntil(
+        recordLinkClick(c.env.DB, link.id, friendId).catch((err) =>
+          console.error(`/t/${linkId} expired-click recording error:`, err),
+        ),
+      );
+      if (link.expired_redirect_url) {
+        return c.redirect(link.expired_redirect_url, 302);
+      }
+      return c.html(buildExpiredHtml(), 410);
     }
   }
 

--- a/packages/db/migrations/050_tracked_links_expiration.sql
+++ b/packages/db/migrations/050_tracked_links_expiration.sql
@@ -1,0 +1,19 @@
+-- 050: Tracked link expiration (deadline links)
+--
+-- Closes the gap with paid tools (UTAGE/L-step) that support "this link dies
+-- N hours after the message reached you" campaign deadlines.
+--
+-- expires_at:                 absolute deadline as a JST ISO-8601 string (same
+--                             format as jstNow()). Clicks after this moment are
+--                             expired for everyone.
+-- expires_minutes_after_send: per-friend relative deadline. Counted from the
+--                             moment THAT friend last received a message
+--                             containing this link (latest matching outgoing
+--                             messages_log row). Requires the click to carry a
+--                             friend identity (?f= / ?lu= / LIFF); anonymous
+--                             clicks fall back to expires_at only.
+-- expired_redirect_url:       where expired clicks are redirected. NULL shows
+--                             a plain "link expired" page instead.
+ALTER TABLE tracked_links ADD COLUMN expires_at TEXT;
+ALTER TABLE tracked_links ADD COLUMN expires_minutes_after_send INTEGER;
+ALTER TABLE tracked_links ADD COLUMN expired_redirect_url TEXT;

--- a/packages/db/src/tracked-links.ts
+++ b/packages/db/src/tracked-links.ts
@@ -18,6 +18,9 @@ export interface TrackedLink {
   og_title: string | null;
   og_description: string | null;
   og_image_url: string | null;
+  expires_at: string | null;
+  expires_minutes_after_send: number | null;
+  expired_redirect_url: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -101,6 +104,9 @@ export interface CreateTrackedLinkInput {
   ogTitle?: string | null;
   ogDescription?: string | null;
   ogImageUrl?: string | null;
+  expiresAt?: string | null;
+  expiresMinutesAfterSend?: number | null;
+  expiredRedirectUrl?: string | null;
 }
 
 export async function createTrackedLink(
@@ -117,8 +123,8 @@ export async function createTrackedLink(
     try {
       await db
         .prepare(
-          `INSERT INTO tracked_links (id, name, original_url, tag_id, scenario_id, intro_template_id, reward_template_id, line_account_id, short_code, is_active, click_count, og_title, og_description, og_image_url, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?, ?)`,
+          `INSERT INTO tracked_links (id, name, original_url, tag_id, scenario_id, intro_template_id, reward_template_id, line_account_id, short_code, is_active, click_count, og_title, og_description, og_image_url, expires_at, expires_minutes_after_send, expired_redirect_url, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?, ?, ?, ?, ?)`,
         )
         .bind(
           id,
@@ -133,6 +139,9 @@ export async function createTrackedLink(
           input.ogTitle ?? null,
           input.ogDescription ?? null,
           input.ogImageUrl ?? null,
+          input.expiresAt ?? null,
+          input.expiresMinutesAfterSend ?? null,
+          input.expiredRedirectUrl ?? null,
           now,
           now,
         )
@@ -159,6 +168,9 @@ export interface UpdateTrackedLinkInput {
   ogTitle?: string | null;
   ogDescription?: string | null;
   ogImageUrl?: string | null;
+  expiresAt?: string | null;
+  expiresMinutesAfterSend?: number | null;
+  expiredRedirectUrl?: string | null;
 }
 
 export async function updateTrackedLink(
@@ -185,14 +197,23 @@ export async function updateTrackedLink(
     input.ogDescription === undefined ? existing.og_description : input.ogDescription;
   const ogImageUrl =
     input.ogImageUrl === undefined ? existing.og_image_url : input.ogImageUrl;
+  const expiresAt = input.expiresAt === undefined ? existing.expires_at : input.expiresAt;
+  const expiresMinutesAfterSend =
+    input.expiresMinutesAfterSend === undefined
+      ? existing.expires_minutes_after_send
+      : input.expiresMinutesAfterSend;
+  const expiredRedirectUrl =
+    input.expiredRedirectUrl === undefined
+      ? existing.expired_redirect_url
+      : input.expiredRedirectUrl;
 
   await db
     .prepare(
       `UPDATE tracked_links
-         SET name = ?, tag_id = ?, scenario_id = ?, intro_template_id = ?, reward_template_id = ?, line_account_id = ?, is_active = ?, og_title = ?, og_description = ?, og_image_url = ?, updated_at = ?
+         SET name = ?, tag_id = ?, scenario_id = ?, intro_template_id = ?, reward_template_id = ?, line_account_id = ?, is_active = ?, og_title = ?, og_description = ?, og_image_url = ?, expires_at = ?, expires_minutes_after_send = ?, expired_redirect_url = ?, updated_at = ?
        WHERE id = ?`,
     )
-    .bind(name, tagId, scenarioId, introTemplateId, rewardTemplateId, lineAccountId, isActive, ogTitle, ogDescription, ogImageUrl, now, id)
+    .bind(name, tagId, scenarioId, introTemplateId, rewardTemplateId, lineAccountId, isActive, ogTitle, ogDescription, ogImageUrl, expiresAt, expiresMinutesAfterSend, expiredRedirectUrl, now, id)
     .run();
 
   return getTrackedLinkById(db, id);
@@ -231,6 +252,68 @@ export async function recordLinkClick(
     .prepare(`SELECT * FROM link_clicks WHERE id = ?`)
     .bind(id)
     .first<LinkClick>())!;
+}
+
+// ── Expiration ────────────────────────────────────────────────────────────────
+
+/**
+ * When the given friend last received a message containing this link.
+ * Matches by tracked-link UUID or short code inside outgoing messages_log
+ * content (scenario steps / broadcasts embed the /t/ URL verbatim).
+ * Returns the JST ISO timestamp, or null if no delivery is recorded.
+ */
+export async function getLinkLastSentAt(
+  db: D1Database,
+  friendId: string,
+  link: Pick<TrackedLink, 'id' | 'short_code'>,
+): Promise<string | null> {
+  const row = await db
+    .prepare(
+      `SELECT created_at FROM messages_log
+        WHERE friend_id = ?
+          AND direction = 'outgoing'
+          AND (content LIKE '%' || ? || '%' OR (? IS NOT NULL AND content LIKE '%/t/' || ? || '%'))
+        ORDER BY created_at DESC
+        LIMIT 1`,
+    )
+    .bind(friendId, link.id, link.short_code, link.short_code)
+    .first<{ created_at: string }>();
+  return row?.created_at ?? null;
+}
+
+/**
+ * Whether a tracked link is expired for this click.
+ *
+ * Two independent deadlines; the earlier one wins:
+ * - expires_at: absolute JST deadline for everyone.
+ * - expires_minutes_after_send: relative per-friend deadline counted from the
+ *   friend's last recorded delivery of this link. Anonymous clicks (no friend)
+ *   cannot be evaluated against it and are treated as not-expired — the
+ *   absolute deadline still applies to them.
+ */
+export async function isTrackedLinkExpired(
+  db: D1Database,
+  link: TrackedLink,
+  friendId: string | null,
+  now: Date = new Date(),
+): Promise<boolean> {
+  if (link.expires_at) {
+    const deadline = new Date(link.expires_at);
+    if (!Number.isNaN(deadline.getTime()) && now.getTime() > deadline.getTime()) {
+      return true;
+    }
+  }
+  if (link.expires_minutes_after_send != null && friendId) {
+    const sentAt = await getLinkLastSentAt(db, friendId, link);
+    if (sentAt) {
+      const sent = new Date(sentAt);
+      if (!Number.isNaN(sent.getTime())) {
+        const deadlineMs = sent.getTime() + link.expires_minutes_after_send * 60_000;
+        if (now.getTime() > deadlineMs) return true;
+      }
+    }
+  }
+  return false;
 }
 
 export interface LinkClickWithFriend extends LinkClick {

--- a/packages/mcp-server/src/tools/create-tracked-link.ts
+++ b/packages/mcp-server/src/tools/create-tracked-link.ts
@@ -41,8 +41,29 @@ export function registerCreateTrackedLink(server: McpServer): void {
       ogTitle: z.string().nullable().optional().describe("OGP title override for the tracking link preview (overrides the destination page's og:title)"),
       ogDescription: z.string().nullable().optional().describe("OGP description override for the tracking link preview"),
       ogImageUrl: z.string().nullable().optional().describe("OGP image URL override for the tracking link preview"),
+      expiresAt: z
+        .string()
+        .nullable()
+        .optional()
+        .describe(
+          "Absolute deadline as ISO-8601 JST (e.g. 2026-08-01T23:59:00+09:00). Clicks after this land on expiredRedirectUrl.",
+        ),
+      expiresMinutesAfterSend: z
+        .number()
+        .int()
+        .positive()
+        .nullable()
+        .optional()
+        .describe(
+          "Per-friend deadline in minutes counted from when THAT friend received the message containing this link (UTAGE-style campaign deadline). Anonymous clicks can't be evaluated and only honor expiresAt.",
+        ),
+      expiredRedirectUrl: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("Where expired clicks are redirected. Omit to show a plain 'link expired' page."),
     },
-    async ({ name, originalUrl, tagId, scenarioId, introTemplateId, rewardTemplateId, accountId, ogTitle, ogDescription, ogImageUrl }) => {
+    async ({ name, originalUrl, tagId, scenarioId, introTemplateId, rewardTemplateId, accountId, ogTitle, ogDescription, ogImageUrl, expiresAt, expiresMinutesAfterSend, expiredRedirectUrl }) => {
       try {
         const client = getClient();
         const link = await client.trackedLinks.create({
@@ -56,6 +77,9 @@ export function registerCreateTrackedLink(server: McpServer): void {
           ogTitle,
           ogDescription,
           ogImageUrl,
+          expiresAt,
+          expiresMinutesAfterSend,
+          expiredRedirectUrl,
         });
         return {
           content: [

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -340,6 +340,12 @@ export interface TrackedLink {
   ogTitle: string | null
   ogDescription: string | null
   ogImageUrl: string | null
+  /** 絶対期限（ISO-8601 JST）。これ以降のクリックは expiredRedirectUrl へ。 */
+  expiresAt?: string | null
+  /** 友だちごとの相対期限（そのリンクを含むメッセージの受信から n 分）。 */
+  expiresMinutesAfterSend?: number | null
+  /** 期限切れクリックのリダイレクト先。null は既定の期限切れページ。 */
+  expiredRedirectUrl?: string | null
   createdAt: string
   updatedAt: string
 }
@@ -367,6 +373,9 @@ export interface CreateTrackedLinkInput {
   ogTitle?: string | null
   ogDescription?: string | null
   ogImageUrl?: string | null
+  expiresAt?: string | null
+  expiresMinutesAfterSend?: number | null
+  expiredRedirectUrl?: string | null
 }
 
 export interface UpdateTrackedLinkInput {
@@ -380,6 +389,9 @@ export interface UpdateTrackedLinkInput {
   ogTitle?: string | null
   ogDescription?: string | null
   ogImageUrl?: string | null
+  expiresAt?: string | null
+  expiresMinutesAfterSend?: number | null
+  expiredRedirectUrl?: string | null
 }
 
 // ─── Forms ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- トラッキングリンク（/t/）に**時限失効**を追加。有料ツール（UTAGE/L-step）の「配信からn時間でリンク失効→締切ページへ」というキャンペーン締切導線を再現できます
- `expires_at` — 全員一律の絶対期限（ISO-8601 JST）
- `expires_minutes_after_send` — **友だちごとの相対期限**。そのリンクを含むメッセージを本人が受信した時刻（messages_logの最新outgoing行）から n 分で失効。ステップ配信のように受信タイミングが人によって違うケースで、各自に公平な締切を実現
- `expired_redirect_url` — 失効後のリダイレクト先。未設定なら410の日本語期限切れページを表示
- 失効クリックは統計用にクリック記録のみ行い、タグ付与・シナリオ登録の副作用は発火しない
- 匿名クリック（friend未特定）は相対期限を評価できないため absolute のみ適用（設計コメントに明記）

## 影響範囲
- `packages/db/migrations/050_tracked_links_expiration.sql`（新規・ALTER 3カラム）
- `packages/db/src/tracked-links.ts`（型・CRUD・`isTrackedLinkExpired`/`getLinkLastSentAt`）
- `apps/worker/src/routes/tracked-links.ts`（POST/PATCHバリデーション・/t/ 失効ゲート）
- `packages/sdk/src/types.ts` / `packages/mcp-server/src/tools/create-tracked-link.ts`（フィールド追加）

## Test plan
- [x] `vitest run src/routes/tracked-links.test.ts` 12件パス（失効5ケース追加：失効→リダイレクト/410、副作用スキップ、非失効通過、期限なしはチェック自体をスキップ、バリデーション400）
- [x] worker 全テスト 677件パス
- [x] `pnpm run test:scripts`（マイグレーション整合）37件パス
- [x] SDK / MCP server ビルド成功
- [ ] D1へのマイグレーション適用＋実機での失効確認（デプロイ後）

Generated with [Claude Code](https://claude.com/claude-code)