### PR TITLE
fix(worker): scenario step の到達タグ付与で tag_change イベントを発火する

### DIFF
--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -25,6 +25,7 @@ import {
 import { buildIntroMessage } from '../services/intro-message.js';
 import { notifyAffiliateFriendAdd } from '../services/affiliate-notifier.js';
 import { safeRedirectTarget } from '../lib/safe-redirect.js';
+import { fireEvent } from '../services/event-bus.js';
 import type { Env } from '../index.js';
 
 const liffRoutes = new Hono<Env>();
@@ -372,9 +373,14 @@ async function applyRefAttribution(
           await completeFriendScenario(db, enrollmentRow.id);
         }
         // 到達タグ付与 (advance / complete の後)
+        // tag_change をイベントバスへ発火し、手動タグ付与と同じく automation を動かす。
         if (firstStep.on_reach_tag_id) {
           try {
             await addTagToFriend(db, friend.id, firstStep.on_reach_tag_id);
+            await fireEvent(db, 'tag_change', {
+              friendId: friend.id,
+              eventData: { tagId: firstStep.on_reach_tag_id, action: 'add' },
+            });
           } catch (err) {
             console.error(`[scenario] tag attach failed step=${firstStep.id}:`, err);
           }

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -316,9 +316,14 @@ async function handleEvent(
                 }
 
                 // 到達タグ付与 (advance / complete の後)
+                // tag_change をイベントバスへ発火し、手動タグ付与と同じく automation を動かす。
                 if (firstStep.on_reach_tag_id) {
                   try {
                     await addTagToFriend(db, friend.id, firstStep.on_reach_tag_id);
+                    await fireEvent(db, 'tag_change', {
+                      friendId: friend.id,
+                      eventData: { tagId: firstStep.on_reach_tag_id, action: 'add' },
+                    });
                   } catch (err) {
                     console.error(`[scenario] tag attach failed step=${firstStep.id}:`, err);
                   }

--- a/apps/worker/src/services/step-delivery.test.ts
+++ b/apps/worker/src/services/step-delivery.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { evaluateCondition, isSupportedConditionType, SUPPORTED_CONDITION_TYPES, processStepDeliveries, expandVariables } from './step-delivery.js';
+import { fireEvent } from './event-bus.js';
 import type { LineClient } from '@line-crm/line-sdk';
+
+vi.mock('./event-bus.js', () => ({
+  fireEvent: vi.fn().mockResolvedValue(undefined),
+}));
 
 /**
  * Regression coverage for OSS issue #120 — scenario step
@@ -380,6 +385,140 @@ describe('condition-false jump (next_step_on_false)', () => {
 
     expect(advances).toHaveLength(1);
     expect(advances[0].nextStepOrder).toBe(2); // no step 99 → sequential path
+  });
+});
+
+/**
+ * Regression coverage: reaching a scenario step with `on_reach_tag_id` set
+ * must fire a `tag_change` event on the event bus, the same way manual
+ * tagging (routes/friends.ts POST /api/friends/:id/tags) and the booking
+ * auto-tag path (services/friend-tag-attach.ts) already do. Pre-fix, the
+ * on_reach tag attach in step-delivery.ts called `addTagToFriend()` directly
+ * against the DB with no event fired, so automations (e.g. switch_rich_menu)
+ * configured on `tag_change` never triggered for scenario-reached tags — only
+ * for manually-applied tags.
+ */
+describe('on_reach_tag_id fires tag_change on the event bus', () => {
+  const fireEventMock = vi.mocked(fireEvent);
+
+  beforeEach(() => {
+    fireEventMock.mockClear();
+  });
+
+  /**
+   * Fake D1 driving processStepDeliveries through the full success path for a
+   * single-step scenario (no condition) whose only step has on_reach_tag_id set.
+   */
+  function successDeliveryMockDb(opts: { onReachTagId: string | null }): {
+    db: D1Database;
+    tagAttachCalls: Array<{ friendId: string; tagId: string }>;
+  } {
+    const tagAttachCalls: Array<{ friendId: string; tagId: string }> = [];
+    const stepRow = {
+      id: 'step-1',
+      scenario_id: 'sc1',
+      step_order: 1,
+      message_type: 'text',
+      message_content: 'hello',
+      template_id: null,
+      delay_minutes: 10,
+      offset_days: null,
+      offset_minutes: null,
+      delivery_time: null,
+      condition_type: null,
+      condition_value: null,
+      next_step_on_false: null,
+      on_reach_tag_id: opts.onReachTagId,
+    };
+
+    const db = {
+      prepare: (sql: string) => {
+        const stmt = (args: unknown[]) => ({
+          first: async () => {
+            if (sql.includes('FROM friends')) {
+              return {
+                id: 'f1',
+                line_user_id: 'U1',
+                display_name: 'Test',
+                is_following: 1,
+                user_id: null,
+                metadata: null,
+                line_account_id: null,
+              };
+            }
+            if (sql.includes('delivery_mode FROM scenarios')) {
+              return { delivery_mode: 'relative' };
+            }
+            return null;
+          },
+          all: async () => {
+            if (sql.includes('FROM friend_scenarios')) {
+              return {
+                results: [
+                  {
+                    id: 'fs1',
+                    friend_id: 'f1',
+                    scenario_id: 'sc1',
+                    current_step_order: 0,
+                    status: 'active',
+                    next_delivery_at: '2026-01-01T00:00:00+09:00',
+                    started_at: '2026-01-01T00:00:00+09:00',
+                  },
+                ],
+              };
+            }
+            if (sql.includes('FROM scenario_steps')) {
+              return { results: [stepRow] };
+            }
+            return { results: [] };
+          },
+          run: async () => {
+            if (sql.includes('INSERT OR IGNORE INTO friend_tags')) {
+              tagAttachCalls.push({ friendId: args[0] as string, tagId: args[1] as string });
+              return { meta: { changes: 1 } };
+            }
+            return { meta: { changes: 1 } }; // claim / advance / complete / messages_log — all succeed
+          },
+        });
+        return {
+          bind: (...args: unknown[]) => stmt(args),
+          ...stmt([]),
+        };
+      },
+    } as unknown as D1Database;
+
+    return { db, tagAttachCalls };
+  }
+
+  function mockLineClient(): { client: LineClient; push: ReturnType<typeof vi.fn> } {
+    const push = vi.fn(async () => ({}));
+    return { client: { pushMessage: push } as unknown as LineClient, push };
+  }
+
+  it('attaches the tag AND fires tag_change when on_reach_tag_id is set', async () => {
+    const { db, tagAttachCalls } = successDeliveryMockDb({ onReachTagId: 'tag-Z' });
+    const { client, push } = mockLineClient();
+
+    await processStepDeliveries(db, client);
+
+    expect(push).toHaveBeenCalledTimes(1); // step was actually delivered
+    expect(tagAttachCalls).toEqual([{ friendId: 'f1', tagId: 'tag-Z' }]);
+    expect(fireEventMock).toHaveBeenCalledTimes(1);
+    expect(fireEventMock).toHaveBeenCalledWith(db, 'tag_change', {
+      friendId: 'f1',
+      eventData: { tagId: 'tag-Z', action: 'add' },
+    });
+  });
+
+  it('does not fire tag_change when the step has no on_reach_tag_id', async () => {
+    const { db, tagAttachCalls } = successDeliveryMockDb({ onReachTagId: null });
+    const { client, push } = mockLineClient();
+
+    await processStepDeliveries(db, client);
+
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(tagAttachCalls).toEqual([]);
+    expect(fireEventMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/worker/src/services/step-delivery.ts
+++ b/apps/worker/src/services/step-delivery.ts
@@ -15,6 +15,7 @@ import {
 import type { LineClient } from '@line-crm/line-sdk';
 import type { Message } from '@line-crm/line-sdk';
 import { jitterDeliveryTime, addJitter, sleep } from './stealth.js';
+import { fireEvent } from './event-bus.js';
 
 /**
  * Replace template variables in message content.
@@ -278,9 +279,15 @@ async function processSingleDelivery(
 
   // 到達タグ付与 (advance / complete の後 = 再送が起きてもタグ付与は影響しない順序)
   // 失敗してもログに残すだけで配信フローは止めない。
+  // tag_change をイベントバスへ発火し、手動タグ付与 (routes/friends.ts) と同じく
+  // automation (switch_rich_menu 等) が到達タグでも動くようにする。
   if (currentStep.on_reach_tag_id) {
     try {
       await addTagToFriend(db, friend.id, currentStep.on_reach_tag_id);
+      await fireEvent(db, 'tag_change', {
+        friendId: friend.id,
+        eventData: { tagId: currentStep.on_reach_tag_id, action: 'add' },
+      });
     } catch (err) {
       console.error(`[scenario] tag attach failed step=${currentStep.id}:`, err);
     }


### PR DESCRIPTION
## 問題

`scenario_steps.on_reach_tag_id`（ステップ到達時タグ）でタグを付与する処理が、以下の3箇所で `@line-crm/db` の `addTagToFriend()` を直接呼んでおり、イベントバス（`fireEvent(db, 'tag_change', ...)`）を経由していませんでした。

- `apps/worker/src/services/step-delivery.ts`（cron の配信ループ、`processSingleDelivery` 内）
- `apps/worker/src/routes/webhook.ts`（webhook 受信直後の即時配信パス）
- `apps/worker/src/routes/liff.ts`（`applyRefAttribution` の即時配信パス）

一方、手動タグ付与（`POST /api/friends/:id/tags`、`apps/worker/src/routes/friends.ts`）や予約の自動タグ付与（`apps/worker/src/services/friend-tag-attach.ts`）は、同じタグ付与後に `tag_change` イベントを発火しています。

`tag_change` は自動化ルール（IF-THEN、例: `switch_rich_menu`）やスコアリング、外向き Webhook のトリガーに使われるため、この非対称により「シナリオを最後まで到達してタグが付いたユーザー」に対しては、上記の automation が一切発火しない、という見えにくい不具合になっていました（手動でタグを付け直せば動くため、原因の切り分けが難しいタイプの不具合です）。

## 修正内容

3箇所すべてで、既存の `addTagToFriend()` 呼び出しの直後・同じ `try/catch` 内に `fireEvent(db, 'tag_change', { friendId, eventData: { tagId, action: 'add' } })` を追加しました。

```ts
if (currentStep.on_reach_tag_id) {
  try {
    await addTagToFriend(db, friend.id, currentStep.on_reach_tag_id);
    await fireEvent(db, 'tag_change', {
      friendId: friend.id,
      eventData: { tagId: currentStep.on_reach_tag_id, action: 'add' },
    });
  } catch (err) {
    console.error(`[scenario] tag attach failed step=${currentStep.id}:`, err);
  }
}
```

- タグ付与自体のロジック（`addTagToFriend` の INSERT OR IGNORE / 冪等性）は変更していません。
- タグ付与・イベント発火のいずれが失敗しても、既存どおりログのみで配信フローは止めません（`try/catch` の範囲をそのまま踏襲）。
- `friend-tag-attach.ts` の `attachTagAndFireSideEffects()` は「新規付与時のみ発火」かつ「tag_added シナリオへの追加 enrollment」も行う、より重い helper のため、今回は流用せず `fireEvent` を直接呼ぶ最小差分にしています（この3箇所は on_reach 経由で毎回タグが変わるとは限らず、enrollment 側の重複判定ロジックの意味合いも異なるため、挙動を増やしすぎない判断です）。循環 import は発生しません（`services/event-bus.ts` は `routes/webhook.ts` / `routes/liff.ts` / `services/step-delivery.ts` のいずれも import していません）。

## テスト

`apps/worker/src/services/step-delivery.test.ts` に新規 `describe('on_reach_tag_id fires tag_change on the event bus')` を追加し、以下を検証しています。

- `on_reach_tag_id` が設定されたステップに到達すると、タグが付与され、かつ `fireEvent` が `(db, 'tag_change', { friendId, eventData: { tagId, action: 'add' } })` で1回呼ばれる
- `on_reach_tag_id` が未設定なら `fireEvent` は呼ばれない（既存挙動の非退行確認）

`webhook.ts` / `liff.ts` は同一パターンのコピーであり、`step-delivery.ts` 側のテストで修正内容のロジックは検証済みのため、個別の新規テストは追加していません（既存の `webhook.test.ts` / `liff*.test.ts` は今回のパスをカバーしていませんでした）。

```
pnpm --filter worker test
# Test Files  62 passed (62)
# Tests  674 passed (674)

pnpm --filter worker typecheck
# (no errors)
```

## 後方互換性

- API 契約・DB スキーマの変更なし。
- 挙動変化は「`tag_change` イベントが追加で発火するようになる」点のみです。既存で `tag_change` を購読する automation / 外向き Webhook / スコアリングルールを設定していないアカウントには実質的な影響はありません。
- 設定済みの automation がある場合、今回の修正によって初めて「シナリオ到達タグ」でも意図通りに発火するようになります（これはバグ修正であり、意図した挙動です）。

## 備考

- CONTRIBUTING の "small reviewable changes" 方針に沿って、無関係なリファクタは行っていません。
- 調査時に `git grep addTagToFriend` で全箇所を洗い出したところ、`on_reach_tag_id` 以外にも直接 `addTagToFriend()` を呼ぶ箇所（`routes/forms.ts` の `on_submit_tag_id`、`routes/tracked-links.ts` のクリックタグ、`routes/liff.ts` の X Harness ゲートタグ等）が複数見つかりましたが、これらは「到達タグ」とは別カテゴリの既存挙動であり、本 PR のスコープ外として意図的に含めていません。必要であれば別 issue / 別 PR として切り出すのが良いと考えます。
