### PR TITLE
sync: instant first-step push — unified service + welcome-speed fixes

### DIFF
--- a/apps/worker/src/routes/booking.ts
+++ b/apps/worker/src/routes/booking.ts
@@ -455,7 +455,10 @@ booking.post('/api/liff/booking/requests', async (c) => {
   if (menuRow.auto_tag_id) {
     const tagId = menuRow.auto_tag_id;
     c.executionCtx.waitUntil(
-      attachTagAndFireSideEffects(c.env.DB, friendId, tagId)
+      attachTagAndFireSideEffects(c.env.DB, friendId, tagId, {
+        defaultAccessToken: c.env.LINE_CHANNEL_ACCESS_TOKEN,
+        workerUrl: c.env.WORKER_URL,
+      })
         .then(() => undefined)
         .catch((err) => console.error('booking auto-tag failed:', err)),
     );

--- a/apps/worker/src/routes/forms.ts
+++ b/apps/worker/src/routes/forms.ts
@@ -11,7 +11,8 @@ import {
   jstNow,
 } from '@line-crm/db';
 import { getFriendByLineUserId, getFriendById } from '@line-crm/db';
-import { addTagToFriend, enrollFriendInScenario } from '@line-crm/db';
+import { enrollFriendInScenario } from '@line-crm/db';
+import { attachTagAndFireSideEffects } from '../services/friend-tag-attach.js';
 import type {
   Form as DbForm,
   FormSubmission as DbFormSubmission,
@@ -447,9 +448,13 @@ forms.post('/api/forms/:id/submit', async (c) => {
         );
       }
 
-      // Add tag
+      // Add tag — guarded attach so a tag_added-triggered scenario fires on
+      // first-time submit (and never re-fires on duplicate submits).
       if (form.on_submit_tag_id) {
-        sideEffects.push(addTagToFriend(db, friendId, form.on_submit_tag_id));
+        sideEffects.push(attachTagAndFireSideEffects(db, friendId, form.on_submit_tag_id, {
+          defaultAccessToken: c.env.LINE_CHANNEL_ACCESS_TOKEN,
+          workerUrl: c.env.WORKER_URL,
+        }));
       }
 
       // Enroll in scenario

--- a/apps/worker/src/routes/liff-offer-attribution.test.ts
+++ b/apps/worker/src/routes/liff-offer-attribution.test.ts
@@ -33,6 +33,11 @@ vi.mock('@line-crm/db', () => dbMocks);
 const notifyAffiliateFriendAdd = vi.fn().mockResolvedValue(undefined);
 vi.mock('../services/affiliate-notifier.js', () => ({ notifyAffiliateFriendAdd }));
 
+// Ref-attribution tag attach now goes through the guarded helper (fires
+// tag_added side effects only on first-time attach) — assert on this mock.
+const attachTagAndFireSideEffects = vi.fn().mockResolvedValue({ added: true });
+vi.mock('../services/friend-tag-attach.js', () => ({ attachTagAndFireSideEffects }));
+
 // Import after the mock so index.ts binds the mocked helpers.
 const worker = (await import('../index.js')).default;
 
@@ -123,10 +128,11 @@ describe('POST /api/liff/link — offer tag/scenario on affiliate-link friend ad
       expect.anything(),
       'OFF-1',
     );
-    expect(dbMocks.addTagToFriend).toHaveBeenCalledWith(
+    expect(attachTagAndFireSideEffects).toHaveBeenCalledWith(
       expect.anything(),
       'F-1',
       'TAG-offer',
+      expect.anything(),
     );
   });
 
@@ -142,7 +148,7 @@ describe('POST /api/liff/link — offer tag/scenario on affiliate-link friend ad
 
     // No offer lookup, no tag application — current behavior unchanged.
     expect(dbMocks.getAffiliateOfferById).not.toHaveBeenCalled();
-    expect(dbMocks.addTagToFriend).not.toHaveBeenCalled();
+    expect(attachTagAndFireSideEffects).not.toHaveBeenCalled();
   });
 
   it('skips tag application when the offer is inactive (is_active = 0)', async () => {
@@ -166,7 +172,7 @@ describe('POST /api/liff/link — offer tag/scenario on affiliate-link friend ad
       expect.anything(),
       'OFF-2',
     );
-    expect(dbMocks.addTagToFriend).not.toHaveBeenCalled();
+    expect(attachTagAndFireSideEffects).not.toHaveBeenCalled();
   });
 
   it('does NOT fire the friend-add notification on an existing-friend re-touch', async () => {
@@ -206,10 +212,11 @@ describe('POST /api/liff/link — offer tag/scenario on affiliate-link friend ad
     // entry_route wins: affiliate link / offer resolution is skipped entirely.
     expect(dbMocks.getAffiliateLinkByRefCode).not.toHaveBeenCalled();
     expect(dbMocks.getAffiliateOfferById).not.toHaveBeenCalled();
-    expect(dbMocks.addTagToFriend).toHaveBeenCalledWith(
+    expect(attachTagAndFireSideEffects).toHaveBeenCalledWith(
       expect.anything(),
       'F-1',
       'TAG-route',
+      expect.anything(),
     );
   });
 });

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -23,6 +23,8 @@ import {
   jstNow,
 } from '@line-crm/db';
 import { buildIntroMessage } from '../services/intro-message.js';
+import { attachTagAndFireSideEffects } from '../services/friend-tag-attach.js';
+import { pushImmediateFirstStep } from '../services/immediate-first-step.js';
 import { notifyAffiliateFriendAdd } from '../services/affiliate-notifier.js';
 import { safeRedirectTarget } from '../lib/safe-redirect.js';
 import type { Env } from '../index.js';
@@ -226,160 +228,35 @@ async function applyRefAttribution(
     route?.scenario_id ?? trackedLink?.scenario_id ?? offer?.scenario_id ?? null;
 
   if (effectiveTagId) {
-    await addTagToFriend(db, friend.id, effectiveTagId);
+    // Guarded attach: fires tag_added scenario enrollment (and tag_change
+    // events) ONLY when the tag is newly applied. Re-clicks and clicks from
+    // other links carrying the same tag are no-ops, so a tag_added-triggered
+    // campaign (e.g. a seminar optin sequence) sends exactly once per friend
+    // no matter how many article links they enter through. Routes that want
+    // push-on-every-click keep using an explicit scenario_id below.
+    await attachTagAndFireSideEffects(db, friend.id, effectiveTagId, {
+      defaultAccessToken: c.env.LINE_CHANNEL_ACCESS_TOKEN,
+      workerUrl: c.env.WORKER_URL,
+      accountChannelId: options?.accountChannelId ?? null,
+    });
   }
   if (effectiveScenarioId) {
     try {
-      const {
-        enrollFriendInScenario,
-        getScenarioSteps,
-        getScenarioById,
-        advanceFriendScenario,
-        completeFriendScenario,
-        getFriendById,
-        computeNextDeliveryAt,
-        resolveStepContent,
-        addTagToFriend,
-      } = await import('@line-crm/db');
-      const { LineClient } = await import('@line-crm/line-sdk');
-      const { buildMessage, expandVariables, resolveMetadata } = await import('../services/step-delivery.js');
-      const scenarioRow = await getScenarioById(db, effectiveScenarioId);
-      if (!scenarioRow) return;
-      const steps = scenarioRow.steps;
-      const firstStep = steps[0];
-      // クリックキャンペーンの即時送信は「now 以前にスケジュールされる」場合のみ。
-      // elapsed/absolute_time の delay_minutes=0 は即時を意味しない（offset/clock-time 起点）。
-      if (!firstStep) return;
-      const enrolledAtJst = new Date(Date.now() + 9 * 60 * 60_000);
-      const firstScheduledAt = computeNextDeliveryAt(
-        { delivery_mode: scenarioRow.delivery_mode ?? 'relative' },
-        firstStep,
-        { enrolledAt: enrolledAtJst, previousDeliveredAt: enrolledAtJst, now: enrolledAtJst },
+      await pushImmediateFirstStep(
+        db,
+        friend.id,
+        effectiveScenarioId,
+        {
+          defaultAccessToken: c.env.LINE_CHANNEL_ACCESS_TOKEN,
+          workerUrl: c.env.WORKER_URL,
+          accountChannelId: options?.accountChannelId ?? null,
+        },
+        // every-click: cooldown before enrolling, push even on re-clicks,
+        // advance only fresh / behind enrollment rows (see the service).
+        // lineUserId comes from the verified id_token / OAuth exchange, so
+        // the push works even before friend.line_user_id is fully wired.
+        { mode: 'every-click', targetLineUserId: lineUserId },
       );
-      if (firstScheduledAt.getTime() > enrolledAtJst.getTime()) return;
-
-      // Cooldown FIRST, before enrolling. /api/liff/link is hit on every
-      // LIFF page load (refresh, back-nav), not only on a fresh
-      // tracked-link click. Doing cooldown after enrollment would leave
-      // a fresh active step-0 row behind for the cron worker to pick up
-      // (because the partial UNIQUE on friend_scenarios is keyed
-      // `WHERE status != 'completed'`, so completed runs don't block
-      // a new INSERT).
-      const cutoff = new Date(Date.now() - 60_000 + 9 * 60 * 60_000)
-        .toISOString()
-        .slice(0, -1) + '+09:00';
-      const recent = await db
-        .prepare(
-          `SELECT 1 FROM messages_log
-           WHERE friend_id = ? AND scenario_step_id = ?
-             AND direction = 'outgoing' AND created_at > ?
-           LIMIT 1`,
-        )
-        .bind(friend.id, firstStep.id, cutoff)
-        .first();
-      if (recent) return;
-
-      // INSERT OR IGNORE — null on re-clicks (already enrolled), still push.
-      const enrollment = await enrollFriendInScenario(db, friend.id, effectiveScenarioId);
-
-      // Resolve push token. Prefer caller-supplied account channel (OAuth
-      // context), then friend.line_account_id, then the env default.
-      let accessToken = c.env.LINE_CHANNEL_ACCESS_TOKEN;
-      if (options?.accountChannelId) {
-        const acct = await getLineAccountByChannelId(db, options.accountChannelId);
-        if (acct?.channel_access_token) accessToken = acct.channel_access_token;
-      } else if (friend.line_account_id) {
-        const acct = await getLineAccountById(db, friend.line_account_id);
-        if (acct?.channel_access_token) accessToken = acct.channel_access_token;
-      }
-      const lineClient = new LineClient(accessToken);
-
-      // Re-read the friend after caller writes (linkFriendToUser /
-      // ref_code UPDATE) so {{uid}}, {{ref}}, and merged metadata
-      // expand against the latest state.
-      const fresh = (await getFriendById(db, friend.id)) ?? friend;
-      const resolvedMeta = await resolveMetadata(db, {
-        user_id: (fresh as unknown as Record<string, string | null>).user_id,
-        metadata: (fresh as unknown as Record<string, string | null>).metadata,
-      });
-      // Resolve template_id → templates table (参照型)
-      const resolved = await resolveStepContent(db, firstStep);
-      const expanded = expandVariables(
-        resolved.messageContent,
-        { ...fresh, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1],
-        c.env.WORKER_URL,
-        resolved.messageType,
-      );
-      const pushedMessage = buildMessage(resolved.messageType, expanded);
-      await lineClient.pushMessage(lineUserId, [pushedMessage]);
-
-      // Log the push so the cooldown above sees it on subsequent calls,
-      // and so /chats and analytics show the message. Derive content from the
-      // built message object (post cleanEmptyNodes / parse-failure fallback)
-      // so the dashboard mirrors LINE exactly.
-      const nowIso = new Date(Date.now() + 9 * 60 * 60_000)
-        .toISOString()
-        .slice(0, -1) + '+09:00';
-      const { messageToLogPayload } = await import('../services/step-delivery.js');
-      const liffLogPayload = messageToLogPayload(pushedMessage);
-      await db
-        .prepare(
-          `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, template_id_at_send, created_at)
-           VALUES (?, ?, 'outgoing', ?, ?, NULL, ?, 'scenario', ?, ?)`,
-        )
-        .bind(
-          crypto.randomUUID(),
-          friend.id,
-          liffLogPayload.messageType,
-          liffLogPayload.content,
-          firstStep.id,
-          resolved.templateIdAtSend,
-          nowIso,
-        )
-        .run();
-
-      // Advance the enrollment so the cron delivery worker does not re-send
-      // step 1. Look up the row for this (friend, scenario) — covers both
-      // the freshly-created enrollment AND a stale row whose previous
-      // attempt failed before reaching this advancement (P2 from review).
-      // Filter out completed rows — the partial UNIQUE allows multiple
-      // historical completed rows to coexist, and we only want to repair
-      // the active one. Pick the most recently updated as a tiebreaker.
-      const enrollmentRow = enrollment ?? await db
-        .prepare(
-          `SELECT id, current_step_order FROM friend_scenarios
-           WHERE friend_id = ? AND scenario_id = ? AND status != 'completed'
-           ORDER BY updated_at DESC LIMIT 1`,
-        )
-        .bind(friend.id, effectiveScenarioId)
-        .first<{ id: string; current_step_order: number }>();
-      if (enrollmentRow && enrollmentRow.current_step_order < firstStep.step_order) {
-        const nextStep = steps[1];
-        if (nextStep) {
-          // step 2 も computeNextDeliveryAt で計算（elapsed/absolute_time で正しい時刻に）
-          const next = computeNextDeliveryAt(
-            { delivery_mode: scenarioRow.delivery_mode ?? 'relative' },
-            nextStep,
-            { enrolledAt: enrolledAtJst, previousDeliveredAt: enrolledAtJst, now: enrolledAtJst },
-          );
-          await advanceFriendScenario(
-            db,
-            enrollmentRow.id,
-            firstStep.step_order,
-            next.toISOString().slice(0, -1) + '+09:00',
-          );
-        } else {
-          await completeFriendScenario(db, enrollmentRow.id);
-        }
-        // 到達タグ付与 (advance / complete の後)
-        if (firstStep.on_reach_tag_id) {
-          try {
-            await addTagToFriend(db, friend.id, firstStep.on_reach_tag_id);
-          } catch (err) {
-            console.error(`[scenario] tag attach failed step=${firstStep.id}:`, err);
-          }
-        }
-      }
     } catch (err) {
       console.error('Ref scenario enrollment error:', err);
     }

--- a/apps/worker/src/routes/tracked-links.ts
+++ b/apps/worker/src/routes/tracked-links.ts
@@ -10,7 +10,8 @@ import {
   getLinkClicks,
   getFriendByLineUserId,
 } from '@line-crm/db';
-import { addTagToFriend, enrollFriendInScenario } from '@line-crm/db';
+import { enrollFriendInScenario } from '@line-crm/db';
+import { attachTagAndFireSideEffects } from '../services/friend-tag-attach.js';
 import type { TrackedLink } from '@line-crm/db';
 import type { Env } from '../index.js';
 import { isLinkPreviewBot } from '../lib/og-bot.js';
@@ -345,7 +346,14 @@ trackedLinks.get('/t/:linkId', async (c) => {
           const actions: Promise<unknown>[] = [];
 
           if (link.tag_id) {
-            actions.push(addTagToFriend(c.env.DB, friendId, link.tag_id));
+            // Guarded attach: fires tag_added scenario enrollment only when
+            // the tag is NEWLY applied — an in-app /t click must start a
+            // tag-triggered campaign exactly like the /auth/line ref path
+            // does, and stay silent on re-clicks.
+            actions.push(attachTagAndFireSideEffects(c.env.DB, friendId, link.tag_id, {
+              defaultAccessToken: c.env.LINE_CHANNEL_ACCESS_TOKEN,
+              workerUrl: c.env.WORKER_URL,
+            }));
           }
 
           if (link.scenario_id) {

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -8,21 +8,16 @@ import {
   getFriendByLineUserId,
   getScenarios,
   enrollFriendInScenario,
-  getScenarioSteps,
-  advanceFriendScenario,
-  completeFriendScenario,
   upsertChatOnMessage,
   getLineAccounts,
   jstNow,
-  computeNextDeliveryAt,
-  resolveStepContent,
-  addTagToFriend,
   getEntryRouteByRefCode,
   getMessageTemplateById,
 } from '@line-crm/db';
 import type { EntryRoute, Friend } from '@line-crm/db';
 import { fireEvent } from '../services/event-bus.js';
 import { buildMessage, expandVariables } from '../services/step-delivery.js';
+import { pushImmediateFirstStep } from '../services/immediate-first-step.js';
 import type { Env } from '../index.js';
 
 const webhook = new Hono<Env>();
@@ -256,77 +251,27 @@ async function handleEvent(
           const friendScenario = await enrollFriendInScenario(db, friend.id, scenario.id);
           if (!friendScenario) continue; // already enrolled
 
-            // Immediate delivery: scenario.delivery_mode を踏まえて step1 が「now 以前」に
-            // スケジュールされる場合のみ replyMessage で即時送信する。
-            // - relative + delay_minutes=0 → 即時
-            // - elapsed + offset_days=0 + offset_minutes=0 → 即時
-            // - absolute_time で過去時刻 → computeNextDeliveryAt が now に clamp するので即時
-            const steps = await getScenarioSteps(db, scenario.id);
-            const firstStep = steps[0];
-            const deliveryMode = scenario.delivery_mode ?? 'relative';
-            const enrolledAtJst = new Date(Date.now() + 9 * 60 * 60_000);
-            const firstScheduledAt = firstStep
-              ? computeNextDeliveryAt(
-                  { delivery_mode: deliveryMode },
-                  firstStep,
-                  { enrolledAt: enrolledAtJst, previousDeliveredAt: enrolledAtJst, now: enrolledAtJst },
-                )
-              : null;
-            const shouldSendImmediately =
-              firstStep &&
-              firstScheduledAt !== null &&
-              firstScheduledAt.getTime() <= enrolledAtJst.getTime() &&
-              friendScenario.status === 'active';
-            if (firstStep && shouldSendImmediately) {
-              try {
-                // Resolve template_id → templates table (参照型)
-                const resolved = await resolveStepContent(db, firstStep);
-                const { resolveMetadata } = await import('../services/step-delivery.js');
-                const resolvedMeta = await resolveMetadata(db, { user_id: (friend as unknown as Record<string, string | null>).user_id, metadata: (friend as unknown as Record<string, string | null>).metadata });
-                const expandedContent = expandVariables(resolved.messageContent, { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1], undefined, resolved.messageType);
-                const message = buildMessage(resolved.messageType, expandedContent);
-                await lineClient.replyMessage(event.replyToken, [message]);
-                console.log(`Immediate delivery: sent step ${firstStep.id} to ${userId}`);
-
-                // Log what was actually delivered (post buildMessage normalization)
-                // so the dashboard chat view mirrors LINE 1:1.
-                const logId = crypto.randomUUID();
-                const { messageToLogPayload: logPayload1 } = await import('../services/step-delivery.js');
-                const wbScenarioPayload = logPayload1(message);
-                await db
-                  .prepare(
-                    `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, delivery_type, source, template_id_at_send, created_at)
-                     VALUES (?, ?, 'outgoing', ?, ?, NULL, ?, 'reply', 'scenario', ?, ?)`,
-                  )
-                  .bind(logId, friend.id, wbScenarioPayload.messageType, wbScenarioPayload.content, firstStep.id, resolved.templateIdAtSend, jstNow())
-                  .run();
-
-                // Advance or complete the friend_scenario — step 2 のスケジュールも
-                // computeNextDeliveryAt で計算する（elapsed/absolute_time で正しく動かすため）
-                const secondStep = steps[1] ?? null;
-                if (secondStep) {
-                  const nextDeliveryDate = computeNextDeliveryAt(
-                    { delivery_mode: deliveryMode },
-                    secondStep,
-                    { enrolledAt: enrolledAtJst, previousDeliveredAt: enrolledAtJst, now: enrolledAtJst },
-                  );
-                  await advanceFriendScenario(db, friendScenario.id, firstStep.step_order, nextDeliveryDate.toISOString().slice(0, -1) + '+09:00');
-                } else {
-                  await completeFriendScenario(db, friendScenario.id);
-                }
-
-                // 到達タグ付与 (advance / complete の後)
-                if (firstStep.on_reach_tag_id) {
-                  try {
-                    await addTagToFriend(db, friend.id, firstStep.on_reach_tag_id);
-                  } catch (err) {
-                    console.error(`[scenario] tag attach failed step=${firstStep.id}:`, err);
-                  }
-                }
-              } catch (err) {
-                console.error('Failed immediate delivery for scenario', scenario.id, err);
-              }
-            }
+          // Immediate delivery: step1 が「now 以前」にスケジュールされる場合のみ
+          // replyMessage で即時送信する (reply token は無料・push 枠を消費しない)。
+          // - relative + delay_minutes=0 → 即時
+          // - elapsed + offset_days=0 + offset_minutes=0 → 即時
+          // - absolute_time で過去時刻 → computeNextDeliveryAt が now に clamp するので即時
+          // reply 失敗時 (2つ目のシナリオで token 消費済み等) は claim が解放され
+          // cron が push で配信する。
+          // skipCooldown: 60秒以内の再フォロー (前の enrollment が completed 済み)
+          // でも必ず welcome を返す — 旧 webhook 実装のセマンティクスを維持。
+          const sent = await pushImmediateFirstStep(
+            db,
+            friend.id,
+            scenario.id,
+            { defaultAccessToken: lineAccessToken, workerUrl },
+            {
+              enrollment: friendScenario,
+              reply: { client: lineClient, replyToken: event.replyToken },
+              skipCooldown: true,
+            },
+          );
+          if (sent) console.log(`Immediate delivery: sent scenario ${scenario.id} step 1 to ${userId}`);
         } catch (err) {
           console.error('Failed to enroll friend in scenario', scenario.id, err);
         }
@@ -349,11 +294,25 @@ async function handleEvent(
         }
       }
 
-      // Dedicated scenario enrollment from referral link
+      // Dedicated scenario enrollment from referral link. A delay-0 first
+      // step is pushed immediately (same instant-welcome semantics as
+      // friend_add / tag_added enrollments — previously this path always
+      // waited for the next cron tick). pushMessage, not reply: the reply
+      // token may already be consumed by an account friend_add scenario
+      // above, and the intro push on this path uses pushMessage too.
       if (referralRoute.scenario_id) {
         try {
-          await enrollFriendInScenario(db, friend.id, referralRoute.scenario_id);
+          const enrollment = await enrollFriendInScenario(db, friend.id, referralRoute.scenario_id);
           console.log(`[follow] referral scenario enrolled scenario=${referralRoute.scenario_id}`);
+          if (enrollment) {
+            await pushImmediateFirstStep(
+              db,
+              friend.id,
+              referralRoute.scenario_id,
+              { defaultAccessToken: lineAccessToken, workerUrl },
+              { enrollment },
+            );
+          }
         } catch (err) {
           console.error('[follow] referral scenario enrollment failed', err);
         }

--- a/apps/worker/src/services/friend-tag-attach.ts
+++ b/apps/worker/src/services/friend-tag-attach.ts
@@ -1,5 +1,6 @@
 import { getScenarios, enrollFriendInScenario, jstNow } from '@line-crm/db';
 import { fireEvent } from './event-bus.js';
+import { pushImmediateFirstStep, type ImmediatePushContext } from './immediate-first-step.js';
 
 // friend に tag を attach し、`POST /api/friends/:id/tags` と同じ side effects を発火する。
 // side effects: tag_added シナリオ enrollment + tag_change イベント (automation/webhook/scoring 用)。
@@ -10,10 +11,15 @@ import { fireEvent } from './event-bus.js';
 // POST /api/friends/:id/tags は手動操作の signal として「毎クリックで発火」する設計のため、
 // この helper には合流させていない (重複 enroll はチェックがあるが tag_change は冪等でない)。
 // 自動経路 (予約 auto-tag 等) はここ経由で呼ぶ。
+// `push` (optional): when supplied, a tag_added scenario whose first step is
+// delay-0 gets that step pushed IMMEDIATELY after enrollment instead of
+// waiting for the delivery cron — welcome messages should land the moment
+// the user arrives. Callers without a push context keep cron delivery.
 export async function attachTagAndFireSideEffects(
   db: D1Database,
   friendId: string,
   tagId: string,
+  push?: ImmediatePushContext,
 ): Promise<{ added: boolean }> {
   const result = await db
     .prepare(
@@ -37,7 +43,10 @@ export async function attachTagAndFireSideEffects(
         .bind(friendId, scenario.id)
         .first();
       if (!existing) {
-        await enrollFriendInScenario(db, friendId, scenario.id);
+        const enrollment = await enrollFriendInScenario(db, friendId, scenario.id);
+        if (push) {
+          await pushImmediateFirstStep(db, friendId, scenario.id, push, { enrollment });
+        }
       }
     }
   }

--- a/apps/worker/src/services/immediate-first-step.test.ts
+++ b/apps/worker/src/services/immediate-first-step.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * pushImmediateFirstStep — the single implementation behind every instant
+ * first-message entry point (tag_added attach, click campaigns, follow
+ * webhook, referral routes). These tests pin the per-mode semantics that the
+ * three original call sites relied on before they were unified:
+ *
+ * - 'once': claim protocol with the cron (exactly-once), cooldown hit
+ *   advances WITHOUT pushing, send failure releases the claim, skipCooldown
+ *   preserves the follow-webhook's always-reply semantics
+ * - 'every-click': cooldown FIRST (before enrolling); a row that still owes
+ *   step 1 is claimed (fencing the cron), re-clicks on an advanced row push
+ *   again without touching it
+ * - reply option: webhook follow sends via the free reply token and logs
+ *   delivery_type='reply' (derived — no separate option)
+ */
+
+const dbMocks = vi.hoisted(() => ({
+  getScenarioById: vi.fn(),
+  getFriendById: vi.fn(),
+  computeNextDeliveryAt: vi.fn(),
+  resolveStepContent: vi.fn(),
+  advanceFriendScenario: vi.fn(),
+  completeFriendScenario: vi.fn(),
+  claimFriendScenarioForDelivery: vi.fn(),
+  enrollFriendInScenario: vi.fn(),
+  getLineAccountByChannelId: vi.fn(),
+  getLineAccountById: vi.fn(),
+  addTagToFriend: vi.fn(),
+  jstNow: vi.fn(),
+  toJstString: vi.fn(),
+}));
+vi.mock('@line-crm/db', () => dbMocks);
+
+const lineClientMock = vi.hoisted(() => ({
+  pushMessage: vi.fn(),
+  replyMessage: vi.fn(),
+}));
+vi.mock('@line-crm/line-sdk', () => ({
+  LineClient: vi.fn().mockImplementation(() => lineClientMock),
+}));
+
+vi.mock('./step-delivery.js', () => ({
+  buildMessage: vi.fn((type: string, content: string) => ({ type, text: content })),
+  expandVariables: vi.fn((content: string) => content),
+  resolveMetadata: vi.fn(async () => ({})),
+  messageToLogPayload: vi.fn((msg: { type: string; text: string }) => ({
+    messageType: msg.type,
+    content: msg.text,
+  })),
+}));
+
+import { pushImmediateFirstStep } from './immediate-first-step.js';
+
+const STEP1 = { id: 'step-1', step_order: 1, delay_minutes: 0, on_reach_tag_id: null };
+const STEP2 = { id: 'step-2', step_order: 2, delay_minutes: 60 };
+
+interface DbCall {
+  sql: string;
+  args: unknown[];
+}
+
+/**
+ * Raw-SQL stub: records every prepare/bind and routes SELECTs by table.
+ * `cooldownHit` backs the messages_log probe; `enrollmentLookup` backs the
+ * friend_scenarios fallback lookup.
+ */
+function makeDb(opts: { cooldownHit?: boolean; enrollmentLookup?: { id: string; current_step_order: number } | null } = {}) {
+  const calls: DbCall[] = [];
+  const db = {
+    prepare: (sql: string) => ({
+      bind: (...args: unknown[]) => {
+        calls.push({ sql, args });
+        return {
+          first: async () => {
+            if (sql.includes('FROM messages_log')) return opts.cooldownHit ? { 1: 1 } : null;
+            if (sql.includes('FROM friend_scenarios')) return opts.enrollmentLookup ?? null;
+            return null;
+          },
+          run: async () => ({ meta: { changes: 1 } }),
+        };
+      },
+    }),
+  } as unknown as D1Database;
+  return { db, calls };
+}
+
+const ctx = { defaultAccessToken: 'default-token', workerUrl: 'https://worker.example.com' };
+
+function insertedLog(calls: DbCall[]): DbCall | undefined {
+  return calls.find((c) => c.sql.includes('INSERT INTO messages_log'));
+}
+
+function claimReleased(calls: DbCall[]): boolean {
+  return calls.some((c) => c.sql.includes(`status = 'active'`) && c.sql.includes(`status = 'delivering'`));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.jstNow.mockReturnValue('2026-07-19T12:00:00.000+09:00');
+  dbMocks.toJstString.mockImplementation((d: Date) => d.toISOString());
+  // delay-0 steps schedule at "now"; later steps at now + delay.
+  dbMocks.computeNextDeliveryAt.mockImplementation(
+    (_scenario: unknown, step: { delay_minutes: number }, args: { now: Date }) =>
+      new Date(args.now.getTime() + (step.delay_minutes ?? 0) * 60_000),
+  );
+  dbMocks.getScenarioById.mockResolvedValue({
+    id: 'scn-1',
+    is_active: 1,
+    delivery_mode: 'relative',
+    steps: [STEP1, STEP2],
+  });
+  dbMocks.getFriendById.mockResolvedValue({
+    id: 'friend-1',
+    line_user_id: 'U-1',
+    line_account_id: null,
+    user_id: null,
+    metadata: '{}',
+  });
+  dbMocks.resolveStepContent.mockResolvedValue({
+    messageType: 'text',
+    messageContent: 'welcome!',
+    templateIdAtSend: null,
+  });
+  dbMocks.claimFriendScenarioForDelivery.mockResolvedValue(true);
+  dbMocks.enrollFriendInScenario.mockResolvedValue({ id: 'fs-1', current_step_order: 0 });
+  lineClientMock.pushMessage.mockResolvedValue({});
+  lineClientMock.replyMessage.mockResolvedValue({});
+});
+
+describe("mode 'once' (default) — claim protocol with the cron", () => {
+  it('claims, pushes step 1, logs, and advances to step 2', async () => {
+    const { db, calls } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+    });
+
+    expect(sent).toBe(true);
+    expect(dbMocks.claimFriendScenarioForDelivery).toHaveBeenCalledWith(db, 'fs-1', 0);
+    expect(lineClientMock.pushMessage).toHaveBeenCalledWith('U-1', [{ type: 'text', text: 'welcome!' }]);
+    const log = insertedLog(calls);
+    expect(log).toBeDefined();
+    // delivery_type bind slot (7th value) stays NULL when not specified.
+    expect(log!.args[5]).toBe(null);
+    expect(dbMocks.advanceFriendScenario).toHaveBeenCalledWith(db, 'fs-1', 1, expect.any(String));
+    expect(dbMocks.completeFriendScenario).not.toHaveBeenCalled();
+  });
+
+  it('backs off without pushing when the cron already claimed the enrollment', async () => {
+    dbMocks.claimFriendScenarioForDelivery.mockResolvedValue(false);
+    const { db } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+    });
+    expect(sent).toBe(false);
+    expect(lineClientMock.pushMessage).not.toHaveBeenCalled();
+    expect(dbMocks.advanceFriendScenario).not.toHaveBeenCalled();
+  });
+
+  it('advances WITHOUT pushing on a cooldown hit (racing sender already delivered step 1)', async () => {
+    const { db } = makeDb({ cooldownHit: true });
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+    });
+    expect(sent).toBe(false);
+    expect(lineClientMock.pushMessage).not.toHaveBeenCalled();
+    expect(dbMocks.advanceFriendScenario).toHaveBeenCalledWith(db, 'fs-1', 1, expect.any(String));
+  });
+
+  it('releases the claim when the push API fails so the cron retries on schedule', async () => {
+    lineClientMock.pushMessage.mockRejectedValue(new Error('LINE 500'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { db, calls } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+    });
+    expect(sent).toBe(false);
+    expect(claimReleased(calls)).toBe(true);
+    expect(dbMocks.advanceFriendScenario).not.toHaveBeenCalled();
+    expect(insertedLog(calls)).toBeUndefined();
+    errorSpy.mockRestore();
+  });
+
+  it('never sends for a paused scenario (is_active = 0) — same gate as the cron', async () => {
+    dbMocks.getScenarioById.mockResolvedValue({
+      id: 'scn-1',
+      is_active: 0,
+      delivery_mode: 'relative',
+      steps: [STEP1, STEP2],
+    });
+    const { db } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+    });
+    expect(sent).toBe(false);
+    expect(dbMocks.claimFriendScenarioForDelivery).not.toHaveBeenCalled();
+    expect(lineClientMock.pushMessage).not.toHaveBeenCalled();
+  });
+
+  it('skipCooldown bypasses the duplicate probe so a re-follow within 60s still gets its welcome', async () => {
+    const { db } = makeDb({ cooldownHit: true });
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+      skipCooldown: true,
+    });
+    expect(sent).toBe(true);
+    expect(lineClientMock.pushMessage).toHaveBeenCalled();
+    expect(dbMocks.advanceFriendScenario).toHaveBeenCalledWith(db, 'fs-1', 1, expect.any(String));
+  });
+
+  it('advances (best effort) in the outer catch when the send succeeded but logging threw — cron must not re-send', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const calls: Array<{ sql: string }> = [];
+    const db = {
+      prepare: (sql: string) => ({
+        bind: () => {
+          calls.push({ sql });
+          return {
+            first: async () => null,
+            run: async () => {
+              if (sql.includes('INSERT INTO messages_log')) throw new Error('D1 transient');
+              return { meta: { changes: 1 } };
+            },
+          };
+        },
+      }),
+    } as unknown as D1Database;
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+    });
+    expect(sent).toBe(true); // the message DID go out
+    expect(dbMocks.advanceFriendScenario).toHaveBeenCalledWith(db, 'fs-1', 1, expect.any(String));
+    // The claim must not be left held once the enrollment is advanced.
+    expect(calls.some((c) => c.sql.includes(`status = 'delivering'`) && c.sql.includes(`status = 'active'`))).toBe(false);
+    errorSpy.mockRestore();
+  });
+
+  it('returns before claiming when step 1 is not immediate (delay > 0)', async () => {
+    dbMocks.getScenarioById.mockResolvedValue({
+      id: 'scn-1',
+      is_active: 1,
+      delivery_mode: 'relative',
+      steps: [{ ...STEP1, delay_minutes: 30 }],
+    });
+    const { db } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+    });
+    expect(sent).toBe(false);
+    expect(dbMocks.claimFriendScenarioForDelivery).not.toHaveBeenCalled();
+    expect(lineClientMock.pushMessage).not.toHaveBeenCalled();
+  });
+
+  it('schedules step 2 at JST wall time WITHOUT double-applying the +9h offset', async () => {
+    // computeNextDeliveryAt operates in the shifted frame (inputs are
+    // Date.now()+9h), so serialization must relabel — not re-shift. A
+    // double shift schedules step 2 nine hours late (regression guard).
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-07-19T03:00:00.000Z')); // 12:00 JST
+      const { db } = makeDb();
+      await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+        enrollment: { id: 'fs-1', current_step_order: 0 },
+      });
+      // STEP2 delay is 60 min → 13:00 JST.
+      expect(dbMocks.advanceFriendScenario).toHaveBeenCalledWith(
+        db,
+        'fs-1',
+        1,
+        '2026-07-19T13:00:00.000+09:00',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('completes the enrollment when the scenario has a single step', async () => {
+    dbMocks.getScenarioById.mockResolvedValue({
+      id: 'scn-1',
+      is_active: 1,
+      delivery_mode: 'relative',
+      steps: [STEP1],
+    });
+    const { db } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+    });
+    expect(sent).toBe(true);
+    expect(dbMocks.completeFriendScenario).toHaveBeenCalledWith(db, 'fs-1');
+    expect(dbMocks.advanceFriendScenario).not.toHaveBeenCalled();
+  });
+});
+
+describe("mode 'every-click' — click-campaign re-delivery", () => {
+  const everyClick = { mode: 'every-click' as const, targetLineUserId: 'U-token' };
+
+  it('checks the cooldown BEFORE enrolling and skips entirely on a hit', async () => {
+    const { db } = makeDb({ cooldownHit: true });
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, everyClick);
+    expect(sent).toBe(false);
+    // No fresh step-0 row may be left behind for the cron.
+    expect(dbMocks.enrollFriendInScenario).not.toHaveBeenCalled();
+    expect(lineClientMock.pushMessage).not.toHaveBeenCalled();
+    expect(dbMocks.advanceFriendScenario).not.toHaveBeenCalled();
+  });
+
+  it('enrolls, claims the fresh row (fencing the cron), pushes to targetLineUserId, and advances it', async () => {
+    const { db, calls } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, everyClick);
+    expect(sent).toBe(true);
+    expect(dbMocks.enrollFriendInScenario).toHaveBeenCalledWith(db, 'friend-1', 'scn-1');
+    // The fresh enrollment's next_delivery_at is already due, so the cron
+    // could race the push — the claim fences it out.
+    expect(dbMocks.claimFriendScenarioForDelivery).toHaveBeenCalledWith(db, 'fs-1', 0);
+    // Push target is the id_token-derived LINE user id, not friend.line_user_id.
+    expect(lineClientMock.pushMessage).toHaveBeenCalledWith('U-token', [{ type: 'text', text: 'welcome!' }]);
+    expect(insertedLog(calls)).toBeDefined();
+    expect(dbMocks.advanceFriendScenario).toHaveBeenCalledWith(db, 'fs-1', 1, expect.any(String));
+  });
+
+  it('skips the push when the claim fails — a concurrent deliverer (cron / follow webhook) owns step 1', async () => {
+    dbMocks.claimFriendScenarioForDelivery.mockResolvedValue(false);
+    const { db } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, everyClick);
+    expect(sent).toBe(false);
+    expect(lineClientMock.pushMessage).not.toHaveBeenCalled();
+    expect(dbMocks.advanceFriendScenario).not.toHaveBeenCalled();
+  });
+
+  it('re-click (already enrolled and advanced): pushes again but leaves the enrollment alone', async () => {
+    dbMocks.enrollFriendInScenario.mockResolvedValue(null); // INSERT OR IGNORE no-op
+    const { db } = makeDb({ enrollmentLookup: { id: 'fs-1', current_step_order: 1 } });
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, everyClick);
+    expect(sent).toBe(true);
+    expect(lineClientMock.pushMessage).toHaveBeenCalled();
+    expect(dbMocks.advanceFriendScenario).not.toHaveBeenCalled();
+    expect(dbMocks.completeFriendScenario).not.toHaveBeenCalled();
+    expect(dbMocks.claimFriendScenarioForDelivery).not.toHaveBeenCalled();
+  });
+
+  it('repairs a stale behind row: re-click with an active step-0 enrollment advances it', async () => {
+    dbMocks.enrollFriendInScenario.mockResolvedValue(null);
+    const { db } = makeDb({ enrollmentLookup: { id: 'fs-stale', current_step_order: 0 } });
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, everyClick);
+    expect(sent).toBe(true);
+    expect(dbMocks.advanceFriendScenario).toHaveBeenCalledWith(db, 'fs-stale', 1, expect.any(String));
+  });
+
+  it('resolves the account token from accountChannelId before friend.line_account_id', async () => {
+    dbMocks.getLineAccountByChannelId.mockResolvedValue({ channel_access_token: 'acct-token' });
+    const { LineClient } = await import('@line-crm/line-sdk');
+    const { db } = makeDb();
+    await pushImmediateFirstStep(
+      db,
+      'friend-1',
+      'scn-1',
+      { ...ctx, accountChannelId: 'CH-1' },
+      everyClick,
+    );
+    expect(dbMocks.getLineAccountByChannelId).toHaveBeenCalledWith(db, 'CH-1');
+    expect(vi.mocked(LineClient)).toHaveBeenCalledWith('acct-token');
+    expect(dbMocks.getLineAccountById).not.toHaveBeenCalled();
+  });
+});
+
+describe('reply option — webhook follow sends via the free reply token', () => {
+  it('sends with replyMessage, never constructs a push client, and logs delivery_type=reply', async () => {
+    const { LineClient } = await import('@line-crm/line-sdk');
+    const replyClient = { replyMessage: vi.fn().mockResolvedValue({}) };
+    const { db, calls } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+      reply: { client: replyClient, replyToken: 'rt-1' },
+    });
+    expect(sent).toBe(true);
+    expect(replyClient.replyMessage).toHaveBeenCalledWith('rt-1', [{ type: 'text', text: 'welcome!' }]);
+    expect(lineClientMock.pushMessage).not.toHaveBeenCalled();
+    expect(vi.mocked(LineClient)).not.toHaveBeenCalled();
+    const log = insertedLog(calls);
+    expect(log!.args[5]).toBe('reply');
+    expect(dbMocks.advanceFriendScenario).toHaveBeenCalledWith(db, 'fs-1', 1, expect.any(String));
+  });
+
+  it('releases the claim when the reply fails (token consumed) so the cron pushes on schedule', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const replyClient = { replyMessage: vi.fn().mockRejectedValue(new Error('Invalid reply token')) };
+    const { db, calls } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+      reply: { client: replyClient, replyToken: 'rt-used' },
+    });
+    expect(sent).toBe(false);
+    expect(claimReleased(calls)).toBe(true);
+    expect(dbMocks.advanceFriendScenario).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe('on_reach_tag', () => {
+  it('attaches the reach tag after advancing', async () => {
+    dbMocks.getScenarioById.mockResolvedValue({
+      id: 'scn-1',
+      is_active: 1,
+      delivery_mode: 'relative',
+      steps: [{ ...STEP1, on_reach_tag_id: 'tag-9' }, STEP2],
+    });
+    const { db } = makeDb();
+    await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      enrollment: { id: 'fs-1', current_step_order: 0 },
+    });
+    expect(dbMocks.addTagToFriend).toHaveBeenCalledWith(db, 'friend-1', 'tag-9');
+  });
+});

--- a/apps/worker/src/services/immediate-first-step.ts
+++ b/apps/worker/src/services/immediate-first-step.ts
@@ -1,0 +1,385 @@
+import {
+  getScenarioById,
+  getFriendById,
+  computeNextDeliveryAt,
+  resolveStepContent,
+  advanceFriendScenario,
+  completeFriendScenario,
+  claimFriendScenarioForDelivery,
+  enrollFriendInScenario,
+  getLineAccountByChannelId,
+  getLineAccountById,
+  addTagToFriend,
+  jstNow,
+  toJstString,
+} from '@line-crm/db';
+import { LineClient } from '@line-crm/line-sdk';
+import {
+  buildMessage,
+  expandVariables,
+  resolveMetadata,
+  messageToLogPayload,
+} from './step-delivery.js';
+
+export interface ImmediatePushContext {
+  defaultAccessToken: string;
+  /** Base URL for {{...}} / {{auth_url:...}} link expansion. Pass the env
+   *  WORKER_URL whenever it is in scope; undefined leaves those variables
+   *  unexpanded (matching expandVariables' own fallback). */
+  workerUrl?: string;
+  accountChannelId?: string | null;
+}
+
+export interface EnrollmentRef {
+  id: string;
+  current_step_order: number;
+}
+
+export interface ImmediatePushOptions {
+  /**
+   * - 'once' (default): exactly-once with the cron via the claim protocol.
+   *   The enrollment must already exist (caller-supplied or looked up) and
+   *   still be at a step before step 1.
+   * - 'every-click': click-campaign semantics (tracked link / entry route).
+   *   Pushes on EVERY hit — re-clicks included — enrolling the friend itself
+   *   (INSERT OR IGNORE). When the enrollment still owes step 1 it is
+   *   CLAIMED like 'once' (fencing the cron and any concurrent follow-path
+   *   sender); a failed claim means someone else is delivering right now, so
+   *   the click is skipped instead of double-sending. Re-clicks on an
+   *   already-advanced enrollment push without touching the row.
+   */
+  mode?: 'once' | 'every-click';
+  /** Pre-created enrollment ('once' mode) — skips the lookup query. */
+  enrollment?: EnrollmentRef | null;
+  /**
+   * Push target override. LIFF/OAuth callers know the LINE user id from the
+   * id_token before the friend row is fully wired; without this the push
+   * requires friend.line_user_id.
+   */
+  targetLineUserId?: string;
+  /**
+   * Send through the follow event's reply token (free, no push quota)
+   * instead of resolving an access token and pushing. On failure the claim
+   * is released so the cron delivers by push on schedule. messages_log
+   * rows are stamped delivery_type='reply' automatically.
+   */
+  reply?: { client: Pick<LineClient, 'replyMessage'>; replyToken: string };
+  /**
+   * Skip the 60s messages_log duplicate probe. The follow-webhook friend_add
+   * path sets this to preserve its historical semantics: a re-follow within
+   * 60s of the previous welcome (possible once the prior enrollment
+   * completed) must still be answered — the fresh INSERT + claim already
+   * fence every same-flow race there.
+   */
+  skipCooldown?: boolean;
+}
+
+/**
+ * Push a scenario's delay-0 first step to a friend RIGHT NOW — no cron wait —
+ * then advance the enrollment so the delivery worker never re-sends step 1.
+ *
+ * Single implementation behind every instant-first-message entry point:
+ * tag-triggered enrollment (friend-tag-attach), the click-campaign block in
+ * applyRefAttribution (liff.ts), and the follow-webhook friend_add /
+ * referral-route enrollments.
+ *
+ * Exactly-once with the cron: the enrollment is CLAIMED
+ * (claimFriendScenarioForDelivery, status active→delivering) before any
+ * network call, using the same optimistic lock the cron delivery worker
+ * uses — whichever side claims first owns step 1, the other backs off.
+ * advance/complete after the push releases the claim (status back to
+ * active / completed).
+ *
+ * Other guards:
+ * - paused scenarios (is_active = 0) never send — same gate as the cron and
+ *   the friend_add / tag_added trigger loops
+ * - non-immediate first steps (delay > 0 / clock-time modes) return before
+ *   claiming/enrolling — cron owns those untouched
+ * - a 60s messages_log cooldown catches a racing sender the claim can't see
+ *   (a different enrollment row, or a send logged before this row existed);
+ *   in 'once' mode a cooldown hit advances WITHOUT pushing (and still
+ *   attaches the reach tag — the racer delivered the step) so the fresh row
+ *   is never re-delivered by the cron, in 'every-click' mode it simply skips
+ * - unresolvable push target releases the claim so the cron can retry on
+ *   schedule
+ * - an unexpected throw after a successful send still advances the
+ *   enrollment (best effort) so the cron cannot re-send; a throw before the
+ *   send releases the claim instead of stranding the row in 'delivering'
+ *   until the stuck-delivery sweep
+ *
+ * Returns true when a message was actually sent.
+ */
+export async function pushImmediateFirstStep(
+  db: D1Database,
+  friendId: string,
+  scenarioId: string,
+  ctx: ImmediatePushContext,
+  options?: ImmediatePushOptions,
+): Promise<boolean> {
+  const mode = options?.mode ?? 'once';
+  // Function-scope so the outer catch can settle a half-finished delivery.
+  let claimedEnrollmentId: string | null = null;
+  let sent = false;
+  let settleAfterSend: (() => Promise<void>) | null = null;
+  try {
+    const scenarioRow = await getScenarioById(db, scenarioId);
+    if (!scenarioRow) return false;
+    // Paused scenarios never send. The cron's due-for-delivery query and the
+    // friend_add / tag_added trigger loops all gate on is_active; without
+    // this an entry route pointing at a deactivated campaign would still
+    // instant-push its first step.
+    if (!scenarioRow.is_active) return false;
+    const steps = scenarioRow.steps;
+    const firstStep = steps[0];
+    if (!firstStep) return false;
+
+    // Immediate only: delay-0 relative steps schedule at-or-before "now".
+    // elapsed/absolute_time modes have offset/clock-time semantics — cron
+    // owns those. Checked BEFORE claiming/enrolling so non-immediate
+    // enrollments are left untouched.
+    const enrolledAtJst = new Date(Date.now() + 9 * 60 * 60_000);
+    const firstScheduledAt = computeNextDeliveryAt(
+      { delivery_mode: scenarioRow.delivery_mode ?? 'relative' },
+      firstStep,
+      { enrolledAt: enrolledAtJst, previousDeliveredAt: enrolledAtJst, now: enrolledAtJst },
+    );
+    if (firstScheduledAt.getTime() > enrolledAtJst.getTime()) return false;
+
+    // Cooldown probe: a racing sender the claim protocol can't see may have
+    // just pushed this exact step (click campaign vs follow webhook, double
+    // LIFF load, …).
+    const isRecentDuplicate = async (): Promise<boolean> => {
+      const cutoff = toJstString(new Date(Date.now() - 60_000));
+      const recent = await db
+        .prepare(
+          `SELECT 1 FROM messages_log
+           WHERE friend_id = ? AND scenario_step_id = ?
+             AND direction = 'outgoing' AND created_at > ?
+           LIMIT 1`,
+        )
+        .bind(friendId, firstStep.id, cutoff)
+        .first();
+      return recent !== null;
+    };
+
+    const lookupEnrollment = () =>
+      db
+        .prepare(
+          `SELECT id, current_step_order FROM friend_scenarios
+           WHERE friend_id = ? AND scenario_id = ? AND status != 'completed'
+           ORDER BY updated_at DESC LIMIT 1`,
+        )
+        .bind(friendId, scenarioId)
+        .first<EnrollmentRef>();
+
+    const advancePastFirstStep = async (enrollmentId: string) => {
+      const nextStep = steps[1];
+      if (nextStep) {
+        const next = computeNextDeliveryAt(
+          { delivery_mode: scenarioRow.delivery_mode ?? 'relative' },
+          nextStep,
+          { enrolledAt: enrolledAtJst, previousDeliveredAt: enrolledAtJst, now: enrolledAtJst },
+        );
+        // `next` is already in the shifted-JST frame (its inputs were
+        // Date.now()+9h), so serialize by relabeling — NOT toJstString(),
+        // which would add the offset a second time and schedule step 2
+        // nine hours late. Matches enrollFriendInScenario / the cron.
+        await advanceFriendScenario(
+          db,
+          enrollmentId,
+          firstStep.step_order,
+          next.toISOString().slice(0, -1) + '+09:00',
+        );
+      } else {
+        await completeFriendScenario(db, enrollmentId);
+      }
+    };
+
+    const attachReachTag = async () => {
+      if (!firstStep.on_reach_tag_id) return;
+      try {
+        await addTagToFriend(db, friendId, firstStep.on_reach_tag_id);
+      } catch (err) {
+        console.error(`[immediate-first-step] tag attach failed step=${firstStep.id}:`, err);
+      }
+    };
+
+    // Which row to advance after a successful send (null = pure re-click
+    // re-delivery: the row is already past step 1, leave it alone).
+    let advanceTargetId: string | null = null;
+
+    if (mode === 'once') {
+      const enrollmentRow = options?.enrollment ?? (await lookupEnrollment());
+      if (!enrollmentRow || enrollmentRow.current_step_order >= firstStep.step_order) return false;
+
+      // Optimistic lock shared with the cron worker: whoever claims first
+      // delivers step 1; the loser backs off. Closes the double-send window
+      // between the enrollment INSERT and the post-push advance.
+      const claimed = await claimFriendScenarioForDelivery(
+        db,
+        enrollmentRow.id,
+        enrollmentRow.current_step_order,
+      );
+      if (!claimed) return false;
+      claimedEnrollmentId = enrollmentRow.id;
+      advanceTargetId = enrollmentRow.id;
+
+      // Advance without pushing on a cooldown hit so the row is neither
+      // stranded at step -1 nor re-delivered by the cron. The racer
+      // delivered step 1, so the reach tag still applies.
+      if (!options?.skipCooldown && (await isRecentDuplicate())) {
+        await advancePastFirstStep(enrollmentRow.id);
+        claimedEnrollmentId = null; // the advance released the claim
+        await attachReachTag();
+        return false;
+      }
+    } else {
+      // every-click: cooldown FIRST, before enrolling. The LIFF entry points
+      // fire on every page load (refresh, back-nav), not only on a fresh
+      // tracked-link click. Enrolling before the cooldown check would leave
+      // a fresh active step-0 row behind for the cron worker to pick up
+      // (the partial UNIQUE on friend_scenarios is keyed
+      // `WHERE status != 'completed'`, so completed runs don't block a new
+      // INSERT).
+      if (await isRecentDuplicate()) return false;
+
+      // INSERT OR IGNORE — null on re-clicks (already enrolled), still push.
+      const enrollment = await enrollFriendInScenario(db, friendId, scenarioId);
+      const row = enrollment ?? (await lookupEnrollment());
+      if (row && row.current_step_order < firstStep.step_order) {
+        // This click owes step 1 to the enrollment — join the claim protocol
+        // so the cron (the fresh row's next_delivery_at is already due) and
+        // the follow-webhook path can't send it concurrently. A failed claim
+        // means another sender is mid-delivery (or the row is paused): skip
+        // rather than double-send.
+        const claimed = await claimFriendScenarioForDelivery(db, row.id, row.current_step_order);
+        if (!claimed) return false;
+        claimedEnrollmentId = row.id;
+        advanceTargetId = row.id;
+      } else {
+        // Pure re-click re-delivery. Re-probe the cooldown: the first probe
+        // ran before the enroll round-trip, and a racing sender may have
+        // logged its send in between.
+        if (await isRecentDuplicate()) return false;
+      }
+    }
+
+    const releaseClaim = async () => {
+      if (!claimedEnrollmentId) return;
+      await releaseClaimById(db, claimedEnrollmentId);
+      claimedEnrollmentId = null;
+    };
+
+    // Re-read the friend after caller writes (linkFriendToUser / ref_code
+    // UPDATE / line_account_id wiring) so {{uid}}, {{ref}}, and merged
+    // metadata expand against the latest state.
+    const friend = await getFriendById(db, friendId);
+    if (!friend) {
+      await releaseClaim();
+      return false;
+    }
+
+    // Independent D1 reads — resolve concurrently; this sits in front of the
+    // reply-token send where latency eats into the token validity window.
+    const [resolvedMeta, resolved] = await Promise.all([
+      resolveMetadata(db, { user_id: friend.user_id, metadata: friend.metadata }),
+      resolveStepContent(db, firstStep),
+    ]);
+    const expanded = expandVariables(
+      resolved.messageContent,
+      { ...friend, metadata: resolvedMeta } as Parameters<typeof expandVariables>[1],
+      ctx.workerUrl,
+      resolved.messageType,
+    );
+    const sentMessage = buildMessage(resolved.messageType, expanded);
+
+    try {
+      if (options?.reply) {
+        await options.reply.client.replyMessage(options.reply.replyToken, [sentMessage]);
+      } else {
+        const pushTarget = options?.targetLineUserId ?? friend.line_user_id;
+        if (!pushTarget) {
+          // Can't push from here — hand the claim back so the cron retries.
+          await releaseClaim();
+          return false;
+        }
+        // Token: caller-supplied account channel → friend's own account → env default.
+        let accessToken = ctx.defaultAccessToken;
+        if (ctx.accountChannelId) {
+          const acct = await getLineAccountByChannelId(db, ctx.accountChannelId);
+          if (acct?.channel_access_token) accessToken = acct.channel_access_token;
+        } else if (friend.line_account_id) {
+          const acct = await getLineAccountById(db, friend.line_account_id);
+          if (acct?.channel_access_token) accessToken = acct.channel_access_token;
+        }
+        const lineClient = new LineClient(accessToken);
+        await lineClient.pushMessage(pushTarget, [sentMessage]);
+      }
+    } catch (err) {
+      // The message never left LINE's API — release so the cron retries on
+      // schedule.
+      console.error('[immediate-first-step] send failed, releasing claim:', err);
+      await releaseClaim();
+      return false;
+    }
+    sent = true;
+    settleAfterSend = async () => {
+      if (advanceTargetId) {
+        await advancePastFirstStep(advanceTargetId);
+        claimedEnrollmentId = null; // the advance released the claim
+        await attachReachTag();
+      }
+    };
+
+    // Log what was actually delivered (post buildMessage normalization) so
+    // the cooldown above sees it on subsequent calls and the dashboard chat
+    // view mirrors LINE 1:1. delivery_type mirrors the send channel.
+    const logPayload = messageToLogPayload(sentMessage);
+    await db
+      .prepare(
+        `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, delivery_type, source, template_id_at_send, created_at)
+         VALUES (?, ?, 'outgoing', ?, ?, NULL, ?, ?, 'scenario', ?, ?)`,
+      )
+      .bind(
+        crypto.randomUUID(),
+        friendId,
+        logPayload.messageType,
+        logPayload.content,
+        firstStep.id,
+        options?.reply ? 'reply' : null,
+        resolved.templateIdAtSend,
+        jstNow(),
+      )
+      .run();
+
+    await settleAfterSend();
+    settleAfterSend = null;
+    return true;
+  } catch (err) {
+    console.error('[immediate-first-step] push failed:', err);
+    try {
+      if (sent && settleAfterSend) {
+        // The message went out but logging/advancing threw — advance anyway
+        // (best effort) so the cron cannot re-deliver step 1.
+        await settleAfterSend();
+      } else if (claimedEnrollmentId) {
+        // Nothing was sent — hand the claim back now instead of leaving the
+        // row in 'delivering' until the stuck-delivery sweep frees it.
+        await releaseClaimById(db, claimedEnrollmentId);
+      }
+    } catch (settleErr) {
+      console.error('[immediate-first-step] post-failure settle failed:', settleErr);
+    }
+    return sent;
+  }
+}
+
+async function releaseClaimById(db: D1Database, enrollmentId: string): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE friend_scenarios SET status = 'active', updated_at = ?
+       WHERE id = ? AND status = 'delivering'`,
+    )
+    .bind(jstNow(), enrollmentId)
+    .run();
+}

--- a/apps/worker/src/services/step-delivery.test.ts
+++ b/apps/worker/src/services/step-delivery.test.ts
@@ -434,3 +434,45 @@ describe('expandVariables comma cleanup scope', () => {
     });
   });
 });
+
+/**
+ * Crash recovery wiring — a claim (active→delivering) whose worker died
+ * mid-delivery must be reset back to 'active' at the start of every cron
+ * run, BEFORE the due query (which only sees 'active' rows). Regression:
+ * recoverStuckDeliveries existed but was never called, stranding
+ * enrollments in 'delivering' forever.
+ */
+describe('processStepDeliveries crash recovery', () => {
+  it("resets stuck 'delivering' enrollments before querying due rows", async () => {
+    const executed: string[] = [];
+    const db = {
+      prepare: (sql: string) => {
+        const stmt = {
+          bind: () => stmt,
+          first: async () => null,
+          all: async () => {
+            executed.push(sql);
+            return { results: [] };
+          },
+          run: async () => {
+            executed.push(sql);
+            return { meta: { changes: 1 } };
+          },
+        };
+        return stmt;
+      },
+    } as unknown as D1Database;
+    const push = vi.fn(async () => ({}));
+    const client = { pushMessage: push } as unknown as LineClient;
+
+    await processStepDeliveries(db, client);
+
+    const recoveryIdx = executed.findIndex(
+      (sql) => sql.includes("SET status = 'active'") && sql.includes("status = 'delivering'"),
+    );
+    const dueQueryIdx = executed.findIndex((sql) => sql.includes('FROM friend_scenarios'));
+    expect(recoveryIdx).toBeGreaterThanOrEqual(0); // recovery ran
+    expect(dueQueryIdx).toBeGreaterThanOrEqual(0);
+    expect(recoveryIdx).toBeLessThan(dueQueryIdx); // and ran first
+  });
+});

--- a/apps/worker/src/services/step-delivery.ts
+++ b/apps/worker/src/services/step-delivery.ts
@@ -5,6 +5,7 @@ import {
   advanceFriendScenario,
   completeFriendScenario,
   claimFriendScenarioForDelivery,
+  recoverStuckDeliveries,
   getFriendById,
   jstNow,
   computeNextDeliveryAt,
@@ -104,6 +105,16 @@ export async function processStepDeliveries(
   lineClient: LineClient,
   workerUrl?: string,
 ): Promise<void> {
+  // Crash recovery: a claim (active→delivering) that never got released means
+  // the worker died mid-delivery — without this, the enrollment is stranded
+  // forever because the due query only picks up 'active' rows. Reclaim after
+  // 5 minutes (at-least-once: a crash after the LINE push but before advance
+  // re-sends that step once).
+  const recovered = await recoverStuckDeliveries(db);
+  if (recovered > 0) {
+    console.warn(`[step-delivery] recovered ${recovered} stuck 'delivering' enrollment(s)`);
+  }
+
   const now = jstNow();
   const dueFriendScenarios = await getFriendScenariosDueForDelivery(db, now);
 

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -29,7 +29,7 @@ binding = "IMAGES"
 bucket_name = "line-harness-images"
 
 [triggers]
-crons = ["*/5 * * * *", "0 */6 * * *"]
+crons = ["* * * * *", "0 */6 * * *"]
 
 # ═══════════════════════════════════════════════════════════════
 # Phase 5 self-update vars — consumed by /admin/update/*. Secrets
@@ -74,4 +74,4 @@ binding = "IMAGES"
 bucket_name = "line-harness-images"
 
 [env.production.triggers]
-crons = ["*/5 * * * *", "0 */6 * * *"]
+crons = ["* * * * *", "0 */6 * * *"]


### PR DESCRIPTION
Private → OSS sync (since #221). Everything below is tested and deployed on the private production instance.

## What's included

### Instant welcome delivery (new + unified)
- **Instant first-step push**: a scenario whose step 1 is delay-0 now sends the moment the friend arrives — no cron wait. One service (`apps/worker/src/services/immediate-first-step.ts`) backs every entry point: tag-triggered enrollment, tracked-link / entry-route click campaigns, follow-webhook `friend_add` (uses the free reply token) and referral-route enrollments (previously always waited for the next cron tick)
- Exactly-once with the cron via the existing claim protocol; click campaigns keep their push-on-every-click semantics with a 60s duplicate guard
- **Step delivery cron `*/5` → every minute** — worst-case welcome latency drops from ~5min to ≤60s

### Fixes
- JST double-offset scheduled step 2 nine hours late on tag-triggered instant pushes
- Paused scenarios (`is_active=0`) no longer instant-push from click campaigns
- Claim released on pre-send failures (no more 5-minute 'delivering' strands); post-send failures still advance so the cron cannot double-deliver step 1
- Cooldown-hit advance now attaches `on_reach_tag_id` so downstream tag automations fire
- `recoverStuckDeliveries` wired into the delivery cron — stuck 'delivering' rows self-heal every tick
- `/t` clicks and form submits fire guarded `tag_added` side effects

### Tests
- New 19-test suite for the unified delivery service (claim fencing, cooldown modes, failure settling, JST serialization regression)
- `pnpm --filter worker test`: 63 files / 692 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)