### PR TITLE
fix(installer): recover partial Admin deploys

### DIFF
--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Set up LINE Harness — AI-operated LINE CRM — with one command",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@line-harness/update-engine": "workspace:^0.0.6",
+    "@line-harness/update-engine": "workspace:^0.0.7",
     "execa": "^9.5.2",
     "picocolors": "^1.1.1"
   },

--- a/packages/create-line-harness/src/commands/update.ts
+++ b/packages/create-line-harness/src/commands/update.ts
@@ -451,7 +451,19 @@ async function promptForMissingFields(
   return updated;
 }
 
-export async function runUpdate(repoDir: string): Promise<void> {
+export interface RunUpdateOptions {
+  /**
+   * Re-deploy only the Admin Pages artifact that matches the currently
+   * deployed Worker. Used to recover from a partial update without touching
+   * D1, the Worker script, bindings, assets, or LIFF.
+   */
+  repairAdmin?: boolean;
+}
+
+export async function runUpdate(
+  repoDir: string,
+  options: RunUpdateOptions = {},
+): Promise<void> {
   p.intro(pc.bgCyan(pc.black(" LINE Harness アップデート ")));
 
   const configPath = join(repoDir, ".line-harness-config.json");
@@ -584,6 +596,38 @@ export async function runUpdate(repoDir: string): Promise<void> {
     process.exit(0);
   }
 
+  // Recovery mode intentionally runs before the "already latest" gate. A
+  // partial update has already stamped the Worker with the target version,
+  // so the ordinary upgrade lookup returns no work even though Admin Pages
+  // is still on the previous release.
+  if (options.repairAdmin) {
+    const release = findReleaseForAdminRepair(manifest.releases, current.version);
+    if (!release) {
+      p.cancel(
+        `現在の Worker v${current.version} に一致する公式リリースが manifest にありません。Admin のみの復旧は安全に実行できません。`,
+      );
+      process.exit(1);
+    }
+
+    p.log.info(
+      `復旧モード: Worker / D1 は変更せず、Admin UI v${release.version} のみ再デプロイします。`,
+    );
+    const creds: CfApiCreds = {
+      accountId: cfg.cfAccountId,
+      apiToken: cfg.cfApiToken,
+    };
+    const bundle = await downloadAndVerifyBundle(release, s);
+    await deployAdminFromBundle(creds, cfg, bundle, s);
+    await configureAdminAuth({
+      workerName: cfg.workerName,
+      workerUrl: cfg.workerPublicUrl,
+      adminUrl: cfg.adminPublicUrl,
+    });
+
+    p.outro(pc.green(`Admin UI v${release.version} の復旧が完了しました`));
+    return;
+  }
+
   // 4) Find upgrade target
   const upgrade = findLatestUpgrade(manifest, current.version);
   if (!upgrade) {
@@ -680,6 +724,14 @@ export async function runUpdate(repoDir: string): Promise<void> {
   persistBundleMode(repoDir, upgrade.version);
 
   p.outro(pc.green(`🎉 v${upgrade.version} にアップデート完了`));
+}
+
+/** Pick the artifact matching the live Worker; never deploy a newer Admin. */
+export function findReleaseForAdminRepair(
+  releases: ReleaseEntry[],
+  currentVersion: string,
+): ReleaseEntry | undefined {
+  return releases.find((release) => release.version === currentVersion);
 }
 
 // ─── Shared deploy steps (normal update + adoption) ──────────────────────────

--- a/packages/create-line-harness/src/index.ts
+++ b/packages/create-line-harness/src/index.ts
@@ -11,10 +11,12 @@ function parseArgs(): {
   command: string;
   repoDir: string | null;
   fromSource: boolean;
+  repairAdmin: boolean;
 } {
   let command = "setup";
   let repoDir: string | null = null;
   let fromSource = false;
+  let repairAdmin = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--repo-dir" && args[i + 1]) {
@@ -25,12 +27,17 @@ function parseArgs(): {
       // the official release bundle. The install reports 0.0.0-dev and is
       // excluded from automatic updates.
       fromSource = true;
+    } else if (args[i] === "--repair-admin") {
+      // Recovery path for a partial update where D1 + Worker succeeded but
+      // the Admin Pages upload failed. This deliberately does not force a
+      // full update or replay migrations.
+      repairAdmin = true;
     } else if (!args[i].startsWith("-")) {
       command = args[i];
     }
   }
 
-  return { command, repoDir, fromSource };
+  return { command, repoDir, fromSource, repairAdmin };
 }
 
 /**
@@ -60,7 +67,20 @@ function getConfigDir(explicitRepoDir: string | null): string {
 }
 
 async function main(): Promise<void> {
-  const { command, repoDir: explicitRepoDir, fromSource } = parseArgs();
+  const {
+    command,
+    repoDir: explicitRepoDir,
+    fromSource,
+    repairAdmin,
+  } = parseArgs();
+
+  if (repairAdmin && command !== "update") {
+    console.error("--repair-admin は update コマンドでのみ使用できます。");
+    console.error(
+      "Usage: create-line-harness update --repair-admin [--repo-dir <path>]",
+    );
+    process.exit(1);
+  }
 
   let repoDir: string;
   if (command === "update") {
@@ -76,11 +96,11 @@ async function main(): Promise<void> {
   if (command === "setup") {
     await runSetup(repoDir, { fromSource });
   } else if (command === "update") {
-    await runUpdate(repoDir);
+    await runUpdate(repoDir, { repairAdmin });
   } else {
     console.error(`Unknown command: ${command}`);
     console.error(
-      "Usage: create-line-harness [setup|update] [--repo-dir <path>] [--from-source]",
+      "Usage: create-line-harness [setup|update] [--repo-dir <path>] [--from-source] [--repair-admin]",
     );
     process.exit(1);
   }

--- a/packages/create-line-harness/test/resolve-state.test.ts
+++ b/packages/create-line-harness/test/resolve-state.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { resolveState } from '../src/commands/update.js';
+import {
+  findReleaseForAdminRepair,
+  resolveState,
+} from '../src/commands/update.js';
+import type { ReleaseEntry } from '@line-harness/update-engine';
 
 const WORKER_URL = 'https://line-harness.acc.workers.dev';
 
@@ -161,5 +165,34 @@ describe('normalizeInstallBindings', () => {
   it('does not mutate the input array', () => {
     normalizeInstallBindings(bindings, OPTS);
     expect(bindings.find((b) => b.name === 'LIFF_PAGES_PROJECT')?.text).toBe('line-harness-liff');
+  });
+});
+
+function release(version: string): ReleaseEntry {
+  return {
+    version,
+    released_at: '2026-07-08T00:00:00Z',
+    worker_hash: `worker-${version}`,
+    admin_hash: `admin-${version}`,
+    liff_hash: `liff-${version}`,
+    worker_bundle_hash: `bundle-${version}`,
+    bundle_url: `https://example.test/${version}.tar.gz`,
+    bundle_size_bytes: 123,
+    required_secrets: [],
+    new_required_secrets: [],
+    migrations: [],
+    changelog_url: 'https://example.test/changelog',
+    min_from_version: '0.0.0',
+  };
+}
+
+describe('findReleaseForAdminRepair', () => {
+  it('selects the artifact matching the live Worker, not the latest release', () => {
+    const releases = [release('0.17.0'), release('0.18.0')];
+    expect(findReleaseForAdminRepair(releases, '0.17.0')?.version).toBe('0.17.0');
+  });
+
+  it('returns undefined instead of deploying a mismatched Admin artifact', () => {
+    expect(findReleaseForAdminRepair([release('0.18.0')], '0.17.0')).toBeUndefined();
   });
 });

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/update-engine",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Self-update engine for LINE Harness — shared between Worker (cloud-side self-update) and CLI (npx create-line-harness update)",
   "type": "module",
   "exports": {

--- a/packages/update-engine/src/cf-api/pages.ts
+++ b/packages/update-engine/src/cf-api/pages.ts
@@ -112,6 +112,18 @@ interface UploadEntry {
   base64: true;
 }
 
+const ASSET_UPLOAD_BATCH_SIZE = 50;
+const ASSET_UPLOAD_MAX_ATTEMPTS = 3;
+const ASSET_UPLOAD_RETRY_BASE_MS = 250;
+
+function isRetryableUploadStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * Push a batch of missing assets to CF. The payload is `key → base64
  * content` plus a small metadata blob (just the Content-Type for now).
@@ -122,19 +134,31 @@ async function uploadAssets(
   jwt: string,
   entries: UploadEntry[],
 ): Promise<void> {
-  const res = await fetch(
-    'https://api.cloudflare.com/client/v4/pages/assets/upload',
-    {
-      method: 'POST',
-      headers: {
-        ...authHeader(jwt),
-        'Content-Type': 'application/json',
+  for (let attempt = 1; attempt <= ASSET_UPLOAD_MAX_ATTEMPTS; attempt++) {
+    const res = await fetch(
+      'https://api.cloudflare.com/client/v4/pages/assets/upload',
+      {
+        method: 'POST',
+        headers: {
+          ...authHeader(jwt),
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ payload: entries }),
       },
-      body: JSON.stringify({ payload: entries }),
-    },
-  );
-  if (!res.ok) {
-    await throwHttpError('POST pages assets upload failed', res);
+    );
+    if (res.ok) return;
+    if (
+      !isRetryableUploadStatus(res.status) ||
+      attempt === ASSET_UPLOAD_MAX_ATTEMPTS
+    ) {
+      await throwHttpError('POST pages assets upload failed', res);
+    }
+    try {
+      await res.text();
+    } catch {
+      /* ignore */
+    }
+    await delay(ASSET_UPLOAD_RETRY_BASE_MS * 2 ** (attempt - 1));
   }
 }
 
@@ -205,7 +229,9 @@ export async function deployPagesProject(opts: {
         base64: true,
       });
     }
-    await uploadAssets(jwt, entries);
+    for (let i = 0; i < entries.length; i += ASSET_UPLOAD_BATCH_SIZE) {
+      await uploadAssets(jwt, entries.slice(i, i + ASSET_UPLOAD_BATCH_SIZE));
+    }
   }
 
   // Step 5: create the deployment with a manifest of "/{path}" → hash

--- a/packages/update-engine/test/cf-api/pages.test.ts
+++ b/packages/update-engine/test/cf-api/pages.test.ts
@@ -191,6 +191,83 @@ describe('deployPagesProject', () => {
     expect(entry.metadata.contentType).toBe('application/octet-stream');
   });
 
+  it('uploads missing assets in batches of at most 50', async () => {
+    const files = new Map<string, Buffer>();
+    const hashes: string[] = [];
+    for (let i = 0; i < 51; i++) {
+      const content = Buffer.from(`file-${i}`);
+      files.set(`asset-${i}.txt`, content);
+      hashes.push(sha256Hex(content));
+    }
+
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ result: { jwt: 'JWT' } }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ result: hashes }),
+      } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200 } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200 } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ result: { id: 'D', url: 'https://x.pages.dev' } }),
+      } as Response);
+
+    await deployPagesProject({ creds, projectName: 'p', files });
+
+    const [, firstUpload] = fetchMock.mock.calls[2] as [string, RequestInit];
+    const [, secondUpload] = fetchMock.mock.calls[3] as [string, RequestInit];
+    expect(JSON.parse(firstUpload.body as string).payload).toHaveLength(50);
+    expect(JSON.parse(secondUpload.body as string).payload).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it('retries a transient Pages asset upload 5xx', async () => {
+    const content = Buffer.from('retry me');
+    const hash = sha256Hex(content);
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ result: { jwt: 'JWT' } }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ result: [hash] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'temporary failure',
+      } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200 } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ result: { id: 'D', url: 'https://x.pages.dev' } }),
+      } as Response);
+
+    await deployPagesProject({
+      creds,
+      projectName: 'p',
+      files: new Map([['index.html', content]]),
+    });
+
+    const uploadCalls = fetchMock.mock.calls.filter(
+      ([url]) => url === 'https://api.cloudflare.com/client/v4/pages/assets/upload',
+    );
+    expect(uploadCalls).toHaveLength(2);
+  });
+
   it('sends manifest with /{path} → hash mapping in final FormData', async () => {
     const indexHtml = Buffer.from('<html/>');
     const appJs = Buffer.from('x');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,7 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@line-harness/update-engine':
-        specifier: workspace:^0.0.6
+        specifier: workspace:^0.0.7
         version: link:../update-engine
       execa:
         specifier: ^9.5.2


### PR DESCRIPTION
## Summary
- add update --repair-admin to redeploy only the Admin artifact matching the live Worker version
- batch Pages asset uploads in groups of 50
- retry HTTP 429 and 5xx asset uploads up to 3 times
- bump create-line-harness to 0.2.5 and update-engine to 0.0.7

## Verification
- update-engine: 157 tests passed + typecheck + build
- create-line-harness: 49 tests passed + typecheck + build
- git diff --check passed
- package tarballs verified with resolved dependency @line-harness/update-engine ^0.0.7