### PR TITLE
Add Shuuka link integration support

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { api } from '@/lib/api'
+import { buildLineExperienceUrl } from '@/lib/line-experience-url'
 import CcPromptButton from '@/components/cc-prompt-button'
 import { useAccount } from '@/contexts/account-context'
 
@@ -73,6 +74,7 @@ function StatCard({ title, value, loading, icon, href, accentColor = '#06C755' }
 
 export default function DashboardPage() {
   const { selectedAccountId, selectedAccount } = useAccount()
+  const lineExperienceUrl = buildLineExperienceUrl(process.env.NEXT_PUBLIC_API_URL)
   const [stats, setStats] = useState<DashboardStats>({
     friendCount: null,
     activeScenarioCount: null,
@@ -152,22 +154,24 @@ export default function DashboardPage() {
       )}
 
       {/* Demo banner */}
-      <a
-        href="https://your-worker.your-subdomain.workers.dev/auth/line?ref=dashboard"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block mb-6 p-4 rounded-xl border border-green-200 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 transition-colors"
-      >
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-sm font-bold text-gray-900">LINE で体験する</p>
-            <p className="text-xs text-gray-500 mt-0.5">友だち追加でステップ配信・フォーム・自動返信を体験</p>
+      {lineExperienceUrl && (
+        <a
+          href={lineExperienceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block mb-6 p-4 rounded-xl border border-green-200 bg-gradient-to-r from-green-50 to-emerald-50 hover:from-green-100 hover:to-emerald-100 transition-colors"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-bold text-gray-900">LINE で体験する</p>
+              <p className="text-xs text-gray-500 mt-0.5">友だち追加でステップ配信・フォーム・自動返信を体験</p>
+            </div>
+            <span className="text-xs px-3 py-1.5 rounded-full text-white font-medium" style={{ backgroundColor: '#06C755' }}>
+              友だち追加
+            </span>
           </div>
-          <span className="text-xs px-3 py-1.5 rounded-full text-white font-medium" style={{ backgroundColor: '#06C755' }}>
-            友だち追加
-          </span>
-        </div>
-      </a>
+        </a>
+      )}
 
       {/* Summary cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 mb-8">

--- a/apps/web/src/lib/line-experience-url.test.ts
+++ b/apps/web/src/lib/line-experience-url.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { buildLineExperienceUrl } from './line-experience-url'
+
+describe('buildLineExperienceUrl', () => {
+  it('builds the LINE auth URL from the deployed Worker URL', () => {
+    expect(buildLineExperienceUrl('https://line-harness.example.workers.dev')).toBe(
+      'https://line-harness.example.workers.dev/auth/line?ref=dashboard',
+    )
+  })
+
+  it('removes trailing slashes and encodes the ref', () => {
+    expect(buildLineExperienceUrl('https://worker.example///', 'gift guide')).toBe(
+      'https://worker.example/auth/line?ref=gift%20guide',
+    )
+  })
+
+  it('returns null when the Worker URL is unavailable', () => {
+    expect(buildLineExperienceUrl(undefined)).toBeNull()
+    expect(buildLineExperienceUrl('  ')).toBeNull()
+  })
+})

--- a/apps/web/src/lib/line-experience-url.ts
+++ b/apps/web/src/lib/line-experience-url.ts
@@ -1,0 +1,9 @@
+export function buildLineExperienceUrl(
+  workerUrl: string | undefined,
+  ref = 'dashboard',
+): string | null {
+  const baseUrl = workerUrl?.trim().replace(/\/+$/, '')
+  if (!baseUrl) return null
+
+  return `${baseUrl}/auth/line?ref=${encodeURIComponent(ref)}`
+}

--- a/apps/worker/src/client/main.ts
+++ b/apps/worker/src/client/main.ts
@@ -251,6 +251,7 @@ async function linkAndAddFlow() {
 
     // 1. UUID linking (always, regardless of friendship)
     const linkParams = new URLSearchParams(window.location.search);
+    let linkTicket: string | null = null;
     const linkPromise = apiCall('/api/liff/link', {
       method: 'POST',
       body: JSON.stringify({
@@ -261,13 +262,15 @@ async function linkAndAddFlow() {
         ig: linkParams.get('ig') || '',
         iga: linkParams.get('iga') || '',
         igan: linkParams.get('igan') || '',
+        redirect: redirectUrl || undefined,
       }),
     }).then(async (res) => {
       if (res.ok) {
-        const data = await res.json() as { success: boolean; data?: { userId?: string } };
+        const data = await res.json() as { success: boolean; data?: { userId?: string; linkTicket?: string | null } };
         if (data?.data?.userId) {
           saveUuid(data.data.userId);
         }
+        linkTicket = data?.data?.linkTicket || null;
       }
       return res;
     }).catch(() => {
@@ -284,10 +287,13 @@ async function linkAndAddFlow() {
 
     // 3. Redirect flow (for wrapped URLs)
     if (redirectUrl) {
-      await Promise.race([
-        linkPromise,
-        new Promise((r) => setTimeout(r, 500)),
-      ]);
+      await linkPromise;
+      if (linkTicket) {
+        const ticketTarget = new URL(redirectUrl, window.location.origin);
+        ticketTarget.searchParams.set('lh_ticket', linkTicket);
+        window.location.href = ticketTarget.toString();
+        return;
+      }
       // Append LINE userId to tracking links so clicks are attributed
       if (redirectUrl.includes('/t/')) {
         const sep = redirectUrl.includes('?') ? '&' : '?';

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -57,6 +57,7 @@ import { conversations } from './routes/conversations.js';
 import { stripe } from './routes/stripe.js';
 import { health } from './routes/health.js';
 import { automations } from './routes/automations.js';
+// Rich menu routes include a live default-menu verification endpoint.
 import { richMenus } from './routes/rich-menus.js';
 import { trackedLinks } from './routes/tracked-links.js';
 import { entryRoutes } from './routes/entry-routes.js';
@@ -109,6 +110,8 @@ export type Env = {
     X_HARNESS_URL?: string;  // Optional: X Harness API URL for account linking
     IG_HARNESS_URL?: string;  // Optional: IG Harness API URL for cross-platform linking
     IG_HARNESS_LINK_SECRET?: string;  // Shared secret for IG Harness link-line webhook
+    SHOPIFY_LINK_SIGNING_SECRET?: string; // Shared HMAC secret for short-lived Shopify link tickets
+    SHOPIFY_LINK_ORIGIN?: string; // Exact HTTPS origin allowed to receive Shopify link tickets
     // Phase 5 self-update — consumed by /admin/update/*. Defaults live in
     // wrangler.toml [vars]; secrets (CF_API_TOKEN, ADMIN_API_KEY) come from
     // `wrangler secret put`. All are optional at the type level so the rest
@@ -308,6 +311,8 @@ app.get('/r/:ref', async (c) => {
   if (liffIdMatch) liffParams.set('liffId', liffIdMatch[1]);
   if (ref) liffParams.set('ref', ref);
   if (formId) liffParams.set('form', formId);
+  const redirect = c.req.query('redirect');
+  if (redirect) liffParams.set('redirect', redirect);
   const gate = c.req.query('gate');
   if (gate) liffParams.set('gate', gate);
   const xh = c.req.query('xh');

--- a/apps/worker/src/lib/external-link-ticket.test.ts
+++ b/apps/worker/src/lib/external-link-ticket.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { createExternalLinkTicket } from './external-link-ticket.js';
+
+describe('createExternalLinkTicket', () => {
+  const env = {
+    SHOPIFY_LINK_SIGNING_SECRET: 'test-signing-secret',
+    SHOPIFY_LINK_ORIGIN: 'https://bridge.example.com',
+  };
+  const claims = { friendId: 'friend-1', lineUserId: 'U123', userId: 'user-1' };
+
+  it('issues a short-lived ticket only for the configured origin', async () => {
+    const ticket = await createExternalLinkTicket(env, 'https://bridge.example.com/t/link', claims, 1000);
+    expect(ticket?.split('.')).toHaveLength(2);
+  });
+
+  it('does not issue tickets to untrusted redirects', async () => {
+    await expect(createExternalLinkTicket(env, 'https://evil.example/t/link', claims, 1000)).resolves.toBeNull();
+    await expect(createExternalLinkTicket(env, 'javascript:alert(1)', claims, 1000)).resolves.toBeNull();
+  });
+});

--- a/apps/worker/src/lib/external-link-ticket.ts
+++ b/apps/worker/src/lib/external-link-ticket.ts
@@ -1,0 +1,59 @@
+type ExternalLinkEnv = {
+  SHOPIFY_LINK_SIGNING_SECRET?: string;
+  SHOPIFY_LINK_ORIGIN?: string;
+};
+
+export type ExternalLinkTicketPayload = {
+  v: 1;
+  aud: string;
+  friendId: string;
+  lineUserId: string;
+  userId: string;
+  nonce: string;
+  exp: number;
+};
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+export async function createExternalLinkTicket(
+  env: ExternalLinkEnv,
+  redirectTarget: string | undefined,
+  claims: Pick<ExternalLinkTicketPayload, 'friendId' | 'lineUserId' | 'userId'>,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): Promise<string | null> {
+  if (!env.SHOPIFY_LINK_SIGNING_SECRET || !env.SHOPIFY_LINK_ORIGIN || !redirectTarget) return null;
+
+  let target: URL;
+  let expectedOrigin: string;
+  try {
+    target = new URL(redirectTarget);
+    expectedOrigin = new URL(env.SHOPIFY_LINK_ORIGIN).origin;
+  } catch {
+    return null;
+  }
+  if (target.origin !== expectedOrigin || target.protocol !== 'https:') return null;
+
+  const payload: ExternalLinkTicketPayload = {
+    v: 1,
+    aud: expectedOrigin,
+    ...claims,
+    nonce: crypto.randomUUID(),
+    exp: nowSeconds + 5 * 60,
+  };
+  const encodedPayload = base64Url(new TextEncoder().encode(JSON.stringify(payload)));
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(env.SHOPIFY_LINK_SIGNING_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = new Uint8Array(
+    await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(encodedPayload)),
+  );
+  return `${encodedPayload}.${base64Url(signature)}`;
+}

--- a/apps/worker/src/routes/affiliate-links-redirect.test.ts
+++ b/apps/worker/src/routes/affiliate-links-redirect.test.ts
@@ -184,4 +184,17 @@ describe('/r/:ref — affiliate_links fallback', () => {
     expect(html).toContain('liff.line.me/1000000000-DefaultAA');
     expect(html).toContain('ref=unknown');
   });
+
+  it('forwards the external redirect target into the LIFF URL', async () => {
+    dbMocks.getEntryRouteByRefCode.mockResolvedValue(null);
+    dbMocks.getAffiliateLinkByRefCode.mockResolvedValue(null);
+    dbMocks.getTrafficPoolBySlug.mockResolvedValue(null);
+
+    const redirect = 'https://bridge.example.com/t/link?shop=example.myshopify.com';
+    const res = await get(`/r/shopify-link?redirect=${encodeURIComponent(redirect)}`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toContain(`redirect=${encodeURIComponent(redirect)}`);
+  });
 });

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -27,6 +27,7 @@ import { attachTagAndFireSideEffects } from '../services/friend-tag-attach.js';
 import { pushImmediateFirstStep } from '../services/immediate-first-step.js';
 import { notifyAffiliateFriendAdd } from '../services/affiliate-notifier.js';
 import { safeRedirectTarget } from '../lib/safe-redirect.js';
+import { createExternalLinkTicket } from '../lib/external-link-ticket.js';
 import type { Env } from '../index.js';
 
 const liffRoutes = new Hono<Env>();
@@ -1144,6 +1145,7 @@ liffRoutes.post('/api/liff/link', async (c) => {
       ig?: string;
       iga?: string;
       igan?: string;
+      redirect?: string;
     }>();
 
     if (!body.idToken) {
@@ -1239,9 +1241,15 @@ liffRoutes.post('/api/liff/link', async (c) => {
           console.error('X Harness token resolution error (non-blocking):', err);
         }
       }
+      const linkedUserId = (friend as unknown as Record<string, unknown>).user_id as string;
+      const linkTicket = await createExternalLinkTicket(c.env, body.redirect, {
+        friendId: friend.id,
+        lineUserId,
+        userId: linkedUserId,
+      });
       return c.json({
         success: true,
-        data: { userId: (friend as unknown as Record<string, unknown>).user_id, alreadyLinked: true },
+        data: { userId: linkedUserId, friendId: friend.id, linkTicket, alreadyLinked: true },
       });
     }
 
@@ -1308,9 +1316,14 @@ liffRoutes.post('/api/liff/link', async (c) => {
       }
     }
 
+    const linkTicket = await createExternalLinkTicket(c.env, body.redirect, {
+      friendId: friend.id,
+      lineUserId,
+      userId,
+    });
     return c.json({
       success: true,
-      data: { userId, alreadyLinked: false },
+      data: { userId, friendId: friend.id, linkTicket, alreadyLinked: false },
     });
   } catch (err) {
     console.error('POST /api/liff/link error:', err);

--- a/apps/worker/src/routes/rich-menus.test.ts
+++ b/apps/worker/src/routes/rich-menus.test.ts
@@ -3,10 +3,14 @@ import { Hono } from 'hono';
 import { richMenus } from './rich-menus.js';
 
 const uploadRichMenuImage = vi.fn();
+const getDefaultRichMenuId = vi.fn();
+const getRichMenuList = vi.fn();
 
 vi.mock('@line-crm/line-sdk', () => ({
   LineClient: vi.fn().mockImplementation(() => ({
     uploadRichMenuImage,
+    getDefaultRichMenuId,
+    getRichMenuList,
   })),
 }));
 
@@ -69,5 +73,38 @@ describe('POST /api/rich-menus/:id/image', () => {
     expect(richMenuId).toBe('richmenu-2');
     expect(contentType).toBe('image/jpeg');
     expect(new TextDecoder().decode(imageData as ArrayBuffer)).toBe('hello');
+  });
+});
+
+describe('GET /api/rich-menus/default', () => {
+  function setupApp() {
+    const app = new Hono<{
+      Bindings: {
+        DB: D1Database;
+        LINE_CHANNEL_ACCESS_TOKEN: string;
+      };
+    }>();
+    app.route('/', richMenus);
+    return app;
+  }
+
+  beforeEach(() => {
+    getDefaultRichMenuId.mockReset();
+    getRichMenuList.mockReset();
+  });
+
+  test('returns the current default id and menu name', async () => {
+    getDefaultRichMenuId.mockResolvedValue('richmenu-live');
+    getRichMenuList.mockResolvedValue({ richmenus: [{ richMenuId: 'richmenu-live', name: '祝果メニュー' }] });
+    const res = await setupApp().request('/api/rich-menus/default', {}, {
+      LINE_CHANNEL_ACCESS_TOKEN: 'token',
+      DB: {} as D1Database,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      success: true,
+      data: { richMenuId: 'richmenu-live', name: '祝果メニュー' },
+    });
   });
 });

--- a/apps/worker/src/routes/rich-menus.ts
+++ b/apps/worker/src/routes/rich-menus.ts
@@ -28,6 +28,24 @@ richMenus.get('/api/rich-menus', async (c) => {
   }
 });
 
+// GET /api/rich-menus/default — resolve the effective default menu from LINE
+richMenus.get('/api/rich-menus/default', async (c) => {
+  try {
+    const lineClient = await resolveLineClient(c);
+    const richMenuId = await lineClient.getDefaultRichMenuId();
+    if (!richMenuId) {
+      return c.json({ success: true, data: { richMenuId: null, name: null } });
+    }
+    const list = await lineClient.getRichMenuList();
+    const menu = (list.richmenus ?? []).find((item) => item.richMenuId === richMenuId);
+    return c.json({ success: true, data: { richMenuId, name: menu?.name ?? null } });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('GET /api/rich-menus/default error:', message);
+    return c.json({ success: false, error: `Failed to fetch default rich menu: ${message}` }, 500);
+  }
+});
+
 // POST /api/rich-menus — create a rich menu via LINE API
 richMenus.post('/api/rich-menus', async (c) => {
   try {

--- a/apps/worker/src/services/step-delivery.test.ts
+++ b/apps/worker/src/services/step-delivery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { evaluateCondition, isSupportedConditionType, SUPPORTED_CONDITION_TYPES, processStepDeliveries, expandVariables } from './step-delivery.js';
+import { buildMessage, evaluateCondition, isSupportedConditionType, SUPPORTED_CONDITION_TYPES, processStepDeliveries, expandVariables } from './step-delivery.js';
 import type { LineClient } from '@line-crm/line-sdk';
 
 /**
@@ -474,5 +474,29 @@ describe('processStepDeliveries crash recovery', () => {
     expect(recoveryIdx).toBeGreaterThanOrEqual(0); // recovery ran
     expect(dueQueryIdx).toBeGreaterThanOrEqual(0);
     expect(recoveryIdx).toBeLessThan(dueQueryIdx); // and ran first
+  });
+});
+
+describe('buildMessage flex compatibility', () => {
+  it('accepts a complete LINE Flex message without nesting the wrapper in contents', () => {
+    const message = buildMessage('flex', JSON.stringify({
+      type: 'flex',
+      altText: '会員連携のご案内',
+      contents: {
+        type: 'bubble',
+        body: {
+          type: 'box',
+          layout: 'vertical',
+          contents: [{ type: 'text', text: 'LINEと会員を連携する' }],
+        },
+      },
+    }));
+
+    expect(message).toMatchObject({
+      type: 'flex',
+      altText: '会員連携のご案内',
+      contents: { type: 'bubble' },
+    });
+    expect((message as { contents: { type: string } }).contents.type).not.toBe('flex');
   });
 });

--- a/apps/worker/src/services/step-delivery.ts
+++ b/apps/worker/src/services/step-delivery.ts
@@ -488,11 +488,26 @@ export function buildMessage(messageType: string, messageContent: string, altTex
 
   if (messageType === 'flex') {
     try {
-      const contents = JSON.parse(messageContent);
+      const parsed = JSON.parse(messageContent);
+      const isCompleteFlexMessage =
+        parsed !== null
+        && typeof parsed === 'object'
+        && parsed.type === 'flex'
+        && parsed.contents !== null
+        && typeof parsed.contents === 'object';
+      const contents = isCompleteFlexMessage ? parsed.contents : parsed;
+      const embeddedAltText =
+        isCompleteFlexMessage && typeof parsed.altText === 'string'
+          ? parsed.altText
+          : undefined;
       // Remove empty text nodes (from {{#if_ref}} conditional blocks)
       cleanEmptyNodes(contents);
       // Extract first text element for altText (shown in notifications)
-      return { type: 'flex', altText: altText || extractFlexAltText(contents), contents };
+      return {
+        type: 'flex',
+        altText: altText || embeddedAltText || extractFlexAltText(contents),
+        contents,
+      };
     } catch {
       return { type: 'text', text: messageContent };
     }

--- a/packages/sdk/src/resources/rich-menus.ts
+++ b/packages/sdk/src/resources/rich-menus.ts
@@ -9,6 +9,13 @@ export class RichMenusResource {
     return res.data
   }
 
+  async getDefault(): Promise<{ richMenuId: string | null; name: string | null }> {
+    const res = await this.http.get<ApiResponse<{ richMenuId: string | null; name: string | null }>>(
+      '/api/rich-menus/default',
+    )
+    return res.data
+  }
+
   async create(menu: CreateRichMenuInput): Promise<{ richMenuId: string }> {
     const res = await this.http.post<ApiResponse<{ richMenuId: string }>>('/api/rich-menus', menu)
     return res.data


### PR DESCRIPTION
## What changed

- Adds short-lived HMAC-signed tickets for handing an authenticated LINE identity to a configured external Shopify bridge.
- Forwards the external redirect target through `/r/:ref` and waits for the LIFF link result before redirecting with `lh_ticket`.
- Adds a default rich-menu verification endpoint and the corresponding SDK method.
- Accepts complete LINE Flex message wrappers without nesting the wrapper inside `contents`.
- Builds the dashboard's “LINE で体験する” link from `NEXT_PUBLIC_API_URL` instead of the placeholder Worker hostname.

## Why

祝果 needs a safe way to connect a verified LINE identity with its Shopify customer-linking bridge. The live integration also needs a simple endpoint for checking the effective default rich menu and compatibility with complete Flex-message JSON already used by delivery flows.

The dashboard banner was still hard-coded to `your-worker.your-subdomain.workers.dev`, so installed admin deployments sent operators to a non-existent Worker instead of their own LINE authorization flow.

## Security and behavior

- Tickets are issued only for the exact configured HTTPS origin.
- Tickets use HMAC-SHA256, include a nonce, and expire after five minutes.
- No ticket is issued when the signing secret, allowed origin, or trusted redirect is missing.
- The dashboard banner is hidden if a Worker URL is unavailable instead of rendering a broken link.
- Deployment-specific `wrangler.toml` values and secrets are intentionally not included in this PR.

## User and developer impact

Customers can complete the LINE-to-Shopify linking flow without exposing an unsigned identity in the redirect URL. Operators can verify the current default rich menu, while existing Flex payload formats remain compatible. The dashboard now opens the installed tenant's real LINE authorization endpoint.

## Validation

- Four targeted Worker test files: 46 tests passed
- `pnpm --filter worker typecheck`
- `pnpm --filter @line-harness/sdk typecheck`
- `pnpm --filter web test`: 11 tests passed
- `NEXT_PUBLIC_API_URL=https://shuuka-line-harness.k-mizutani.workers.dev pnpm --filter web build`
- Production export contains the configured Worker URL and no placeholder hostname
- `git diff --check`
