### PR TITLE
feat(runtime): persist LINE provider receipts for durable send readback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ name: Release
 #
 # Required secrets for downstream installs (documented here so create-line-harness
 # stays in sync):
-#   - LINE_CHANNEL_TOKEN
+#   - LINE_CHANNEL_ACCESS_TOKEN
 #   - LINE_CHANNEL_SECRET
 #   - LINE_LOGIN_CHANNEL_ID
-#   - ADMIN_API_KEY
 #   - LIFF_URL
+#   - API_KEY
 #
 # This workflow itself only needs the default `GITHUB_TOKEN` to create a
 # draft Release — no Cloudflare credentials are required. Deploy workflows
@@ -210,11 +210,11 @@ jobs:
             "bundle_url": "${bundle_url}",
             "bundle_size_bytes": ${{ steps.bundle.outputs.size }},
             "required_secrets": [
-              "LINE_CHANNEL_TOKEN",
+              "LINE_CHANNEL_ACCESS_TOKEN",
               "LINE_CHANNEL_SECRET",
               "LINE_LOGIN_CHANNEL_ID",
-              "ADMIN_API_KEY",
-              "LIFF_URL"
+              "LIFF_URL",
+              "API_KEY"
             ],
             "new_required_secrets": [],
             "migrations": ${{ steps.migrations.outputs.list }},

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -78,6 +78,7 @@ import { messageTemplates } from './routes/message-templates.js';
 import dedupPreview from './routes/dedup-preview.js';
 import { profileRefresh } from './routes/profile-refresh.js';
 import { richMenuGroups } from './routes/rich-menu-groups.js';
+import { runtimeMessages } from './routes/runtime-messages.js';
 import adminVersion from './routes/admin-version.js';
 import adminUpdate from './routes/admin-update.js';
 import { isLinkPreviewBot } from './lib/og-bot.js';
@@ -200,6 +201,7 @@ app.route('/', messageTemplates);
 app.route('/', dedupPreview);
 app.route('/', profileRefresh);
 app.route('/', richMenuGroups);
+app.route('/', runtimeMessages);
 
 // Phase 5 (upgrade flow) — public build metadata endpoint. Mounted under
 // /admin/ but intentionally unauthenticated: the dashboard fetches /admin/version

--- a/apps/worker/src/line-client-receipt.test.ts
+++ b/apps/worker/src/line-client-receipt.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { LineClient } from '@line-crm/line-sdk';
+
+const retryKey = '123e4567-e89b-12d3-a456-426614174000';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('LineClient.pushMessageWithReceipt', () => {
+  test('captures the provider request id and sent message ids on 200', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      sentMessages: [
+        { id: '461230966842064897', quoteToken: 'quote-token' },
+      ],
+    }), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+        'x-line-request-id': 'provider-request-1',
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new LineClient('channel-token');
+    const receipt = await client.pushMessageWithReceipt(
+      'Urecipient',
+      [{ type: 'text', text: 'hello' }],
+      retryKey,
+    );
+
+    expect(receipt).toEqual({
+      httpStatus: 200,
+      providerRequestId: 'provider-request-1',
+      acceptedRequestId: null,
+      providerMessageIds: ['461230966842064897'],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(new Headers(init.headers).get('x-line-retry-key')).toBe(retryKey);
+    expect(new Headers(init.headers).get('authorization')).toBe('Bearer channel-token');
+  });
+
+  test('treats LINE 409 retry acknowledgement as the original accepted receipt', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      message: 'The retry key is already accepted',
+      sentMessages: [{ id: '461230966842064897', quoteToken: 'quote-token' }],
+    }), {
+      status: 409,
+      headers: {
+        'content-type': 'application/json',
+        'x-line-request-id': 'provider-request-2',
+        'x-line-accepted-request-id': 'provider-request-1',
+      },
+    })));
+
+    const client = new LineClient('channel-token');
+    const receipt = await client.pushMessageWithReceipt(
+      'Urecipient',
+      [{ type: 'text', text: 'hello' }],
+      retryKey,
+    );
+
+    expect(receipt).toEqual({
+      httpStatus: 409,
+      providerRequestId: 'provider-request-2',
+      acceptedRequestId: 'provider-request-1',
+      providerMessageIds: ['461230966842064897'],
+    });
+  });
+
+  test('does not report provider acceptance without request and message ids', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })));
+
+    const client = new LineClient('channel-token');
+    await expect(client.pushMessageWithReceipt(
+      'Urecipient',
+      [{ type: 'text', text: 'hello' }],
+      retryKey,
+    )).rejects.toThrow('LINE provider receipt is incomplete');
+  });
+});

--- a/apps/worker/src/middleware/auth.test.ts
+++ b/apps/worker/src/middleware/auth.test.ts
@@ -46,6 +46,7 @@ function app() {
   }));
   a.use('*', authMiddleware);
   a.route('/', adminAuth);
+  a.get('/api/health', (c) => c.json({ status: 'ok' }));
   a.get('/api/protected', (c) => c.json({ success: true, data: c.get('staff') }));
   a.post('/api/protected', (c) => c.json({ success: true, data: c.get('staff') }));
   return a;
@@ -127,6 +128,12 @@ describe('topology guard', () => {
 });
 
 describe('protected API access', () => {
+  test('keeps the public liveness endpoint unauthenticated', async () => {
+    const res = await app().request('/api/health', {}, crossSiteEnv());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok' });
+  });
+
   test('accepts the admin session cookie (GET, no CSRF needed)', async () => {
     const res = await app().request('/api/protected', {
       headers: { Cookie: 'lh_admin_session=staff-key' },

--- a/apps/worker/src/middleware/auth.ts
+++ b/apps/worker/src/middleware/auth.ts
@@ -152,6 +152,7 @@ export async function authMiddleware(c: Context<Env>, next: Next): Promise<Respo
   }
   if (
     path === '/webhook' ||
+    path === '/api/health' ||
     path === '/docs' ||
     path === '/openapi.json' ||
     path === '/api/affiliates/click' ||

--- a/apps/worker/src/routes/capabilities.test.ts
+++ b/apps/worker/src/routes/capabilities.test.ts
@@ -52,6 +52,7 @@ describe('GET /api/capabilities', () => {
     expect(body.data.features).toContain('provider_receipt_v1');
     expect(body.data.features).toContain('dispatch_readback_v1');
     expect(body.data.features).toContain('push_retry_key_v1');
+    expect(body.data.features).toContain('account_scope_fingerprint_v1');
     expect(body.data.min_app_version).toBeDefined();
     expect(body.data.product).toBe('line-harness');
     expect(body.data.platform).toBe('line');
@@ -62,6 +63,8 @@ describe('GET /api/capabilities', () => {
     expect(body.data.endpoints.staffMe).toBe('/api/staff/me');
     expect(body.data.endpoints.trackedLinks).toBe('/api/tracked-links');
     expect(body.data.endpoints.runtimeMessageSend).toBe('/api/runtime/messages:send');
+    expect(body.data.endpoints.runtimeAccountScope)
+      .toBe('/api/runtime/conversations/:conversationRef/account-scope');
     expect(body.data.endpoints.runtimeDispatchReadback)
       .toBe('/api/runtime/dispatches/:clientRequestId');
     expect(body.data.external_writes.message_send).toBe('provider_receipt_v1');

--- a/apps/worker/src/routes/capabilities.test.ts
+++ b/apps/worker/src/routes/capabilities.test.ts
@@ -22,6 +22,7 @@ type CapabilitiesResponse = {
       supportedLinks: string[];
     };
     endpoints: Record<string, string>;
+    external_writes: Record<string, string>;
   };
 };
 
@@ -44,10 +45,13 @@ describe('GET /api/capabilities', () => {
     expect(body.success).toBe(true);
     expect(body.data.harness_kind).toBe('line');
     expect(body.data.harness_version).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(body.data.api_version).toBe(1);
+    expect(body.data.api_version).toBe(2);
     expect(body.data.features).toContain('friends');
     expect(body.data.features).toContain('broadcasts');
     expect(body.data.features).toContain('staff');
+    expect(body.data.features).toContain('provider_receipt_v1');
+    expect(body.data.features).toContain('dispatch_readback_v1');
+    expect(body.data.features).toContain('push_retry_key_v1');
     expect(body.data.min_app_version).toBeDefined();
     expect(body.data.product).toBe('line-harness');
     expect(body.data.platform).toBe('line');
@@ -57,6 +61,10 @@ describe('GET /api/capabilities', () => {
     expect(body.data.identity.supportedLinks).toContain('ig_igsid');
     expect(body.data.endpoints.staffMe).toBe('/api/staff/me');
     expect(body.data.endpoints.trackedLinks).toBe('/api/tracked-links');
+    expect(body.data.endpoints.runtimeMessageSend).toBe('/api/runtime/messages:send');
+    expect(body.data.endpoints.runtimeDispatchReadback)
+      .toBe('/api/runtime/dispatches/:clientRequestId');
+    expect(body.data.external_writes.message_send).toBe('provider_receipt_v1');
   });
 
   test('accessible to any authenticated role', async () => {

--- a/apps/worker/src/routes/capabilities.ts
+++ b/apps/worker/src/routes/capabilities.ts
@@ -1,8 +1,11 @@
 import { Hono } from 'hono';
 import type { Env } from '../index.js';
+import { BUNDLE_VERSION, WORKER_HASH } from '../_version.js';
 
-export const HARNESS_VERSION = '0.12.0';
-export const API_VERSION = 1;
+export const HARNESS_VERSION = BUNDLE_VERSION === '0.0.0-dev'
+  ? '0.17.0'
+  : BUNDLE_VERSION;
+export const API_VERSION = 2;
 export const CONNECTOR_VERSION = '2026-05-20';
 export const MIN_APP_VERSION = '1.0.0';
 export const FEATURES = [
@@ -28,6 +31,9 @@ export const FEATURES = [
   'line-cross-link',
   'x-cross-link',
   'ig-cross-link',
+  'provider_receipt_v1',
+  'dispatch_readback_v1',
+  'push_retry_key_v1',
 ] as const;
 
 export const capabilities = new Hono<Env>();
@@ -45,6 +51,13 @@ capabilities.get('/api/capabilities', async (c) => {
       platform: 'line',
       version: HARNESS_VERSION,
       connectorVersion: CONNECTOR_VERSION,
+      release: {
+        version: BUNDLE_VERSION,
+        workerHash: WORKER_HASH,
+      },
+      external_writes: {
+        message_send: 'provider_receipt_v1',
+      },
       identity: {
         primaryKey: 'line_friend_id',
         supportedLinks: ['x_user_id', 'ig_igsid'],
@@ -61,6 +74,8 @@ capabilities.get('/api/capabilities', async (c) => {
         forms: '/api/forms',
         tags: '/api/tags',
         chats: '/api/chats',
+        runtimeMessageSend: '/api/runtime/messages:send',
+        runtimeDispatchReadback: '/api/runtime/dispatches/:clientRequestId',
         liff: '/liff',
       },
     },

--- a/apps/worker/src/routes/capabilities.ts
+++ b/apps/worker/src/routes/capabilities.ts
@@ -34,6 +34,7 @@ export const FEATURES = [
   'provider_receipt_v1',
   'dispatch_readback_v1',
   'push_retry_key_v1',
+  'account_scope_fingerprint_v1',
 ] as const;
 
 export const capabilities = new Hono<Env>();
@@ -75,6 +76,7 @@ capabilities.get('/api/capabilities', async (c) => {
         tags: '/api/tags',
         chats: '/api/chats',
         runtimeMessageSend: '/api/runtime/messages:send',
+        runtimeAccountScope: '/api/runtime/conversations/:conversationRef/account-scope',
         runtimeDispatchReadback: '/api/runtime/dispatches/:clientRequestId',
         liff: '/liff',
       },

--- a/apps/worker/src/routes/health.ts
+++ b/apps/worker/src/routes/health.ts
@@ -8,16 +8,26 @@ import {
   updateAccountMigration,
 } from '@line-crm/db';
 import type { Env } from '../index.js';
+import { BUNDLE_VERSION, WORKER_HASH } from '../_version.js';
+import { API_VERSION } from './capabilities.js';
 
 const health = new Hono<Env>();
 
 // ========== Liveness ==========
 // Public (no auth, see middleware/auth.ts skip list): probed by
 // `create-line-harness update` and by the self-update verify phase
-// (capabilities advertises `/api/health`). Deliberately dependency-free —
-// it exists only to prove the Worker booted and is routing requests.
+// (capabilities advertises `/api/health`). Tenant, binding, D1 and credential
+// details are intentionally excluded.
 
-const LIVENESS_BODY = { success: true, data: { status: 'ok' } } as const;
+const LIVENESS_BODY = {
+  success: true,
+  data: {
+    status: 'ok',
+    releaseVersion: BUNDLE_VERSION,
+    workerHash: WORKER_HASH,
+    apiVersion: API_VERSION,
+  },
+} as const;
 
 health.get('/health', (c) => c.json(LIVENESS_BODY));
 health.get('/api/health', (c) => c.json(LIVENESS_BODY));

--- a/apps/worker/src/routes/public-health.test.ts
+++ b/apps/worker/src/routes/public-health.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest';
+import { Hono } from 'hono';
+import { health } from './health.js';
+
+describe('GET /api/health', () => {
+  test('is public and returns release identity without tenant data', async () => {
+    const app = new Hono();
+    app.route('/', health);
+    const response = await app.request('/api/health');
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      success: boolean;
+      data: {
+        status: string;
+        releaseVersion: string;
+        workerHash: string;
+        apiVersion: number;
+      };
+      [key: string]: unknown;
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.status).toBe('ok');
+    expect(body.data.releaseVersion).toBe('0.0.0-dev');
+    expect(body.data.workerHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(body.data.apiVersion).toBe(2);
+    expect(body).not.toHaveProperty('accountId');
+    expect(body).not.toHaveProperty('databaseId');
+  });
+});

--- a/apps/worker/src/routes/runtime-messages.test.ts
+++ b/apps/worker/src/routes/runtime-messages.test.ts
@@ -1,0 +1,336 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { Hono } from 'hono';
+import { runtimeMessages } from './runtime-messages.js';
+
+const pushMessageWithReceipt = vi.fn();
+
+vi.mock('@line-crm/line-sdk', () => ({
+  LineClient: vi.fn().mockImplementation(() => ({ pushMessageWithReceipt })),
+}));
+
+type DispatchRow = {
+  id: string;
+  client_request_id: string;
+  request_hash: string;
+  conversation_ref: string;
+  friend_id: string;
+  account_scope_fingerprint: string;
+  status: string;
+  release_version: string;
+  worker_hash: string;
+  provider_http_status: number | null;
+  provider_request_id: string | null;
+  accepted_request_id: string | null;
+  provider_message_ids: string | null;
+  receipt_hash: string | null;
+  dispatch_started_at: string | null;
+  provider_accepted_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+class FakeStatement {
+  private values: unknown[] = [];
+
+  constructor(private readonly db: FakeDb, private readonly sql: string) {}
+
+  bind(...values: unknown[]) {
+    this.values = values;
+    return this;
+  }
+
+  async first<T>(): Promise<T | null> {
+    if (this.sql.includes('FROM provider_message_dispatches')) {
+      return (this.db.dispatches.get(String(this.values[0])) ?? null) as T | null;
+    }
+    if (this.sql.includes('FROM chats c')) {
+      return this.values[0] === this.db.recipient.chat_id
+        ? this.db.recipient as T
+        : null;
+    }
+    return null;
+  }
+
+  async run(): Promise<D1Result<unknown>> {
+    if (this.sql.includes('INSERT INTO provider_message_dispatches')) {
+      const [
+        id,
+        clientRequestId,
+        requestHash,
+        conversationRef,
+        friendId,
+        accountScopeFingerprint,
+        releaseVersion,
+        workerHash,
+        now,
+      ] = this.values.map(String);
+      this.db.dispatches.set(clientRequestId, {
+        id,
+        client_request_id: clientRequestId,
+        request_hash: requestHash,
+        conversation_ref: conversationRef,
+        friend_id: friendId,
+        account_scope_fingerprint: accountScopeFingerprint,
+        status: 'dispatching',
+        release_version: releaseVersion,
+        worker_hash: workerHash,
+        provider_http_status: null,
+        provider_request_id: null,
+        accepted_request_id: null,
+        provider_message_ids: null,
+        receipt_hash: null,
+        dispatch_started_at: now,
+        provider_accepted_at: null,
+        created_at: now,
+        updated_at: now,
+      });
+    } else if (this.sql.includes("status = 'provider_accepted'")) {
+      const [
+        httpStatus,
+        providerRequestId,
+        acceptedRequestId,
+        providerMessageIds,
+        receiptHash,
+        now,
+        _updatedAt,
+        clientRequestId,
+      ] = this.values;
+      const row = this.db.dispatches.get(String(clientRequestId));
+      if (row) {
+        Object.assign(row, {
+          status: 'provider_accepted',
+          provider_http_status: Number(httpStatus),
+          provider_request_id: String(providerRequestId),
+          accepted_request_id: acceptedRequestId === null ? null : String(acceptedRequestId),
+          provider_message_ids: String(providerMessageIds),
+          receipt_hash: String(receiptHash),
+          provider_accepted_at: String(now),
+          updated_at: String(now),
+        });
+      }
+    } else if (this.sql.includes("status = 'reconciliation_required'")) {
+      const [now, clientRequestId] = this.values;
+      const row = this.db.dispatches.get(String(clientRequestId));
+      if (row) Object.assign(row, { status: 'reconciliation_required', updated_at: String(now) });
+    } else if (this.sql.includes('INSERT INTO messages_log')) {
+      this.db.messageLogCount += 1;
+    }
+    return { success: true } as D1Result<unknown>;
+  }
+}
+
+class FakeDb {
+  readonly dispatches = new Map<string, DispatchRow>();
+  readonly recipient = {
+    chat_id: 'chat-1',
+    friend_id: 'friend-1',
+    line_user_id: 'Urecipient',
+    line_account_id: null,
+    account_channel_id: null,
+    channel_access_token: null,
+  };
+  messageLogCount = 0;
+
+  prepare(sql: string) {
+    return new FakeStatement(this, sql) as unknown as D1PreparedStatement;
+  }
+}
+
+const requestBase = {
+  schemaVersion: 1,
+  clientRequestId: '123e4567-e89b-12d3-a456-426614174000',
+  conversationRef: 'chat-1',
+  messages: [{ type: 'text', text: 'hello' }],
+  release: {
+    version: '0.0.0-dev',
+    workerHash: `sha256:${'0'.repeat(64)}`,
+  },
+};
+
+function setup(db: FakeDb, role: 'owner' | 'admin' | 'staff' = 'owner') {
+  const app = new Hono<{
+    Bindings: {
+      DB: D1Database;
+      LINE_CHANNEL_ACCESS_TOKEN: string;
+      LINE_CHANNEL_ID: string;
+    };
+    Variables: { staff: { id: string; role: 'owner' | 'admin' | 'staff' } };
+  }>();
+  app.use('*', async (c, next) => {
+    c.set('staff', { id: 'service-owner', role });
+    await next();
+  });
+  app.route('/', runtimeMessages);
+  const env = {
+    DB: db as unknown as D1Database,
+    LINE_CHANNEL_ACCESS_TOKEN: 'channel-token',
+    LINE_CHANNEL_ID: 'line-channel',
+  };
+  return { app, env };
+}
+
+async function expectedFingerprint() {
+  const bytes = new TextEncoder().encode('line-channel');
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return `sha256:${Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+async function hash(value: string) {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return `sha256:${Array.from(new Uint8Array(digest)).map((byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+async function buildRequestBody() {
+  const accountScopeFingerprint = await expectedFingerprint();
+  const requestHash = await hash(JSON.stringify({
+    schemaVersion: 1,
+    accountScopeFingerprint,
+    conversationRef: requestBase.conversationRef,
+    messages: requestBase.messages,
+  }));
+  return { ...requestBase, requestHash, accountScopeFingerprint };
+}
+
+beforeEach(() => {
+  pushMessageWithReceipt.mockReset();
+  pushMessageWithReceipt.mockResolvedValue({
+    httpStatus: 200,
+    providerRequestId: 'provider-request-1',
+    acceptedRequestId: null,
+    providerMessageIds: ['provider-message-1'],
+  });
+});
+
+describe('runtime message dispatch receipt contract', () => {
+  test('persists a provider receipt and returns it through readback', async () => {
+    const db = new FakeDb();
+    const { app, env } = setup(db);
+    const body = await buildRequestBody();
+
+    const send = await app.request('/api/runtime/messages:send', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }, env);
+    expect(send.status).toBe(200);
+    const sendJson = await send.json() as { data: { state: string; providerMessageIds: string[] } };
+    expect(sendJson.data.state).toBe('provider_accepted');
+    expect(sendJson.data.providerMessageIds).toEqual(['provider-message-1']);
+    expect(db.messageLogCount).toBe(1);
+
+    const readback = await app.request(
+      `/api/runtime/dispatches/${requestBase.clientRequestId}`,
+      undefined,
+      env,
+    );
+    expect(readback.status).toBe(200);
+    const readbackJson = await readback.json() as { data: { state: string; receiptHash: string } };
+    expect(readbackJson.data.state).toBe('provider_accepted');
+    expect(readbackJson.data.receiptHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  test('replays the persisted receipt without sending twice', async () => {
+    const db = new FakeDb();
+    const { app, env } = setup(db);
+    const body = await buildRequestBody();
+    const init = {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    };
+
+    expect((await app.request('/api/runtime/messages:send', init, env)).status).toBe(200);
+    const replay = await app.request('/api/runtime/messages:send', init, env);
+    expect(replay.status).toBe(200);
+    expect((await replay.json() as { data: { replayed: boolean } }).data.replayed).toBe(true);
+    expect(pushMessageWithReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects the same request id with a different request hash', async () => {
+    const db = new FakeDb();
+    const { app, env } = setup(db);
+    const first = await buildRequestBody();
+    const second = { ...first, requestHash: `sha256:${'c'.repeat(64)}` };
+
+    await app.request('/api/runtime/messages:send', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(first),
+    }, env);
+    const conflict = await app.request('/api/runtime/messages:send', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(second),
+    }, env);
+
+    expect(conflict.status).toBe(409);
+    expect(pushMessageWithReceipt).toHaveBeenCalledTimes(1);
+  });
+
+  test('moves an unknown provider result to reconciliation without automatic resend', async () => {
+    const db = new FakeDb();
+    const { app, env } = setup(db);
+    const body = await buildRequestBody();
+    const init = {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    };
+    pushMessageWithReceipt.mockRejectedValueOnce(new Error('network timeout'));
+
+    const first = await app.request('/api/runtime/messages:send', init, env);
+    expect(first.status).toBe(502);
+    const second = await app.request('/api/runtime/messages:send', init, env);
+    expect(second.status).toBe(409);
+    expect(pushMessageWithReceipt).toHaveBeenCalledTimes(1);
+    expect(db.dispatches.get(requestBase.clientRequestId)?.status)
+      .toBe('reconciliation_required');
+  });
+
+  test('rejects message tampering when the canonical request hash is stale', async () => {
+    const db = new FakeDb();
+    const { app, env } = setup(db);
+    const body = await buildRequestBody();
+    const tampered = { ...body, messages: [{ type: 'text', text: 'changed' }] };
+
+    const response = await app.request('/api/runtime/messages:send', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(tampered),
+    }, env);
+
+    expect(response.status).toBe(409);
+    expect(pushMessageWithReceipt).not.toHaveBeenCalled();
+  });
+
+  test('rejects a correctly hashed request for a different account scope', async () => {
+    const db = new FakeDb();
+    const { app, env } = setup(db);
+    const base = await buildRequestBody();
+    const accountScopeFingerprint = `sha256:${'d'.repeat(64)}`;
+    const requestHash = await hash(JSON.stringify({
+      schemaVersion: 1,
+      accountScopeFingerprint,
+      conversationRef: base.conversationRef,
+      messages: base.messages,
+    }));
+
+    const response = await app.request('/api/runtime/messages:send', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...base, accountScopeFingerprint, requestHash }),
+    }, env);
+
+    expect(response.status).toBe(409);
+    expect(pushMessageWithReceipt).not.toHaveBeenCalled();
+  });
+
+  test('allows only the owner service credential to dispatch', async () => {
+    const db = new FakeDb();
+    const { app, env } = setup(db, 'staff');
+    const response = await app.request('/api/runtime/messages:send', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(await buildRequestBody()),
+    }, env);
+
+    expect(response.status).toBe(403);
+    expect(pushMessageWithReceipt).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/routes/runtime-messages.test.ts
+++ b/apps/worker/src/routes/runtime-messages.test.ts
@@ -202,6 +202,26 @@ beforeEach(() => {
 });
 
 describe('runtime message dispatch receipt contract', () => {
+  test('returns the opaque conversation account scope without provider identity', async () => {
+    const db = new FakeDb();
+    const { app, env } = setup(db);
+
+    const response = await app.request(
+      '/api/runtime/conversations/chat-1/account-scope',
+      undefined,
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      data: Record<string, unknown>;
+    };
+    expect(body.data.accountScopeFingerprint).toBe(await expectedFingerprint());
+    expect(body.data.conversationRef).toBe('chat-1');
+    expect(body.data).not.toHaveProperty('lineUserId');
+    expect(body.data).not.toHaveProperty('channelId');
+  });
+
   test('persists a provider receipt and returns it through readback', async () => {
     const db = new FakeDb();
     const { app, env } = setup(db);

--- a/apps/worker/src/routes/runtime-messages.ts
+++ b/apps/worker/src/routes/runtime-messages.ts
@@ -52,6 +52,7 @@ type RuntimeSendRequest = {
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const OPAQUE_REF_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 
 function validRequest(value: unknown): value is RuntimeSendRequest {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
@@ -65,8 +66,7 @@ function validRequest(value: unknown): value is RuntimeSendRequest {
     || typeof body.accountScopeFingerprint !== 'string'
     || !SHA256_PATTERN.test(body.accountScopeFingerprint)
     || typeof body.conversationRef !== 'string'
-    || body.conversationRef.length < 1
-    || body.conversationRef.length > 128
+    || !OPAQUE_REF_PATTERN.test(body.conversationRef)
     || !body.release
     || typeof body.release.version !== 'string'
     || typeof body.release.workerHash !== 'string'
@@ -183,6 +183,34 @@ async function buildReceiptHash(
 }
 
 export const runtimeMessages = new Hono<Env>();
+
+runtimeMessages.get('/api/runtime/conversations/:conversationRef/account-scope', async (c) => {
+  if (c.get('staff')?.role !== 'owner') {
+    return c.json({ success: false, error: 'Owner access required' }, 403);
+  }
+  const conversationRef = c.req.param('conversationRef');
+  if (!OPAQUE_REF_PATTERN.test(conversationRef)) {
+    return c.json({ success: false, error: 'Invalid conversation reference' }, 400);
+  }
+  const recipient = await resolveRecipient(c.env.DB, conversationRef);
+  if (!recipient) {
+    return c.json({ success: false, error: 'Conversation not found' }, 404);
+  }
+  return c.json({
+    success: true,
+    data: {
+      schemaVersion: 1,
+      conversationRef,
+      accountScopeFingerprint: await sha256(
+        recipient.account_channel_id ?? c.env.LINE_CHANNEL_ID,
+      ),
+      release: {
+        version: BUNDLE_VERSION,
+        workerHash: WORKER_HASH,
+      },
+    },
+  });
+});
 
 runtimeMessages.post('/api/runtime/messages:send', async (c) => {
   if (c.get('staff')?.role !== 'owner') {

--- a/apps/worker/src/routes/runtime-messages.ts
+++ b/apps/worker/src/routes/runtime-messages.ts
@@ -1,0 +1,360 @@
+import { Hono } from 'hono';
+import { LineClient, type LineProviderReceipt, type Message } from '@line-crm/line-sdk';
+import { BUNDLE_VERSION, WORKER_HASH } from '../_version.js';
+import type { Env } from '../index.js';
+
+type DispatchState =
+  | 'dispatching'
+  | 'provider_accepted'
+  | 'failed_terminal'
+  | 'reconciliation_required';
+
+type DispatchRow = {
+  client_request_id: string;
+  request_hash: string;
+  conversation_ref: string;
+  account_scope_fingerprint: string;
+  status: DispatchState;
+  release_version: string;
+  worker_hash: string;
+  provider_http_status: number | null;
+  provider_request_id: string | null;
+  accepted_request_id: string | null;
+  provider_message_ids: string | null;
+  receipt_hash: string | null;
+  dispatch_started_at: string | null;
+  provider_accepted_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type RecipientRow = {
+  chat_id: string;
+  friend_id: string;
+  line_user_id: string;
+  line_account_id: string | null;
+  account_channel_id: string | null;
+  channel_access_token: string | null;
+};
+
+type RuntimeSendRequest = {
+  schemaVersion: 1;
+  clientRequestId: string;
+  requestHash: string;
+  accountScopeFingerprint: string;
+  conversationRef: string;
+  messages: Array<{ type: 'text'; text: string }>;
+  release: {
+    version: string;
+    workerHash: string;
+  };
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+function validRequest(value: unknown): value is RuntimeSendRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const body = value as Partial<RuntimeSendRequest>;
+  if (
+    body.schemaVersion !== 1
+    || typeof body.clientRequestId !== 'string'
+    || !UUID_PATTERN.test(body.clientRequestId)
+    || typeof body.requestHash !== 'string'
+    || !SHA256_PATTERN.test(body.requestHash)
+    || typeof body.accountScopeFingerprint !== 'string'
+    || !SHA256_PATTERN.test(body.accountScopeFingerprint)
+    || typeof body.conversationRef !== 'string'
+    || body.conversationRef.length < 1
+    || body.conversationRef.length > 128
+    || !body.release
+    || typeof body.release.version !== 'string'
+    || typeof body.release.workerHash !== 'string'
+    || !Array.isArray(body.messages)
+    || body.messages.length < 1
+    || body.messages.length > 5
+  ) return false;
+
+  return body.messages.every((message) => (
+    message
+    && typeof message === 'object'
+    && !Array.isArray(message)
+    && message.type === 'text'
+    && typeof message.text === 'string'
+    && message.text.length >= 1
+    && message.text.length <= 5000
+    && Object.keys(message).every((key) => key === 'type' || key === 'text')
+  ));
+}
+
+async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  const hex = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+  return `sha256:${hex}`;
+}
+
+async function canonicalRequestHash(input: RuntimeSendRequest): Promise<string> {
+  return sha256(JSON.stringify({
+    schemaVersion: 1,
+    accountScopeFingerprint: input.accountScopeFingerprint,
+    conversationRef: input.conversationRef,
+    messages: input.messages,
+  }));
+}
+
+function parseProviderMessageIds(value: string | null): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function receiptProjection(row: DispatchRow, replayed: boolean) {
+  return {
+    schemaVersion: 1,
+    clientRequestId: row.client_request_id,
+    requestHash: row.request_hash,
+    state: row.status,
+    release: {
+      version: row.release_version,
+      workerHash: row.worker_hash,
+    },
+    accountScopeFingerprint: row.account_scope_fingerprint,
+    httpStatus: row.provider_http_status,
+    providerRequestId: row.provider_request_id,
+    acceptedRequestId: row.accepted_request_id,
+    providerMessageIds: parseProviderMessageIds(row.provider_message_ids),
+    receiptHash: row.receipt_hash,
+    dispatchStartedAt: row.dispatch_started_at,
+    providerAcceptedAt: row.provider_accepted_at,
+    replayed,
+  };
+}
+
+async function readDispatch(db: D1Database, clientRequestId: string) {
+  return db.prepare(
+    `SELECT client_request_id, request_hash, conversation_ref,
+            account_scope_fingerprint, status, release_version, worker_hash,
+            provider_http_status, provider_request_id, accepted_request_id,
+            provider_message_ids, receipt_hash, dispatch_started_at,
+            provider_accepted_at, created_at, updated_at
+       FROM provider_message_dispatches
+      WHERE client_request_id = ?`,
+  ).bind(clientRequestId).first<DispatchRow>();
+}
+
+async function resolveRecipient(db: D1Database, conversationRef: string) {
+  return db.prepare(
+    `SELECT c.id AS chat_id, f.id AS friend_id, f.line_user_id,
+            f.line_account_id, la.channel_id AS account_channel_id,
+            la.channel_access_token
+       FROM chats c
+       JOIN friends f ON f.id = c.friend_id
+       LEFT JOIN line_accounts la ON la.id = f.line_account_id
+      WHERE c.id = ?
+      LIMIT 1`,
+  ).bind(conversationRef).first<RecipientRow>();
+}
+
+async function buildReceiptHash(
+  input: RuntimeSendRequest,
+  receipt: LineProviderReceipt,
+  accountScopeFingerprint: string,
+): Promise<string> {
+  return sha256(JSON.stringify({
+    schemaVersion: 1,
+    clientRequestId: input.clientRequestId,
+    requestHash: input.requestHash,
+    accountScopeFingerprint,
+    releaseVersion: BUNDLE_VERSION,
+    workerHash: WORKER_HASH,
+    httpStatus: receipt.httpStatus,
+    providerRequestId: receipt.providerRequestId,
+    acceptedRequestId: receipt.acceptedRequestId,
+    providerMessageIds: receipt.providerMessageIds,
+  }));
+}
+
+export const runtimeMessages = new Hono<Env>();
+
+runtimeMessages.post('/api/runtime/messages:send', async (c) => {
+  if (c.get('staff')?.role !== 'owner') {
+    return c.json({ success: false, error: 'Owner access required' }, 403);
+  }
+
+  const contentLength = Number(c.req.header('content-length') ?? '0');
+  if (Number.isFinite(contentLength) && contentLength > 64 * 1024) {
+    return c.json({ success: false, error: 'Request body too large' }, 413);
+  }
+
+  let input: unknown;
+  try {
+    input = await c.req.json();
+  } catch {
+    return c.json({ success: false, error: 'Invalid JSON body' }, 400);
+  }
+  if (!validRequest(input)) {
+    return c.json({ success: false, error: 'Invalid runtime send request' }, 400);
+  }
+  if (
+    input.release.version !== BUNDLE_VERSION
+    || input.release.workerHash !== WORKER_HASH
+  ) {
+    return c.json({ success: false, error: 'Release identity mismatch' }, 409);
+  }
+  if (input.requestHash !== await canonicalRequestHash(input)) {
+    return c.json({ success: false, error: 'Request hash mismatch' }, 409);
+  }
+
+  const existing = await readDispatch(c.env.DB, input.clientRequestId);
+  if (existing) {
+    if (existing.request_hash !== input.requestHash) {
+      return c.json({ success: false, error: 'Request hash conflict' }, 409);
+    }
+    if (existing.status === 'provider_accepted') {
+      return c.json({ success: true, data: receiptProjection(existing, true) });
+    }
+    return c.json({
+      success: false,
+      error: 'Dispatch requires readback reconciliation',
+      data: receiptProjection(existing, true),
+    }, 409);
+  }
+
+  const recipient = await resolveRecipient(c.env.DB, input.conversationRef);
+  if (!recipient) {
+    return c.json({ success: false, error: 'Conversation not found' }, 404);
+  }
+  const accountScopeFingerprint = await sha256(
+    recipient.account_channel_id ?? c.env.LINE_CHANNEL_ID,
+  );
+  if (accountScopeFingerprint !== input.accountScopeFingerprint) {
+    return c.json({ success: false, error: 'Account scope mismatch' }, 409);
+  }
+
+  const now = new Date().toISOString();
+  try {
+    await c.env.DB.prepare(
+      `INSERT INTO provider_message_dispatches (
+         id, client_request_id, request_hash, conversation_ref, friend_id,
+         account_scope_fingerprint, status, release_version, worker_hash,
+         dispatch_started_at, created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, 'dispatching', ?, ?, ?, ?, ?)`,
+    ).bind(
+      crypto.randomUUID(),
+      input.clientRequestId,
+      input.requestHash,
+      input.conversationRef,
+      recipient.friend_id,
+      accountScopeFingerprint,
+      BUNDLE_VERSION,
+      WORKER_HASH,
+      now,
+      now,
+      now,
+    ).run();
+  } catch {
+    const concurrent = await readDispatch(c.env.DB, input.clientRequestId);
+    if (!concurrent || concurrent.request_hash !== input.requestHash) {
+      return c.json({ success: false, error: 'Request claim conflict' }, 409);
+    }
+    if (concurrent.status === 'provider_accepted') {
+      return c.json({ success: true, data: receiptProjection(concurrent, true) });
+    }
+    return c.json({
+      success: false,
+      error: 'Dispatch is already in progress; automatic resend is disabled',
+      data: receiptProjection(concurrent, true),
+    }, 409);
+  }
+
+  let receipt: LineProviderReceipt;
+  let receiptHash: string;
+  try {
+    const accessToken = recipient.channel_access_token ?? c.env.LINE_CHANNEL_ACCESS_TOKEN;
+    receipt = await new LineClient(accessToken).pushMessageWithReceipt(
+      recipient.line_user_id,
+      input.messages as Message[],
+      input.clientRequestId,
+    );
+    receiptHash = await buildReceiptHash(input, receipt, accountScopeFingerprint);
+    const acceptedAt = new Date().toISOString();
+    await c.env.DB.prepare(
+      `UPDATE provider_message_dispatches
+          SET status = 'provider_accepted', provider_http_status = ?,
+              provider_request_id = ?, accepted_request_id = ?,
+              provider_message_ids = ?, receipt_hash = ?,
+              provider_accepted_at = ?, updated_at = ?
+        WHERE client_request_id = ? AND status = 'dispatching'`,
+    ).bind(
+      receipt.httpStatus,
+      receipt.providerRequestId,
+      receipt.acceptedRequestId,
+      JSON.stringify(receipt.providerMessageIds),
+      receiptHash,
+      acceptedAt,
+      acceptedAt,
+      input.clientRequestId,
+    ).run();
+  } catch {
+    const failedAt = new Date().toISOString();
+    await c.env.DB.prepare(
+      `UPDATE provider_message_dispatches
+          SET status = 'reconciliation_required', updated_at = ?
+        WHERE client_request_id = ? AND status = 'dispatching'`,
+    ).bind(failedAt, input.clientRequestId).run();
+    return c.json({
+      success: false,
+      error: 'Provider result is unknown; automatic resend is disabled',
+    }, 502);
+  }
+
+  try {
+    const loggedAt = new Date().toISOString();
+    for (const message of input.messages) {
+      await c.env.DB.prepare(
+        `INSERT INTO messages_log (
+           id, friend_id, direction, message_type, content, delivery_type,
+           source, line_account_id, created_at
+         ) VALUES (?, ?, 'outgoing', 'text', ?, 'push', 'runtime', ?, ?)`,
+      ).bind(
+        crypto.randomUUID(),
+        recipient.friend_id,
+        message.text,
+        recipient.line_account_id,
+        loggedAt,
+      ).run();
+    }
+  } catch {
+    console.error('Runtime message was accepted but chat history mirroring failed');
+  }
+
+  const stored = await readDispatch(c.env.DB, input.clientRequestId);
+  if (!stored || stored.status !== 'provider_accepted') {
+    return c.json({
+      success: false,
+      error: 'Provider receipt readback failed; automatic resend is disabled',
+    }, 502);
+  }
+  return c.json({ success: true, data: receiptProjection(stored, false) });
+});
+
+runtimeMessages.get('/api/runtime/dispatches/:clientRequestId', async (c) => {
+  if (c.get('staff')?.role !== 'owner') {
+    return c.json({ success: false, error: 'Owner access required' }, 403);
+  }
+  const clientRequestId = c.req.param('clientRequestId');
+  if (!UUID_PATTERN.test(clientRequestId)) {
+    return c.json({ success: false, error: 'Invalid client request id' }, 400);
+  }
+  const row = await readDispatch(c.env.DB, clientRequestId);
+  if (!row) return c.json({ success: false, error: 'Dispatch not found' }, 404);
+  return c.json({ success: true, data: receiptProjection(row, true) });
+});

--- a/packages/db/bootstrap-meta.json
+++ b/packages/db/bootstrap-meta.json
@@ -55,7 +55,8 @@
     "046_link_tracking_controls.sql",
     "047_affiliate_offers.sql",
     "048_chats_friend_unique.sql",
-    "049_tracked_links_short_code.sql"
+    "049_tracked_links_short_code.sql",
+    "050_provider_message_dispatches.sql"
   ],
-  "migrationCount": 56
+  "migrationCount": 57
 }

--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -605,6 +605,29 @@ CREATE TABLE pool_accounts (
   UNIQUE(pool_id, line_account_id)
 );
 
+CREATE TABLE provider_message_dispatches (
+  id                        TEXT PRIMARY KEY,
+  client_request_id         TEXT NOT NULL UNIQUE,
+  request_hash              TEXT NOT NULL,
+  conversation_ref          TEXT NOT NULL,
+  friend_id                 TEXT NOT NULL REFERENCES friends(id),
+  account_scope_fingerprint TEXT NOT NULL,
+  status                    TEXT NOT NULL CHECK (
+    status IN ('dispatching', 'provider_accepted', 'failed_terminal', 'reconciliation_required')
+  ),
+  release_version           TEXT NOT NULL,
+  worker_hash               TEXT NOT NULL,
+  provider_http_status      INTEGER,
+  provider_request_id       TEXT,
+  accepted_request_id       TEXT,
+  provider_message_ids      TEXT,
+  receipt_hash              TEXT,
+  dispatch_started_at       TEXT,
+  provider_accepted_at      TEXT,
+  created_at                TEXT NOT NULL,
+  updated_at                TEXT NOT NULL
+);
+
 CREATE TABLE ref_tracking (
   id              TEXT PRIMARY KEY,
   ref_code        TEXT NOT NULL,
@@ -965,6 +988,12 @@ CREATE INDEX idx_messages_log_friend_source ON messages_log (friend_id, source);
 CREATE INDEX idx_notifications_created ON notifications (created_at);
 
 CREATE INDEX idx_notifications_status ON notifications (status);
+
+CREATE INDEX idx_provider_message_dispatches_conversation
+  ON provider_message_dispatches(conversation_ref, created_at);
+
+CREATE INDEX idx_provider_message_dispatches_status
+  ON provider_message_dispatches(status, updated_at);
 
 CREATE INDEX idx_ref_tracking_friend ON ref_tracking (friend_id);
 

--- a/packages/db/migrations/050_provider_message_dispatches.sql
+++ b/packages/db/migrations/050_provider_message_dispatches.sql
@@ -1,0 +1,36 @@
+-- Durable provider receipt ledger for idempotent runtime push messages.
+-- Provider identifiers stay inside the per-instance D1 database and are
+-- exposed only through the authenticated runtime readback endpoint.
+CREATE TABLE IF NOT EXISTS provider_message_dispatches (
+  id                        TEXT PRIMARY KEY,
+  client_request_id         TEXT NOT NULL UNIQUE,
+  request_hash              TEXT NOT NULL,
+  conversation_ref          TEXT NOT NULL,
+  friend_id                 TEXT NOT NULL REFERENCES friends(id),
+  account_scope_fingerprint TEXT NOT NULL,
+  status                    TEXT NOT NULL CHECK (
+    status IN (
+      'dispatching',
+      'provider_accepted',
+      'failed_terminal',
+      'reconciliation_required'
+    )
+  ),
+  release_version           TEXT NOT NULL,
+  worker_hash               TEXT NOT NULL,
+  provider_http_status      INTEGER,
+  provider_request_id       TEXT,
+  accepted_request_id       TEXT,
+  provider_message_ids      TEXT,
+  receipt_hash              TEXT,
+  dispatch_started_at       TEXT,
+  provider_accepted_at      TEXT,
+  created_at                TEXT NOT NULL,
+  updated_at                TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_message_dispatches_status
+  ON provider_message_dispatches(status, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_provider_message_dispatches_conversation
+  ON provider_message_dispatches(conversation_ref, created_at);

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -192,6 +192,37 @@ CREATE INDEX IF NOT EXISTS idx_messages_log_friend_source ON messages_log (frien
 CREATE INDEX IF NOT EXISTS idx_messages_log_friend_direction_created ON messages_log (friend_id, direction, created_at);
 
 -- ============================================================
+-- Provider Message Dispatches
+-- ============================================================
+CREATE TABLE IF NOT EXISTS provider_message_dispatches (
+  id                        TEXT PRIMARY KEY,
+  client_request_id         TEXT NOT NULL UNIQUE,
+  request_hash              TEXT NOT NULL,
+  conversation_ref          TEXT NOT NULL,
+  friend_id                 TEXT NOT NULL REFERENCES friends(id),
+  account_scope_fingerprint TEXT NOT NULL,
+  status                    TEXT NOT NULL CHECK (
+    status IN ('dispatching', 'provider_accepted', 'failed_terminal', 'reconciliation_required')
+  ),
+  release_version           TEXT NOT NULL,
+  worker_hash               TEXT NOT NULL,
+  provider_http_status      INTEGER,
+  provider_request_id       TEXT,
+  accepted_request_id       TEXT,
+  provider_message_ids      TEXT,
+  receipt_hash              TEXT,
+  dispatch_started_at       TEXT,
+  provider_accepted_at      TEXT,
+  created_at                TEXT NOT NULL,
+  updated_at                TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_provider_message_dispatches_status
+  ON provider_message_dispatches(status, updated_at);
+CREATE INDEX IF NOT EXISTS idx_provider_message_dispatches_conversation
+  ON provider_message_dispatches(conversation_ref, created_at);
+
+-- ============================================================
 -- Auto Replies
 -- ============================================================
 CREATE TABLE IF NOT EXISTS auto_replies (

--- a/packages/line-sdk/src/client.ts
+++ b/packages/line-sdk/src/client.ts
@@ -18,6 +18,13 @@ export interface FollowersInsight {
   blocks?: number;
 }
 
+export interface LineProviderReceipt {
+  httpStatus: 200 | 409;
+  providerRequestId: string;
+  acceptedRequestId: string | null;
+  providerMessageIds: string[];
+}
+
 export class LineClient {
   constructor(private readonly channelAccessToken: string) {}
 
@@ -79,6 +86,63 @@ export class LineClient {
     const body: PushMessageRequest = { to, messages };
     const { data } = await this.request('POST', '/v2/bot/message/push', body);
     return data;
+  }
+
+  /**
+   * Push a message with LINE's retry-key contract and retain the provider
+   * receipt required for durable readback. A 409 response is successful only
+   * when LINE proves the original request was accepted.
+   */
+  async pushMessageWithReceipt(
+    to: string,
+    messages: Message[],
+    retryKey: string,
+  ): Promise<LineProviderReceipt> {
+    const url = `${LINE_API_BASE}/v2/bot/message/push`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.channelAccessToken}`,
+        'X-Line-Retry-Key': retryKey,
+      },
+      body: JSON.stringify({ to, messages } satisfies PushMessageRequest),
+    });
+
+    const text = await res.text().catch(() => '');
+    let data: { sentMessages?: Array<{ id?: unknown }> } = {};
+    if (text) {
+      try {
+        data = JSON.parse(text) as typeof data;
+      } catch {
+        data = {};
+      }
+    }
+
+    if (res.status !== 200 && res.status !== 409) {
+      throw new Error(`LINE API error: ${res.status} ${res.statusText}`);
+    }
+
+    const providerRequestId = res.headers.get('x-line-request-id');
+    const acceptedRequestId = res.headers.get('x-line-accepted-request-id');
+    const providerMessageIds = (data.sentMessages ?? [])
+      .map((message) => message.id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+    if (
+      !providerRequestId
+      || providerMessageIds.length === 0
+      || (res.status === 409 && !acceptedRequestId)
+    ) {
+      throw new Error('LINE provider receipt is incomplete');
+    }
+
+    return {
+      httpStatus: res.status,
+      providerRequestId,
+      acceptedRequestId,
+      providerMessageIds,
+    };
   }
 
   async multicast(

--- a/packages/line-sdk/src/index.ts
+++ b/packages/line-sdk/src/index.ts
@@ -1,4 +1,5 @@
 export { LineClient } from './client.js';
+export type { LineProviderReceipt } from './client.js';
 export { verifySignature } from './webhook.js';
 export {
   textMessage,


### PR DESCRIPTION
## Summary
- add an owner-only idempotent runtime message send contract
- persist exact LINE provider receipt identifiers in D1
- expose a separate dispatch readback endpoint without automatic resend
- advertise immutable release identity and receipt capabilities
- align deployment manifest secret names with the Worker runtime

## Safety contract
- request hash and account-scope fingerprint are verified before dispatch
- a client request ID can be claimed only once
- unknown provider outcomes move to reconciliation_required
- duplicate or uncertain requests are never automatically resent
- receipt readback is distinct from render/dispatch acknowledgement

## Verification
- targeted worker tests: 33 passed, 0 failed
- line-sdk typecheck: passed
- worker typecheck: passed
- worker production build: passed
- generated D1 bootstrap consistency: passed
- git diff check: passed

A full worker-suite run on the pinned v0.17 compatibility branch reported 660 passed and 2 unrelated date-fixture failures in booking-admin.test.ts (the fixture date is now in the past).