### PR TITLE
feat(worker): auto-reply keyword match を NFKC 正規化して全角/半角ゆらぎを吸収

### DIFF
--- a/apps/worker/src/routes/webhook.test.ts
+++ b/apps/worker/src/routes/webhook.test.ts
@@ -44,6 +44,8 @@ vi.mock('../services/event-bus.js', () => ({
 vi.mock('../services/step-delivery.js', () => ({
   buildMessage: vi.fn(),
   expandVariables: vi.fn(),
+  resolveMetadata: vi.fn().mockResolvedValue({}),
+  messageToLogPayload: vi.fn().mockReturnValue({ messageType: 'text', content: 'logged' }),
 }));
 
 import { verifySignature } from '@line-crm/line-sdk';
@@ -295,5 +297,131 @@ describe('POST /webhook — first-contact existing friends', () => {
     expect(addTagToFriend).not.toHaveBeenCalled();
     expect(getEntryRouteByRefCode).not.toHaveBeenCalled();
     expect(getMessageTemplateById).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /webhook — auto-reply keyword NFKC normalization', () => {
+  const knownFriend = {
+    id: 'friend-1',
+    line_user_id: 'U-existing',
+    display_name: 'Existing Friend',
+    picture_url: null,
+    status_message: null,
+    is_following: 1,
+    user_id: null,
+    line_account_id: null,
+    metadata: '{}',
+    first_tracked_link_id: null,
+    created_at: '2026-06-18T12:00:00.000+09:00',
+    updated_at: '2026-06-18T12:00:00.000+09:00',
+  };
+
+  function setupDbWithAutoReply(rule: { keyword: string; match_type: 'exact' | 'contains' }) {
+    const genericStmt = {
+      bind: vi.fn(),
+      run: vi.fn().mockResolvedValue({}),
+      all: vi.fn().mockResolvedValue({ results: [] }),
+      first: vi.fn().mockResolvedValue(null),
+    };
+    genericStmt.bind.mockReturnValue(genericStmt);
+    const autoReplyStmt = {
+      bind: vi.fn(),
+      run: vi.fn().mockResolvedValue({}),
+      all: vi.fn().mockResolvedValue({
+        results: [
+          {
+            id: 'rule-1',
+            keyword: rule.keyword,
+            match_type: rule.match_type,
+            response_type: 'text',
+            response_content: 'ご予約はこちら',
+            template_id: null,
+            is_active: 1,
+            created_at: '2026-06-18T12:00:00.000+09:00',
+          },
+        ],
+      }),
+      first: vi.fn().mockResolvedValue(null),
+    };
+    autoReplyStmt.bind.mockReturnValue(autoReplyStmt);
+    const db = {
+      prepare: vi.fn().mockImplementation((sql: string) =>
+        sql.includes('FROM auto_replies') ? autoReplyStmt : genericStmt,
+      ),
+    } as unknown as D1Database;
+    return db;
+  }
+
+  async function postTextMessage(db: D1Database, text: string) {
+    vi.mocked(verifySignature).mockResolvedValue(true);
+    vi.mocked(getFriendByLineUserId).mockResolvedValue(knownFriend as never);
+    vi.mocked(jstNow).mockReturnValue('2026-06-18T12:00:00.000+09:00');
+
+    const executionCtx = {
+      waitUntil: vi.fn(),
+      passThroughOnException: vi.fn(),
+      props: {},
+    } as unknown as ExecutionContext;
+
+    const app = setupApp();
+    const validShapedSignature = 'A'.repeat(43) + '=';
+    const res = await app.request(
+      '/webhook',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Line-Signature': validShapedSignature,
+        },
+        body: JSON.stringify({
+          destination: 'bot',
+          events: [
+            {
+              type: 'message',
+              replyToken: 'reply-token',
+              message: { type: 'text', id: 'message-1', text },
+              timestamp: Date.now(),
+              source: { type: 'user', userId: 'U-existing' },
+              webhookEventId: 'event-1',
+              deliveryContext: { isRedelivery: false },
+              mode: 'active',
+            },
+          ],
+        }),
+      },
+      { ...baseEnv, DB: db },
+      executionCtx,
+    );
+    expect(res.status).toBe(200);
+    const processing = vi.mocked(executionCtx.waitUntil).mock.calls[0]?.[0] as Promise<unknown>;
+    await processing;
+  }
+
+  test('contains rule with half-width keyword matches full-width message text', async () => {
+    // 「0627」(半角) の包含ルールに「０６２７お願いします」(全角+後続文) がマッチする
+    const db = setupDbWithAutoReply({ keyword: '0627', match_type: 'contains' });
+    await postTextMessage(db, '０６２７お願いします');
+
+    expect(lineClientMocks.replyMessage).toHaveBeenCalledTimes(1);
+    // matched=true なので unread 化 (upsertChatOnMessage) は起きない
+    expect(upsertChatOnMessage).not.toHaveBeenCalled();
+  });
+
+  test('exact rule matches mixed-width text with surrounding whitespace', async () => {
+    // 「0627」(半角・完全一致) に「 06２７ 」(混在全角+前後空白) がマッチする
+    const db = setupDbWithAutoReply({ keyword: '0627', match_type: 'exact' });
+    await postTextMessage(db, ' 06２７ ');
+
+    expect(lineClientMocks.replyMessage).toHaveBeenCalledTimes(1);
+    expect(upsertChatOnMessage).not.toHaveBeenCalled();
+  });
+
+  test('exact rule still rejects text that merely contains the keyword', async () => {
+    // 正規化しても exact の意味は変えない: 「０６２７お願いします」は完全一致にはならない
+    const db = setupDbWithAutoReply({ keyword: '0627', match_type: 'exact' });
+    await postTextMessage(db, '０６２７お願いします');
+
+    expect(lineClientMocks.replyMessage).not.toHaveBeenCalled();
+    expect(upsertChatOnMessage).toHaveBeenCalledWith(db, 'friend-1');
   });
 });

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -578,11 +578,13 @@ async function handleEvent(
 
     let matched = false;
     let replyTokenConsumed = false;
+    const normalizedIncomingText = normalizeForKeywordMatch(incomingText);
     for (const rule of autoReplies.results) {
+      const normalizedKeyword = normalizeForKeywordMatch(rule.keyword);
       const isMatch =
         rule.match_type === 'exact'
-          ? incomingText === rule.keyword
-          : incomingText.includes(rule.keyword);
+          ? normalizedIncomingText === normalizedKeyword
+          : normalizedIncomingText.includes(normalizedKeyword);
 
       if (isMatch) {
         // silent タイプ: 返信しないが matched=true にして unread / push を抑止する
@@ -641,6 +643,16 @@ async function handleEvent(
 
     return;
   }
+}
+
+/**
+ * auto_replies の keyword マッチ用正規化。NFKC で全角英数字→半角・半角カナ→
+ * 全角に揃え、前後の空白を落とす。ユーザーが「０６２７」「062７」「0627 」の
+ * ように全角/半角ゆらぎで入力してもルール1本('0627')でマッチさせるため。
+ * postback data は開発者定義の機械的な値なので正規化しない(テキスト入力のみ)。
+ */
+function normalizeForKeywordMatch(s: string): string {
+  return s.normalize('NFKC').trim();
 }
 
 /**


### PR DESCRIPTION
## 背景

自動返信ルールのキーワードマッチが素の文字列比較 (`===` / `includes`) のため、ユーザーが全角数字や混在幅で入力するとマッチしません。

例: ルール `0627` (完全一致) に対して
- `０６２７` (全角) → マッチしない
- `06２７` (混在) → マッチしない
- `0627 ` (末尾空白) → マッチしない

実運用では、これを拾うために全角/半角の全組合せ (4文字で16ルール) を登録する羽目になり、管理画面のルール一覧も肥大化します (実例あり: 弊インスタンスで16ルール登録して回避中です)。

## 変更内容

テキストメッセージの auto_replies マッチ時に、受信テキストとルール keyword の双方を **NFKC 正規化 + trim** してから比較するようにしました。

- `normalizeForKeywordMatch()` ヘルパーを追加 (NFKC + trim)
- exact / contains の意味論は不変 (exact が包含に化けないことをテストで担保)
- **postback data のマッチは対象外** — 開発者定義の機械的な値のため正規化しない判断です (必要ならご指摘ください)
- automations (event-bus) の keyword 条件も同様の問題がありますが、スコープを絞るため本PRでは触れていません。方針が合えば follow-up を出せます

## テスト

`webhook.test.ts` に3ケース追加:
1. 包含ルール(半角keyword) × 全角メッセージ → マッチ
2. 完全一致ルール × 混在幅+前後空白 → マッチ
3. 完全一致ルール × キーワードを含むだけの文 → 従来どおり非マッチ

`apps/worker`: 695 tests passed / `tsc --noEmit` clean

## 互換性への影響

正規化により、これまでマッチしなかった入力がマッチするようになります (マッチ範囲は広がる方向のみ)。既存ルールの設定変更は不要です。半角カナ→全角カナも NFKC で同一視されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)