### PR TITLE
fix(auth): OAuth state のエンコードを UTF-8 対応にする(日本語 UTM で /auth/line が 500 になる問題の修正)

### DIFF
--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -29,6 +29,19 @@ import { notifyAffiliateFriendAdd } from '../services/affiliate-notifier.js';
 import { safeRedirectTarget } from '../lib/safe-redirect.js';
 import type { Env } from '../index.js';
 
+
+// OAuth state base64 helpers. btoa() only accepts Latin-1, so a single
+// multibyte query param (e.g. utm_campaign=夏キャンペーン) used to throw
+// InvalidCharacterError and turn the whole /auth/line request into a 500.
+// Encode via UTF-8 bytes instead. decodeState is byte-compatible with
+// states produced by the old plain btoa (ASCII-only payloads).
+function encodeState(state: string): string {
+  return btoa(String.fromCharCode(...new TextEncoder().encode(state)));
+}
+function decodeState(encoded: string): string {
+  return new TextDecoder().decode(Uint8Array.from(atob(encoded), (ch) => ch.charCodeAt(0)));
+}
+
 const liffRoutes = new Hono<Env>();
 
 // Persist ig_igsid on the LINE friend and notify IG Harness.
@@ -394,7 +407,7 @@ liffRoutes.get('/auth/line', async (c) => {
   // Without these, the form falls back to the gateId baked into the form's
   // onSubmitWebhookUrl (which is stale when a form is reused across campaigns).
   const state = JSON.stringify({ ref, redirect, form: formId, gate: gateParam, xh: xhParam2, gclid, fbclid, twclid, ttclid, utmSource, utmMedium, utmCampaign, account: accountParam || poolAccount, uid: uidParam, ig: igParam, iga: igaParam, igan: iganParam });
-  const encodedState = btoa(state);
+  const encodedState = encodeState(state);
   const loginUrl = new URL('https://access.line.me/oauth2/v2.1/authorize');
   loginUrl.searchParams.set('response_type', 'code');
   loginUrl.searchParams.set('client_id', channelId);
@@ -553,7 +566,7 @@ liffRoutes.get('/auth/oauth', async (c) => {
     account: accountParam || poolAccount, uid: uidParam, ig: igParam,
     iga: igaParam, igan: iganParam,
   });
-  const encodedState = btoa(state);
+  const encodedState = encodeState(state);
   const loginUrl = new URL('https://access.line.me/oauth2/v2.1/authorize');
   loginUrl.searchParams.set('response_type', 'code');
   loginUrl.searchParams.set('client_id', channelId);
@@ -594,7 +607,7 @@ liffRoutes.get('/auth/callback', async (c) => {
   let igaParam = '';
   let iganParam = '';
   try {
-    const parsed = JSON.parse(atob(stateParam));
+    const parsed = JSON.parse(decodeState(stateParam));
     ref = parsed.ref || '';
     redirect = parsed.redirect || '';
     formId = parsed.form || '';


### PR DESCRIPTION
Closes #235

## 問題

`/auth/line` と `/auth/oauth` の OAuth state 生成が `btoa(JSON.stringify(state))` で、`btoa` は Latin-1 前提のため、日本語などマルチバイトのクエリパラメータ(例: `utm_campaign=夏キャンペーン`)が 1 つでもあると `InvalidCharacterError` で 500 になります。state 生成は分岐前に無条件実行されるため、そのクリックの流入が丸ごと失われます。再現手順は #235。

## 変更内容(最小構成)

- `apps/worker/src/routes/liff.ts` — `encodeState()` / `decodeState()` ヘルパーを追加(TextEncoder/TextDecoder で UTF-8 バイト列を base64 化)。encode 2 箇所(`/auth/line`, `/auth/oauth`)と decode 1 箇所(`/auth/callback`)を置換

後方互換: ASCII のみの state は旧 `btoa` と同一のバイト列になるため、**デプロイまたぎで旧形式の state が `/auth/callback` に返ってきてもデコード互換**です。

## 実行した検証

```
pnpm --filter worker typecheck   # パス
pnpm --filter worker test        # 63ファイル/692件パス
```

手元のフォーク環境(Cloudflare Workers 本番相当)で `?utm_content=テスト`(URL エンコード済み日本語)付きの `/auth/line` が 500 にならず正常応答することを確認済み。

## 未検証

- LINE OAuth の実ログイン往復(state が access.line.me を経由して callback に戻る経路)は、手元環境では ASCII state でのみ実機確認。マルチバイト state の往復は base64url 安全な文字集合のみを出力するため理論上問題ありませんが、実機往復は未実施です

🤖 Generated with [Claude Code](https://claude.com/claude-code)