### PR TITLE
fix(ci): build update-engine in admin deploy and watch its paths

### DIFF
--- a/.github/workflows/deploy-cloudflare-admin.yml
+++ b/.github/workflows/deploy-cloudflare-admin.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'apps/web/**'
       - 'packages/shared/**'
+      - 'packages/update-engine/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-cloudflare-admin.yml'
@@ -26,7 +27,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm --filter @line-crm/shared build
+      - run: pnpm --filter @line-crm/shared --filter @line-harness/update-engine build
 
       - name: Capture build metadata
         id: build-meta

--- a/.github/workflows/deploy-cloudflare-worker.yml
+++ b/.github/workflows/deploy-cloudflare-worker.yml
@@ -10,6 +10,7 @@ on:
       - 'packages/db/**'
       - 'packages/shared/**'
       - 'packages/line-sdk/**'
+      - 'packages/update-engine/**'
       - '.github/workflows/deploy-cloudflare-worker.yml'
 
 jobs:


### PR DESCRIPTION
## Summary

- Problem: `Deploy Cloudflare Admin` fails on a fresh CI checkout with `Module not found: Can't resolve '@line-harness/update-engine/pure'` — the workflow only built `@line-crm/shared` before `pnpm --filter web build`, but `apps/web/src/lib/update-client.ts` value-imports `@line-harness/update-engine/pure` since v0.17. Additionally, neither deploy workflow watched `packages/update-engine/**`, so releases touching only update-engine left the admin panel and worker undeployed with stale logic.
- Solution: build `@line-harness/update-engine` alongside `@line-crm/shared` (same approach as the worker-side fix in #164), and add `packages/update-engine/**` to the `paths` filters of both deploy workflows (matching `worker-ci.yml`, which already watches it).
- What changed: `.github/workflows/deploy-cloudflare-admin.yml` (build step + paths), `.github/workflows/deploy-cloudflare-worker.yml` (paths only).
- What did NOT change: build steps of the worker workflow (already fixed in #164), any application code.

Supersedes #167 (same build fix, closed unmerged) and additionally covers the paths-filter gap. Reported by a downstream fork user running v0.18.1 who confirmed both fixes make push-triggered admin deploys pass.

## Related Issue

Relates to #164, supersedes #167

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Security hardening
- [ ] Documentation
- [ ] Tests only
- [x] Chore / infra
- [ ] Private sync

## Scope

- [ ] Admin web UI
- [ ] Worker API
- [ ] LINE webhook / postback / reply token
- [ ] Broadcast / multicast / step delivery / reminders
- [ ] Auth / API keys / cookies / CORS / staff permissions
- [ ] D1 schema / migrations / account scoping
- [ ] SDK / MCP / create-line-harness CLI
- [x] Cloudflare deploy / release / update workflow
- [ ] Docs only

## Verification

- Commands: `grep` confirmed `apps/web`'s only workspace deps are `@line-crm/shared` and `@line-harness/update-engine` (and update-engine itself has no workspace deps), so the two explicit filters cover the full dependency closure of `web`.
- Manual checks: compared against `worker-ci.yml` (already watches `packages/update-engine/**`) and the merged #164 build-step style.
- Not tested: no live Cloudflare deploy from this repo (deploy jobs are gated off on `Shudesu/line-harness-oss`); a downstream fork on v0.18.1 confirmed the same two changes make the admin deploy pass.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Message sending behavior changed? No
- Customer/friend data access changed? No
- D1 migration or data deletion changed? No

## Safety Checklist

- [x] This PR is focused on one problem and contains no unrelated commits.
- [x] I searched for existing issues/PRs to avoid duplicates.
- [x] No secrets, tokens, customer data, friend IDs, private URLs, or private configuration are included.
- [x] No generated build output, `.tsbuildinfo`, local env files, or formatting-only churn is included.
- [x] Docs or tests were updated when useful.
- [x] Deployment impact is understood.
- [x] For high-risk areas, I included a clear rollback or recovery note.
- [x] I personally verified the behavior described above.

## Rollback / Recovery

Revert this commit. Worst case is the previous behavior: admin deploys fail on fresh checkouts and update-engine-only pushes don't trigger deploys — no runtime impact on already-deployed instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)