### PR TITLE
fix(broadcasts): test-send returns 500 when WORKER_URL is unset

### DIFF
--- a/apps/worker/src/routes/broadcasts-test-send.test.ts
+++ b/apps/worker/src/routes/broadcasts-test-send.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const pushMessage = vi.fn();
+
+vi.mock('@line-crm/line-sdk', () => ({
+  LineClient: vi.fn().mockImplementation(() => ({ pushMessage })),
+}));
+
+const BROADCAST = {
+  id: 'broadcast-1',
+  title: 'test',
+  message_type: 'text',
+  message_content: 'ご案内です https://example.com/lp',
+  target_type: 'all',
+  target_tag_id: null,
+  status: 'draft',
+  scheduled_at: null,
+  sent_at: null,
+  total_count: 0,
+  success_count: 0,
+  created_at: '2026-01-01T00:00:00+09:00',
+  line_account_id: 'account-1',
+  alt_text: null,
+  track_links: 1,
+};
+
+vi.mock('@line-crm/db', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getBroadcastById: vi.fn(async () => BROADCAST),
+  getLineAccountById: vi.fn(async () => ({
+    id: 'account-1',
+    channel_access_token: 'token',
+    is_active: 1,
+  })),
+  getOrCreateAutoTrackedLink: vi.fn(async () => ({ id: 'link-1', short_code: 'AbC1234' })),
+  getTrackedLinkBaseUrl: vi.fn(async () => null),
+}));
+
+const { broadcasts } = await import('./broadcasts.js');
+
+/**
+ * Minimal D1 stub: test-send only needs the `account_settings` lookup
+ * (test recipients), the `friends` lookup, and the `messages_log` insert.
+ */
+function makeDb(): D1Database {
+  return {
+    prepare(sql: string) {
+      const stmt = {
+        bind: () => stmt,
+        first: async () =>
+          sql.includes('account_settings') ? { value: JSON.stringify(['friend-1']) } : null,
+        all: async () => ({ results: [{ id: 'friend-1', line_user_id: 'U-line-1' }] }),
+        run: async () => ({ success: true }),
+      };
+      return stmt;
+    },
+  } as unknown as D1Database;
+}
+
+function setupApp() {
+  const app = new Hono();
+  app.route('/', broadcasts as unknown as Hono);
+  return app;
+}
+
+describe('POST /api/broadcasts/:id/test-send', () => {
+  beforeEach(() => {
+    pushMessage.mockReset();
+    pushMessage.mockResolvedValue(undefined);
+  });
+
+  test('sends when WORKER_URL is configured', async () => {
+    const res = await setupApp().request(
+      'http://worker.example.com/api/broadcasts/broadcast-1/test-send',
+      { method: 'POST' },
+      { DB: makeDb(), WORKER_URL: 'https://worker.example.com' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, sent: 1, failed: 0 });
+  });
+
+  // Regression: WORKER_URL is absent from the wrangler.toml template, so installs
+  // that never set it hit `workerUrl.replace(...)` on undefined inside
+  // autoTrackContent and test-send answers 500 — while the real send path stays
+  // quiet because it guards with `if (workerUrl && ...)`.
+  test('still sends when WORKER_URL is unset (falls back to the request origin)', async () => {
+    const res = await setupApp().request(
+      'http://worker.example.com/api/broadcasts/broadcast-1/test-send',
+      { method: 'POST' },
+      { DB: makeDb() },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, sent: 1, failed: 0 });
+    expect(pushMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/worker/src/routes/broadcasts.ts
+++ b/apps/worker/src/routes/broadcasts.ts
@@ -844,10 +844,17 @@ broadcasts.post('/api/broadcasts/:id/test-send', async (c) => {
     }
 
     // Auto-track URLs (track_links=0 なら本番送信と同様に短縮せず raw のまま)
+    // WORKER_URL が未設定でも request origin にフォールバックする。API route を
+    // 処理している時点で origin は Worker 自身なので同じ値になる。素で渡すと
+    // autoTrackContent 内の `workerUrl.replace(...)` が undefined で TypeError に
+    // なり、test-send だけが 500 で死ぬ (本番送信側は processBroadcastSend の
+    // `if (workerUrl && ...)` で守られている)。DM 送信 (routes/friends.ts) は
+    // 既にこのフォールバックを使っているので、そちらに揃える。
+    const trackWorkerUrl = c.env.WORKER_URL || new URL(c.req.url).origin;
     let tracked = { messageType: broadcast.message_type as string, content: messageContent };
     if (broadcast.track_links !== 0) {
       const { autoTrackContent } = await import('../services/auto-track.js');
-      tracked = await autoTrackContent(c.env.DB, broadcast.message_type, messageContent, c.env.WORKER_URL, {
+      tracked = await autoTrackContent(c.env.DB, broadcast.message_type, messageContent, trackWorkerUrl, {
         lineAccountId: accountId,
       });
     }

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -40,6 +40,10 @@ crons = ["* * * * *", "0 */6 * * *"]
 # 不活性になる (本番挙動を変えないための判断, 2026-07-07)。
 # ═══════════════════════════════════════════════════════════════
 [vars]
+# Worker 自身の公開 URL。Env 型では必須 (WORKER_URL: string) で、短縮リンク /t/、
+# LIFF、フォーム、予約通知、画像 proxy が参照する。未設定のままだと
+# test-send が 500 になるため、デプロイ先の URL に書き換えて使う。
+WORKER_URL = "https://line-harness.workers.dev"
 WORKER_NAME = "line-harness"
 ADMIN_PAGES_PROJECT = "line-harness-admin"
 LIFF_PAGES_PROJECT = "line-harness-liff"


### PR DESCRIPTION
## Summary

- **Problem**: `POST /api/broadcasts/:id/test-send` returns 500 on any install that has not manually set `WORKER_URL`. The variable is required by the Worker `Env` type (`WORKER_URL: string`) but is absent from the `[vars]` block of `apps/worker/wrangler.toml`, so `env.WORKER_URL` is `undefined` and `autoTrackContent()` throws `TypeError: Cannot read properties of undefined (reading 'replace')`.
- **Solution**: fall back to the request origin, exactly as `POST /api/friends/:id/message` already does. While an API route is being handled, the origin *is* the Worker's own URL, so tracked links keep working instead of being dropped. Also add `WORKER_URL` to the `[vars]` template so new installs set it deliberately rather than discovering it through a 500.
- **What changed**: one fallback expression in the test-send handler, one template variable, and a regression test.
- **What did NOT change**: the real send paths. `processBroadcastSend`, `processQueuedBroadcasts` and `processStepDeliveries` already guard with `if (workerUrl && ...)`, and their behaviour is untouched.

### Why this is worth fixing rather than documenting

Every other `autoTrackContent()` caller is already protected — test-send is the only one that is not:

| Caller | Guard |
|---|---|
| `processBroadcastSend` / `processQueuedBroadcasts` | `if (workerUrl && broadcast.track_links !== 0)` |
| `processStepDeliveries` | `if (workerUrl)` |
| `POST /api/friends/:id/message` | `c.env.WORKER_URL \|\| new URL(c.req.url).origin` |
| `POST /api/broadcasts/:id/test-send` | none — passes `c.env.WORKER_URL` straight through |

The asymmetry is what makes it costly in practice: the scheduled send silently skips tracking and delivers fine, while the preview of that same broadcast answers 500. From the dashboard it looks like the broadcast itself is broken, so an operator cannot verify a broadcast that would in fact deliver.

## Related Issue

N/A — found while preparing a broadcast on a self-hosted install.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Security hardening
- [ ] Documentation
- [ ] Tests only
- [ ] Chore / infra
- [ ] Private sync

## Scope

- [ ] Admin web UI
- [x] Worker API
- [ ] LINE webhook / postback / reply token
- [x] Broadcast / multicast / step delivery / reminders
- [ ] Auth / API keys / cookies / CORS / staff permissions
- [ ] D1 schema / migrations / account scoping
- [ ] SDK / MCP / create-line-harness CLI
- [x] Cloudflare deploy / release / update workflow
- [ ] Docs only

## Verification

- **Commands**: `npx tsc --noEmit` (clean) and `npx vitest run` in `apps/worker` — 71 files / 816 tests passing, including the new `src/routes/broadcasts-test-send.test.ts`.
- **Manual checks**: reproduced on a live Cloudflare Workers deployment. A draft broadcast whose content held a URL with `track_links = 1` returned `{"success":false,"error":"Internal server error"}` from test-send; the same draft with `track_links = 0` returned `{"sent":1,"failed":0}`. After defining `WORKER_URL` the tracking path succeeded and `/t/<code>` redirected correctly and incremented `click_count`.
- **Screenshots/logs**: the regression test asserts the failure directly — on `main` it fails with `expected 500 to be 200`, and the underlying stack is `TypeError: Cannot read properties of undefined (reading 'replace')` at `auto-track.ts` `workerUrl.replace(/\/$/, '')`.
- **Not tested**: no admin UI change, so nothing to check there.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — the same tracked-link creation as when `WORKER_URL` is set; only the base URL source changed.
- Message sending behavior changed? `Yes` — test-send now succeeds where it previously 500'd, and its URLs are wrapped as tracked links. This matches what the real send does when `WORKER_URL` is set. Test-send only reaches the configured test recipients, so blast radius is unchanged.
- Customer/friend data access changed? `No`
- D1 migration or data deletion changed? `No`

## Safety Checklist

- [x] This PR is focused on one problem and contains no unrelated commits.
- [x] I searched for existing issues/PRs to avoid duplicates.
- [x] No secrets, tokens, customer data, friend IDs, private URLs, or private configuration are included.
- [x] No generated build output, `.tsbuildinfo`, local env files, or formatting-only churn is included.
- [x] Docs or tests were updated when useful.
- [x] Deployment impact is understood.
- [x] For high-risk areas, I included a clear rollback or recovery note.
- [x] I personally verified the behavior described above.

## Rollback / Recovery

Revert the commit. There is no schema or data change, so a redeploy of the previous Worker version restores the old behaviour exactly. Installs that already set `WORKER_URL` are unaffected either way, since the fallback only applies when it is empty.
