### PR TITLE
feat(broadcasts): send LINE imagemap (rich message) from image broadcasts

### DIFF
--- a/apps/worker/src/services/broadcast.test.ts
+++ b/apps/worker/src/services/broadcast.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildMessage } from './broadcast.js';
+
+describe('buildMessage', () => {
+  test('text は素通し', () => {
+    expect(buildMessage('text', 'こんにちは')).toEqual({ type: 'text', text: 'こんにちは' });
+  });
+
+  test('image payload は従来どおり image message になる', () => {
+    const content = JSON.stringify({
+      originalContentUrl: 'https://example.com/a.jpg',
+      previewImageUrl: 'https://example.com/a-preview.jpg',
+    });
+    expect(buildMessage('image', content)).toEqual({
+      type: 'image',
+      originalContentUrl: 'https://example.com/a.jpg',
+      previewImageUrl: 'https://example.com/a-preview.jpg',
+    });
+  });
+
+  test('baseUrl + baseSize を持つ image payload は imagemap になる', () => {
+    const content = JSON.stringify({
+      baseUrl: 'https://example.com/img/campaign',
+      baseSize: { width: 1040, height: 1040 },
+      actions: [
+        {
+          type: 'uri',
+          linkUri: 'https://example.com/lp',
+          area: { x: 0, y: 0, width: 1040, height: 1040 },
+        },
+      ],
+    });
+
+    expect(buildMessage('image', content, 'キャンペーンのお知らせ')).toEqual({
+      type: 'imagemap',
+      baseUrl: 'https://example.com/img/campaign',
+      altText: 'キャンペーンのお知らせ',
+      baseSize: { width: 1040, height: 1040 },
+      actions: [
+        {
+          type: 'uri',
+          linkUri: 'https://example.com/lp',
+          area: { x: 0, y: 0, width: 1040, height: 1040 },
+        },
+      ],
+    });
+  });
+
+  test('imagemap の altText は 引数 → payload → 既定値 の順に決まる', () => {
+    const base = { baseUrl: 'https://example.com/img/x', baseSize: { width: 1040, height: 520 } };
+
+    expect(buildMessage('image', JSON.stringify({ ...base, altText: 'payload 側' }))).toMatchObject({
+      altText: 'payload 側',
+    });
+    expect(
+      buildMessage('image', JSON.stringify({ ...base, altText: 'payload 側' }), '引数側'),
+    ).toMatchObject({ altText: '引数側' });
+    expect(buildMessage('image', JSON.stringify(base))).toMatchObject({ altText: 'お知らせ' });
+  });
+
+  test('actions 未指定の imagemap は空配列になる', () => {
+    const content = JSON.stringify({
+      baseUrl: 'https://example.com/img/x',
+      baseSize: { width: 1040, height: 1040 },
+    });
+    expect(buildMessage('image', content)).toMatchObject({ type: 'imagemap', actions: [] });
+  });
+
+  test('baseSize が欠けていれば imagemap 扱いしない', () => {
+    // baseUrl だけの payload を imagemap にすると LINE 側で 400 になるため、
+    // 従来の image 分岐に落とす (後方互換)。
+    const content = JSON.stringify({
+      baseUrl: 'https://example.com/img/x',
+      originalContentUrl: 'https://example.com/a.jpg',
+      previewImageUrl: 'https://example.com/a.jpg',
+    });
+    expect(buildMessage('image', content)).toMatchObject({ type: 'image' });
+  });
+
+  test('baseSize の width/height が数値でなければ imagemap 扱いしない', () => {
+    const content = JSON.stringify({
+      baseUrl: 'https://example.com/img/x',
+      baseSize: { width: '1040', height: '1040' },
+      originalContentUrl: 'https://example.com/a.jpg',
+      previewImageUrl: 'https://example.com/a.jpg',
+    });
+    expect(buildMessage('image', content)).toMatchObject({ type: 'image' });
+  });
+
+  test('壊れた JSON は text にフォールバックする', () => {
+    expect(buildMessage('image', 'not json')).toEqual({ type: 'text', text: 'not json' });
+  });
+
+  test('flex の altText は本文の先頭テキストから拾う', () => {
+    const content = JSON.stringify({
+      type: 'bubble',
+      body: { type: 'box', layout: 'vertical', contents: [{ type: 'text', text: '本文の先頭' }] },
+    });
+    expect(buildMessage('flex', content)).toMatchObject({ type: 'flex', altText: '本文の先頭' });
+  });
+});

--- a/apps/worker/src/services/broadcast.ts
+++ b/apps/worker/src/services/broadcast.ts
@@ -423,6 +423,51 @@ async function processQueuedBroadcastBatches(
   await updateBroadcastStatus(db, broadcast.id, 'sent');
 }
 
+/**
+ * imagemap (LINE 公式アカウントマネージャーでいう「リッチメッセージ」) の payload か
+ * どうかを message_content の形で判定する。
+ *
+ * 専用の message_type を足さないのは意図的:
+ * `broadcasts.message_type` は CHECK (message_type IN ('text','image','flex')) で
+ * 固定されていて、SQLite/D1 で CHECK を変えるにはテーブル再作成 = DROP TABLE +
+ * ALTER TABLE ... RENAME TO が必要になる。どちらも additive-only のマイグレーション
+ * 方針 (scripts/check-migrations.ts) で禁止されている。'image' のまま payload の形で
+ * 分岐すれば、マイグレーションも既存行の移行もなしで済む。
+ *
+ * 画像メッセージの payload は { originalContentUrl, previewImageUrl }、imagemap は
+ * { baseUrl, baseSize } なのでキーが衝突せず、後方互換に判別できる。
+ */
+function isImagemapContent(parsed: Record<string, unknown>): boolean {
+  const baseSize = parsed.baseSize as { width?: unknown; height?: unknown } | undefined;
+  return (
+    typeof parsed.baseUrl === 'string' &&
+    parsed.baseUrl.length > 0 &&
+    typeof baseSize === 'object' &&
+    baseSize !== null &&
+    typeof baseSize.width === 'number' &&
+    typeof baseSize.height === 'number'
+  );
+}
+
+/**
+ * imagemap payload を LINE の imagemap message に変換する。
+ *
+ * baseUrl は拡張子を含まないプレフィックスで、LINE 側が `{baseUrl}/240` のように
+ * 幅 (240 / 300 / 460 / 700 / 1040) を足して取得する。配信側はその 5 サイズを
+ * image/jpeg か image/png で返せる場所に置いておく必要がある。
+ */
+function toImagemapMessage(parsed: Record<string, unknown>, altText?: string): Message {
+  const actions = Array.isArray(parsed.actions) ? (parsed.actions as Record<string, unknown>[]) : [];
+  return {
+    type: 'imagemap',
+    baseUrl: parsed.baseUrl as string,
+    // altText は LINE の必須項目。未指定なら flex と同じ既定値に揃える。
+    altText: altText || (typeof parsed.altText === 'string' ? parsed.altText : '') || 'お知らせ',
+    baseSize: parsed.baseSize as { width: number; height: number },
+    actions,
+  };
+}
+
 export function buildMessage(messageType: string, messageContent: string, altText?: string): Message {
   if (messageType === 'text') {
     return { type: 'text', text: messageContent };
@@ -430,15 +475,13 @@ export function buildMessage(messageType: string, messageContent: string, altTex
 
   if (messageType === 'image') {
     try {
-      const parsed = JSON.parse(messageContent) as {
+      const parsed = JSON.parse(messageContent) as Record<string, unknown>;
+      if (isImagemapContent(parsed)) return toImagemapMessage(parsed, altText);
+      const { originalContentUrl, previewImageUrl } = parsed as unknown as {
         originalContentUrl: string;
         previewImageUrl: string;
       };
-      return {
-        type: 'image',
-        originalContentUrl: parsed.originalContentUrl,
-        previewImageUrl: parsed.previewImageUrl,
-      };
+      return { type: 'image', originalContentUrl, previewImageUrl };
     } catch {
       return { type: 'text', text: messageContent };
     }

--- a/docs/wiki/Broadcasts.md
+++ b/docs/wiki/Broadcasts.md
@@ -12,7 +12,7 @@
 |--------|-----|------|
 | `id` | TEXT (UUID) | 主キー |
 | `title` | TEXT | 配信タイトル（管理用） |
-| `message_type` | TEXT | `text` / `image` / `flex` |
+| `message_type` | TEXT | `text` / `image` / `flex`（`image` は payload の形で imagemap も送れる。[imagemap 配信](#imagemap-配信リッチメッセージ)参照） |
 | `message_content` | TEXT | メッセージ内容 |
 | `target_type` | TEXT | `all` / `tag` |
 | `target_tag_id` | TEXT | tag 指定時のタグID |
@@ -270,12 +270,49 @@ curl -X POST "https://your-worker.your-subdomain.workers.dev/api/broadcasts" \
   }'
 ```
 
+### imagemap 配信（リッチメッセージ）
+
+LINE 公式アカウントマネージャーの「リッチメッセージ」にあたる形式です。吹き出しもアカウントアイコンも出ない全幅表示になり、画像そのものをタップ領域にできます。
+
+`messageType` は `image` のままで、`messageContent` が `baseUrl` と `baseSize` を持っていれば imagemap として送信されます。専用の `messageType` を足していないのは、`broadcasts.message_type` の CHECK 制約を変えるにはテーブル再作成が必要で、additive-only のマイグレーション方針（`scripts/check-migrations.ts`）に反するためです。従来の画像配信 payload（`originalContentUrl` / `previewImageUrl`）とはキーが衝突しないため、後方互換です。
+
+```bash
+curl -X POST "https://your-worker.your-subdomain.workers.dev/api/broadcasts" \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "キャンペーン告知",
+    "messageType": "image",
+    "messageContent": "{\"baseUrl\":\"https://example.com/img/campaign\",\"baseSize\":{\"width\":1040,\"height\":1040},\"actions\":[{\"type\":\"uri\",\"linkUri\":\"https://example.com/lp\",\"area\":{\"x\":0,\"y\":0,\"width\":1040,\"height\":1040}}]}",
+    "targetType": "all",
+    "altText": "キャンペーンのお知らせ"
+  }'
+```
+
+| フィールド | 説明 |
+|-----------|------|
+| `baseUrl` | 拡張子を含まない画像 URL のプレフィックス |
+| `baseSize` | `{ width, height }`。`width` は 1040 固定 |
+| `actions` | タップ領域。座標は `baseSize` の座標系。省略時は空配列（タップ不可） |
+
+`altText` は通知バナーとトーク一覧に出る文字で、LINE の必須項目です。broadcast の `altText` フィールド、payload 内の `altText`、既定値 `お知らせ` の順に採用されます。
+
+**画像の置き方**: LINE は `{baseUrl}/240` のように幅を足して取りに来るため、**240 / 300 / 460 / 700 / 1040 の 5 サイズを拡張子なしのファイル名**で配置し、`image/jpeg` か `image/png` の Content-Type で返す必要があります。拡張子が無いと静的ホスティングによっては `application/octet-stream` になり、LINE 側で表示されません。
+
+```
+https://example.com/img/campaign/240
+https://example.com/img/campaign/300
+https://example.com/img/campaign/460
+https://example.com/img/campaign/700
+https://example.com/img/campaign/1040
+```
+
 リクエストボディ:
 
 | フィールド | 型 | 必須 | 説明 |
 |-----------|-----|------|------|
 | `title` | string | 必須 | 管理用タイトル |
-| `messageType` | string | 必須 | `text` / `image` / `flex` |
+| `messageType` | string | 必須 | `text` / `image` / `flex`（`image` は payload の形で imagemap も送れる。[imagemap 配信](#imagemap-配信リッチメッセージ)参照） |
 | `messageContent` | string | 必須 | メッセージ内容 |
 | `targetType` | string | 必須 | `all` / `tag` |
 | `targetTagId` | string | 条件付き | targetType=tag の場合必須 |


### PR DESCRIPTION
## Summary

- **Problem**: Harness cannot send a LINE imagemap — what the LINE Official Account Manager calls a「リッチメッセージ」. That is the full-width format with no bubble and no account icon, where the image itself is the tap target. Operators migrating from the official console expect it, and neither existing type reproduces it: `image` sends a plain image message (LINE image messages carry no action at all, so it cannot link anywhere) and `flex` always renders inside a bubble with the account icon.
- **Solution**: `buildMessage()` emits an imagemap when an `image` broadcast's `message_content` carries `baseUrl` plus a numeric `baseSize`.
- **What changed**: the `image` branch of `buildMessage()`, a new unit-test file for `buildMessage` (it had none), and a section in `docs/wiki/Broadcasts.md`.
- **What did NOT change**: existing image broadcasts, all other message types, the DB schema, and the delivery paths. No migration.

### Why not a dedicated `messageType: 'imagemap'`

`broadcasts.message_type` is pinned by `CHECK (message_type IN ('text','image','flex'))`. Changing a CHECK constraint in SQLite/D1 means recreating the table — `DROP TABLE` plus `ALTER TABLE ... RENAME TO` — and both are forbidden for new migrations by the additive-only policy in `scripts/check-migrations.ts`. Discriminating on the payload shape needs no migration, no backfill, and no table rewrite on live operator data.

The two payloads cannot collide, so this stays backward compatible:

| Message | Payload keys |
|---|---|
| image | `originalContentUrl`, `previewImageUrl` |
| imagemap | `baseUrl`, `baseSize` |

The shape check requires `baseSize.width` and `baseSize.height` to be numbers, so a half-written payload falls through to the existing image branch rather than being sent as an imagemap that LINE would reject with a 400.

`altText` resolution mirrors the flex branch: argument, then payload, then the existing `お知らせ` default.

If you would rather expose this as a first-class `messageType` and are willing to take the table rebuild, I am happy to rework it — I chose the payload-shape route specifically to respect the migration policy.

## Related Issue

N/A — happy to open one first if you would prefer to discuss the direction before code, per CONTRIBUTING.

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Security hardening
- [ ] Documentation
- [ ] Tests only
- [ ] Chore / infra
- [ ] Private sync

## Scope

- [ ] Admin web UI
- [x] Worker API
- [ ] LINE webhook / postback / reply token
- [x] Broadcast / multicast / step delivery / reminders
- [ ] Auth / API keys / cookies / CORS / staff permissions
- [ ] D1 schema / migrations / account scoping
- [ ] SDK / MCP / create-line-harness CLI
- [ ] Cloudflare deploy / release / update workflow
- [ ] Docs only

Note: no admin UI is included. The feature is API-only in this PR to keep the diff reviewable; a form control can follow separately if you want it in the dashboard.

## Verification

- **Commands**: `npx tsc --noEmit` (clean) and `npx vitest run` in `apps/worker` — 71 files / 823 tests passing, including the new `src/services/broadcast.test.ts` (9 tests).
- **Manual checks**: sent on a live Cloudflare Workers deployment against a real LINE Messaging API channel. The imagemap arrived full-width with no bubble and no account icon, and tapping anywhere on the image opened the linked URL. The same account's existing `flex` and `text` broadcasts were unaffected.
- **Screenshots/logs**: not attached — the only screenshots available are from a client's production account and contain customer-visible content.
- **Not tested**: no admin UI change, so nothing to check there.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same LINE send path, different message body.
- Message sending behavior changed? `Yes` — an `image` broadcast whose payload carries `baseUrl` + numeric `baseSize` now delivers as an imagemap instead of an image message. No stored broadcast can be affected unless it already holds those keys, which the existing image path never wrote.
- Customer/friend data access changed? `No`
- D1 migration or data deletion changed? `No`

## Safety Checklist

- [x] This PR is focused on one problem and contains no unrelated commits.
- [x] I searched for existing issues/PRs to avoid duplicates.
- [x] No secrets, tokens, customer data, friend IDs, private URLs, or private configuration are included.
- [x] No generated build output, `.tsbuildinfo`, local env files, or formatting-only churn is included.
- [x] Docs or tests were updated when useful.
- [x] Deployment impact is understood.
- [x] For high-risk areas, I included a clear rollback or recovery note.
- [x] I personally verified the behavior described above.

## Rollback / Recovery

Revert the commit. There is no schema or data change, so a redeploy of the previous Worker version restores the old behaviour. A broadcast created with an imagemap payload would then be sent through the old image branch with `originalContentUrl`/`previewImageUrl` undefined and be rejected by LINE — so on rollback, delete or rewrite any imagemap drafts.

### Operator note

LINE fetches `{baseUrl}/240`, `/300`, `/460`, `/700` and `/1040`, so all five widths must be served under extensionless names with an `image/jpeg` or `image/png` Content-Type. On static hosts an extensionless file is often served as `application/octet-stream`, and LINE then renders nothing. This is documented in the new section of `docs/wiki/Broadcasts.md`.
