### PR TITLE
Add LICENSE file (MIT, same text as ig-harness-oss / x-harness-oss)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shudesu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Adds a top-level `LICENSE` file containing the MIT License text.

The README states "MIT License. 商用利用・改変・再配布自由." in several places, but this
repository currently has no `LICENSE` file, so GitHub reports `license: null` for it and the
license badge/detection does not work.

The sibling projects already ship this file:

| Repository | LICENSE file | GitHub detection |
| --- | --- | --- |
| `ig-harness-oss` | present | MIT |
| `x-harness-oss` | present | MIT |
| `the-harness-oss` | present | MIT |
| `line-harness-oss` (this repo) | **missing** | none |

## What this changes

The added text is **byte-for-byte identical** to the `LICENSE` already used in
`ig-harness-oss` and `x-harness-oss`, including the copyright line
(`Copyright (c) 2026 Shudesu`). Nothing else is modified — no code, docs, or configuration.

## Why it helps

- GitHub, package managers and license scanners can detect the license automatically
- Users evaluating the project for business use can confirm the terms from the repository itself
- Brings this repository in line with the other Harness projects

If the intended license for this repository differs from the sibling projects, please feel free
to close this PR — happy to adjust to whatever you prefer.

Thanks for building and maintaining Harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
