### PR TITLE
sync: auto-webinar full feature set (CTA cards, registrations, reminders, iOS fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist-mcp/
 *.toml.bak
 .env.production
 .env.staging
+# Wrangler local secrets — matches apps/worker/.dev.vars and any other worker's copy at any depth
+.dev.vars
+.dev.vars.*
 apps/web/out/
 apps/worker/dist/
 .worktrees/

--- a/apps/web/src/app/webinars/edit/page.tsx
+++ b/apps/web/src/app/webinars/edit/page.tsx
@@ -2,10 +2,13 @@
 
 import { Suspense, useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
 import Header from '@/components/layout/header'
 import WebinarForm from '@/components/webinars/webinar-form'
 import {
+  fetchApi,
   webinarApi,
+  type WebinarCtaCard,
   type Webinar,
   type WebinarSakuraComment,
   type WebinarAnalytics,
@@ -13,12 +16,15 @@ import {
 } from '@/lib/api'
 
 function fmtSec(sec: number): string {
-  const h = Math.floor(sec / 3600)
-  const m = Math.floor((sec % 3600) / 60)
-  const s = sec % 60
+  // 負 = 開始前 (待機ルーム) の相対時刻。-330 → -5:30
+  const sign = sec < 0 ? '-' : ''
+  const abs = Math.abs(sec)
+  const h = Math.floor(abs / 3600)
+  const m = Math.floor((abs % 3600) / 60)
+  const s = abs % 60
   return h > 0
-    ? `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-    : `${m}:${String(s).padStart(2, '0')}`
+    ? `${sign}${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+    : `${sign}${m}:${String(s).padStart(2, '0')}`
 }
 
 function fmtSession(epoch: number): string {
@@ -67,7 +73,8 @@ function CommentsTab({ webinarId }: { webinarId: string }) {
     if (typeof raw !== 'object' || raw === null) return 'オブジェクトではありません'
     const rec = raw as Record<string, unknown>
     const atSeconds = Math.floor(Number(rec.atSeconds))
-    if (!Number.isFinite(atSeconds) || atSeconds < 0) return 'atSeconds が不正です'
+    // 負の atSeconds = 開始前 (待機ルーム) コメント。サーバーと同じく -3600 まで許容
+    if (!Number.isFinite(atSeconds) || atSeconds < -3600) return 'atSeconds が不正です (-3600〜)'
     const authorName = typeof rec.authorName === 'string' ? rec.authorName.trim() : ''
     if (!authorName) return 'authorName が空です'
     if (authorName.length > 50) return 'authorName が50字を超えています'
@@ -197,99 +204,550 @@ function CommentsTab({ webinarId }: { webinarId: string }) {
   )
 }
 
-function AnalyticsTab({ webinarId }: { webinarId: string }) {
+function percent(value: number, total: number): string {
+  return total > 0 ? `${Math.round((value / total) * 100)}%` : '—'
+}
+
+function compactDateTime(value: string): string {
+  return new Date(value).toLocaleString('ja-JP', {
+    month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  })
+}
+
+function ParticipantAvatar({
+  name,
+  pictureUrl,
+  size = 'md',
+}: {
+  name: string
+  pictureUrl: string | null
+  size?: 'sm' | 'md' | 'lg'
+}) {
+  const sizeClass = size === 'lg' ? 'h-11 w-11 text-sm' : size === 'sm' ? 'h-7 w-7 text-[10px]' : 'h-9 w-9 text-xs'
+  if (pictureUrl) {
+    return (
+      <img
+        src={pictureUrl}
+        alt=""
+        className={`${sizeClass} shrink-0 rounded-full bg-slate-100 object-cover ring-2 ring-white`}
+      />
+    )
+  }
+  return (
+    <span className={`${sizeClass} flex shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-100 to-indigo-100 font-bold text-blue-700 ring-2 ring-white`}>
+      {name.trim().charAt(0) || '?'}
+    </span>
+  )
+}
+
+function AnalyticsTab({ webinarId, durationSeconds }: { webinarId: string; durationSeconds: number }) {
   const [analytics, setAnalytics] = useState<WebinarAnalytics | null>(null)
   const [userComments, setUserComments] = useState<WebinarUserComment[]>([])
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    webinarApi.analytics(webinarId).then((res) => setAnalytics(res.data))
-    webinarApi.userComments(webinarId).then((res) => setUserComments(res.data))
+    setError(null)
+    Promise.all([webinarApi.analytics(webinarId), webinarApi.userComments(webinarId)])
+      .then(([analyticsRes, commentsRes]) => {
+        setAnalytics(analyticsRes.data)
+        setUserComments(commentsRes.data)
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)))
   }, [webinarId])
 
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-200 bg-red-50 p-5 text-sm text-red-700">
+        分析データを読み込めませんでした。ページを再読み込みしてください。
+      </div>
+    )
+  }
   if (!analytics) return <div className="text-gray-500 text-sm">読み込み中...</div>
 
+  const { summary } = analytics
   const maxDropoff = Math.max(1, ...analytics.dropoff.map((d) => d.viewers))
+  const daily = analytics.daily.slice(-14)
+  const maxDaily = Math.max(
+    1,
+    ...daily.flatMap((d) => [d.reservations, d.viewers, d.ctaClicks, d.formSubmissions]),
+  )
+  const recentParticipants = analytics.participants.slice(0, 16)
+  const funnel = [
+    { label: '参加', value: summary.viewers, color: 'bg-blue-500', note: 'ユニーク' },
+    { label: '5分視聴', value: summary.watched5m, color: 'bg-cyan-500', note: percent(summary.watched5m, summary.viewers) },
+    { label: 'CTAクリック', value: summary.ctaClicks, color: 'bg-violet-500', note: percent(summary.ctaClicks, summary.viewers) },
+    { label: 'フォーム送信', value: summary.formSubmissions, color: 'bg-emerald-500', note: percent(summary.formSubmissions, summary.viewers) },
+  ]
+  const metricCards = [
+    {
+      label: 'ユニーク参加者',
+      value: summary.viewers.toLocaleString('ja-JP'),
+      detail: `予約 ${summary.reservations.toLocaleString('ja-JP')}人`,
+      tone: 'from-blue-50 to-white border-blue-100',
+      dot: 'bg-blue-500',
+    },
+    {
+      label: '予約者の参加率',
+      value: percent(summary.registeredAndJoined, summary.reservations),
+      detail: `${summary.registeredAndJoined.toLocaleString('ja-JP')} / ${summary.reservations.toLocaleString('ja-JP')}人`,
+      tone: 'from-cyan-50 to-white border-cyan-100',
+      dot: 'bg-cyan-500',
+    },
+    {
+      label: '90%以上視聴',
+      value: percent(summary.completed, summary.viewers),
+      detail: `${summary.completed.toLocaleString('ja-JP')}人・平均 ${fmtSec(summary.avgWatchedSeconds)}`,
+      tone: 'from-violet-50 to-white border-violet-100',
+      dot: 'bg-violet-500',
+    },
+    {
+      label: 'フォーム送信',
+      value: summary.formSubmissions.toLocaleString('ja-JP'),
+      detail: `CTAから ${percent(summary.formSubmissions, summary.ctaClicks)}`,
+      tone: 'from-emerald-50 to-white border-emerald-100',
+      dot: 'bg-emerald-500',
+    },
+  ]
 
   return (
-    <div className="space-y-8">
-      <section>
-        <h3 className="mb-2 font-semibold text-gray-900">セッション別</h3>
-        {analytics.sessions.length === 0 ? (
-          <p className="text-sm text-gray-500">まだ視聴データがありません</p>
-        ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-gray-200 text-left text-gray-500">
-                <th className="py-1 font-medium">開始日時</th>
-                <th className="font-medium">参加者</th>
-                <th className="font-medium">平均視聴</th>
-                <th className="font-medium">CTAクリック</th>
-                <th className="font-medium">CTR</th>
-              </tr>
-            </thead>
-            <tbody>
-              {analytics.sessions.map((s) => (
-                <tr key={s.sessionStartAt} className="border-b border-gray-100">
-                  <td className="py-1">{fmtSession(s.sessionStartAt)}</td>
-                  <td>{s.viewers}</td>
-                  <td>{fmtSec(s.avgWatchedSeconds)}</td>
-                  <td>{s.ctaClicks}</td>
-                  <td>{s.viewers > 0 ? `${Math.round((s.ctaClicks / s.viewers) * 100)}%` : '-'}</td>
-                </tr>
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-blue-600">Performance overview</p>
+          <h2 className="mt-1 text-xl font-bold tracking-tight text-slate-950">参加の流れをひと目で確認</h2>
+          <p className="mt-1 text-sm text-slate-500">再入場や複数回参加は、同じ友だちとしてまとめています。</p>
+        </div>
+        {analytics.participants.length > 0 && (
+          <div className="flex items-center gap-3 rounded-full border border-slate-200 bg-white px-3 py-2 shadow-sm">
+            <div className="flex -space-x-2">
+              {analytics.participants.slice(0, 5).map((p) => (
+                <ParticipantAvatar
+                  key={p.friendId}
+                  name={p.friendName ?? '友だち'}
+                  pictureUrl={p.pictureUrl}
+                  size="sm"
+                />
               ))}
-            </tbody>
-          </table>
-        )}
-      </section>
-      <section>
-        <h3 className="mb-2 font-semibold text-gray-900">離脱位置分布（最終視聴位置・10分刻み）</h3>
-        {analytics.dropoff.length === 0 ? (
-          <p className="text-sm text-gray-500">まだ視聴データがありません</p>
-        ) : (
-          analytics.dropoff.map((d) => (
-            <div key={d.bucketStart} className="mb-1 flex items-center gap-2 text-xs">
-              <span className="w-16 shrink-0 text-gray-500">{fmtSec(d.bucketStart)}〜</span>
-              <div className="h-4 bg-blue-500 rounded" style={{ width: `${(d.viewers / maxDropoff) * 100}%` }} />
-              <span>{d.viewers}</span>
             </div>
-          ))
+            <span className="text-xs font-medium text-slate-600">最近の参加者</span>
+          </div>
         )}
+      </div>
+
+      <section className="grid grid-cols-2 gap-3 xl:grid-cols-4">
+        {metricCards.map((metric) => (
+          <div key={metric.label} className={`rounded-2xl border bg-gradient-to-br p-4 ${metric.tone}`}>
+            <div className="flex items-center gap-2 text-xs font-semibold text-slate-500">
+              <span className={`h-2 w-2 rounded-full ${metric.dot}`} />
+              {metric.label}
+            </div>
+            <div className="mt-3 text-3xl font-bold tracking-tight text-slate-950">{metric.value}</div>
+            <div className="mt-1 text-xs text-slate-500">{metric.detail}</div>
+          </div>
+        ))}
       </section>
-      <section>
-        <h3 className="mb-2 font-semibold text-gray-900">視聴者コメント</h3>
-        {userComments.length === 0 ? (
-          <p className="text-sm text-gray-500">まだコメントがありません</p>
-        ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-gray-200 text-left text-gray-500">
-                <th className="py-1 font-medium">友だち</th>
-                <th className="font-medium">位置</th>
-                <th className="font-medium">本文</th>
-                <th className="font-medium">セッション</th>
-              </tr>
-            </thead>
-            <tbody>
-              {userComments.map((c) => (
-                <tr key={c.id} className="border-b border-gray-100">
-                  <td className="py-1">{c.friendName ?? c.friendId.slice(0, 8)}</td>
-                  <td>{fmtSec(c.atSeconds)}</td>
-                  <td>{c.body}</td>
-                  <td className="text-gray-500">{fmtSession(c.sessionStartAt)}</td>
-                </tr>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)]">
+        <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h3 className="font-bold text-slate-900">参加ファネル</h3>
+              <p className="mt-1 text-xs text-slate-500">どこで人数が減っているか</p>
+            </div>
+            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-medium text-slate-600">全期間</span>
+          </div>
+          <div className="mt-5 space-y-4">
+            {funnel.map((stage) => (
+              <div key={stage.label}>
+                <div className="mb-1.5 flex items-center justify-between text-xs">
+                  <span className="font-medium text-slate-700">{stage.label}</span>
+                  <span className="text-slate-500"><strong className="text-slate-900">{stage.value}</strong>人 · {stage.note}</span>
+                </div>
+                <div className="h-2.5 overflow-hidden rounded-full bg-slate-100">
+                  <div
+                    className={`h-full rounded-full ${stage.color}`}
+                    style={{ width: `${Math.max(stage.value > 0 ? 3 : 0, (stage.value / Math.max(1, summary.viewers)) * 100)}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-5 grid grid-cols-2 gap-3 border-t border-slate-100 pt-4">
+            <div>
+              <div className="text-[11px] text-slate-500">15分以上視聴</div>
+              <div className="mt-1 text-lg font-bold text-slate-900">{summary.watched15m}人</div>
+            </div>
+            <div>
+              <div className="text-[11px] text-slate-500">CTA → フォーム</div>
+              <div className="mt-1 text-lg font-bold text-slate-900">{percent(summary.formSubmissions, summary.ctaClicks)}</div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h3 className="font-bold text-slate-900">日別の参加ペース</h3>
+              <p className="mt-1 text-xs text-slate-500">直近14日・日ごとのユニーク人数</p>
+            </div>
+            <div className="flex flex-wrap gap-3 text-[11px] text-slate-500">
+              <span className="flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-slate-300" />予約</span>
+              <span className="flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-blue-500" />参加</span>
+              <span className="flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-violet-500" />CTA</span>
+              <span className="flex items-center gap-1"><i className="h-2 w-2 rounded-full bg-emerald-500" />フォーム</span>
+            </div>
+          </div>
+          {daily.length === 0 ? (
+            <div className="flex h-52 items-center justify-center text-sm text-slate-400">まだ日別データがありません</div>
+          ) : (
+            <div className="mt-5 flex h-52 items-end gap-2 overflow-x-auto border-b border-slate-200 pb-7">
+              {daily.map((day) => (
+                <div key={day.date} className="relative flex h-full min-w-10 flex-1 items-end justify-center gap-0.5" title={`${day.date} 予約${day.reservations}・参加${day.viewers}・CTA${day.ctaClicks}・フォーム${day.formSubmissions}`}>
+                  <div className="w-2 rounded-t bg-slate-300" style={{ height: `${Math.max(day.reservations > 0 ? 3 : 0, (day.reservations / maxDaily) * 100)}%` }} />
+                  <div className="w-2 rounded-t bg-blue-500" style={{ height: `${Math.max(day.viewers > 0 ? 3 : 0, (day.viewers / maxDaily) * 100)}%` }} />
+                  <div className="w-2 rounded-t bg-violet-500" style={{ height: `${Math.max(day.ctaClicks > 0 ? 3 : 0, (day.ctaClicks / maxDaily) * 100)}%` }} />
+                  <div className="w-2 rounded-t bg-emerald-500" style={{ height: `${Math.max(day.formSubmissions > 0 ? 3 : 0, (day.formSubmissions / maxDaily) * 100)}%` }} />
+                  <span className="absolute -bottom-6 whitespace-nowrap text-[10px] text-slate-400">
+                    {new Date(`${day.date}T00:00:00+09:00`).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' })}
+                  </span>
+                </div>
               ))}
-            </tbody>
-          </table>
+            </div>
+          )}
+        </section>
+      </div>
+
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="flex flex-col gap-3 border-b border-slate-100 p-5 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="font-bold text-slate-900">最近の参加者</h3>
+            <p className="mt-1 text-xs text-slate-500">顔写真・視聴状況・フォーム到達を友だち単位で表示</p>
+          </div>
+          <span className="text-xs text-slate-500">全 {analytics.participants.length.toLocaleString('ja-JP')}人</span>
+        </div>
+        {recentParticipants.length === 0 ? (
+          <div className="p-10 text-center text-sm text-slate-400">まだ参加者がいません</div>
+        ) : (
+          <>
+            <div className="hidden overflow-x-auto md:block">
+              <table className="w-full min-w-[760px] text-sm">
+                <thead>
+                  <tr className="bg-slate-50/80 text-left text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+                    <th className="px-5 py-3">参加者</th>
+                    <th className="px-4 py-3">最終参加</th>
+                    <th className="px-4 py-3">視聴</th>
+                    <th className="px-4 py-3">アクション</th>
+                    <th className="px-5 py-3 text-right">詳細</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {recentParticipants.map((p) => {
+                    const name = p.friendName ?? `友だち ${p.friendId.slice(0, 6)}`
+                    const watchedRate = Math.min(100, Math.round((p.maxWatchedSeconds / Math.max(1, durationSeconds)) * 100))
+                    return (
+                      <tr key={p.friendId} className="hover:bg-blue-50/30">
+                        <td className="px-5 py-3.5">
+                          <div className="flex items-center gap-3">
+                            <ParticipantAvatar name={name} pictureUrl={p.pictureUrl} size="lg" />
+                            <div className="min-w-0">
+                              <div className="max-w-48 truncate font-semibold text-slate-900">{name}</div>
+                              <div className="mt-0.5 text-[11px] text-slate-400">{p.sessions > 1 ? `${p.sessions}回参加` : p.registered ? '予約から参加' : '直接参加'}</div>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3.5 text-xs text-slate-600">{compactDateTime(p.latestJoinedAt)}</td>
+                        <td className="w-48 px-4 py-3.5">
+                          <div className="flex items-center justify-between text-[11px] text-slate-500">
+                            <span>{fmtSec(p.maxWatchedSeconds)}</span><span>{watchedRate}%</span>
+                          </div>
+                          <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-slate-100">
+                            <div className="h-full rounded-full bg-blue-500" style={{ width: `${watchedRate}%` }} />
+                          </div>
+                        </td>
+                        <td className="px-4 py-3.5">
+                          <div className="flex flex-wrap gap-1.5">
+                            {p.formSubmittedAt ? (
+                              <span className="rounded-full bg-emerald-50 px-2 py-1 text-[10px] font-semibold text-emerald-700">フォーム送信</span>
+                            ) : p.ctaClickedAt ? (
+                              <span className="rounded-full bg-violet-50 px-2 py-1 text-[10px] font-semibold text-violet-700">CTAクリック</span>
+                            ) : (
+                              <span className="rounded-full bg-slate-100 px-2 py-1 text-[10px] font-medium text-slate-500">視聴のみ</span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-5 py-3.5 text-right">
+                          <Link href={`/chats?friend=${p.friendId}`} className="text-xs font-semibold text-blue-600 hover:text-blue-700">チャットを見る →</Link>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+            <div className="divide-y divide-slate-100 md:hidden">
+              {recentParticipants.map((p) => {
+                const name = p.friendName ?? `友だち ${p.friendId.slice(0, 6)}`
+                return (
+                  <Link key={p.friendId} href={`/chats?friend=${p.friendId}`} className="flex items-center gap-3 p-4 active:bg-slate-50">
+                    <ParticipantAvatar name={name} pictureUrl={p.pictureUrl} size="lg" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-semibold text-slate-900">{name}</div>
+                      <div className="mt-1 text-[11px] text-slate-500">{compactDateTime(p.latestJoinedAt)} · {fmtSec(p.maxWatchedSeconds)}視聴</div>
+                    </div>
+                    <span className={`h-2.5 w-2.5 rounded-full ${p.formSubmittedAt ? 'bg-emerald-500' : p.ctaClickedAt ? 'bg-violet-500' : 'bg-slate-300'}`} />
+                  </Link>
+                )
+              })}
+            </div>
+          </>
         )}
       </section>
+
+      <details className="group overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-5">
+          <div>
+            <h3 className="font-bold text-slate-900">視聴維持・回別の詳細</h3>
+            <p className="mt-1 text-xs text-slate-500">必要なときだけ、離脱位置と各回の数字を確認</p>
+          </div>
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600 group-open:bg-blue-50 group-open:text-blue-700">{analytics.sessions.length}回 ▾</span>
+        </summary>
+        <div className="grid gap-6 border-t border-slate-100 p-5 xl:grid-cols-2">
+          <div>
+            <h4 className="mb-3 text-sm font-semibold text-slate-800">最終視聴位置</h4>
+            {analytics.dropoff.length === 0 ? (
+              <p className="text-sm text-slate-400">まだ視聴データがありません</p>
+            ) : analytics.dropoff.map((d) => (
+              <div key={d.bucketStart} className="mb-2 flex items-center gap-2 text-xs">
+                <span className="w-16 shrink-0 text-slate-500">{fmtSec(d.bucketStart)}〜</span>
+                <div className="h-2.5 flex-1 overflow-hidden rounded-full bg-slate-100">
+                  <div className="h-full rounded-full bg-blue-500" style={{ width: `${(d.viewers / maxDropoff) * 100}%` }} />
+                </div>
+                <span className="w-7 text-right font-semibold text-slate-700">{d.viewers}</span>
+              </div>
+            ))}
+          </div>
+          <div className="min-w-0">
+            <h4 className="mb-3 text-sm font-semibold text-slate-800">直近の開催回</h4>
+            <div className="max-h-80 overflow-auto rounded-xl border border-slate-200">
+              <table className="w-full min-w-[520px] text-xs">
+                <thead className="sticky top-0 bg-slate-50 text-left text-slate-500">
+                  <tr><th className="px-3 py-2 font-medium">開始</th><th className="font-medium">参加</th><th className="font-medium">平均視聴</th><th className="font-medium">CTA</th></tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {analytics.sessions.slice(0, 30).map((s) => (
+                    <tr key={s.sessionStartAt}><td className="px-3 py-2 text-slate-700">{fmtSession(s.sessionStartAt)}</td><td>{s.viewers}</td><td>{fmtSec(s.avgWatchedSeconds)}</td><td>{s.ctaClicks} ({percent(s.ctaClicks, s.viewers)})</td></tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </details>
+
+      {userComments.length > 0 && (
+        <details className="group overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <summary className="flex cursor-pointer list-none items-center justify-between p-5">
+            <div><h3 className="font-bold text-slate-900">視聴者コメント</h3><p className="mt-1 text-xs text-slate-500">実際に届いたコメントを参加者の顔と一緒に確認</p></div>
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-600">{userComments.length}件 ▾</span>
+          </summary>
+          <div className="grid gap-3 border-t border-slate-100 p-5 md:grid-cols-2">
+            {userComments.map((c) => {
+              const name = c.friendName ?? `友だち ${c.friendId.slice(0, 6)}`
+              return (
+                <Link key={c.id} href={`/chats?friend=${c.friendId}`} className="flex gap-3 rounded-xl border border-slate-100 bg-slate-50/60 p-3 hover:border-blue-200 hover:bg-blue-50/40">
+                  <ParticipantAvatar name={name} pictureUrl={c.pictureUrl} />
+                  <div className="min-w-0"><div className="flex flex-wrap items-center gap-2"><span className="text-xs font-semibold text-slate-800">{name}</span><span className="text-[10px] text-slate-400">{fmtSec(c.atSeconds)}</span></div><p className="mt-1 text-sm leading-6 text-slate-700">{c.body}</p></div>
+                </Link>
+              )
+            })}
+          </div>
+        </details>
+      )}
+    </div>
+  )
+}
+
+function fmtMinSec(sec: number): string {
+  return `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, '0')}`
+}
+
+function parseMinSec(v: string): number | null {
+  const m = /^(\d+):([0-5]?\d)$/.exec(v.trim())
+  if (m) return Number(m[1]) * 60 + Number(m[2])
+  const n = Number(v.trim())
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : null
+}
+
+function CtasTab({ webinarId }: { webinarId: string }) {
+  const [ctas, setCtas] = useState<WebinarCtaCard[]>([])
+  const [forms, setForms] = useState<Array<{ id: string; name: string }>>([])
+  const [times, setTimes] = useState<string[]>([])
+  const [message, setMessage] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    // ロード失敗時に空の状態で保存すると all-or-nothing 置換で既存 CTA を消して
+    // しまうため、初回 GET が成功するまで保存を無効化する
+    webinarApi
+      .ctas(webinarId)
+      .then((res) => {
+        setCtas(res.data)
+        setTimes(res.data.map((c) => fmtMinSec(c.atSeconds)))
+        setLoaded(true)
+      })
+      .catch(() => setMessage('CTAカードの読み込みに失敗しました。リロードしてください。'))
+    fetchApi<{ success: boolean; data: Array<{ id: string; name: string }> }>('/api/forms')
+      .then((res) => setForms(res.data.map((f) => ({ id: f.id, name: f.name }))))
+      .catch(() => undefined)
+  }, [webinarId])
+
+  const update = (i: number, patch: Partial<WebinarCtaCard>) =>
+    setCtas((prev) => prev.map((c, j) => (j === i ? { ...c, ...patch } : c)))
+
+  const save = async () => {
+    setMessage(null)
+    const merged: WebinarCtaCard[] = []
+    for (let i = 0; i < ctas.length; i++) {
+      const at = parseMinSec(times[i] ?? '')
+      if (at === null) {
+        setMessage(`${i + 1}行目の表示時間が不正です（例: 45:00 または秒数）`)
+        return
+      }
+      merged.push({ ...ctas[i], atSeconds: at })
+    }
+    setSaving(true)
+    try {
+      const sorted = [...merged].sort((a, b) => a.atSeconds - b.atSeconds)
+      await webinarApi.saveCtas(webinarId, sorted)
+      setCtas(sorted)
+      setTimes(sorted.map((c) => fmtMinSec(c.atSeconds)))
+      setMessage(`${sorted.length}件保存しました`)
+    } catch (err) {
+      setMessage(`保存に失敗しました: ${(err as Error).message}`)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-500">
+        指定時間にチャット欄へ CTA カードが流れます。「フォーム」はウェビナー内でそのまま回答でき、
+        フォーム機能のタグ付与・シナリオ発火が自動で動きます。「URL」は外部ページを開きます。
+      </p>
+      {message && <p className="rounded bg-blue-50 p-2 text-sm">{message}</p>}
+      {ctas.map((c, i) => (
+        <div key={i} className="space-y-2 rounded border border-gray-200 p-3">
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <label className="flex items-center gap-1">
+              表示時間
+              <input
+                value={times[i] ?? ''}
+                onChange={(e) =>
+                  setTimes((prev) => prev.map((t, j) => (j === i ? e.target.value : t)))
+                }
+                placeholder="45:00"
+                className="w-20 rounded border px-2 py-1"
+              />
+            </label>
+            <select
+              value={c.kind}
+              onChange={(e) => update(i, { kind: e.target.value as 'form' | 'url' })}
+              className="rounded border px-2 py-1"
+            >
+              <option value="form">フォーム</option>
+              <option value="url">URL</option>
+            </select>
+            {c.kind === 'form' ? (
+              <select
+                value={c.formId ?? ''}
+                onChange={(e) => update(i, { formId: e.target.value || null })}
+                className="min-w-40 rounded border px-2 py-1"
+              >
+                <option value="">フォームを選択...</option>
+                {forms.map((f) => (
+                  <option key={f.id} value={f.id}>{f.name}</option>
+                ))}
+              </select>
+            ) : (
+              <input
+                value={c.url ?? ''}
+                onChange={(e) => update(i, { url: e.target.value || null })}
+                placeholder="https://..."
+                className="min-w-60 flex-1 rounded border px-2 py-1"
+              />
+            )}
+            {c.kind === 'form' && (
+              <label className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={c.autoOpen}
+                  onChange={(e) => update(i, { autoOpen: e.target.checked })}
+                />
+                自動でフォームを開く
+              </label>
+            )}
+            <button
+              onClick={() => {
+                setCtas((prev) => prev.filter((_, j) => j !== i))
+                setTimes((prev) => prev.filter((_, j) => j !== i))
+              }}
+              className="ml-auto text-red-500"
+            >
+              削除
+            </button>
+          </div>
+          <input
+            value={c.title}
+            onChange={(e) => update(i, { title: e.target.value })}
+            placeholder="カード見出し（例: 🎁 個別導入診断、受付中です）"
+            className="w-full rounded border px-2 py-1 text-sm font-bold"
+          />
+          <input
+            value={c.body ?? ''}
+            onChange={(e) => update(i, { body: e.target.value || null })}
+            placeholder="補足文（任意。例: この配信を見ている方限定・枠が少なめです）"
+            className="w-full rounded border px-2 py-1 text-sm"
+          />
+          <input
+            value={c.buttonLabel}
+            onChange={(e) => update(i, { buttonLabel: e.target.value })}
+            placeholder="ボタン文言（例: 無料で診断を受ける）"
+            className="w-full rounded border px-2 py-1 text-sm"
+          />
+        </div>
+      ))}
+      <div className="flex gap-2">
+        <button
+          onClick={() => {
+            setCtas((prev) => [...prev, {
+              atSeconds: 0, kind: 'form', title: '', body: null,
+              buttonLabel: '', autoOpen: false, formId: null, url: null,
+            }])
+            setTimes((prev) => [...prev, '0:00'])
+          }}
+          className="rounded border px-3 py-1 text-sm"
+        >
+          + CTAカード追加
+        </button>
+        <button
+          onClick={() => void save()}
+          disabled={saving || !loaded}
+          className="rounded bg-blue-600 px-4 py-1 text-sm text-white disabled:opacity-50"
+        >
+          {saving ? '保存中...' : '保存'}
+        </button>
+      </div>
     </div>
   )
 }
 
 const TABS = [
-  ['settings', '設定'],
-  ['comments', 'サクラコメント'],
-  ['analytics', '分析'],
+  ['analytics', '概要・分析'],
+  ['settings', '配信設定'],
+  ['ctas', 'CTA・フォーム'],
+  ['comments', 'コメント演出'],
 ] as const
 
 type TabKey = (typeof TABS)[number][0]
@@ -299,7 +757,7 @@ function EditWebinarInner() {
   const [webinar, setWebinar] = useState<Webinar | null>(null)
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
-  const [tab, setTab] = useState<TabKey>('settings')
+  const [tab, setTab] = useState<TabKey>('analytics')
 
   useEffect(() => {
     if (!id) return
@@ -338,32 +796,51 @@ function EditWebinarInner() {
 
   return (
     <>
-      <Header title={webinar.title} />
-      <div className="p-6 max-w-4xl mx-auto">
-        <p className="mb-4 font-mono text-xs text-gray-500 break-all">
-          配信URL: https://liff.line.me/{'{liffId}'}/?page=webinar&slug={webinar.slug}&liffId={'{liffId}'}
-        </p>
+      <Header
+        title={webinar.title}
+        description="参加ペースと相談フォームへの到達を、友だち単位で確認できます"
+        action={
+          <Link href="/webinars" className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50">
+            ← 一覧へ
+          </Link>
+        }
+      />
+      <div className="mx-auto max-w-[1400px] px-3 pb-10 sm:px-6">
+        <div className="mb-4 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${webinar.status === 'active' ? 'bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.12)]' : webinar.status === 'draft' ? 'bg-slate-400' : 'bg-amber-500'}`} />
+            <div className="min-w-0">
+              <div className="text-xs font-semibold text-slate-700">{webinar.status === 'active' ? '24時間 配信中' : webinar.status === 'draft' ? '下書き' : 'アーカイブ'}</div>
+              <div className="mt-0.5 truncate font-mono text-[11px] text-slate-400">/webinar/{webinar.slug}</div>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+            <span className="rounded-full bg-slate-100 px-2.5 py-1">動画 {fmtSec(webinar.durationSeconds)}</span>
+            <span className="rounded-full bg-slate-100 px-2.5 py-1">開催ルール {webinar.schedule.length}件</span>
+          </div>
+        </div>
 
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-          <div className="flex border-b border-gray-200">
+        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <div className="grid grid-cols-2 gap-1 border-b border-slate-200 bg-slate-50/70 p-2 sm:flex sm:gap-0 sm:overflow-x-auto sm:px-4 sm:pb-0 sm:pt-2">
             {TABS.map(([key, label]) => (
               <button
                 key={key}
                 onClick={() => setTab(key)}
-                className={`flex-1 px-4 py-3 text-sm font-medium transition-colors border-b-2 ${
+                className={`shrink-0 rounded-lg border px-2 py-2.5 text-xs font-semibold transition-colors sm:rounded-b-none sm:rounded-t-xl sm:border-x-0 sm:border-t-0 sm:border-b-2 sm:px-5 sm:py-3 sm:text-sm ${
                   tab === key
-                    ? 'border-blue-600 text-blue-600 bg-blue-50'
-                    : 'border-transparent text-gray-600 hover:bg-gray-50'
+                    ? 'border-blue-200 bg-blue-50 text-blue-700 sm:border-b-blue-600 sm:bg-white sm:shadow-[0_-1px_0_0_rgba(226,232,240,1)]'
+                    : 'border-transparent text-slate-500 hover:bg-white/70 hover:text-slate-800'
                 }`}
               >
                 {label}
               </button>
             ))}
           </div>
-          <div className="p-6">
+          <div className="bg-slate-50/40 p-4 sm:p-6 xl:p-8">
             {tab === 'settings' && <WebinarForm initial={webinar} />}
             {tab === 'comments' && <CommentsTab webinarId={webinar.id} />}
-            {tab === 'analytics' && <AnalyticsTab webinarId={webinar.id} />}
+            {tab === 'ctas' && <CtasTab webinarId={webinar.id} />}
+            {tab === 'analytics' && <AnalyticsTab webinarId={webinar.id} durationSeconds={webinar.durationSeconds} />}
           </div>
         </div>
       </div>

--- a/apps/web/src/app/webinars/page.tsx
+++ b/apps/web/src/app/webinars/page.tsx
@@ -18,13 +18,30 @@ const STATUS_BADGE: Record<Webinar['status'], string> = {
 function scheduleSummary(w: Webinar): string {
   if (w.schedule.length === 0) return '未設定'
   const DAYS = ['日', '月', '火', '水', '木', '金', '土']
-  return w.schedule
-    .map((r) => {
-      if (r.type === 'daily') return `毎日 ${r.time}`
-      if (r.type === 'weekly') return `毎週${(r.days ?? []).map((d) => DAYS[d]).join('・')} ${r.time}`
-      return r.at ? new Date(r.at).toLocaleString('ja-JP') : ''
-    })
-    .join(' / ')
+  const dailyTimes = w.schedule
+    .filter((rule) => rule.type === 'daily' && rule.time)
+    .map((rule) => rule.time as string)
+    .sort()
+  const otherRules = w.schedule.filter((rule) => rule.type !== 'daily')
+  const parts: string[] = []
+  if (dailyTimes.length > 0) {
+    const toMinutes = (time: string) => {
+      const [hours, minutes] = time.split(':').map(Number)
+      return hours * 60 + minutes
+    }
+    const intervals = dailyTimes.slice(1).map((time, index) => toMinutes(time) - toMinutes(dailyTimes[index]))
+    const interval = intervals.length > 0 && intervals.every((value) => value === intervals[0]) ? intervals[0] : null
+    parts.push(
+      dailyTimes.length === 1
+        ? `毎日 ${dailyTimes[0]}`
+        : `毎日 ${dailyTimes[0]}〜${dailyTimes[dailyTimes.length - 1]}${interval ? `・${interval}分間隔` : ''}（${dailyTimes.length}枠）`,
+    )
+  }
+  otherRules.forEach((rule) => {
+    if (rule.type === 'weekly') parts.push(`毎週${(rule.days ?? []).map((day) => DAYS[day]).join('・')} ${rule.time}`)
+    if (rule.type === 'once') parts.push(rule.at ? new Date(rule.at).toLocaleString('ja-JP') : '単発・日時未設定')
+  })
+  return parts.join(' / ')
 }
 
 export default function WebinarsPage() {
@@ -88,37 +105,31 @@ export default function WebinarsPage() {
             </Link>
           </div>
         ) : (
-          <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-gray-200 text-left text-gray-500">
-                  <th className="py-3 px-4 font-medium">タイトル</th>
-                  <th className="font-medium">slug</th>
-                  <th className="font-medium">スケジュール</th>
-                  <th className="font-medium">状態</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {items.map((w) => (
-                  <tr key={w.id} className="border-b border-gray-100 last:border-0 hover:bg-gray-50">
-                    <td className="py-3 px-4 font-medium text-gray-900">{w.title}</td>
-                    <td className="text-gray-500 font-mono text-xs">{w.slug}</td>
-                    <td className="text-gray-600">{scheduleSummary(w)}</td>
-                    <td>
-                      <span className={`text-xs px-2 py-0.5 rounded-full ${STATUS_BADGE[w.status]}`}>
-                        {STATUS_LABEL[w.status]}
-                      </span>
-                    </td>
-                    <td className="text-right px-4">
-                      <Link href={`/webinars/edit?id=${w.id}`} className="text-blue-600 hover:underline">
-                        編集
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="grid gap-4 lg:grid-cols-2">
+            {items.map((w) => (
+              <Link
+                key={w.id}
+                href={`/webinars/edit?id=${w.id}`}
+                className="group overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md"
+              >
+                <div className="flex items-start gap-4 p-5">
+                  <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-indigo-600 text-white shadow-sm">
+                    <svg viewBox="0 0 24 24" fill="none" className="h-5 w-5" stroke="currentColor" strokeWidth="2"><path d="M15 10l4.55-2.28A1 1 0 0 1 21 8.62v6.76a1 1 0 0 1-1.45.9L15 14M5 18h8a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2Z" strokeLinecap="round" strokeLinejoin="round" /></svg>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <h2 className="line-clamp-2 font-bold leading-6 text-slate-900 group-hover:text-blue-700">{w.title}</h2>
+                      <span className={`shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold ${STATUS_BADGE[w.status]}`}>{STATUS_LABEL[w.status]}</span>
+                    </div>
+                    <p className="mt-3 text-sm leading-6 text-slate-600">{scheduleSummary(w)}</p>
+                    <div className="mt-4 flex flex-wrap items-center justify-between gap-2 border-t border-slate-100 pt-3">
+                      <span className="font-mono text-[11px] text-slate-400">/{w.slug}</span>
+                      <span className="text-xs font-semibold text-blue-600">概要・分析を見る →</span>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))}
           </div>
         )}
       </div>

--- a/apps/web/src/components/chats/friend-info-sidebar.tsx
+++ b/apps/web/src/components/chats/friend-info-sidebar.tsx
@@ -12,6 +12,14 @@ interface FriendDetail {
   refCode: string | null
   createdAt: string
   tags: Array<{ id: string; name: string; color: string }>
+  formSubmissions: Array<{
+    id: string
+    formId: string
+    formName: string
+    fields: Array<{ name: string; label: string }>
+    data: Record<string, unknown>
+    createdAt: string
+  }>
 }
 
 interface ChatStatusInfo {
@@ -238,6 +246,39 @@ export default function FriendInfoSidebar({ friendId, chatStatus, operatorName }
                     </div>
                   ))}
                 </dl>
+              </div>
+            )}
+
+            {/* Form answers — save_to_metadata の設定に関係なく回答履歴を表示 */}
+            {friend.formSubmissions?.length > 0 && (
+              <div className="p-4">
+                <h4 className="text-[11px] font-medium text-gray-500 mb-2">フォーム回答</h4>
+                <div className="space-y-3">
+                  {friend.formSubmissions.map((submission) => {
+                    const labels = new Map(submission.fields.map((field) => [field.name, field.label]))
+                    const answers = Object.entries(submission.data).filter(([key]) => !key.startsWith('_'))
+                    return (
+                      <div key={submission.id} className="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                        <div className="flex items-start justify-between gap-2">
+                          <p className="text-xs font-medium text-gray-700 break-words">{submission.formName}</p>
+                          <time className="shrink-0 text-[10px] text-gray-400">
+                            {formatDate(submission.createdAt)}
+                          </time>
+                        </div>
+                        <dl className="mt-2 space-y-2">
+                          {answers.map(([key, value]) => (
+                            <div key={key}>
+                              <dt className="text-[10px] text-gray-400">{labels.get(key) ?? key}</dt>
+                              <dd className="mt-0.5 whitespace-pre-wrap break-words text-xs text-gray-700">
+                                {renderValue(value)}
+                              </dd>
+                            </div>
+                          ))}
+                        </dl>
+                      </div>
+                    )
+                  })}
+                </div>
               </div>
             )}
 

--- a/apps/web/src/components/webinars/webinar-form.tsx
+++ b/apps/web/src/components/webinars/webinar-form.tsx
@@ -10,6 +10,26 @@ const inputClass =
   'w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
 const labelClass = 'block text-sm font-medium text-gray-700 mb-1.5'
 
+function timeToMinutes(value: string): number {
+  const [hours, minutes] = value.split(':').map(Number)
+  return (Number.isFinite(hours) ? hours : 0) * 60 + (Number.isFinite(minutes) ? minutes : 0)
+}
+
+function minutesToTime(value: number): string {
+  const normalized = ((value % 1440) + 1440) % 1440
+  return `${String(Math.floor(normalized / 60)).padStart(2, '0')}:${String(normalized % 60).padStart(2, '0')}`
+}
+
+function inferDailySchedule(rules: WebinarScheduleRule[]): { start: string; end: string; interval: number } {
+  const times = rules
+    .filter((rule) => rule.type === 'daily' && rule.time)
+    .map((rule) => rule.time as string)
+    .sort((a, b) => timeToMinutes(a) - timeToMinutes(b))
+  const intervals = times.slice(1).map((time, index) => timeToMinutes(time) - timeToMinutes(times[index]))
+  const interval = intervals.length > 0 && intervals.every((value) => value === intervals[0]) ? intervals[0] : 30
+  return { start: times[0] ?? '00:00', end: times[times.length - 1] ?? '23:30', interval: interval > 0 ? interval : 30 }
+}
+
 export interface WebinarFormProps {
   initial?: Webinar
 }
@@ -24,6 +44,10 @@ export default function WebinarForm({ initial }: WebinarFormProps) {
     initial ? Math.round(initial.durationSeconds / 60) : 120,
   )
   const [rules, setRules] = useState<WebinarScheduleRule[]>(initial?.schedule ?? [])
+  const initialDaily = inferDailySchedule(initial?.schedule ?? [])
+  const [bulkStart, setBulkStart] = useState(initialDaily.start)
+  const [bulkEnd, setBulkEnd] = useState(initialDaily.end)
+  const [bulkInterval, setBulkInterval] = useState(initialDaily.interval)
   const [ctaEnabled, setCtaEnabled] = useState(Boolean(initial?.cta))
   const [ctaLabel, setCtaLabel] = useState(initial?.cta?.label ?? '今すぐ申し込む')
   const [ctaUrl, setCtaUrl] = useState(initial?.cta?.url ?? '')
@@ -35,6 +59,25 @@ export default function WebinarForm({ initial }: WebinarFormProps) {
 
   const updateRule = (i: number, patch: Partial<WebinarScheduleRule>) =>
     setRules((prev) => prev.map((r, j) => (j === i ? { ...r, ...patch } : r)))
+
+  const applyDailySchedule = () => {
+    const start = timeToMinutes(bulkStart)
+    const end = timeToMinutes(bulkEnd)
+    if (end < start || bulkInterval <= 0) {
+      setError('一括設定の開始・終了時間を確認してください')
+      return
+    }
+    const generated: WebinarScheduleRule[] = []
+    for (let minute = start; minute <= end; minute += bulkInterval) {
+      generated.push({ type: 'daily', time: minutesToTime(minute) })
+    }
+    setRules((prev) => [...prev.filter((rule) => rule.type !== 'daily'), ...generated])
+    setError(null)
+  }
+
+  const dailyRules = rules.filter((rule) => rule.type === 'daily' && rule.time)
+  const dailyOverview = inferDailySchedule(rules)
+  const nonDailyCount = rules.length - dailyRules.length
 
   const save = async () => {
     setSaving(true)
@@ -65,27 +108,18 @@ export default function WebinarForm({ initial }: WebinarFormProps) {
   }
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="max-w-4xl space-y-5">
       {error && (
         <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
           {error}
         </div>
       )}
 
-      <section className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
-        <h2 className="font-semibold text-gray-900">基本情報</h2>
+      <section className="space-y-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+        <div><h2 className="font-bold text-slate-900">基本情報</h2><p className="mt-1 text-xs text-slate-500">普段変更する項目だけを表示しています</p></div>
         <div>
           <label className={labelClass}>タイトル</label>
           <input value={title} onChange={(e) => setTitle(e.target.value)} className={inputClass} />
-        </div>
-        <div>
-          <label className={labelClass}>slug（URL 用・半角英数とハイフン）</label>
-          <input
-            value={slug}
-            onChange={(e) => setSlug(e.target.value)}
-            placeholder="my-seminar"
-            className={`${inputClass} font-mono text-xs`}
-          />
         </div>
         <div>
           <label className={labelClass}>状態</label>
@@ -109,20 +143,57 @@ export default function WebinarForm({ initial }: WebinarFormProps) {
             className={`${inputClass} w-32`}
           />
         </div>
-        <div>
-          <label className={labelClass}>
-            動画 R2 プレフィックス（encode-webinar.sh の出力。例: webinars/my-seminar）
-          </label>
-          <input
-            value={videoPrefix}
-            onChange={(e) => setVideoPrefix(e.target.value)}
-            className={`${inputClass} font-mono text-xs`}
-          />
-        </div>
+        <details className="group rounded-xl border border-slate-200 bg-slate-50/60">
+          <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-3 text-sm font-semibold text-slate-700">
+            URL・動画ファイルの詳細設定
+            <span className="text-xs text-slate-400 group-open:rotate-180">▾</span>
+          </summary>
+          <div className="space-y-4 border-t border-slate-200 p-4">
+            <div>
+              <label className={labelClass}>slug（URL 用・半角英数とハイフン）</label>
+              <input value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="my-seminar" className={`${inputClass} font-mono text-xs`} />
+            </div>
+            <div>
+              <label className={labelClass}>動画 R2 プレフィックス</label>
+              <input value={videoPrefix} onChange={(e) => setVideoPrefix(e.target.value)} className={`${inputClass} font-mono text-xs`} />
+            </div>
+          </div>
+        </details>
       </section>
 
-      <section className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-3">
-        <h2 className="font-semibold text-gray-900">開催スケジュール（日本時間）</h2>
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="p-5 sm:p-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div><h2 className="font-bold text-slate-900">開催スケジュール</h2><p className="mt-1 text-xs text-slate-500">日本時間・参加画面には直近の候補だけを表示します</p></div>
+            <span className="w-fit rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700">{rules.length}枠</span>
+          </div>
+          {dailyRules.length > 0 ? (
+            <div className="mt-4 flex flex-col gap-1 rounded-xl border border-blue-100 bg-gradient-to-r from-blue-50 to-cyan-50 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm font-bold text-slate-900">毎日 {dailyOverview.start}〜{dailyOverview.end}</div>
+              <div className="text-xs font-medium text-slate-600">{dailyOverview.interval}分間隔 · {dailyRules.length}枠{nonDailyCount > 0 ? ` ＋ 個別${nonDailyCount}枠` : ''}</div>
+            </div>
+          ) : (
+            <div className="mt-4 rounded-xl bg-amber-50 p-4 text-sm text-amber-700">毎日の配信枠は未設定です</div>
+          )}
+        </div>
+
+        <details className="group border-t border-slate-200">
+          <summary className="flex cursor-pointer list-none items-center justify-between px-5 py-4 text-sm font-semibold text-slate-700 hover:bg-slate-50 sm:px-6">
+            枠を一括設定・個別編集する
+            <span className="text-xs text-slate-400 group-open:rotate-180">▾</span>
+          </summary>
+          <div className="space-y-4 border-t border-slate-100 bg-slate-50/50 p-4 sm:p-6">
+            <div className="rounded-xl border border-slate-200 bg-white p-4">
+              <div className="mb-3 text-xs font-bold text-slate-700">毎日の枠をまとめて作成</div>
+              <div className="flex flex-wrap items-end gap-3">
+                <label className="text-xs text-slate-500">開始<input type="time" value={bulkStart} onChange={(e) => setBulkStart(e.target.value)} className="mt-1 block rounded-lg border border-slate-300 px-2 py-2 text-sm" /></label>
+                <label className="text-xs text-slate-500">終了<input type="time" value={bulkEnd} onChange={(e) => setBulkEnd(e.target.value)} className="mt-1 block rounded-lg border border-slate-300 px-2 py-2 text-sm" /></label>
+                <label className="text-xs text-slate-500">間隔<select value={bulkInterval} onChange={(e) => setBulkInterval(Number(e.target.value))} className="mt-1 block rounded-lg border border-slate-300 px-2 py-2 text-sm"><option value={30}>30分</option><option value={60}>60分</option><option value={120}>120分</option></select></label>
+                <button type="button" onClick={applyDailySchedule} className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800">毎日の枠を置き換える</button>
+              </div>
+              <p className="mt-2 text-[11px] text-slate-400">下の保存ボタンを押すまでは本番へ反映されません。</p>
+            </div>
+            <div className="max-h-[420px] space-y-2 overflow-y-auto pr-1">
         {rules.map((r, i) => (
           <div key={i} className="flex flex-wrap items-center gap-2 rounded-lg border border-gray-200 p-2 text-sm">
             <select
@@ -182,16 +253,20 @@ export default function WebinarForm({ initial }: WebinarFormProps) {
             </button>
           </div>
         ))}
+            </div>
         <button
           onClick={() => setRules((prev) => [...prev, { type: 'daily', time: '20:00' }])}
           className="px-3 py-1.5 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50"
         >
           ＋ ルール追加
         </button>
+          </div>
+        </details>
       </section>
 
-      <section className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-3">
-        <h2 className="font-semibold text-gray-900">CTA（決済ページ誘導）</h2>
+      <details className="group overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <summary className="flex cursor-pointer list-none items-center justify-between p-5 text-sm font-bold text-slate-900 sm:p-6">従来CTAボタンの設定<span className="text-xs text-slate-400 group-open:rotate-180">▾</span></summary>
+        <section className="space-y-3 border-t border-slate-200 p-5 sm:p-6">
         <label className="flex items-center gap-2 text-sm text-gray-700">
           <input type="checkbox" checked={ctaEnabled} onChange={(e) => setCtaEnabled(e.target.checked)} />
           CTA ボタンを表示する
@@ -223,15 +298,13 @@ export default function WebinarForm({ initial }: WebinarFormProps) {
             </div>
           </>
         )}
-      </section>
+        </section>
+      </details>
 
-      <button
-        onClick={() => void save()}
-        disabled={saving}
-        className="px-6 py-2.5 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
-      >
-        {saving ? '保存中...' : '保存'}
-      </button>
+      <div className="sticky bottom-3 z-10 flex items-center justify-between rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-lg backdrop-blur">
+        <span className="hidden text-xs text-slate-500 sm:block">変更内容を確認して本番へ反映します</span>
+        <button onClick={() => void save()} disabled={saving} className="ml-auto rounded-xl bg-blue-600 px-6 py-2.5 text-sm font-bold text-white shadow-sm hover:bg-blue-700 disabled:opacity-50">{saving ? '保存中...' : '変更を保存'}</button>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -173,6 +173,15 @@ export type FriendListParams = {
 }
 
 export type FriendWithTags = Friend & { tags: Tag[] }
+export type FriendFormSubmission = {
+  id: string
+  formId: string
+  formName: string
+  fields: Array<{ name: string; label: string }>
+  data: Record<string, unknown>
+  createdAt: string
+}
+export type FriendDetail = FriendWithTags & { formSubmissions: FriendFormSubmission[] }
 /** Friend list items, optionally hydrated with chat status (when ?includeChatStatus=true) */
 export type FriendListItem = FriendWithTags & Partial<{
   latestIncomingMessage: { content: string; messageType: string; createdAt: string } | null
@@ -199,7 +208,7 @@ export const api = {
       )
     },
     get: (id: string) =>
-      fetchApi<ApiResponse<FriendWithTags>>(`/api/friends/${id}`),
+      fetchApi<ApiResponse<FriendDetail>>(`/api/friends/${id}`),
     count: (params?: { accountId?: string }) => {
       const query = params?.accountId ? '?lineAccountId=' + params.accountId : ''
       return fetchApi<ApiResponse<{ count: number }>>('/api/friends/count' + query)
@@ -1847,6 +1856,36 @@ export type WebinarInput = Partial<Omit<Webinar, 'id' | 'createdAt' | 'updatedAt
 export type WebinarSakuraComment = { id?: string; atSeconds: number; authorName: string; body: string }
 
 export type WebinarAnalytics = {
+  summary: {
+    reservations: number
+    viewers: number
+    registeredAndJoined: number
+    watched5m: number
+    watched15m: number
+    completed: number
+    avgWatchedSeconds: number
+    ctaClicks: number
+    formSubmissions: number
+  }
+  daily: Array<{
+    date: string
+    reservations: number
+    viewers: number
+    ctaClicks: number
+    formSubmissions: number
+  }>
+  participants: Array<{
+    friendId: string
+    friendName: string | null
+    pictureUrl: string | null
+    sessions: number
+    firstJoinedAt: string
+    latestJoinedAt: string
+    maxWatchedSeconds: number
+    ctaClickedAt: string | null
+    registered: boolean
+    formSubmittedAt: string | null
+  }>
   sessions: Array<{ sessionStartAt: number; viewers: number; avgWatchedSeconds: number; ctaClicks: number }>
   dropoff: Array<{ bucketStart: number; viewers: number }>
 }
@@ -1855,10 +1894,23 @@ export type WebinarUserComment = {
   id: string
   friendId: string
   friendName: string | null
+  pictureUrl: string | null
   sessionStartAt: number
   atSeconds: number
   body: string
   createdAt: string
+}
+
+export type WebinarCtaCard = {
+  id?: string
+  atSeconds: number
+  kind: 'form' | 'url'
+  title: string
+  body: string | null
+  buttonLabel: string
+  autoOpen: boolean
+  formId: string | null
+  url: string | null
 }
 
 export const webinarApi = {
@@ -1875,6 +1927,16 @@ export const webinarApi = {
     fetchApi<{ data: { count: number } }>(`/api/webinars/${id}/comments`, {
       method: 'PUT',
       body: JSON.stringify({ comments: comments.map(({ atSeconds, authorName, body }) => ({ atSeconds, authorName, body })) }),
+    }),
+  ctas: (id: string) => fetchApi<{ data: WebinarCtaCard[] }>(`/api/webinars/${id}/ctas`),
+  saveCtas: (id: string, ctas: WebinarCtaCard[]) =>
+    fetchApi<{ data: { count: number } }>(`/api/webinars/${id}/ctas`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        ctas: ctas.map(({ atSeconds, kind, title, body, buttonLabel, autoOpen, formId, url }) => ({
+          atSeconds, kind, title, body, buttonLabel, autoOpen, formId, url,
+        })),
+      }),
     }),
   analytics: (id: string) => fetchApi<{ data: WebinarAnalytics }>(`/api/webinars/${id}/analytics`),
   userComments: (id: string) =>

--- a/apps/worker/index.html
+++ b/apps/worker/index.html
@@ -2,7 +2,12 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- maximum-scale=1: iOS が input フォーカスで自動ズームし、解除後も拡大が
+       残る問題の防止 (LIFF はアプリ的 UI なのでピンチズーム不要)。 -->
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+  />
   <title>LINE CRM</title>
   <script charset="utf-8" src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>
   <style>

--- a/apps/worker/src/client/main.ts
+++ b/apps/worker/src/client/main.ts
@@ -32,6 +32,7 @@ declare const liff: {
   getFriendship(): Promise<{ friendFlag: boolean }>;
   isInClient(): boolean;
   closeWindow(): void;
+  logout(): void;
 };
 
 // Resolve LIFF ID: ?liffId= param (from endpoint URL) > env var (fallback to ①)
@@ -622,6 +623,46 @@ async function initAffiliate(): Promise<void> {
 
 // ─── Entry Point ────────────────────────────────────────
 
+// External-browser LIFF sessions persist in localStorage, and the SDK keeps
+// returning the cached id_token without refreshing it. LINE id_tokens expire
+// after 1h, so a returning PC visitor gets 401 from every verify-backed API
+// (/api/liff/link, webinar load, forms). In-client (LINE app) sessions get a
+// fresh token on every launch and never hit this.
+function isIdTokenStale(idToken: string | null): boolean {
+  if (!idToken) return true;
+  try {
+    const payloadB64 = idToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+    const payload = JSON.parse(atob(payloadB64)) as { exp?: number };
+    // 60s margin so a token about to expire mid-flow also counts as stale
+    return typeof payload.exp !== 'number' || payload.exp * 1000 < Date.now() + 60_000;
+  } catch {
+    return true;
+  }
+}
+
+const RELOGIN_GUARD_KEY = 'lh_relogin_at';
+
+function forceReloginForStaleToken(): boolean {
+  if (liff.isInClient()) return false;
+  if (!isIdTokenStale(liff.getIDToken())) return false;
+  // Loop guard: if we already round-tripped through LINE Login within the
+  // last minute and the token is still stale (clock skew, login cancelled),
+  // fall through instead of redirecting forever.
+  let lastAttempt = 0;
+  try {
+    lastAttempt = Number(sessionStorage.getItem(RELOGIN_GUARD_KEY) || 0);
+  } catch { /* sessionStorage unavailable — still attempt a single redirect */ }
+  if (Date.now() - lastAttempt < 60_000) return false;
+  try {
+    sessionStorage.setItem(RELOGIN_GUARD_KEY, String(Date.now()));
+  } catch { /* ignore */ }
+  try {
+    liff.logout();
+  } catch { /* ignore — login below still re-issues tokens */ }
+  liff.login({ redirectUri: window.location.href });
+  return true;
+}
+
 async function main() {
   try {
     await liff.init({ liffId: LIFF_ID });
@@ -630,6 +671,8 @@ async function main() {
       liff.login({ redirectUri: window.location.href });
       return;
     }
+
+    if (forceReloginForStaleToken()) return;
 
     // Resolve bot basic ID from API (multi-account support)
     try {

--- a/apps/worker/src/client/webinar/date-options.test.ts
+++ b/apps/worker/src/client/webinar/date-options.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { buildMeetingDateOptions } from './date-options.js';
+
+describe('buildMeetingDateOptions', () => {
+  test('本日から指定日数分の値と見えるラベルを返す', () => {
+    const options = buildMeetingDateOptions('2026-08-06', 3);
+
+    expect(options).toEqual([
+      { value: '2026-08-06', label: '8/6(木)（本日）' },
+      { value: '2026-08-07', label: '8/7(金)' },
+      { value: '2026-08-08', label: '8/8(土)' },
+    ]);
+  });
+
+  test('月をまたいでも日付値が崩れない', () => {
+    expect(buildMeetingDateOptions('2026-08-31', 2).map((option) => option.value)).toEqual([
+      '2026-08-31',
+      '2026-09-01',
+    ]);
+  });
+});

--- a/apps/worker/src/client/webinar/date-options.ts
+++ b/apps/worker/src/client/webinar/date-options.ts
@@ -1,0 +1,22 @@
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+export interface MeetingDateOption {
+  value: string;
+  label: string;
+}
+
+/** iOS/LINE 内ブラウザでも空欄に見えない、日付プルダウン用の候補を作る。 */
+export function buildMeetingDateOptions(todayJst: string, days = 31): MeetingDateOption[] {
+  return Array.from({ length: days }, (_, offset) => {
+    const date = new Date(`${todayJst}T00:00:00+09:00`);
+    date.setUTCDate(date.getUTCDate() + offset);
+    const value = new Date(date.getTime() + JST_OFFSET_MS).toISOString().slice(0, 10);
+    const label = new Intl.DateTimeFormat('ja-JP', {
+      month: 'numeric',
+      day: 'numeric',
+      weekday: 'short',
+      timeZone: 'Asia/Tokyo',
+    }).format(date);
+    return { value, label: offset === 0 ? `${label}（本日）` : label };
+  });
+}

--- a/apps/worker/src/client/webinar/main.tsx
+++ b/apps/worker/src/client/webinar/main.tsx
@@ -10,6 +10,7 @@
 
 import { StrictMode, useCallback, useEffect, useRef, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { buildMeetingDateOptions } from './date-options.js';
 import './styles.css';
 
 // LIFF SDK は index.html の script タグでグローバル注入される
@@ -42,6 +43,38 @@ interface WebinarCta {
   showAtSeconds: number;
 }
 
+// チャット欄に流れる CTA カード (webinar_ctas)。kind='form' は既存フォームを
+// ボトムシートで開いて離脱なしで回答させる。kind='url' は外部 URL。
+interface WebinarCtaCard {
+  id: string;
+  atSeconds: number;
+  kind: 'form' | 'url';
+  title: string;
+  body: string | null;
+  buttonLabel: string;
+  autoOpen: boolean;
+  formId: string | null;
+  url: string | null;
+}
+
+interface FormField {
+  name: string;
+  label: string;
+  type: 'text' | 'email' | 'tel' | 'number' | 'textarea' | 'select' | 'radio' | 'checkbox' | 'date';
+  required?: boolean;
+  options?: string[];
+  placeholder?: string;
+}
+
+interface FormDef {
+  id: string;
+  name: string;
+  description: string | null;
+  fields: FormField[];
+  isActive: boolean;
+  onSubmitMessageContent?: string | null;
+}
+
 interface WebinarSakuraComment {
   atSeconds: number;
   authorName: string;
@@ -51,6 +84,7 @@ interface WebinarSakuraComment {
 type WebinarState =
   | {
       live: true;
+      replay?: boolean;
       title: string;
       durationSeconds: number;
       sessionStartAt: number;
@@ -58,14 +92,37 @@ type WebinarState =
       playlistUrl: string;
       cta: WebinarCta | null;
       comments: WebinarSakuraComment[];
+      ctas: WebinarCtaCard[];
+      // 参加ゲート用: 今後の回と自分の予約
+      upcoming?: number[];
+      registeredSessionAt?: number | null;
+      registeredForThisSession?: boolean;
     }
-  | { live: false; title: string; nextSessionAt: number | null };
+  // 待機ルーム (開始10分前〜): 開始前サクラコメント (負の atSeconds) が流れる
+  | {
+      live: false;
+      waiting: true;
+      title: string;
+      nextSessionAt: number;
+      offsetSeconds: number;
+      comments: WebinarSakuraComment[];
+    }
+  | {
+      live: false;
+      waiting?: undefined;
+      title: string;
+      nextSessionAt: number | null;
+      // セッション選択メニュー: 今後の開催回 (epoch 秒) と自分の予約
+      upcoming?: number[];
+      registeredSessionAt?: number | null;
+    };
 
 interface ChatItem {
   key: string;
   authorName: string;
   body: string;
   mine?: boolean;
+  ctaCard?: WebinarCtaCard;
 }
 
 function buildAuthHeaders(ctx: WebinarContext, extra: Record<string, string> = {}): Record<string, string> {
@@ -112,18 +169,33 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
   const [ended, setEnded] = useState(false);
   const [needsTap, setNeedsTap] = useState(false);
   const [countdown, setCountdown] = useState('');
+  // ライブ参加ゲート: 予約した回だけ再生する。未予約なら開始直後でも予約画面。
+  const [joined, setJoined] = useState(false);
+  const joinedRef = useRef(false);
+  joinedRef.current = joined;
   const [chat, setChat] = useState<ChatItem[]>([]);
   const [input, setInput] = useState('');
   const [ctaVisible, setCtaVisible] = useState(false);
   const [muted, setMuted] = useState(true);
   const [rate, setRate] = useState(1);
+  const [activeCta, setActiveCta] = useState<WebinarCtaCard | null>(null);
+  const [formSheet, setFormSheet] = useState<
+    | null
+    | { cta: WebinarCtaCard; phase: 'loading' }
+    | { cta: WebinarCtaCard; phase: 'form'; def: FormDef }
+    | { cta: WebinarCtaCard; phase: 'done'; def: FormDef }
+    | { cta: WebinarCtaCard; phase: 'error'; message: string }
+  >(null);
   const rateRef = useRef(1);
   rateRef.current = rate;
 
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const t0Ref = useRef(0);            // state 受信時の performance.now()
+  const waitT0Ref = useRef(0);        // 待機ルーム受信時の Date.now()
   const baseOffsetRef = useRef(0);    // state.offsetSeconds
   const commentIdxRef = useRef(0);    // 次に表示するサクラコメント index
+  const ctaIdxRef = useRef(0);        // 次に表示する CTA カード index
+  const openCtaRef = useRef<(card: WebinarCtaCard) => void>(() => undefined);
   const chatBoxRef = useRef<HTMLDivElement | null>(null);
   const stateRef = useRef<WebinarState | null>(null);
   stateRef.current = state;
@@ -135,13 +207,28 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
 
   const load = useCallback(async () => {
     try {
-      const s = await apiGet<WebinarState>(`/api/liff/webinars/${encodeURIComponent(slug)}`, ctx);
+      const admissionSession = new URLSearchParams(window.location.search).get('sessionStartAt');
+      const path = `/api/liff/webinars/${encodeURIComponent(slug)}` +
+        (admissionSession ? `?sessionStartAt=${encodeURIComponent(admissionSession)}` : '');
+      const s = await apiGet<WebinarState>(path, ctx);
       if (s.live) {
         t0Ref.current = performance.now();
         baseOffsetRef.current = s.offsetSeconds;
         commentIdxRef.current = 0;
+        ctaIdxRef.current = 0;
         setChat([]);
         setCtaVisible(false);
+        setActiveCta(null);
+        // 入場できるのはプレビューか、この回を予約していた本人のみ。
+        // 「開始直後なら未予約でも自動再生」の例外は、予約画面を飛ばすため禁止。
+        setJoined(IS_PREVIEW || s.registeredForThisSession === true);
+      } else if (s.waiting) {
+        // 待機ルーム: 位置は壁時計基準 (バックグラウンドで performance.now が
+        // 止まる端末でもカウントダウンとズレない)
+        waitT0Ref.current = Date.now();
+        baseOffsetRef.current = s.offsetSeconds;
+        commentIdxRef.current = 0;
+        setChat([]);
       }
       setState(s);
     } catch (err) {
@@ -156,6 +243,14 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
   useEffect(() => {
     void load();
   }, [load]);
+
+  // ライブ/待機ルームだけページスクロールをロックする。セッション選択
+  // メニューはボタンが縦に並ぶためスクロール可能なままにする。
+  useEffect(() => {
+    const lock = state ? (state.live ? joined : state.waiting === true) : false;
+    document.body.classList.toggle('wb-lock', lock);
+    return () => document.body.classList.remove('wb-lock');
+  }, [state, joined]);
 
   // 待機画面: カウントダウン + 開始時刻到達で自動リロード
   useEffect(() => {
@@ -180,17 +275,23 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
 
   // ライブ画面: プレーヤー初期化
   useEffect(() => {
-    if (!state?.live) return;
+    if (!state?.live || !joined) return;
     const video = videoRef.current;
     if (!video) return;
     let hls: { destroy: () => void } | null = null;
     let cancelled = false;
+    let cleanupVerify: (() => void) | null = null;
 
     async function setup() {
       const v = video!;
       const src = state as Extract<WebinarState, { live: true }>;
+      // 途中参加位置はプレイリスト側の #EXT-X-START で宣言する (?at=)。
+      // iOS native HLS はクライアント側シークが 0 に巻き戻ることがあるため、
+      // currentTime のシークはあくまでフォールバック。プレビューは常に頭から。
+      const liveAt = src.replay ? 0 : Math.max(0, Math.floor(expectedPosition()));
+      const playlistUrl = IS_PREVIEW ? src.playlistUrl : `${src.playlistUrl}?at=${liveAt}`;
       if (v.canPlayType('application/vnd.apple.mpegurl')) {
-        v.src = src.playlistUrl;
+        v.src = playlistUrl;
       } else {
         const { default: Hls } = await import('hls.js');
         if (cancelled) return;
@@ -199,7 +300,7 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
           return;
         }
         const instance = new Hls();
-        instance.loadSource(src.playlistUrl);
+        instance.loadSource(playlistUrl);
         instance.attachMedia(v);
         hls = instance;
       }
@@ -207,24 +308,57 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
       setMuted(true);
       if (IS_PREVIEW) v.controls = true;
       const seekAndPlay = () => {
-        v.currentTime = IS_PREVIEW ? 0 : expectedPosition();
+        v.currentTime = IS_PREVIEW || src.replay ? 0 : expectedPosition();
         v.play().then(() => setNeedsTap(true)).catch(() => setNeedsTap(true));
       };
       if (v.readyState >= 1) seekAndPlay();
       else v.addEventListener('loadedmetadata', seekAndPlay, { once: true });
+      // iOS Safari (LINE in-app) の native HLS は loadedmetadata 直後の
+      // currentTime 代入が 0 に巻き戻ることがある。実際に再生が立ち上がる
+      // イベントで位置を検証し、ズレていたら再シークして途中参加を保証する。
+      const verifyLivePosition = () => {
+        if (IS_PREVIEW || src.replay) return;
+        const pos = expectedPosition();
+        if (pos > DRIFT_TOLERANCE && Math.abs(v.currentTime - pos) >= DRIFT_TOLERANCE) {
+          v.currentTime = pos;
+        }
+      };
+      v.addEventListener('canplay', verifyLivePosition);
+      v.addEventListener('playing', verifyLivePosition);
+      // ライブに一時停止は存在しない: AirPods の耳外し・ルート変更などシステム
+      // 起因の pause は自動で再生復帰させる (復帰後はドリフト補正がライブ位置へ
+      // 追いつかせる)。配信終了後・バックグラウンド・プレビュー (controls あり)
+      // は対象外。
+      const onPause = () => {
+        if (IS_PREVIEW || src.replay) return;
+        if (document.visibilityState !== 'visible') return;
+        if (expectedPosition() >= src.durationSeconds) return;
+        setTimeout(() => {
+          if (!v.paused || document.visibilityState !== 'visible') return;
+          if (expectedPosition() >= src.durationSeconds) return;
+          void v.play().catch(() => undefined);
+        }, 300);
+      };
+      v.addEventListener('pause', onPause);
+      cleanupVerify = () => {
+        v.removeEventListener('canplay', verifyLivePosition);
+        v.removeEventListener('playing', verifyLivePosition);
+        v.removeEventListener('pause', onPause);
+      };
     }
     void setup();
     return () => {
       cancelled = true;
+      cleanupVerify?.();
       hls?.destroy();
     };
-  }, [state, expectedPosition]);
+  }, [state, joined, expectedPosition]);
 
   // ライブ進行: ドリフト補正・サクラコメント・CTA・終了判定 (1秒 tick)
   // プレビューは video.currentTime を位置の真とし、巻き戻しシークにも追従する
   const lastTickPosRef = useRef(0);
   useEffect(() => {
-    if (!state?.live) return;
+    if (!state?.live || !joined) return;
     const src = state;
     const timer = setInterval(() => {
       const video = videoRef.current;
@@ -232,8 +366,10 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
       if (IS_PREVIEW && pos < lastTickPosRef.current - 1) {
         // 巻き戻された: コメントを頭から再構築
         commentIdxRef.current = 0;
+        ctaIdxRef.current = 0;
         setChat([]);
         setCtaVisible(false);
+        setActiveCta(null);
       }
       lastTickPosRef.current = pos;
       if (IS_PREVIEW && video && video.playbackRate !== rateRef.current) {
@@ -245,9 +381,11 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
         clearInterval(timer);
         return;
       }
+      // readyState >= 1 (metadata あり) から補正する。iOS で初期シークが
+      // 巻き戻された場合も、この 1 秒 tick が毎回ライブ位置へ戻す。
       if (
         !IS_PREVIEW &&
-        video && video.readyState >= 2 && Math.abs(video.currentTime - pos) >= DRIFT_TOLERANCE
+        video && video.readyState >= 1 && Math.abs(video.currentTime - pos) >= DRIFT_TOLERANCE
       ) {
         video.currentTime = pos;
       }
@@ -266,11 +404,48 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
         });
         commentIdxRef.current += 1;
       }
+      // CTA カード流し込み (カードは通常コメントと同じくチャットに積む)
+      const cards = src.ctas ?? [];
+      while (ctaIdxRef.current < cards.length && cards[ctaIdxRef.current].atSeconds <= pos) {
+        const card = cards[ctaIdxRef.current];
+        items.push({
+          key: `c-${card.id}`,
+          authorName: '',
+          body: '',
+          ctaCard: card,
+        });
+        setActiveCta(card);
+        ctaIdxRef.current += 1;
+        // autoOpen: カード出現と同時にチャット欄をフォームへ切り替える
+        if (card.autoOpen && card.kind === 'form') openCtaRef.current(card);
+      }
       if (items.length > 0) setChat((prev) => [...prev.slice(-200), ...items]);
-      if (src.cta && pos >= src.cta.showAtSeconds) setCtaVisible(true);
+      // レガシー下部 CTA (cta_json) はカード未設定のウェビナーでのみ使用
+      if (cards.length === 0 && src.cta && pos >= src.cta.showAtSeconds) setCtaVisible(true);
     }, 1000);
     return () => clearInterval(timer);
-  }, [state, expectedPosition]);
+  }, [state, joined, expectedPosition]);
+
+  // 待機ルーム: 開始前サクラコメント (負の atSeconds) の流し込み (1秒 tick)
+  useEffect(() => {
+    if (!state || state.live || !state.waiting) return;
+    const src = state;
+    const timer = setInterval(() => {
+      const pos = baseOffsetRef.current + (Date.now() - waitT0Ref.current) / 1000;
+      const comments = src.comments;
+      const items: ChatItem[] = [];
+      while (
+        commentIdxRef.current < comments.length &&
+        comments[commentIdxRef.current].atSeconds <= pos
+      ) {
+        const cm = comments[commentIdxRef.current];
+        items.push({ key: `w-${commentIdxRef.current}`, authorName: cm.authorName, body: cm.body });
+        commentIdxRef.current += 1;
+      }
+      if (items.length > 0) setChat((prev) => [...prev.slice(-200), ...items]);
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [state]);
 
   // チャット自動スクロール
   useEffect(() => {
@@ -281,7 +456,7 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
   useEffect(() => {
     const onVisible = () => {
       const video = videoRef.current;
-      if (!IS_PREVIEW && document.visibilityState === 'visible' && video && stateRef.current?.live && !ended) {
+      if (!IS_PREVIEW && document.visibilityState === 'visible' && video && stateRef.current?.live && joinedRef.current && !ended) {
         video.currentTime = expectedPosition();
         // バックグラウンド復帰でブラウザが muted に戻すことがあるので状態を同期
         void video.play().catch(() => undefined);
@@ -294,7 +469,7 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
 
   // ハートビート (配信終了後は送らない)
   useEffect(() => {
-    if (!state?.live || ended || IS_PREVIEW) return;
+    if (!state?.live || !joined || ended || IS_PREVIEW) return;
     const src = state;
     const timer = setInterval(() => {
       const pos = Math.min(Math.floor(expectedPosition()), src.durationSeconds);
@@ -304,10 +479,22 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
       }, ctx).catch(() => undefined);
     }, HEARTBEAT_MS);
     return () => clearInterval(timer);
-  }, [state, slug, ctx, expectedPosition, ended]);
+  }, [state, joined, slug, ctx, expectedPosition, ended]);
 
   const sendComment = async () => {
-    if (!state?.live) return;
+    if (!state) return;
+    // ライブ中は現在位置、待機ルーム中は次回セッション帰属の負の位置で投稿する
+    let sessionStartAt: number;
+    let atSeconds: number;
+    if (state.live) {
+      sessionStartAt = state.sessionStartAt;
+      atSeconds = Math.floor(expectedPosition());
+    } else if (state.waiting) {
+      sessionStartAt = state.nextSessionAt;
+      atSeconds = Math.floor(baseOffsetRef.current + (Date.now() - waitT0Ref.current) / 1000);
+    } else {
+      return;
+    }
     const text = input.trim();
     if (!text) return;
     setInput('');
@@ -317,14 +504,67 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
     ]);
     try {
       await apiPost(`/api/liff/webinars/${encodeURIComponent(slug)}/comments`, {
-        sessionStartAt: state.sessionStartAt,
-        atSeconds: Math.floor(expectedPosition()),
+        sessionStartAt,
+        atSeconds,
         body: text,
       }, ctx);
     } catch (err) {
       console.warn('comment post failed:', err);
     }
   };
+
+  const openCta = (card: WebinarCtaCard) => {
+    if (!state?.live) return;
+    // クリック記録 (fire-and-forget、プレビューでは送らない)
+    if (!IS_PREVIEW) {
+      void apiPost(`/api/liff/webinars/${encodeURIComponent(slug)}/cta-click`, {
+        sessionStartAt: state.sessionStartAt,
+      }, ctx).catch(() => undefined);
+    }
+    if (card.kind === 'url' && card.url) {
+      if (typeof liff !== 'undefined' && liff.isInClient()) {
+        liff.openWindow({ url: card.url, external: true });
+      } else {
+        window.open(card.url, '_blank', 'noopener');
+      }
+      return;
+    }
+    if (card.kind === 'form' && card.formId) {
+      setFormSheet({ cta: card, phase: 'loading' });
+      // 開封記録 (フォーム機能側のファネル計測に乗せる)
+      if (!IS_PREVIEW) {
+        // 帰属は Authorization の LINE ID トークンで判定される (body の ID は無視)
+        void fetch(`/api/forms/${encodeURIComponent(card.formId)}/opened`, {
+          method: 'POST',
+          headers: buildAuthHeaders(ctx, { 'Content-Type': 'application/json' }),
+          body: JSON.stringify({}),
+        }).catch(() => undefined);
+      }
+      void fetch(`/api/forms/${encodeURIComponent(card.formId)}`)
+        .then(async (r) => {
+          const json = (await r.json()) as { success: boolean; data?: FormDef };
+          if (!r.ok || !json.success || !json.data) throw new Error('form fetch failed');
+          // シートが閉じられた/別カードに切り替わった後の遅延解決で上書きしない
+          setFormSheet((prev) =>
+            prev && prev.phase === 'loading' && prev.cta.id === card.id
+              ? { cta: card, phase: 'form', def: json.data! }
+              : prev,
+          );
+        })
+        .catch(() => {
+          setFormSheet((prev) =>
+            prev && prev.phase === 'loading' && prev.cta.id === card.id
+              ? {
+                  cta: card, phase: 'error',
+                  message: 'フォームを読み込めませんでした。もう一度お試しください。',
+                }
+              : prev,
+          );
+        });
+    }
+  };
+
+  openCtaRef.current = openCta;
 
   const toggleMute = () => {
     const v = videoRef.current;
@@ -348,6 +588,24 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
     }
   };
 
+  const [registering, setRegistering] = useState(false);
+  // 24時間分48枠を最初から見せず、直近3時間（6枠）から段階的に開く。
+  const [visibleSessionCount, setVisibleSessionCount] = useState(6);
+  const registerSession = async (sessionStartAt: number) => {
+    if (registering) return;
+    setRegistering(true);
+    try {
+      await apiPost(`/api/liff/webinars/${encodeURIComponent(slug)}/register`, { sessionStartAt }, ctx);
+      // 現在回を開始5分以内に予約した場合、その場でサーバーの予約判定を通して
+      // 再生画面へ切り替える。未来回なら予約済み表示／待機ルームへ更新される。
+      await load();
+    } catch (err) {
+      console.warn('register failed:', err);
+    } finally {
+      setRegistering(false);
+    }
+  };
+
   if (error) {
     return <div className="p-8 text-center text-gray-300">{error}</div>;
   }
@@ -355,10 +613,113 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
     return <div className="p-8 text-center text-gray-500">読み込み中...</div>;
   }
 
-  // ---- 待機画面 ----
+  // ---- 待機ルーム (開始10分前〜): カウントダウン + 開始前チャット ----
+  if (!state.live && state.waiting) {
+    return (
+      <div className="flex h-dvh justify-center bg-gray-900 text-white">
+        <div className="flex h-full w-full max-w-md flex-col">
+          <div className="relative flex aspect-video w-full shrink-0 flex-col items-center justify-center bg-gray-800 px-4">
+            <span className="absolute left-2 top-2 rounded bg-gray-600 px-2 py-0.5 text-xs font-bold">
+              まもなく開始
+            </span>
+            <p className="text-center text-sm font-bold text-gray-200">{state.title}</p>
+            <p className="mt-3 font-mono text-4xl font-bold">{countdown}</p>
+            <p className="mt-1 text-sm text-gray-400">で配信が始まります</p>
+          </div>
+
+          <div ref={chatBoxRef} className="flex-1 overflow-y-auto p-3 text-sm">
+            {chat.map((item) => (
+              <div key={item.key} className="mb-2">
+                <span className={item.mine ? 'font-medium text-[#06C755]' : 'font-medium text-gray-400'}>
+                  {item.authorName}
+                </span>{' '}
+                <span className="text-gray-100">{item.body}</span>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex gap-2 border-t border-gray-700 p-2">
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void sendComment();
+              }}
+              placeholder="コメントを入力..."
+              maxLength={500}
+              className="flex-1 rounded-full bg-gray-800 px-4 py-2 text-base text-white placeholder-gray-500"
+            />
+            <button
+              onClick={() => void sendComment()}
+              className="rounded-full bg-[#06C755] px-4 py-2 text-sm font-bold active:opacity-80"
+            >
+              送信
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ---- セッション選択メニュー (開催回を選んで予約) ----
+  if (!state.live && (state.upcoming?.length ?? 0) > 0) {
+    const upcoming = state.upcoming!;
+    const visibleUpcoming = upcoming.slice(0, visibleSessionCount);
+    const registered = state.registeredSessionAt ?? null;
+    return (
+      <div className="flex min-h-dvh flex-col items-center justify-center bg-gray-900 p-6 text-white">
+        <p className="mb-2 text-sm text-gray-400">ライブ配信</p>
+        <h1 className="mb-1 text-center text-xl font-bold">{state.title}</h1>
+        {registered !== null ? (
+          <div className="mt-5 w-full max-w-sm rounded-2xl bg-gray-800 p-5 text-center">
+            <p className="text-sm text-[#06C755]">✅ 予約済み</p>
+            <p className="mt-2 text-lg font-bold">{formatJp(registered)} の回</p>
+            <p className="mt-3 text-xs leading-relaxed text-gray-400">
+              開始前にLINEで視聴リンクをお送りします。
+              <br />
+              時間になったらこのページも自動で配信に切り替わります
+            </p>
+            <p className="mt-4 text-xs text-gray-500">別の回に変更する場合はもう一度選んでください</p>
+          </div>
+        ) : (
+          <p className="mt-2 text-sm text-gray-400">参加する回を選んでください</p>
+        )}
+        <div className="mt-5 flex w-full max-w-sm flex-col gap-2">
+          {visibleUpcoming.map((t) => (
+            <button
+              key={t}
+              disabled={registering}
+              onClick={() => void registerSession(t)}
+              className={`rounded-full py-3 text-center font-bold active:opacity-80 disabled:opacity-50 ${
+                registered === t
+                  ? 'bg-[#06C755] text-white'
+                  : 'bg-gray-800 text-gray-100'
+              }`}
+            >
+              {t <= Math.floor(Date.now() / 1000)
+                ? `${formatJp(t)} の回（今すぐ途中参加）`
+                : `${formatJp(t)} の回`}
+              {registered === t ? ' ✅' : ''}
+            </button>
+          ))}
+          {visibleUpcoming.length < upcoming.length && (
+            <button
+              type="button"
+              onClick={() => setVisibleSessionCount((count) => Math.min(count + 6, upcoming.length))}
+              className="mt-1 rounded-full border border-gray-700 py-3 text-sm font-bold text-gray-300 active:opacity-80"
+            >
+              もっと先の時間を見る
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ---- 待機画面 (スケジュール未設定・開催予定なし) ----
   if (!state.live) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-gray-900 p-6 text-white">
+      <div className="flex min-h-dvh flex-col items-center justify-center bg-gray-900 p-6 text-white">
         <p className="mb-2 text-sm text-gray-400">次回のライブ配信</p>
         <h1 className="mb-6 text-center text-xl font-bold">{state.title}</h1>
         {state.nextSessionAt !== null ? (
@@ -374,14 +735,77 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
     );
   }
 
+  // ---- ライブ参加ゲート (途中参加の強制再生を防ぐ) ----
+  if (state.live && !joined) {
+    const elapsedMin = Math.max(1, Math.floor(expectedPosition() / 60));
+    const upcoming = state.upcoming ?? [];
+    const visibleUpcoming = upcoming.slice(0, visibleSessionCount);
+    const registered = state.registeredSessionAt ?? null;
+    return (
+      <div className="flex min-h-dvh flex-col items-center justify-center bg-gray-900 p-6 text-white">
+        <span className="rounded bg-red-600 px-2 py-0.5 text-xs font-bold">● LIVE</span>
+        <h1 className="mt-3 text-center text-xl font-bold">{state.title}</h1>
+        <div className="mt-5 w-full max-w-sm rounded-2xl bg-gray-800/60 p-5 text-center">
+          <p className="text-sm font-bold text-gray-400">🔴 いま配信中です（{elapsedMin}分経過）</p>
+          <p className="mt-2 text-xs leading-relaxed text-gray-500">
+            この回への途中からの参加はできません。
+            <br />
+            次の回のスタートからご参加ください
+          </p>
+        </div>
+        {upcoming.length > 0 && (
+          <>
+            <p className="mt-6 text-sm text-gray-300">
+              {registered !== null
+                ? `✅ ${formatJp(registered)} の回を予約済み`
+                : '次の回を最初から予約する'}
+            </p>
+            <div className="mt-3 flex w-full max-w-sm flex-col gap-2">
+              {visibleUpcoming.map((t) => (
+                <button
+                  key={t}
+                  disabled={registering}
+                  onClick={() => void registerSession(t)}
+                  className={`rounded-full py-3 text-center font-bold active:opacity-80 disabled:opacity-50 ${
+                    registered === t ? 'bg-[#06C755] text-white' : 'bg-gray-800 text-gray-100'
+                  }`}
+                >
+                  {formatJp(t)} の回{registered === t ? ' ✅' : ''}
+                </button>
+              ))}
+              {visibleUpcoming.length < upcoming.length && (
+                <button
+                  type="button"
+                  onClick={() => setVisibleSessionCount((count) => Math.min(count + 6, upcoming.length))}
+                  className="mt-1 rounded-full border border-gray-700 py-3 text-sm font-bold text-gray-300 active:opacity-80"
+                >
+                  もっと先の時間を見る
+                </button>
+              )}
+            </div>
+            {registered !== null && (
+              <p className="mt-3 text-xs text-gray-500">
+                開始5分前にLINEでお知らせします。このページは閉じてOKです
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    );
+  }
+
   // ---- ライブ / 終了画面 ----
+  // PC の横長ウィンドウで video (w-full) が画面高を食い尽くしてチャット欄が
+  // 潰れないよう、全体をスマホ幅カラム (max-w-md) に閉じ込めて中央寄せする。
+  // スマホでは max-w-md は効かないので挙動不変。
   return (
-    <div className="flex h-screen flex-col bg-gray-900 text-white">
-      <div className="relative">
+    <div className="flex h-dvh justify-center bg-gray-900 text-white">
+      <div className="flex h-full w-full max-w-md flex-col">
+      <div className="relative shrink-0">
         <video ref={videoRef} className="w-full" playsInline />
         {!ended && (
-          <span className={`absolute left-2 top-2 rounded px-2 py-0.5 text-xs font-bold ${IS_PREVIEW ? 'bg-gray-600' : 'bg-red-600'}`}>
-            {IS_PREVIEW ? 'PREVIEW' : '● LIVE'}
+          <span className={`absolute left-2 top-2 rounded px-2 py-0.5 text-xs font-bold ${IS_PREVIEW || state.replay ? 'bg-gray-600' : 'bg-red-600'}`}>
+            {IS_PREVIEW ? 'PREVIEW' : state.replay ? 'REPLAY' : '● LIVE'}
           </span>
         )}
         {!ended && (
@@ -430,7 +854,7 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
                 if (v) v.playbackRate = r;
                 setRate(r);
               }}
-              className={`rounded px-2 py-1 font-bold ${rate === r ? 'bg-blue-600 text-white' : 'bg-gray-800 text-gray-300'}`}
+              className={`rounded-full px-2.5 py-1 font-bold ${rate === r ? 'bg-white text-gray-900' : 'bg-gray-800 text-gray-400'}`}
             >
               {r}x
             </button>
@@ -439,26 +863,51 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
       )}
 
       <div ref={chatBoxRef} className="flex-1 overflow-y-auto p-3 text-sm">
-        {chat.map((item) => (
-          <div key={item.key} className="mb-2">
-            <span className={item.mine ? 'font-bold text-green-400' : 'font-bold text-blue-300'}>
-              {item.authorName}
-            </span>{' '}
-            <span className="text-gray-100">{item.body}</span>
-          </div>
-        ))}
+        {chat.map((item) =>
+          item.ctaCard ? (
+            <div
+              key={item.key}
+              className="cta-card wb-card mb-3 p-4"
+            >
+              <p className="text-base font-bold text-gray-900">{item.ctaCard.title}</p>
+              {item.ctaCard.body && (
+                <p className="mt-1 text-sm leading-relaxed text-gray-600">{item.ctaCard.body}</p>
+              )}
+              <button
+                onClick={() => openCta(item.ctaCard!)}
+                className="mt-3 w-full rounded-full bg-[#06C755] py-3 text-center text-base font-bold text-white active:opacity-80"
+              >
+                {item.ctaCard.buttonLabel}
+              </button>
+            </div>
+          ) : (
+            <div key={item.key} className="mb-2">
+              <span className={item.mine ? 'font-medium text-[#06C755]' : 'font-medium text-gray-400'}>
+                {item.authorName}
+              </span>{' '}
+              <span className="text-gray-100">{item.body}</span>
+            </div>
+          ),
+        )}
       </div>
 
-      {ctaVisible && state.cta && (
+      {activeCta ? (
+        <button
+          onClick={() => openCta(activeCta)}
+          className="mx-3 mb-2 rounded-full bg-[#06C755] py-3 text-center font-bold text-white active:opacity-80"
+        >
+          {activeCta.buttonLabel}
+        </button>
+      ) : ctaVisible && state.cta ? (
         <button
           onClick={clickCta}
-          className="mx-3 mb-2 rounded-lg bg-orange-500 py-3 text-center font-bold text-white shadow-lg"
+          className="mx-3 mb-2 rounded-full bg-[#06C755] py-3 text-center font-bold text-white active:opacity-80"
         >
           {state.cta.label}
         </button>
-      )}
+      ) : null}
 
-      {!ended && (
+      {!ended && !state.replay && (
         <div className="flex gap-2 border-t border-gray-700 p-2">
           <input
             value={input}
@@ -468,16 +917,298 @@ function WebinarApp({ ctx, slug }: { ctx: WebinarContext; slug: string }) {
             }}
             placeholder="コメントを入力..."
             maxLength={500}
-            className="flex-1 rounded bg-gray-800 px-3 py-2 text-base text-white placeholder-gray-500"
+            className="flex-1 rounded-full bg-gray-800 px-4 py-2 text-base text-white placeholder-gray-500"
           />
           <button
             onClick={() => void sendComment()}
-            className="rounded bg-blue-600 px-4 py-2 text-sm font-bold"
+            className="rounded-full bg-[#06C755] px-4 py-2 text-sm font-bold active:opacity-80"
           >
             送信
           </button>
         </div>
       )}
+
+      {formSheet && (
+        <FormSheet
+          sheet={formSheet}
+          ctx={ctx}
+          onClose={() => setFormSheet(null)}
+          onSubmitted={(def) => setFormSheet({ cta: formSheet.cta, phase: 'done', def })}
+        />
+      )}
+      </div>
+    </div>
+  );
+}
+
+// ─── インラインフォームシート ─────────────────────────────
+// 動画は上部で再生継続したまま、下からせり上がるシートでフォーム回答を完結させる。
+// 送信は既存 POST /api/forms/:id/submit — タグ付与・シナリオ発火・回答保存が
+// フォーム機能側でそのまま動く。
+
+function FormSheet({
+  sheet,
+  ctx,
+  onClose,
+  onSubmitted,
+}: {
+  sheet:
+    | { cta: WebinarCtaCard; phase: 'loading' }
+    | { cta: WebinarCtaCard; phase: 'form'; def: FormDef }
+    | { cta: WebinarCtaCard; phase: 'done'; def: FormDef }
+    | { cta: WebinarCtaCard; phase: 'error'; message: string };
+  ctx: WebinarContext;
+  onClose: () => void;
+  onSubmitted: (def: FormDef) => void;
+}) {
+  const [values, setValues] = useState<Record<string, string | string[]>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setValue = (name: string, v: string | string[]) =>
+    setValues((prev) => ({ ...prev, [name]: v }));
+
+  const submit = async () => {
+    if (sheet.phase !== 'form' || submitting) return;
+    const def = sheet.def;
+    for (const f of def.fields) {
+      const v = values[f.name];
+      const empty = v === undefined || v === '' || (Array.isArray(v) && v.length === 0);
+      if (f.required && empty) {
+        setError(`「${f.label}」は必須項目です`);
+        return;
+      }
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const r = await fetch(`/api/forms/${encodeURIComponent(def.id)}/submit`, {
+        method: 'POST',
+        headers: buildAuthHeaders(ctx, { 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ data: values }),
+      });
+      const json = (await r.json()) as { success: boolean; error?: string };
+      if (!r.ok || !json.success) {
+        setError(json.error || '送信に失敗しました。もう一度お試しください。');
+        setSubmitting(false);
+        return;
+      }
+      onSubmitted(def);
+    } catch {
+      setError('送信に失敗しました。通信環境をご確認ください。');
+      setSubmitting(false);
+    }
+  };
+
+  const inputCls =
+    'w-full min-w-0 rounded border border-gray-300 bg-white px-3 py-2 text-base text-gray-900';
+  const todayJst = new Date(Date.now() + 9 * 3600_000).toISOString().slice(0, 10);
+  const meetingDateOptions = buildMeetingDateOptions(todayJst);
+
+  const completionUrl = sheet.phase === 'done'
+    ? sheet.def.onSubmitMessageContent?.match(/https?:\/\/[^\s]+/)?.[0] ?? null
+    : null;
+
+  const openCompletionUrl = () => {
+    if (!completionUrl) return;
+    if (typeof liff !== 'undefined' && liff.isInClient()) {
+      liff.openWindow({ url: completionUrl, external: false });
+    } else {
+      window.open(completionUrl, '_blank', 'noopener');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col justify-end">
+      <button
+        aria-label="閉じる"
+        className="flex-1 bg-black/40"
+        onClick={onClose}
+      />
+      <div className="mx-auto w-full max-w-md max-h-[75vh] overflow-y-auto rounded-t-2xl bg-white p-5 text-gray-900">
+        <div className="mx-auto mb-3 h-1 w-10 rounded bg-gray-300" />
+        {sheet.phase === 'loading' && (
+          <p className="py-8 text-center text-gray-500">読み込み中...</p>
+        )}
+        {sheet.phase === 'error' && (
+          <div className="py-6 text-center">
+            <p className="text-gray-700">{sheet.message}</p>
+            <button onClick={onClose} className="mt-4 rounded bg-gray-200 px-6 py-2 font-bold">
+              閉じる
+            </button>
+          </div>
+        )}
+        {sheet.phase === 'done' && (
+          <div className="py-6 text-center">
+            <p className="text-2xl">🎉</p>
+            <p className="mt-2 text-lg font-bold">あと1ステップで予約完了です</p>
+            <p className="mt-1 text-sm text-gray-500">
+              空いている15分枠を選んでください。
+            </p>
+            {completionUrl && (
+              <button
+                onClick={openCompletionUrl}
+                className="mt-5 w-full rounded-full bg-[#06C755] px-6 py-3 font-bold text-white active:opacity-80"
+              >
+                日程を選んで予約を完了する
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="mt-4 rounded-full border border-gray-300 px-8 py-2.5 font-bold text-gray-600 active:opacity-80"
+            >
+              あとで予約する
+            </button>
+          </div>
+        )}
+        {sheet.phase === 'form' && (
+          <>
+            <h2 className="text-lg font-bold">{sheet.def.name}</h2>
+            {sheet.def.description && (
+              <p className="mt-1 text-sm text-gray-500">{sheet.def.description}</p>
+            )}
+            <div className="mt-4 space-y-4 pb-2">
+              {sheet.def.fields.map((f) => {
+                const dateMatch = /^meeting_date_(\d+)$/.exec(f.name);
+                const timeMatch = /^meeting_time_(\d+)$/.exec(f.name);
+                if (
+                  timeMatch &&
+                  sheet.def.fields.some((candidate) => candidate.name === `meeting_date_${timeMatch[1]}`)
+                ) {
+                  return null;
+                }
+                if (dateMatch) {
+                  const order = dateMatch[1];
+                  const timeField = sheet.def.fields.find(
+                    (candidate) => candidate.name === `meeting_time_${order}`,
+                  );
+                  if (timeField) {
+                    return (
+                      <fieldset key={f.name} className="rounded-xl border border-gray-200 bg-gray-50 p-3">
+                        <legend className="px-1 text-sm font-bold text-gray-700">
+                          第{order}希望
+                          {(f.required || timeField.required) && (
+                            <span className="ml-1 text-red-500">*</span>
+                          )}
+                        </legend>
+                        <div className="grid grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] gap-2">
+                          <label className="block text-xs font-medium text-gray-600">
+                            日付
+                            <select
+                              value={(values[f.name] as string) ?? ''}
+                              onChange={(e) => setValue(f.name, e.target.value)}
+                              className={`mt-1 ${inputCls}`}
+                            >
+                              <option value="">日付を選択</option>
+                              {meetingDateOptions.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                  {option.label}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                          <label className="block text-xs font-medium text-gray-600">
+                            開始時刻
+                            <select
+                              value={(values[timeField.name] as string) ?? ''}
+                              onChange={(e) => setValue(timeField.name, e.target.value)}
+                              className={`mt-1 ${inputCls}`}
+                            >
+                              <option value="">選択</option>
+                              {(timeField.options ?? []).map((option) => (
+                                <option key={option} value={option}>{option}</option>
+                              ))}
+                            </select>
+                          </label>
+                        </div>
+                      </fieldset>
+                    );
+                  }
+                }
+                return (
+                <label key={f.name} className="block text-sm">
+                  <span className="font-medium">
+                    {f.label}
+                    {f.required && <span className="ml-1 text-red-500">*</span>}
+                  </span>
+                  {f.type === 'textarea' ? (
+                    <textarea
+                      rows={3}
+                      placeholder={f.placeholder}
+                      value={(values[f.name] as string) ?? ''}
+                      onChange={(e) => setValue(f.name, e.target.value)}
+                      className={`mt-1 ${inputCls}`}
+                    />
+                  ) : f.type === 'select' ? (
+                    <select
+                      value={(values[f.name] as string) ?? ''}
+                      onChange={(e) => setValue(f.name, e.target.value)}
+                      className={`mt-1 ${inputCls}`}
+                    >
+                      <option value="">選択してください</option>
+                      {(f.options ?? []).map((o) => (
+                        <option key={o} value={o}>{o}</option>
+                      ))}
+                    </select>
+                  ) : f.type === 'radio' ? (
+                    <div className="mt-1 space-y-1.5">
+                      {(f.options ?? []).map((o) => (
+                        <label key={o} className="flex items-center gap-2">
+                          <input
+                            type="radio"
+                            name={f.name}
+                            checked={values[f.name] === o}
+                            onChange={() => setValue(f.name, o)}
+                          />
+                          <span>{o}</span>
+                        </label>
+                      ))}
+                    </div>
+                  ) : f.type === 'checkbox' ? (
+                    <div className="mt-1 space-y-1.5">
+                      {(f.options ?? []).map((o) => {
+                        const cur = (values[f.name] as string[]) ?? [];
+                        return (
+                          <label key={o} className="flex items-center gap-2">
+                            <input
+                              type="checkbox"
+                              checked={cur.includes(o)}
+                              onChange={(e) =>
+                                setValue(
+                                  f.name,
+                                  e.target.checked ? [...cur, o] : cur.filter((x) => x !== o),
+                                )
+                              }
+                            />
+                            <span>{o}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  ) : (
+                    <input
+                      type={f.type}
+                      placeholder={f.placeholder}
+                      value={(values[f.name] as string) ?? ''}
+                      onChange={(e) => setValue(f.name, e.target.value)}
+                      className={`mt-1 ${inputCls}`}
+                    />
+                  )}
+                </label>
+                );
+              })}
+            </div>
+            {error && <p className="mt-2 text-sm font-bold text-red-600">{error}</p>}
+            <button
+              onClick={() => void submit()}
+              disabled={submitting}
+              className="mt-4 w-full rounded-full bg-[#06C755] py-3 text-base font-bold text-white shadow disabled:opacity-50 active:opacity-80"
+            >
+              {submitting ? '送信中...' : '送信する'}
+            </button>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/worker/src/client/webinar/styles.css
+++ b/apps/worker/src/client/webinar/styles.css
@@ -17,3 +17,134 @@ body.wb-active #app {
   width: 100% !important;
   padding: 0 !important;
 }
+
+/* ─── 必要最低限の preflight (event-booking と同一パターン) ──────
+ * これが無いと iOS Safari 等で button/input の UA デフォルト装飾
+ * (ベベル・枠線・光沢) がそのまま出てしまう。 */
+:where(body.wb-active),
+:where(body.wb-active) *,
+:where(body.wb-active) *::before,
+:where(body.wb-active) *::after {
+  box-sizing: border-box;
+}
+:where(body.wb-active) h1,
+:where(body.wb-active) h2,
+:where(body.wb-active) h3,
+:where(body.wb-active) h4,
+:where(body.wb-active) h5,
+:where(body.wb-active) h6 {
+  font-size: inherit;
+  font-weight: inherit;
+  margin: 0;
+}
+:where(body.wb-active) p,
+:where(body.wb-active) dl,
+:where(body.wb-active) dd,
+:where(body.wb-active) dt,
+:where(body.wb-active) ol,
+:where(body.wb-active) ul,
+:where(body.wb-active) figure,
+:where(body.wb-active) blockquote {
+  margin: 0;
+}
+:where(body.wb-active) ol,
+:where(body.wb-active) ul {
+  list-style: none;
+  padding: 0;
+}
+:where(body.wb-active) button {
+  -webkit-appearance: none;
+  appearance: none;
+  font-family: inherit;
+  font-size: 100%;
+  font-weight: inherit;
+  line-height: inherit;
+  color: inherit;
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  background-image: none;
+  border: 0;
+  cursor: pointer;
+}
+:where(body.wb-active) button:disabled {
+  cursor: not-allowed;
+}
+:where(body.wb-active) input,
+:where(body.wb-active) textarea,
+:where(body.wb-active) select {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: inherit;
+  color: inherit;
+  margin: 0;
+}
+/* テキスト系入力だけ UA 装飾 (ベベル・枠線) を除去。
+ * radio / checkbox は native 描画を残して accent-color で揃える (form.ts と同じ)。
+ * select は appearance を消すと矢印が消えるので残す。 */
+:where(body.wb-active) input:not([type='radio']):not([type='checkbox']),
+:where(body.wb-active) textarea {
+  -webkit-appearance: none;
+  appearance: none;
+  /* border: 0 (style が none になる) にすると Tailwind の .border 系
+   * (幅・色のみ指定) が描画されなくなる。Tailwind preflight と同じく
+   * 幅 0 + style solid でリセットする。 */
+  border-width: 0;
+  border-style: solid;
+  border-color: currentColor;
+  border-radius: 0;
+  background-color: transparent;
+}
+:where(body.wb-active) input[type='radio'],
+:where(body.wb-active) input[type='checkbox'] {
+  accent-color: #06c755;
+  width: 18px;
+  height: 18px;
+}
+:where(body.wb-active) textarea {
+  resize: vertical;
+}
+:where(body.wb-active) img,
+:where(body.wb-active) svg,
+:where(body.wb-active) video,
+:where(body.wb-active) canvas {
+  display: block;
+  max-width: 100%;
+}
+:where(body.wb-active) a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/* ハウススタイルのカード (eb-card と同じトーン) */
+.wb-card {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15), 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+/* CTA カードの登場モーメント: チャットに滑り込むフェード+リフト。
+ * 「ボタン出ました」の瞬間だけ動きで注意を引く。 */
+.cta-card {
+  animation: wb-cta-in 0.35s ease-out;
+}
+@keyframes wb-cta-in {
+  from { opacity: 0; transform: translateY(10px) scale(0.97); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cta-card { animation: none; }
+}
+
+/* ライブ視聴・待機ルーム中だけページの縦スクロールを禁止する (wb-lock は
+ * クライアントが state に応じて付け外し)。高さは dvh 基準 (モバイルの URL
+ * バー分 100vh が実画面より高くなる問題の回避)。スクロールはチャット欄の
+ * 内部のみ。セッション選択メニュー等の通常ページはスクロール可能なまま。 */
+body.wb-active.wb-lock {
+  height: 100dvh;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+body.wb-active.wb-lock #app {
+  height: 100%;
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -866,7 +866,7 @@ app.notFound(notFoundHandler);
 async function scheduled(
   event: ScheduledEvent,
   env: Env['Bindings'],
-  _ctx: ExecutionContext,
+  ctx: ExecutionContext,
 ): Promise<void> {
   // Get all active accounts from DB
   const dbAccounts = await getLineAccounts(env.DB);
@@ -929,6 +929,28 @@ async function scheduled(
     }
   } catch (e) {
     console.error('event-booking-reminders error:', e);
+  }
+
+  // ウェビナー予約リマインド (セッション選択メニュー)。時刻厳守・軽量なので
+  // booking 系リマインドと同じく重いジョブより先に実行する。
+  try {
+    const { processWebinarReminders } = await import('./services/webinar-reminders.js');
+    const liffMatch = /liff\.line\.me\/([^/?]+)/.exec(env.LIFF_URL ?? '');
+    const result = await processWebinarReminders(
+      env.DB,
+      {
+        proxyBaseUrl:
+          env.WORKER_PUBLIC_URL ?? 'https://your-worker.your-subdomain.workers.dev',
+        defaultAccessToken: env.LINE_CHANNEL_ACCESS_TOKEN,
+        defaultLiffId: liffMatch?.[1] ?? null,
+        proxyDispatch: (request) => Promise.resolve(lineProxy.fetch(request, env, ctx)),
+      },
+    );
+    if (result.sent + result.failed > 0) {
+      console.log(`[webinar-reminders] sent=${result.sent} failed=${result.failed}`);
+    }
+  } catch (e) {
+    console.error('webinar-reminders error:', e);
   }
 
   // Phase 2: 配信系と定期ジョブを並列実行する。processScheduledBroadcasts は tag/all の

--- a/apps/worker/src/routes/forms.security.test.ts
+++ b/apps/worker/src/routes/forms.security.test.ts
@@ -7,6 +7,8 @@ const mocks = vi.hoisted(() => ({
   getFriendByLineUserId: vi.fn(),
   createFormSubmission: vi.fn(),
   verifyCallerLineUserId: vi.fn(),
+  getLineAccountById: vi.fn(),
+  dispatchLineProxyLocally: vi.fn(),
 }));
 
 vi.mock('@line-crm/db', () => ({
@@ -20,6 +22,9 @@ vi.mock('@line-crm/db', () => ({
   createFormSubmission: mocks.createFormSubmission,
   getFriendByLineUserId: mocks.getFriendByLineUserId,
   getFriendById: vi.fn(),
+  getTrackedLinkById: vi.fn(),
+  getMessageTemplateById: vi.fn(),
+  getLineAccountById: mocks.getLineAccountById,
   enrollFriendInScenario: vi.fn(),
   jstNow: vi.fn(() => '2026-08-04T12:00:00+09:00'),
 }));
@@ -30,6 +35,10 @@ vi.mock('../services/liff-auth.js', () => ({
 
 vi.mock('../services/friend-tag-attach.js', () => ({
   attachTagAndFireSideEffects: vi.fn(),
+}));
+
+vi.mock('../services/local-line-proxy.js', () => ({
+  dispatchLineProxyLocally: mocks.dispatchLineProxyLocally,
 }));
 
 import { forms } from './forms.js';
@@ -96,6 +105,7 @@ beforeEach(() => {
     data: input.data,
     created_at: '2026-08-04T12:00:00+09:00',
   }));
+  mocks.dispatchLineProxyLocally.mockResolvedValue(new Response(null, { status: 200 }));
 });
 
 afterEach(() => {
@@ -137,6 +147,62 @@ describe('public form representation', () => {
 });
 
 describe('LIFF identity enforcement', () => {
+  test('stores every required AI consultation field including the selected meeting slot', async () => {
+    mocks.getFormById.mockResolvedValue({
+      ...baseForm,
+      fields: JSON.stringify([
+        { name: 'name', label: 'お名前', type: 'text', required: true },
+        { name: 'company', label: '会社名・屋号', type: 'text', required: true },
+        { name: 'annual_revenue', label: '年商規模', type: 'select', required: true },
+        { name: 'budget', label: '予算感', type: 'select', required: true },
+        { name: 'ai_goal', label: '改善したいこと', type: 'textarea', required: true },
+        { name: 'meeting_date_1', label: '第1希望日', type: 'date', required: true },
+        { name: 'meeting_time_1', label: '第1希望開始時刻', type: 'select', required: true },
+      ]),
+      on_submit_tag_id: null,
+      on_submit_scenario_id: null,
+      on_submit_message_type: null,
+      on_submit_message_content: null,
+      on_submit_webhook_url: null,
+      on_submit_webhook_headers: null,
+      on_submit_webhook_fail_message: null,
+      save_to_metadata: 0,
+    });
+    mocks.verifyCallerLineUserId.mockResolvedValue('line-real');
+    mocks.getFriendByLineUserId.mockResolvedValue({
+      id: 'friend-real',
+      line_user_id: null,
+      display_name: 'Real User',
+      metadata: '{}',
+    });
+    const { bindings } = env();
+    const data = {
+      name: '山田太郎',
+      company: '株式会社テスト',
+      annual_revenue: '3,000万〜1億円',
+      budget: '10万〜30万円',
+      ai_goal: '問い合わせ対応を自動化したい',
+      meeting_date_1: '2026-08-12',
+      meeting_time_1: '14:30',
+    };
+
+    const res = await app().request('/api/forms/form-1/submit', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer valid-line-id-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ data }),
+    }, bindings);
+
+    expect(res.status).toBe(201);
+    expect(mocks.createFormSubmission).toHaveBeenCalledWith(bindings.DB, {
+      formId: 'form-1',
+      friendId: 'friend-real',
+      data: JSON.stringify(data),
+    });
+  });
+
   test('rejects partial metadata writes without a valid LINE ID token', async () => {
     const { bindings, prepare } = env();
     const res = await app().request('/api/forms/form-1/partial', {
@@ -240,5 +306,51 @@ describe('LIFF identity enforcement', () => {
       expect.objectContaining({ friendId: 'victim-friend' }),
     );
     expect((await res.json() as { data: { webhookPassed: boolean } }).data.webhookPassed).toBe(false);
+  });
+
+  test('webhook rejection reply goes through the Harness proxy', async () => {
+    mocks.verifyCallerLineUserId.mockResolvedValue('line-real');
+    mocks.getFriendByLineUserId.mockResolvedValue({
+      id: 'friend-real',
+      line_user_id: 'U-real',
+      line_account_id: null,
+      display_name: 'Real User',
+      metadata: '{}',
+    });
+    const fetchMock = vi.fn<
+      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    >(async (input) => {
+      const url = String(input);
+      if (url.startsWith('https://verify.example.test/')) {
+        return new Response(JSON.stringify({ eligible: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const { bindings } = env();
+
+    const res = await app().request('/api/forms/form-1/submit', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer valid-line-id-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ data: { x_username: 'alice' } }),
+    }, bindings);
+
+    expect(res.status).toBe(201);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mocks.dispatchLineProxyLocally).toHaveBeenCalledTimes(1);
+    const proxyRequest = mocks.dispatchLineProxyLocally.mock.calls[0][0] as Request;
+    expect(proxyRequest.url).toBe('http://localhost/line-api/v2/bot/message/push');
+    expect(proxyRequest.headers.get('Authorization')).toBe('Bearer line-token');
+    expect(await proxyRequest.json()).toEqual({
+      to: 'U-real',
+      messages: [{ type: 'text', text: '条件を満たしていません' }],
+    });
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('api.line.me'))).toBe(false);
   });
 });

--- a/apps/worker/src/routes/forms.ts
+++ b/apps/worker/src/routes/forms.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import {
   getForms,
   getFormsWithStats,
@@ -8,20 +8,45 @@ import {
   deleteForm,
   getFormSubmissions,
   createFormSubmission,
+  getFriendByLineUserId,
+  getFriendById,
+  getLineAccountById,
   jstNow,
 } from '@line-crm/db';
-import { getFriendByLineUserId, getFriendById } from '@line-crm/db';
 import { enrollFriendInScenario } from '@line-crm/db';
 import { attachTagAndFireSideEffects } from '../services/friend-tag-attach.js';
 import { verifyCallerLineUserId } from '../services/liff-auth.js';
+import { pushViaHarnessProxy } from '../services/line-proxy-send.js';
+import { dispatchLineProxyLocally } from '../services/local-line-proxy.js';
 import type {
   Form as DbForm,
   FormSubmission as DbFormSubmission,
   FormUsedByAccount,
+  Friend as DbFriend,
 } from '@line-crm/db';
 import type { Env } from '../index.js';
 
 const forms = new Hono<Env>();
+
+function optionalExecutionCtx(c: Context<Env>): ExecutionContext | undefined {
+  try {
+    return c.executionCtx;
+  } catch {
+    // Hono unit tests do not provide a Workers ExecutionContext.
+    return undefined;
+  }
+}
+
+async function resolveFriendAccessToken(
+  db: D1Database,
+  friend: DbFriend,
+  defaultAccessToken: string,
+): Promise<string> {
+  const accountId = friend.line_account_id ?? null;
+  if (!accountId) return defaultAccessToken;
+  const account = await getLineAccountById(db, accountId);
+  return account?.channel_access_token ?? defaultAccessToken;
+}
 
 function serializeForm(
   row: DbForm,
@@ -389,22 +414,19 @@ forms.post('/api/forms/:id/submit', async (c) => {
         if (form.on_submit_webhook_fail_message) {
           if (friend.line_user_id) {
             try {
-              const { LineClient } = await import('@line-crm/line-sdk');
-              let accessToken = c.env.LINE_CHANNEL_ACCESS_TOKEN;
-              if ((friend as unknown as Record<string, unknown>).line_account_id) {
-                const { getLineAccountById } = await import('@line-crm/db');
-                const account = await getLineAccountById(c.env.DB, (friend as unknown as Record<string, unknown>).line_account_id as string);
-                if (account) accessToken = account.channel_access_token;
-              }
-              const lineClient = new LineClient(accessToken);
-              await lineClient.pushMessage(friend.line_user_id, [{ type: 'text', text: form.on_submit_webhook_fail_message }]);
-              await c.env.DB
-                .prepare(
-                  `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, created_at)
-                   VALUES (?, ?, 'outgoing', 'text', ?, NULL, NULL, 'auto_reply', ?)`,
-                )
-                .bind(crypto.randomUUID(), friend.id, form.on_submit_webhook_fail_message, jstNow())
-                .run();
+              const accessToken = await resolveFriendAccessToken(
+                c.env.DB,
+                friend,
+                c.env.LINE_CHANNEL_ACCESS_TOKEN,
+              );
+              await pushViaHarnessProxy(
+                new URL(c.req.url).origin,
+                accessToken,
+                friend.line_user_id,
+                [{ type: 'text', text: form.on_submit_webhook_fail_message }],
+                crypto.randomUUID(),
+                (request) => dispatchLineProxyLocally(request, c.env, optionalExecutionCtx(c)),
+              );
             } catch (e) {
               console.error('Failed to send webhook fail message:', e);
             }
@@ -499,14 +521,11 @@ forms.post('/api/forms/:id/submit', async (c) => {
           (async () => {
             const friend = await getFriendById(db, friendId!);
             if (!friend?.line_user_id) return;
-            const { LineClient } = await import('@line-crm/line-sdk');
-            let accessToken = c.env.LINE_CHANNEL_ACCESS_TOKEN;
-            if ((friend as unknown as Record<string, unknown>).line_account_id) {
-              const { getLineAccountById } = await import('@line-crm/db');
-              const account = await getLineAccountById(db, (friend as unknown as Record<string, unknown>).line_account_id as string);
-              if (account) accessToken = account.channel_access_token;
-            }
-            const lineClient = new LineClient(accessToken);
+            const accessToken = await resolveFriendAccessToken(
+              db,
+              friend,
+              c.env.LINE_CHANNEL_ACCESS_TOKEN,
+            );
             const joinUrl = String(webhookData!.join_url);
             const meetFlex = {
               type: 'bubble',
@@ -535,16 +554,14 @@ forms.post('/api/forms/:id/submit', async (c) => {
                 paddingAll: '16px',
               },
             };
-            await lineClient.pushMessage(friend.line_user_id, [
-              { type: 'flex', altText: 'ヒアリングの準備ができました', contents: meetFlex },
-            ]);
-            await db
-              .prepare(
-                `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, created_at)
-                 VALUES (?, ?, 'outgoing', 'flex', ?, NULL, NULL, 'auto_reply', ?)`,
-              )
-              .bind(crypto.randomUUID(), friend.id, JSON.stringify(meetFlex), jstNow())
-              .run();
+            await pushViaHarnessProxy(
+              new URL(c.req.url).origin,
+              accessToken,
+              friend.line_user_id,
+              [{ type: 'flex', altText: 'ヒアリングの準備ができました', contents: meetFlex }],
+              crypto.randomUUID(),
+              (request) => dispatchLineProxyLocally(request, c.env, optionalExecutionCtx(c)),
+            );
           })(),
         );
       }
@@ -556,15 +573,11 @@ forms.post('/api/forms/:id/submit', async (c) => {
           const friend = await getFriendById(db, friendId!);
           if (!friend?.line_user_id) { console.log('Form reply: no line_user_id'); return; }
           console.log('Form reply: sending to', friend.line_user_id);
-          const { LineClient } = await import('@line-crm/line-sdk');
-          // Resolve access token from friend's account (multi-account support)
-          let accessToken = c.env.LINE_CHANNEL_ACCESS_TOKEN;
-          if ((friend as unknown as Record<string, unknown>).line_account_id) {
-            const { getLineAccountById } = await import('@line-crm/db');
-            const account = await getLineAccountById(db, (friend as unknown as Record<string, unknown>).line_account_id as string);
-            if (account) accessToken = account.channel_access_token;
-          }
-          const lineClient = new LineClient(accessToken);
+          const accessToken = await resolveFriendAccessToken(
+            db,
+            friend,
+            c.env.LINE_CHANNEL_ACCESS_TOKEN,
+          );
           const { buildMessage, expandVariables } = await import('../services/step-delivery.js');
           const apiOrigin = new URL(c.req.url).origin;
           const { resolveMetadata } = await import('../services/step-delivery.js');
@@ -633,23 +646,15 @@ forms.post('/api/forms/:id/submit', async (c) => {
             messages.push(buildMessage('flex', JSON.stringify(resultFlex)));
           }
 
-          await lineClient.pushMessage(friend.line_user_id, messages);
-
-          // Mirror every pushed message into messages_log so the dashboard chat
-          // view stays consistent with what the user actually receives in LINE.
-          // Without this the form's auto-reply is invisible to operators.
-          const { messageToLogPayload } = await import('../services/step-delivery.js');
-          const sentAt = jstNow();
-          for (const m of messages) {
-            const payload = messageToLogPayload(m);
-            await db
-              .prepare(
-                `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, created_at)
-                 VALUES (?, ?, 'outgoing', ?, ?, NULL, NULL, 'auto_reply', ?)`,
-              )
-              .bind(crypto.randomUUID(), friend.id, payload.messageType, payload.content, sentAt)
-              .run();
-          }
+          // プロキシが LINE 送信と messages_log 記録を一体で行う。
+          await pushViaHarnessProxy(
+            new URL(c.req.url).origin,
+            accessToken,
+            friend.line_user_id,
+            messages,
+            crypto.randomUUID(),
+            (request) => dispatchLineProxyLocally(request, c.env, optionalExecutionCtx(c)),
+          );
         })(),
       );
 

--- a/apps/worker/src/routes/friends.ts
+++ b/apps/worker/src/routes/friends.ts
@@ -6,6 +6,7 @@ import {
   addTagToFriend,
   removeTagFromFriend,
   getFriendTags,
+  getFormSubmissionsByFriend,
   getScenarios,
   enrollFriendInScenario,
   jstNow,
@@ -396,9 +397,10 @@ friends.get('/api/friends/:id', async (c) => {
     const id = c.req.param('id');
     const db = c.env.DB;
 
-    const [friend, tags] = await Promise.all([
+    const [friend, tags, formSubmissions] = await Promise.all([
       getFriendById(db, id),
       getFriendTags(db, id),
+      getFormSubmissionsByFriend(db, id, 10),
     ]);
 
     if (!friend) {
@@ -410,6 +412,14 @@ friends.get('/api/friends/:id', async (c) => {
       data: {
         ...serializeFriend(friend),
         tags: tags.map(serializeTag),
+        formSubmissions: formSubmissions.map((submission) => ({
+          id: submission.id,
+          formId: submission.form_id,
+          formName: submission.form_name,
+          fields: JSON.parse(submission.form_fields || '[]') as unknown[],
+          data: JSON.parse(submission.data || '{}') as Record<string, unknown>,
+          createdAt: submission.created_at,
+        })),
       },
     });
   } catch (err) {

--- a/apps/worker/src/routes/inbox.ts
+++ b/apps/worker/src/routes/inbox.ts
@@ -5,8 +5,33 @@ import {
   countUnanswered,
   type UnansweredInboxOptions,
 } from '../services/unanswered-inbox.js';
+import {
+  getActivityDigest,
+  parseActivityDigestHours,
+} from '../services/activity-digest.js';
 
 export const inbox = new Hono<Env>();
+
+// GET /api/inbox/activity-digest?hours=3
+// Codex の定期レポートなど、読み取り専用の外部クライアント向け集約 API。
+// グローバル authMiddleware 配下なので Bearer API key / admin session が必須。
+inbox.get('/api/inbox/activity-digest', async (c) => {
+  const hours = parseActivityDigestHours(c.req.query('hours'));
+  if (hours === null) {
+    return c.json({
+      success: false,
+      error: 'hours must be an integer between 1 and 168',
+    }, 400);
+  }
+
+  try {
+    const data = await getActivityDigest(c.env.DB, { hours });
+    return c.json({ success: true, data });
+  } catch (err) {
+    console.error('GET /api/inbox/activity-digest error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
 
 inbox.get('/api/inbox/unanswered', async (c) => {
   try {

--- a/apps/worker/src/routes/liff-offer-attribution.test.ts
+++ b/apps/worker/src/routes/liff-offer-attribution.test.ts
@@ -16,6 +16,7 @@ const dbMocks = {
   recoverStuckDeliveries: vi.fn(),
   // /api/liff/link + applyRefAttribution helpers
   getFriendByLineUserId: vi.fn(),
+  getFriendByLineUserIdForAccount: vi.fn(),
   getEntryRouteByRefCode: vi.fn().mockResolvedValue(null),
   getTrackedLinkById: vi.fn().mockResolvedValue(null),
   getAffiliateLinkByRefCode: vi.fn().mockResolvedValue(null),
@@ -93,6 +94,9 @@ function link(ref: string) {
 
 describe('POST /api/liff/link — offer tag/scenario on affiliate-link friend add', () => {
   beforeEach(() => {
+  dbMocks.getFriendByLineUserIdForAccount.mockImplementation(
+    (...args: unknown[]) => dbMocks.getFriendByLineUserId(...(args as [unknown, unknown])),
+  );
     vi.clearAllMocks();
     installVerifyMock();
     // Already-linked friend: user_id set so applyRefAttribution runs without

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -1,6 +1,7 @@
 import { Hono, type Context } from 'hono';
 import {
   getFriendByLineUserId,
+  getFriendByLineUserIdForAccount,
   createUser,
   getUserByEmail,
   linkFriendToUser,
@@ -1142,13 +1143,17 @@ liffRoutes.post('/api/liff/link', async (c) => {
     }
 
     let verifyRes: Response | null = null;
+    let matchedLoginChannelId: string | null = null;
     for (const channelId of loginChannelIds) {
       verifyRes = await fetch('https://api.line.me/oauth2/v2.1/verify', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({ id_token: body.idToken, client_id: channelId }),
       });
-      if (verifyRes.ok) break;
+      if (verifyRes.ok) {
+        matchedLoginChannelId = channelId;
+        break;
+      }
     }
 
     if (!verifyRes?.ok) {
@@ -1160,7 +1165,15 @@ liffRoutes.post('/api/liff/link', async (c) => {
     const email = verified.email || null;
 
     const db = c.env.DB;
-    const friend = await getFriendByLineUserId(db, lineUserId);
+    // id_token を検証できたログインチャネル = ユーザーが開いている LIFF のアカウント。
+    // friend 行とプッシュ先をそのアカウントに揃える (同一プロバイダーの兄弟アカウント
+    // では line_user_id が同一で、無指定の先頭一致だと別アカウントに吸われるため)。
+    const matchedAccount = matchedLoginChannelId
+      ? dbAccounts.find((a) => a.login_channel_id === matchedLoginChannelId) ?? null
+      : null;
+    const friend = await getFriendByLineUserIdForAccount(
+      db, lineUserId, matchedAccount?.id ?? null,
+    );
     if (!friend) {
       return c.json({ success: false, error: 'Friend not found' }, 404);
     }
@@ -1194,7 +1207,9 @@ liffRoutes.post('/api/liff/link', async (c) => {
         } catch { /* silent */ }
       }
       if (body.ref) {
-        await applyRefAttribution(c, body.ref, friend, lineUserId);
+        await applyRefAttribution(c, body.ref, friend, lineUserId, {
+          accountChannelId: matchedAccount?.channel_id ?? null,
+        });
       }
       // X Harness token resolution for already-linked friends
       if (body.ref && body.ref.startsWith('xh:')) {
@@ -1261,7 +1276,9 @@ liffRoutes.post('/api/liff/link', async (c) => {
       } catch { /* silent */ }
 
       // Apply ref attribution (tag + scenario push) for newly-linked friends
-      await applyRefAttribution(c, body.ref, friend, lineUserId);
+      await applyRefAttribution(c, body.ref, friend, lineUserId, {
+        accountChannelId: matchedAccount?.channel_id ?? null,
+      });
     }
 
     // X Harness token resolution: ref starting with "xh:" links X account to LINE friend

--- a/apps/worker/src/routes/webinars.test.ts
+++ b/apps/worker/src/routes/webinars.test.ts
@@ -8,6 +8,9 @@ const dbMocks = {
   updateWebinar: vi.fn(),
   deleteWebinar: vi.fn(),
   getWebinarComments: vi.fn(),
+  getWebinarCtas: vi.fn(),
+  replaceWebinarCtas: vi.fn(),
+  getFormById: vi.fn(),
   replaceWebinarComments: vi.fn(),
   upsertWebinarViewer: vi.fn(),
   updateWebinarViewerPosition: vi.fn(),
@@ -17,7 +20,18 @@ const dbMocks = {
   getWebinarUserComments: vi.fn(),
   getWebinarSessionStats: vi.fn(),
   getWebinarDropoff: vi.fn(),
+  getWebinarParticipantStats: vi.fn(),
+  getWebinarAnalyticsSummary: vi.fn(),
+  getWebinarDailyStats: vi.fn(),
   getFriendByLineUserId: vi.fn(),
+  getFriendByLineUserIdForAccount: vi.fn(),
+  getFriendById: vi.fn(),
+  getLineAccountById: vi.fn(),
+  upsertWebinarRegistration: vi.fn(),
+  getUpcomingWebinarRegistration: vi.fn(),
+  getWebinarRegistration: vi.fn(),
+  getDueWebinarRegistrations: vi.fn(),
+  markWebinarRegistrationNotified: vi.fn(),
 };
 vi.mock('@line-crm/db', () => dbMocks);
 
@@ -26,6 +40,9 @@ vi.mock('../services/liff-auth.js', () => authMock);
 
 const tagMock = { attachTagAndFireSideEffects: vi.fn() };
 vi.mock('../services/friend-tag-attach.js', () => tagMock);
+
+const localProxyMock = { dispatchLineProxyLocally: vi.fn() };
+vi.mock('../services/local-line-proxy.js', () => localProxyMock);
 
 const { webinarRoutes } = await import('./webinars.js');
 const { signWebinarToken } = await import('../lib/webinar-token.js');
@@ -53,7 +70,10 @@ function makeWebinar(over: Record<string, unknown> = {}) {
   };
 }
 
-const env = { DB: {} as D1Database, LINE_CHANNEL_SECRET: SECRET, IMAGES: {} as R2Bucket };
+const env = {
+  DB: {} as D1Database, LINE_CHANNEL_SECRET: SECRET, IMAGES: {} as R2Bucket,
+  LINE_CHANNEL_ACCESS_TOKEN: 'test-token', LIFF_URL: 'https://liff.line.me/999-test',
+};
 const execCtx = { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as unknown as ExecutionContext;
 
 function req(path: string, init?: RequestInit) {
@@ -63,15 +83,23 @@ function req(path: string, init?: RequestInit) {
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.useFakeTimers();
-  // ライブ開始30分後
-  vi.setSystemTime(new Date((SESSION_START + 1800) * 1000));
+  // ライブ開始3分後（予約済み本人が途中参加できる5分窓内）
+  vi.setSystemTime(new Date((SESSION_START + 180) * 1000));
   authMock.verifyCallerLineUserId.mockResolvedValue('U123');
   dbMocks.getFriendByLineUserId.mockResolvedValue({ id: 'friend-1' });
+  dbMocks.getFriendByLineUserIdForAccount.mockResolvedValue({ id: 'friend-1' });
   dbMocks.getWebinarBySlug.mockResolvedValue(makeWebinar());
   dbMocks.getWebinarComments.mockResolvedValue([
     { id: 'c1', webinar_id: 'w1', at_seconds: 10, author_name: '田中', body: '楽しみ!', created_at: 'x' },
   ]);
   dbMocks.upsertWebinarViewer.mockResolvedValue({ firstJoin: true });
+  dbMocks.getWebinarCtas.mockResolvedValue([]);
+  dbMocks.getUpcomingWebinarRegistration.mockResolvedValue(null);
+  dbMocks.getWebinarRegistration.mockResolvedValue({
+    id: 'reg-current', webinar_id: 'w1', friend_id: 'friend-1',
+    session_start_at: SESSION_START, notified_at: 'x', created_at: 'x',
+  });
+  localProxyMock.dispatchLineProxyLocally.mockResolvedValue(new Response(null, { status: 200 }));
 });
 
 describe('GET /api/liff/webinars/:slug', () => {
@@ -82,13 +110,131 @@ describe('GET /api/liff/webinars/:slug', () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.live).toBe(true);
-    expect(body.offsetSeconds).toBe(1800);
+    expect(body.offsetSeconds).toBe(180);
     expect(body.sessionStartAt).toBe(SESSION_START);
     expect(body.playlistUrl).toMatch(
       /^\/webinar-assets\/\d+\.[A-Za-z0-9_-]+\/test-webinar\/master\.m3u8$/,
     );
     expect(body.comments).toEqual([{ atSeconds: 10, authorName: '田中', body: '楽しみ!' }]);
+    // 予約済み本人だけが動画 URL を受け取る
+    expect(body.upcoming).toEqual([]);
+    expect(body.registeredSessionAt).toBeNull();
+    expect(body.registeredForThisSession).toBe(true);
     expect(dbMocks.upsertWebinarViewer).toHaveBeenCalledWith({}, 'w1', 'friend-1', SESSION_START);
+  });
+
+  test('friend はウェビナーのアカウント配下の行を優先解決する', async () => {
+    dbMocks.getWebinarBySlug.mockResolvedValue(makeWebinar({ account_id: 'acc-b' }));
+    await req('/api/liff/webinars/test-webinar', { headers: { Authorization: 'Bearer t' } });
+    expect(dbMocks.getFriendByLineUserIdForAccount).toHaveBeenCalledWith(
+      expect.anything(), 'U123', 'acc-b',
+    );
+  });
+
+  test('この回を予約済みの本人には registeredForThisSession=true を返す', async () => {
+    dbMocks.getWebinarRegistration.mockResolvedValue({
+      id: 'reg-1', webinar_id: 'w1', friend_id: 'friend-1',
+      session_start_at: SESSION_START, notified_at: 'x', created_at: 'x',
+    });
+    const res = await req('/api/liff/webinars/test-webinar', {
+      headers: { Authorization: 'Bearer t' },
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.registeredForThisSession).toBe(true);
+    expect(dbMocks.getWebinarRegistration).toHaveBeenCalledWith(
+      expect.anything(), 'w1', 'friend-1', SESSION_START,
+    );
+  });
+
+  test('開始ぴったりでも未予約者には動画URLを返さず、現在回を予約候補にする', async () => {
+    vi.setSystemTime(new Date(SESSION_START * 1000));
+    dbMocks.getWebinarRegistration.mockResolvedValue(null);
+    const res = await req('/api/liff/webinars/test-webinar', {
+      headers: { Authorization: 'Bearer t' },
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.live).toBe(false);
+    expect(body.upcoming).toEqual([SESSION_START]);
+    expect(body.playlistUrl).toBeUndefined();
+    expect(dbMocks.upsertWebinarViewer).not.toHaveBeenCalled();
+    expect(execCtx.waitUntil).not.toHaveBeenCalled();
+  });
+
+  test('開始5分ちょうどまでは、未予約者に現在回を予約候補として出す', async () => {
+    vi.setSystemTime(new Date((SESSION_START + 300) * 1000));
+    dbMocks.getWebinarRegistration.mockResolvedValue(null);
+    const res = await req('/api/liff/webinars/test-webinar', {
+      headers: { Authorization: 'Bearer t' },
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.live).toBe(false);
+    expect(body.upcoming).toEqual([SESSION_START]);
+    expect(body.playlistUrl).toBeUndefined();
+  });
+
+  test('開始5分を過ぎても、その回の予約済み本人は再入場できる', async () => {
+    vi.setSystemTime(new Date((SESSION_START + 301) * 1000));
+    const res = await req('/api/liff/webinars/test-webinar', {
+      headers: { Authorization: 'Bearer t' },
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.live).toBe(true);
+    expect(body.sessionStartAt).toBe(SESSION_START);
+    expect(body.offsetSeconds).toBe(301);
+    expect(body.registeredForThisSession).toBe(true);
+    expect(body.playlistUrl).toBeDefined();
+    expect(dbMocks.upsertWebinarViewer).toHaveBeenCalledWith(
+      expect.anything(), 'w1', 'friend-1', SESSION_START,
+    );
+  });
+
+  test('開始5分を過ぎた未予約者は、現在回に入れず次回選択に戻る', async () => {
+    vi.setSystemTime(new Date((SESSION_START + 301) * 1000));
+    dbMocks.getWebinarRegistration.mockResolvedValue(null);
+    const res = await req('/api/liff/webinars/test-webinar', {
+      headers: { Authorization: 'Bearer t' },
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.live).toBe(false);
+    expect(body.upcoming).toEqual([]);
+    expect(body.playlistUrl).toBeUndefined();
+    expect(dbMocks.upsertWebinarViewer).not.toHaveBeenCalled();
+  });
+
+  test('専用入場リンクは配信終了後も予約した回を再生できる', async () => {
+    vi.setSystemTime(new Date((SESSION_START + 7200 + 3600) * 1000));
+    dbMocks.getWebinarRegistration.mockResolvedValue({
+      id: 'reg-past', webinar_id: 'w1', friend_id: 'friend-1',
+      session_start_at: SESSION_START, notified_at: 'x', created_at: 'x',
+    });
+    const res = await req(
+      `/api/liff/webinars/test-webinar?sessionStartAt=${SESSION_START}`,
+      { headers: { Authorization: 'Bearer t' } },
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.live).toBe(true);
+    expect(body.replay).toBe(true);
+    expect(body.sessionStartAt).toBe(SESSION_START);
+    expect(body.offsetSeconds).toBe(0);
+    expect(body.registeredForThisSession).toBe(true);
+    expect(body.playlistUrl).toBeDefined();
+    expect(dbMocks.upsertWebinarViewer).toHaveBeenCalledWith(
+      expect.anything(), 'w1', 'friend-1', SESSION_START,
+    );
+  });
+
+  test('専用リンクの時刻を推測しても、本人の予約がなければ再生できない', async () => {
+    vi.setSystemTime(new Date((SESSION_START + 7200 + 3600) * 1000));
+    dbMocks.getWebinarRegistration.mockResolvedValue(null);
+    const res = await req(
+      `/api/liff/webinars/test-webinar?sessionStartAt=${SESSION_START}`,
+      { headers: { Authorization: 'Bearer t' } },
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.live).toBe(false);
+    expect(body.replay).toBeUndefined();
+    expect(body.playlistUrl).toBeUndefined();
+    expect(dbMocks.upsertWebinarViewer).not.toHaveBeenCalled();
   });
 
   test('tag_on_attend が waitUntil 経由で付与される', async () => {
@@ -96,15 +242,67 @@ describe('GET /api/liff/webinars/:slug', () => {
     expect(execCtx.waitUntil).toHaveBeenCalled();
   });
 
-  test('時間外は live:false と nextSessionAt', async () => {
-    vi.setSystemTime(new Date((SESSION_START - 600) * 1000));
+  test('開始10分より前は live:false と nextSessionAt のみ (待機ルームなし)', async () => {
+    vi.setSystemTime(new Date((SESSION_START - 3600) * 1000));
     const res = await req('/api/liff/webinars/test-webinar', {
       headers: { Authorization: 'Bearer t' },
     });
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.live).toBe(false);
+    expect(body.waiting).toBeUndefined();
     expect(body.nextSessionAt).toBe(SESSION_START);
+    expect(body.upcoming).toEqual([SESSION_START]);
+    expect(body.registeredSessionAt).toBeNull();
     expect(dbMocks.upsertWebinarViewer).not.toHaveBeenCalled();
+  });
+
+  test('開始10分前でも未予約者は待機ルームへ直行せず、予約画面を出す', async () => {
+    vi.setSystemTime(new Date((SESSION_START - 300) * 1000));
+    dbMocks.getUpcomingWebinarRegistration.mockResolvedValue(null);
+    const res = await req('/api/liff/webinars/test-webinar', {
+      headers: { Authorization: 'Bearer t' },
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.live).toBe(false);
+    expect(body.waiting).toBeUndefined();
+    expect(body.upcoming).toEqual([SESSION_START]);
+  });
+
+  test('開始10分前から予約済み本人だけ待機ルームに入る', async () => {
+    vi.setSystemTime(new Date((SESSION_START - 300) * 1000));
+    dbMocks.getUpcomingWebinarRegistration.mockResolvedValue({
+      id: 'reg-next', webinar_id: 'w1', friend_id: 'friend-1',
+      session_start_at: SESSION_START, notified_at: null, created_at: 'x',
+    });
+    dbMocks.getWebinarComments.mockResolvedValue([
+      { id: 'c0', webinar_id: 'w1', at_seconds: -120, author_name: 'みお', body: '楽しみ', created_at: 'x' },
+    ]);
+    const res = await req('/api/liff/webinars/test-webinar', {
+      headers: { Authorization: 'Bearer t' },
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.live).toBe(false);
+    expect(body.waiting).toBe(true);
+    expect(body.offsetSeconds).toBe(-300);
+    expect(body.nextSessionAt).toBe(SESSION_START);
+    expect(body.comments).toEqual([{ atSeconds: -120, authorName: 'みお', body: '楽しみ' }]);
+    expect(body.playlistUrl).toBeUndefined();
+    // 待機中は視聴ログを作らない
+    expect(dbMocks.upsertWebinarViewer).not.toHaveBeenCalled();
+    expect(execCtx.waitUntil).not.toHaveBeenCalled();
+  });
+
+  test('待機窓の境界 (ちょうど600秒前) は待機ルーム', async () => {
+    vi.setSystemTime(new Date((SESSION_START - 600) * 1000));
+    dbMocks.getUpcomingWebinarRegistration.mockResolvedValue({
+      id: 'reg-next', webinar_id: 'w1', friend_id: 'friend-1',
+      session_start_at: SESSION_START, notified_at: null, created_at: 'x',
+    });
+    const res = await req('/api/liff/webinars/test-webinar', {
+      headers: { Authorization: 'Bearer t' },
+    });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.waiting).toBe(true);
   });
 
   test('id_token 検証失敗は 401', async () => {
@@ -122,7 +320,7 @@ describe('GET /api/liff/webinars/:slug', () => {
   });
 
   test('friend 未登録は 403', async () => {
-    dbMocks.getFriendByLineUserId.mockResolvedValue(null);
+    dbMocks.getFriendByLineUserIdForAccount.mockResolvedValue(null);
     const res = await req('/api/liff/webinars/test-webinar', {
       headers: { Authorization: 'Bearer t' },
     });
@@ -143,7 +341,10 @@ describe('GET /webinar-assets/:token/:slug/*', () => {
     return {
       get: vi.fn(async (key: string) =>
         objects[key] !== undefined
-          ? { body: objects[key], etag: 'etag1', httpMetadata: {} }
+          ? {
+              body: objects[key], etag: 'etag1', httpMetadata: {},
+              text: async () => objects[key],
+            }
           : null,
       ),
     };
@@ -174,6 +375,60 @@ describe('GET /webinar-assets/:token/:slug/*', () => {
     );
     expect(res.headers.get('Content-Type')).toBe('application/vnd.apple.mpegurl');
     expect(res.headers.get('Cache-Control')).toContain('max-age=3600');
+  });
+
+  test('?at= 付き master は EXT-X-START 注入 + variant URI へ at 伝播 + no-store', async () => {
+    const master = '#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-STREAM-INF:BANDWIDTH=3506325\n0/index.m3u8\n\n#EXT-X-STREAM-INF:BANDWIDTH=1842400\n1/index.m3u8\n';
+    const r2 = makeR2({ 'webinars/test-webinar/master.m3u8': master });
+    const token = await signWebinarToken(SECRET, 'test-webinar', SESSION_START + 99999);
+    const res = await webinarRoutes.request(
+      `/webinar-assets/${token}/test-webinar/master.m3u8?at=571`,
+      undefined, { ...env, IMAGES: r2 as unknown as R2Bucket }, execCtx,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('#EXT-X-START:TIME-OFFSET=571,PRECISE=YES');
+    expect(body).toContain('0/index.m3u8?at=571');
+    expect(body).toContain('1/index.m3u8?at=571');
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+  });
+
+  test('?at= 付き variant (media playlist) はタグ注入のみでセグメント URI は不変', async () => {
+    const media = '#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-PLAYLIST-TYPE:VOD\n#EXTINF:6.0,\nseg_00000.ts\n#EXT-X-ENDLIST\n';
+    const r2 = makeR2({ 'webinars/test-webinar/0/index.m3u8': media });
+    const token = await signWebinarToken(SECRET, 'test-webinar', SESSION_START + 99999);
+    const res = await webinarRoutes.request(
+      `/webinar-assets/${token}/test-webinar/0/index.m3u8?at=571`,
+      undefined, { ...env, IMAGES: r2 as unknown as R2Bucket }, execCtx,
+    );
+    const body = await res.text();
+    expect(body).toContain('#EXT-X-START:TIME-OFFSET=571,PRECISE=YES');
+    expect(body).toContain('\nseg_00000.ts\n');
+    expect(body).not.toContain('seg_00000.ts?at');
+  });
+
+  test('?at= が範囲外 (負・動画長超) は 400、セグメントの at は無視', async () => {
+    const r2 = makeR2({
+      'webinars/test-webinar/master.m3u8': '#EXTM3U',
+      'webinars/test-webinar/0/seg_0001.ts': 'DATA',
+    });
+    const token = await signWebinarToken(SECRET, 'test-webinar', SESSION_START + 99999);
+    const over = await webinarRoutes.request(
+      `/webinar-assets/${token}/test-webinar/master.m3u8?at=999999`,
+      undefined, { ...env, IMAGES: r2 as unknown as R2Bucket }, execCtx,
+    );
+    expect(over.status).toBe(400);
+    const neg = await webinarRoutes.request(
+      `/webinar-assets/${token}/test-webinar/master.m3u8?at=-5`,
+      undefined, { ...env, IMAGES: r2 as unknown as R2Bucket }, execCtx,
+    );
+    expect(neg.status).toBe(400);
+    const seg = await webinarRoutes.request(
+      `/webinar-assets/${token}/test-webinar/0/seg_0001.ts?at=571`,
+      undefined, { ...env, IMAGES: r2 as unknown as R2Bucket }, execCtx,
+    );
+    expect(seg.status).toBe(200);
+    expect(await seg.text()).toBe('DATA');
   });
 
   test('不正トークンは 403、存在しないキーは 404、パストラバーサルは 400', async () => {
@@ -268,14 +523,40 @@ describe('POST /api/liff/webinars/:slug/comments', () => {
     expect(res.status).toBe(429);
   });
 
-  test('ライブ外・偽セッションの投稿は 409', async () => {
-    // ライブ時間外（開始前）にサーバー時刻をセットし、sessionStartAt を偽装しても弾かれることを確認
-    vi.setSystemTime(new Date((SESSION_START - 600) * 1000));
+  test('待機窓より前の投稿は 409', async () => {
+    vi.setSystemTime(new Date((SESSION_START - 3600) * 1000));
     const res = await postJson('/api/liff/webinars/test-webinar/comments', {
       sessionStartAt: SESSION_START, atSeconds: 1, body: 'x',
     });
     expect(res.status).toBe(409);
     expect(dbMocks.insertWebinarUserComment).not.toHaveBeenCalled();
+  });
+
+  test('待機ルーム中は次回セッション帰属で負の atSeconds を保存する', async () => {
+    vi.setSystemTime(new Date((SESSION_START - 300) * 1000));
+    const res = await postJson('/api/liff/webinars/test-webinar/comments', {
+      sessionStartAt: SESSION_START, atSeconds: -300, body: '待機中です',
+    });
+    expect(res.status).toBe(200);
+    expect(dbMocks.insertWebinarUserComment).toHaveBeenCalledWith(expect.anything(), {
+      webinarId: 'w1', friendId: 'friend-1', sessionStartAt: SESSION_START,
+      atSeconds: -300, body: '待機中です',
+    });
+  });
+
+  test('待機ルーム中でも偽 sessionStartAt は 409', async () => {
+    vi.setSystemTime(new Date((SESSION_START - 300) * 1000));
+    const res = await postJson('/api/liff/webinars/test-webinar/comments', {
+      sessionStartAt: SESSION_START - 86400, atSeconds: -300, body: 'x',
+    });
+    expect(res.status).toBe(409);
+  });
+
+  test('-3600 を下回る atSeconds は 422', async () => {
+    const res = await postJson('/api/liff/webinars/test-webinar/comments', {
+      sessionStartAt: SESSION_START, atSeconds: -4000, body: 'x',
+    });
+    expect(res.status).toBe(422);
   });
 });
 
@@ -297,6 +578,45 @@ describe('POST /api/liff/webinars/:slug/cta-click', () => {
       sessionStartAt: SESSION_START,
     });
     expect(execCtx.waitUntil).toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/liff/webinars/:slug/register', () => {
+  test('実在する未来セッションを予約し確認プッシュを waitUntil で送る', async () => {
+    vi.setSystemTime(new Date((SESSION_START - 3600) * 1000));
+    const res = await postJson('/api/liff/webinars/test-webinar/register', {
+      sessionStartAt: SESSION_START,
+    });
+    expect(res.status).toBe(200);
+    expect(dbMocks.upsertWebinarRegistration).toHaveBeenCalledWith(
+      expect.anything(), 'w1', 'friend-1', SESSION_START,
+    );
+    expect(execCtx.waitUntil).toHaveBeenCalled();
+  });
+
+  test('スケジュール上に存在しない時刻は 400', async () => {
+    vi.setSystemTime(new Date((SESSION_START - 3600) * 1000));
+    const res = await postJson('/api/liff/webinars/test-webinar/register', {
+      sessionStartAt: SESSION_START + 123,
+    });
+    expect(res.status).toBe(400);
+    expect(dbMocks.upsertWebinarRegistration).not.toHaveBeenCalled();
+  });
+
+  test('開始5分ちょうどまでは現在セッションを予約できる', async () => {
+    vi.setSystemTime(new Date((SESSION_START + 300) * 1000));
+    const res = await postJson('/api/liff/webinars/test-webinar/register', {
+      sessionStartAt: SESSION_START,
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('開始5分を1秒でも過ぎた現在セッションは 400', async () => {
+    vi.setSystemTime(new Date((SESSION_START + 301) * 1000));
+    const res = await postJson('/api/liff/webinars/test-webinar/register', {
+      sessionStartAt: SESSION_START,
+    });
+    expect(res.status).toBe(400);
   });
 });
 
@@ -357,6 +677,28 @@ describe('admin CRUD', () => {
     ]);
   });
 
+  test('PUT comments — 負の atSeconds (待機ルーム) は -3600 まで許容', async () => {
+    dbMocks.getWebinarById.mockResolvedValue(makeWebinar());
+    dbMocks.replaceWebinarComments.mockResolvedValue(1);
+    const ok = await req('/api/webinars/w1/comments', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        comments: [{ atSeconds: -300, authorName: 'みお', body: '楽しみです' }],
+      }),
+    });
+    expect(ok.status).toBe(200);
+    expect(dbMocks.replaceWebinarComments).toHaveBeenCalledWith(expect.anything(), 'w1', [
+      { atSeconds: -300, authorName: 'みお', body: '楽しみです' },
+    ]);
+    const tooEarly = await req('/api/webinars/w1/comments', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        comments: [{ atSeconds: -4000, authorName: 'みお', body: 'x' }],
+      }),
+    });
+    expect(tooEarly.status).toBe(400);
+  });
+
   test('PUT comments — 不正要素があれば 400 で何も書かない', async () => {
     dbMocks.getWebinarById.mockResolvedValue(makeWebinar());
     const res = await req('/api/webinars/w1/comments', {
@@ -367,18 +709,74 @@ describe('admin CRUD', () => {
     expect(dbMocks.replaceWebinarComments).not.toHaveBeenCalled();
   });
 
-  test('GET /api/webinars/:id/analytics — sessions + dropoff', async () => {
+  test('GET /api/webinars/:id/analytics — summary + trend + participants', async () => {
     dbMocks.getWebinarById.mockResolvedValue(makeWebinar());
     dbMocks.getWebinarSessionStats.mockResolvedValue([
       { session_start_at: SESSION_START, viewers: 10, avg_watched_seconds: 3600, cta_clicks: 3 },
     ]);
     dbMocks.getWebinarDropoff.mockResolvedValue([{ bucket_start: 0, viewers: 4 }]);
+    dbMocks.getWebinarAnalyticsSummary.mockResolvedValue({
+      reservations: 12,
+      viewers: 2,
+      registered_and_joined: 1,
+      watched_5m: 2,
+      watched_15m: 1,
+      completed: 1,
+      avg_watched_seconds: 3550,
+      cta_clicks: 1,
+      form_submissions: 1,
+    });
+    dbMocks.getWebinarParticipantStats.mockResolvedValue([
+      {
+        friend_id: 'friend-1', friend_name: '山田太郎', picture_url: 'https://example.com/u.jpg',
+        sessions: 2, first_joined_at: '2026-08-05T10:00:00+09:00',
+        latest_joined_at: '2026-08-06T10:00:00+09:00', max_watched_seconds: 6500,
+        cta_clicked_at: '2026-08-06T11:00:00+09:00', registered: 1,
+        form_submitted_at: '2026-08-06T11:01:00+09:00',
+      },
+      {
+        friend_id: 'friend-2', friend_name: '佐藤花子', picture_url: null,
+        sessions: 1, first_joined_at: '2026-08-06T10:00:00+09:00',
+        latest_joined_at: '2026-08-06T10:00:00+09:00', max_watched_seconds: 600,
+        cta_clicked_at: null, registered: 0, form_submitted_at: null,
+      },
+    ]);
+    dbMocks.getWebinarDailyStats.mockResolvedValue([
+      { stat_date: '2026-08-06', reservations: 5, viewers: 4, cta_clicks: 2, form_submissions: 1 },
+    ]);
     const res = await req('/api/webinars/w1/analytics');
-    const body = (await res.json()) as { data: Record<string, unknown> };
+    const body = (await res.json()) as {
+      data: {
+        sessions: unknown;
+        dropoff: unknown;
+        summary: unknown;
+        daily: unknown;
+        participants: Array<Record<string, unknown>>;
+      };
+    };
     expect(body.data.sessions).toEqual([
       { sessionStartAt: SESSION_START, viewers: 10, avgWatchedSeconds: 3600, ctaClicks: 3 },
     ]);
     expect(body.data.dropoff).toEqual([{ bucketStart: 0, viewers: 4 }]);
+    expect(body.data.summary).toEqual({
+      reservations: 12,
+      viewers: 2,
+      registeredAndJoined: 1,
+      watched5m: 2,
+      watched15m: 1,
+      completed: 1,
+      avgWatchedSeconds: 3550,
+      ctaClicks: 1,
+      formSubmissions: 1,
+    });
+    expect(body.data.daily).toEqual([
+      { date: '2026-08-06', reservations: 5, viewers: 4, ctaClicks: 2, formSubmissions: 1 },
+    ]);
+    expect(body.data.participants).toHaveLength(2);
+    expect(body.data.participants[0]).toMatchObject({
+      friendId: 'friend-1', friendName: '山田太郎', registered: true,
+      pictureUrl: 'https://example.com/u.jpg', formSubmittedAt: '2026-08-06T11:01:00+09:00',
+    });
   });
 
   test('DELETE /api/webinars/:id', async () => {
@@ -396,5 +794,100 @@ describe('admin CRUD', () => {
     });
     expect(res.status).toBe(400);
     expect(dbMocks.updateWebinar).not.toHaveBeenCalled();
+  });
+});
+
+
+describe('webinar CTA cards', () => {
+  const CTA_ROW = {
+    id: 'cta1', webinar_id: 'w1', at_seconds: 300, kind: 'form',
+    title: '個別導入診断', body: '限定枠です', button_label: '診断を受ける',
+    auto_open: 1, form_id: 'form-1', url: null, created_at: 'x', updated_at: 'x',
+  };
+
+  test('LIFF state に ctas が camelCase で含まれる', async () => {
+    dbMocks.getWebinarCtas.mockResolvedValue([CTA_ROW]);
+    const res = await req('/api/liff/webinars/test-webinar', {
+      headers: { Authorization: 'Bearer t' },
+    });
+    const body = (await res.json()) as { ctas: unknown[] };
+    expect(body.ctas).toEqual([{
+      id: 'cta1', atSeconds: 300, kind: 'form', title: '個別導入診断',
+      body: '限定枠です', buttonLabel: '診断を受ける', autoOpen: true, formId: 'form-1', url: null,
+    }]);
+  });
+
+  test('PUT /api/webinars/:id/ctas — form kind は forms 実在チェック後に置換', async () => {
+    dbMocks.getWebinarById.mockResolvedValue(makeWebinar());
+    dbMocks.getFormById.mockResolvedValue({ id: 'form-1', is_active: 1 });
+    dbMocks.replaceWebinarCtas.mockResolvedValue(1);
+    const res = await req('/api/webinars/w1/ctas', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ctas: [{
+        atSeconds: 300, kind: 'form', title: '個別導入診断',
+        body: '限定枠です', buttonLabel: '診断を受ける', autoOpen: true, formId: 'form-1',
+      }] }),
+    });
+    expect(res.status).toBe(200);
+    expect(dbMocks.replaceWebinarCtas).toHaveBeenCalledWith(expect.anything(), 'w1', [{
+      atSeconds: 300, kind: 'form', title: '個別導入診断', body: '限定枠です',
+      buttonLabel: '診断を受ける', autoOpen: true, formId: 'form-1', url: null,
+    }]);
+  });
+
+  test('PUT ctas — 存在しない form は 400 で何も書かない', async () => {
+    dbMocks.getWebinarById.mockResolvedValue(makeWebinar());
+    dbMocks.getFormById.mockResolvedValue(null);
+    const res = await req('/api/webinars/w1/ctas', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ctas: [{
+        atSeconds: 0, kind: 'form', title: 't', buttonLabel: 'b', formId: 'nope',
+      }] }),
+    });
+    expect(res.status).toBe(400);
+    expect(dbMocks.replaceWebinarCtas).not.toHaveBeenCalled();
+  });
+
+  test('PUT ctas — url kind は https 必須', async () => {
+    dbMocks.getWebinarById.mockResolvedValue(makeWebinar());
+    const bad = await req('/api/webinars/w1/ctas', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ctas: [{
+        atSeconds: 0, kind: 'url', title: 't', buttonLabel: 'b', url: 'javascript:alert(1)',
+      }] }),
+    });
+    expect(bad.status).toBe(400);
+    dbMocks.replaceWebinarCtas.mockResolvedValue(1);
+    const ok = await req('/api/webinars/w1/ctas', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ctas: [{
+        atSeconds: 0, kind: 'url', title: 't', buttonLabel: 'b', url: 'https://example.com/pay',
+      }] }),
+    });
+    expect(ok.status).toBe(200);
+  });
+
+  test('PUT ctas — 無効化されたフォームは 400', async () => {
+    dbMocks.getWebinarById.mockResolvedValue(makeWebinar());
+    dbMocks.getFormById.mockResolvedValue({ id: 'form-1', is_active: 0 });
+    const res = await req('/api/webinars/w1/ctas', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ctas: [{
+        atSeconds: 0, kind: 'form', title: 't', buttonLabel: 'b', formId: 'form-1',
+      }] }),
+    });
+    expect(res.status).toBe(400);
+    expect(dbMocks.replaceWebinarCtas).not.toHaveBeenCalled();
+  });
+
+  test('GET /api/webinars/:id/ctas — serialize して返す', async () => {
+    dbMocks.getWebinarById.mockResolvedValue(makeWebinar());
+    dbMocks.getWebinarCtas.mockResolvedValue([CTA_ROW]);
+    const res = await req('/api/webinars/w1/ctas');
+    const body = (await res.json()) as { data: unknown[] };
+    expect(body.data).toEqual([{
+      id: 'cta1', atSeconds: 300, kind: 'form', title: '個別導入診断',
+      body: '限定枠です', buttonLabel: '診断を受ける', autoOpen: true, formId: 'form-1', url: null,
+    }]);
   });
 });

--- a/apps/worker/src/routes/webinars.ts
+++ b/apps/worker/src/routes/webinars.ts
@@ -21,6 +21,8 @@ import {
   updateWebinar,
   deleteWebinar,
   getWebinarComments,
+  getWebinarCtas,
+  replaceWebinarCtas,
   replaceWebinarComments,
   upsertWebinarViewer,
   updateWebinarViewerPosition,
@@ -30,12 +32,22 @@ import {
   getWebinarUserComments,
   getWebinarSessionStats,
   getWebinarDropoff,
+  getWebinarParticipantStats,
+  getWebinarAnalyticsSummary,
+  getWebinarDailyStats,
   getFriendByLineUserId,
+  getFriendByLineUserIdForAccount,
+  getFormById,
   type Webinar,
+  upsertWebinarRegistration,
+  getUpcomingWebinarRegistration,
+  getWebinarRegistration,
 } from '@line-crm/db';
 import { verifyCallerLineUserId } from '../services/liff-auth.js';
 import { attachTagAndFireSideEffects } from '../services/friend-tag-attach.js';
-import { resolveSession, parseScheduleRules } from '../services/webinar-schedule.js';
+import { resolveSession, parseScheduleRules, upcomingSessions } from '../services/webinar-schedule.js';
+import { sendWebinarRegistrationConfirmation } from '../services/webinar-reminders.js';
+import { dispatchLineProxyLocally } from '../services/local-line-proxy.js';
 import { signWebinarToken, verifyWebinarToken } from '../lib/webinar-token.js';
 import type { Env } from '../index.js';
 
@@ -44,20 +56,36 @@ const webinarRoutes = new Hono<Env>();
 const COMMENT_MAX = 500;
 const SESSION_COMMENT_LIMIT = 60;
 const TOKEN_GRACE_SECONDS = 3600;
+// 開始後もこの秒数までは、その回を予約して途中参加できる。
+// ただし未予約者へ再生トークンは一切返さず、必ず予約を先に通す。
+const CURRENT_SESSION_JOIN_GRACE_SECONDS = 5 * 60;
+// 開始前「待機ルーム」を開く秒数。この窓内はサクラコメント (負の at_seconds)
+// と視聴者コメントが動く。管理画面での編集余地を持たせて負方向は 1h まで許容。
+const WAITING_ROOM_SECONDS = 600;
+const COMMENT_MIN_AT_SECONDS = -3600;
 
 function nowEpoch(): number {
   return Math.floor(Date.now() / 1000);
 }
 
-// LIFF caller → friend を解決。失敗時は Response を返す
-async function resolveLiffFriend(
+// LIFF caller を認証し、webinar とそのアカウント配下の friend を解決する。
+// 認証 (401) を webinar 存在確認より先に行う (existence oracle 対策)。
+// friend はウェビナーのアカウント配下の行を優先する (同一プロバイダーの複数
+// アカウントは line_user_id が同一のため、無指定の先頭一致だと別アカウントの
+// friend 行に吸われて予約・確認プッシュ・リマインドのアカウントがズレる)。
+async function resolveWebinarCaller(
   c: Context<Env>,
-): Promise<{ friendId: string } | Response> {
+  slug: string,
+): Promise<{ webinar: Webinar; friendId: string } | Response> {
   const lineUserId = await verifyCallerLineUserId(c.req.header('Authorization'), c.env);
   if (!lineUserId) return c.json({ error: 'unauthorized' }, 401);
-  const friend = await getFriendByLineUserId(c.env.DB, lineUserId);
+  const loaded = await loadActiveWebinar(c, slug);
+  if (loaded instanceof Response) return loaded;
+  const friend = await getFriendByLineUserIdForAccount(
+    c.env.DB, lineUserId, loaded.webinar.account_id,
+  );
   if (!friend) return c.json({ error: 'friend_not_found' }, 403);
-  return { friendId: friend.id };
+  return { webinar: loaded.webinar, friendId: friend.id };
 }
 
 async function loadActiveWebinar(
@@ -77,28 +105,144 @@ async function loadActiveWebinar(
 
 webinarRoutes.get('/api/liff/webinars/:slug', async (c) => {
   try {
-    // 認証を先に確認する: loadActiveWebinar (404) を先に走らせると、未認証の
-    // 呼び出し元でもステータスコードから「その slug に active な webinar が
-    // 存在するか」を判別できてしまう (existence oracle)。
-    const auth = await resolveLiffFriend(c);
+    const auth = await resolveWebinarCaller(c, c.req.param('slug'));
     if (auth instanceof Response) return auth;
-
-    const loaded = await loadActiveWebinar(c, c.req.param('slug'));
-    if (loaded instanceof Response) return loaded;
-    const { webinar } = loaded;
+    const { webinar } = auth;
 
     const now = nowEpoch();
-    const session = resolveSession(
-      parseScheduleRules(webinar.schedule_json),
-      webinar.duration_seconds,
-      now,
-    );
+    const rules = parseScheduleRules(webinar.schedule_json);
+    const session = resolveSession(rules, webinar.duration_seconds, now);
+
+    // 予約後に発行した専用リンクは sessionStartAt を含む。
+    // LIFF で本人確認した上で、同じ webinar×friend×session の予約行が
+    // 実在する場合だけ予約パスとして扱う。URL を転送しても他人は通らない。
+    const requestedSessionRaw = c.req.query('sessionStartAt');
+    const requestedSessionStartAt = requestedSessionRaw === undefined
+      ? null
+      : Number(requestedSessionRaw);
+    const admissionReg =
+      requestedSessionStartAt !== null &&
+      Number.isInteger(requestedSessionStartAt) &&
+      requestedSessionStartAt > 0
+        ? await getWebinarRegistration(
+            c.env.DB, webinar.id, auth.friendId, requestedSessionStartAt,
+          )
+        : null;
+
+    // 配信終了後でも、専用リンクを持つ予約済み本人には
+    // その回を先頭から再生する。アセットトークンは開くたびに再発行するため、
+    // 入場リンク自体に期限を持たせない。
+    if (
+      admissionReg &&
+      requestedSessionStartAt !== null &&
+      now >= requestedSessionStartAt + webinar.duration_seconds
+    ) {
+      await upsertWebinarViewer(
+        c.env.DB, webinar.id, auth.friendId, requestedSessionStartAt,
+      );
+      if (webinar.tag_on_attend) {
+        c.executionCtx.waitUntil(
+          Promise.resolve(
+            attachTagAndFireSideEffects(c.env.DB, auth.friendId, webinar.tag_on_attend),
+          ).catch((err) => console.error('webinar replay attend tag error:', err)),
+        );
+      }
+
+      const exp = now + webinar.duration_seconds + TOKEN_GRACE_SECONDS;
+      const token = await signWebinarToken(c.env.LINE_CHANNEL_SECRET, webinar.slug, exp);
+      const [comments, ctas] = await Promise.all([
+        getWebinarComments(c.env.DB, webinar.id),
+        getWebinarCtas(c.env.DB, webinar.id),
+      ]);
+      return c.json({
+        live: true,
+        replay: true,
+        title: webinar.title,
+        durationSeconds: webinar.duration_seconds,
+        sessionStartAt: requestedSessionStartAt,
+        offsetSeconds: 0,
+        upcoming: upcomingSessions(rules, webinar.duration_seconds, now, 48),
+        registeredSessionAt: null,
+        registeredForThisSession: true,
+        playlistUrl: `/webinar-assets/${token}/${webinar.slug}/master.m3u8`,
+        cta: webinar.cta_json ? (JSON.parse(webinar.cta_json) as unknown) : null,
+        comments: comments.map((cm) => ({
+          atSeconds: cm.at_seconds,
+          authorName: cm.author_name,
+          body: cm.body,
+        })),
+        ctas: ctas.map((ct) => ({
+          id: ct.id,
+          atSeconds: ct.at_seconds,
+          kind: ct.kind,
+          title: ct.title,
+          body: ct.body,
+          buttonLabel: ct.button_label,
+          autoOpen: Boolean(ct.auto_open),
+          formId: ct.form_id,
+          url: ct.url,
+        })),
+      });
+    }
 
     if (!session.live) {
+      const reg = await getUpcomingWebinarRegistration(c.env.DB, webinar.id, auth.friendId, now);
+      // 開始 WAITING_ROOM_SECONDS 前からは「待機ルーム」: 開始前サクラコメント
+      // (負の at_seconds) を流すためのペイロードを返す。ハートビート・attend
+      // タグ・再生トークンはライブ開始まで発行しない。未予約者は待機ルームへ
+      // 直行させず、必ずセッション選択メニューを表示する。
+      const next = session.nextSessionAt;
+      if (
+        next !== null &&
+        next - now <= WAITING_ROOM_SECONDS &&
+        reg?.session_start_at === next
+      ) {
+        const comments = await getWebinarComments(c.env.DB, webinar.id);
+        return c.json({
+          live: false,
+          waiting: true,
+          title: webinar.title,
+          nextSessionAt: next,
+          offsetSeconds: now - next,
+          comments: comments.map((cm) => ({
+            atSeconds: cm.at_seconds,
+            authorName: cm.author_name,
+            body: cm.body,
+          })),
+        });
+      }
+      // 30分間隔・24時間開催の1日分。クライアントは直近6件から段階表示し、
+      // 48件を一度に並べて離脱を招かない。
+      const upcoming = upcomingSessions(rules, webinar.duration_seconds, now, 48);
       return c.json({
         live: false,
         title: webinar.title,
-        nextSessionAt: session.nextSessionAt,
+        nextSessionAt: next,
+        upcoming,
+        registeredSessionAt: reg?.session_start_at ?? null,
+      });
+    }
+
+    const [currentReg, liveReg] = await Promise.all([
+      getWebinarRegistration(c.env.DB, webinar.id, auth.friendId, session.sessionStartAt!),
+      getUpcomingWebinarRegistration(c.env.DB, webinar.id, auth.friendId, now),
+    ]);
+    const withinJoinGrace = (session.offsetSeconds ?? Infinity) <= CURRENT_SESSION_JOIN_GRACE_SECONDS;
+    const liveUpcoming = upcomingSessions(rules, webinar.duration_seconds, now, 48);
+
+    // 直リンクを含め、未予約者へは動画 URL / 再生トークンを返さない。
+    // 開始5分以内だけ現在回を新規予約できる。一方、すでにこの回を
+    // 予約済みの本人は、LIFF を閉じた後でも配信終了まで再入場できる。
+    if (!currentReg) {
+      const bookable = withinJoinGrace
+        ? [session.sessionStartAt!, ...liveUpcoming].slice(0, 48)
+        : liveUpcoming;
+      return c.json({
+        live: false,
+        title: webinar.title,
+        nextSessionAt: bookable[0] ?? session.nextSessionAt,
+        upcoming: bookable,
+        registeredSessionAt: liveReg?.session_start_at ?? null,
       });
     }
 
@@ -113,7 +257,10 @@ webinarRoutes.get('/api/liff/webinars/:slug', async (c) => {
 
     const exp = session.sessionStartAt! + webinar.duration_seconds + TOKEN_GRACE_SECONDS;
     const token = await signWebinarToken(c.env.LINE_CHANNEL_SECRET, webinar.slug, exp);
-    const comments = await getWebinarComments(c.env.DB, webinar.id);
+    const [comments, ctas] = await Promise.all([
+      getWebinarComments(c.env.DB, webinar.id),
+      getWebinarCtas(c.env.DB, webinar.id),
+    ]);
 
     return c.json({
       live: true,
@@ -121,12 +268,26 @@ webinarRoutes.get('/api/liff/webinars/:slug', async (c) => {
       durationSeconds: webinar.duration_seconds,
       sessionStartAt: session.sessionStartAt,
       offsetSeconds: session.offsetSeconds,
+      upcoming: liveUpcoming,
+      registeredSessionAt: liveReg?.session_start_at ?? null,
+      registeredForThisSession: true,
       playlistUrl: `/webinar-assets/${token}/${webinar.slug}/master.m3u8`,
       cta: webinar.cta_json ? (JSON.parse(webinar.cta_json) as unknown) : null,
       comments: comments.map((cm) => ({
         atSeconds: cm.at_seconds,
         authorName: cm.author_name,
         body: cm.body,
+      })),
+      ctas: ctas.map((ct) => ({
+        id: ct.id,
+        atSeconds: ct.at_seconds,
+        kind: ct.kind,
+        title: ct.title,
+        body: ct.body,
+        buttonLabel: ct.button_label,
+        autoOpen: Boolean(ct.auto_open),
+        formId: ct.form_id,
+        url: ct.url,
       })),
     });
   } catch (err) {
@@ -137,11 +298,9 @@ webinarRoutes.get('/api/liff/webinars/:slug', async (c) => {
 
 webinarRoutes.post('/api/liff/webinars/:slug/heartbeat', async (c) => {
   try {
-    // 認証を先に確認する (existence oracle 対策、GET ルートと同じ理由)。
-    const auth = await resolveLiffFriend(c);
+    const auth = await resolveWebinarCaller(c, c.req.param('slug'));
     if (auth instanceof Response) return auth;
-    const loaded = await loadActiveWebinar(c, c.req.param('slug'));
-    if (loaded instanceof Response) return loaded;
+    const loaded = { webinar: auth.webinar };
 
     const body = await c.req.json<{ sessionStartAt?: unknown; positionSeconds?: unknown }>();
     const sessionStartAt = Number(body.sessionStartAt);
@@ -166,10 +325,9 @@ webinarRoutes.post('/api/liff/webinars/:slug/heartbeat', async (c) => {
 
 webinarRoutes.post('/api/liff/webinars/:slug/comments', async (c) => {
   try {
-    const auth = await resolveLiffFriend(c);
+    const auth = await resolveWebinarCaller(c, c.req.param('slug'));
     if (auth instanceof Response) return auth;
-    const loaded = await loadActiveWebinar(c, c.req.param('slug'));
-    if (loaded instanceof Response) return loaded;
+    const loaded = { webinar: auth.webinar };
 
     const body = await c.req.json<{
       sessionStartAt?: unknown; atSeconds?: unknown; body?: unknown;
@@ -179,19 +337,29 @@ webinarRoutes.post('/api/liff/webinars/:slug/comments', async (c) => {
     const text = typeof body.body === 'string' ? body.body.trim() : '';
     if (
       !Number.isFinite(sessionStartAt) || !Number.isFinite(atSeconds) ||
-      atSeconds < 0 || text.length === 0 || text.length > COMMENT_MAX
+      atSeconds < COMMENT_MIN_AT_SECONDS || text.length === 0 || text.length > COMMENT_MAX
     ) {
       return c.json({ error: 'invalid_body' }, 422);
     }
     // sessionStartAt はクライアント申告値。サーバー側で現在のセッションを再計算し、
     // ライブ外や偽装 sessionStartAt でのコメント投稿（60件上限バイパス含む）を防ぐ。
+    // 待機ルーム中 (次回開始まで WAITING_ROOM_SECONDS 以内) は次回セッション帰属で
+    // 負の atSeconds を受ける。
     const session = resolveSession(
       parseScheduleRules(loaded.webinar.schedule_json),
       loaded.webinar.duration_seconds,
       nowEpoch(),
     );
-    if (!session.live || sessionStartAt !== session.sessionStartAt) {
-      return c.json({ error: 'not_live' }, 409);
+    if (session.live) {
+      if (sessionStartAt !== session.sessionStartAt) {
+        return c.json({ error: 'not_live' }, 409);
+      }
+    } else {
+      const next = session.nextSessionAt;
+      const inWaitingRoom = next !== null && next - nowEpoch() <= WAITING_ROOM_SECONDS;
+      if (!inWaitingRoom || sessionStartAt !== next) {
+        return c.json({ error: 'not_live' }, 409);
+      }
     }
     const count = await countSessionUserComments(
       c.env.DB, loaded.webinar.id, auth.friendId, sessionStartAt,
@@ -213,12 +381,61 @@ webinarRoutes.post('/api/liff/webinars/:slug/comments', async (c) => {
   }
 });
 
+// セッション選択メニューの予約。sessionStartAt はスケジュール上の実在する
+// 未来セッションに加え、開始後5分以内だけ現在回も受理。
+// 冪等 (同一回の再予約は成功扱い)。
+webinarRoutes.post('/api/liff/webinars/:slug/register', async (c) => {
+  try {
+    const auth = await resolveWebinarCaller(c, c.req.param('slug'));
+    if (auth instanceof Response) return auth;
+    const loaded = { webinar: auth.webinar };
+    const { webinar } = loaded;
+
+    const body = await c.req.json<{ sessionStartAt?: unknown }>();
+    const sessionStartAt = Number(body.sessionStartAt);
+    const rules = parseScheduleRules(webinar.schedule_json);
+    const now = nowEpoch();
+    const session = resolveSession(rules, webinar.duration_seconds, now);
+    const upcoming = upcomingSessions(rules, webinar.duration_seconds, now, 48);
+    const currentIsBookable =
+      session.live &&
+      session.sessionStartAt === sessionStartAt &&
+      (session.offsetSeconds ?? Infinity) <= CURRENT_SESSION_JOIN_GRACE_SECONDS;
+    if (
+      !Number.isFinite(sessionStartAt) ||
+      (!currentIsBookable && !upcoming.includes(sessionStartAt))
+    ) {
+      return c.json({ error: 'invalid_session' }, 400);
+    }
+    await upsertWebinarRegistration(c.env.DB, webinar.id, auth.friendId, sessionStartAt);
+    const liffMatch = /liff\.line\.me\/([^/?]+)/.exec(c.env.LIFF_URL ?? '');
+    c.executionCtx.waitUntil(
+      sendWebinarRegistrationConfirmation(
+        c.env.DB,
+        webinar,
+        auth.friendId,
+        sessionStartAt,
+        {
+          proxyBaseUrl: new URL(c.req.url).origin,
+          defaultAccessToken: c.env.LINE_CHANNEL_ACCESS_TOKEN,
+          defaultLiffId: liffMatch?.[1] ?? null,
+          proxyDispatch: (request) =>
+            dispatchLineProxyLocally(request, c.env, c.executionCtx),
+        },
+      ),
+    );
+    return c.json({ ok: true, sessionStartAt });
+  } catch (err) {
+    console.error('POST webinar register error:', err);
+    return c.json({ error: 'internal_error' }, 500);
+  }
+});
+
 webinarRoutes.post('/api/liff/webinars/:slug/cta-click', async (c) => {
   try {
-    const auth = await resolveLiffFriend(c);
+    const auth = await resolveWebinarCaller(c, c.req.param('slug'));
     if (auth instanceof Response) return auth;
-    const loaded = await loadActiveWebinar(c, c.req.param('slug'));
-    if (loaded instanceof Response) return loaded;
+    const loaded = { webinar: auth.webinar };
 
     const body = await c.req.json<{ sessionStartAt?: unknown }>();
     const sessionStartAt = Number(body.sessionStartAt);
@@ -275,6 +492,35 @@ webinarRoutes.get('/webinar-assets/:token/:slug/*', async (c) => {
   const ext = rest.split('.').pop() ?? '';
   const headers = new Headers();
   headers.set('Content-Type', CONTENT_TYPES[ext] ?? 'application/octet-stream');
+
+  // ?at=<秒> 付きプレイリストは #EXT-X-START を注入し、途中参加位置からの
+  // 再生を「配信側で」宣言する。iOS native HLS (LINE in-app) はクライアント側
+  // の currentTime シークが 0 に巻き戻ることがあるため、開始位置はプレイリスト
+  // で示すのが確実。master 内の variant URI にも ?at= を伝播する。
+  const atRaw = c.req.query('at');
+  if (ext === 'm3u8' && atRaw !== undefined) {
+    const at = Math.floor(Number(atRaw));
+    if (!Number.isFinite(at) || at < 0 || at > webinar.duration_seconds) {
+      return c.json({ error: 'bad_at' }, 400);
+    }
+    const text = await object.text();
+    const isMaster = text.includes('#EXT-X-STREAM-INF');
+    const out: string[] = [];
+    for (const line of text.split('\n')) {
+      out.push(
+        isMaster && line.trim() !== '' && !line.startsWith('#')
+          ? `${line.trim()}${line.includes('?') ? '&' : '?'}at=${at}`
+          : line,
+      );
+      if (line.startsWith('#EXTM3U')) {
+        out.push(`#EXT-X-START:TIME-OFFSET=${at},PRECISE=YES`);
+      }
+    }
+    // 開始位置は視聴タイミング依存の動的レスポンスなのでキャッシュさせない
+    headers.set('Cache-Control', 'private, no-store');
+    return new Response(out.join('\n'), { headers });
+  }
+
   headers.set(
     'Cache-Control',
     ext === 'm3u8' ? 'public, max-age=3600' : 'public, max-age=31536000, immutable',
@@ -481,8 +727,9 @@ webinarRoutes.put('/api/webinars/:id/comments', async (c) => {
       const atSeconds = Math.floor(Number(raw?.atSeconds));
       const authorName = typeof raw?.authorName === 'string' ? raw.authorName.trim() : '';
       const text = typeof raw?.body === 'string' ? raw.body.trim() : '';
+      // 負の atSeconds = 開始前 (待機ルーム) コメント。-1h まで許容
       if (
-        !Number.isFinite(atSeconds) || atSeconds < 0 ||
+        !Number.isFinite(atSeconds) || atSeconds < COMMENT_MIN_AT_SECONDS ||
         !authorName || authorName.length > 50 ||
         !text || text.length > COMMENT_MAX
       ) {
@@ -498,18 +745,144 @@ webinarRoutes.put('/api/webinars/:id/comments', async (c) => {
   }
 });
 
+webinarRoutes.get('/api/webinars/:id/ctas', async (c) => {
+  try {
+    const id = c.req.param('id');
+    const row = await getWebinarById(c.env.DB, id);
+    if (!row) return c.json({ success: false, error: 'Not found' }, 404);
+    const ctas = await getWebinarCtas(c.env.DB, id);
+    return c.json({
+      success: true,
+      data: ctas.map((ct) => ({
+        id: ct.id,
+        atSeconds: ct.at_seconds,
+        kind: ct.kind,
+        title: ct.title,
+        body: ct.body,
+        buttonLabel: ct.button_label,
+        autoOpen: Boolean(ct.auto_open),
+        formId: ct.form_id,
+        url: ct.url,
+      })),
+    });
+  } catch (err) {
+    console.error('GET /api/webinars/:id/ctas error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
+// CTA カード一括置換。kind='form' は forms 実在チェック、kind='url' は https? 必須。
+// 全要素検証 → 不正が1件でもあれば何も書かない (comments と同じ all-or-nothing)。
+webinarRoutes.put('/api/webinars/:id/ctas', async (c) => {
+  try {
+    const id = c.req.param('id');
+    const row = await getWebinarById(c.env.DB, id);
+    if (!row) return c.json({ success: false, error: 'Not found' }, 404);
+    const body = await c.req.json<{ ctas?: unknown }>();
+    if (!Array.isArray(body.ctas)) {
+      return c.json({ success: false, error: 'ctas_required' }, 400);
+    }
+    if (body.ctas.length > 20) {
+      return c.json({ success: false, error: 'too_many_ctas' }, 400);
+    }
+    const cleaned: Array<{
+      atSeconds: number; kind: 'form' | 'url'; title: string; body: string | null;
+      buttonLabel: string; autoOpen: boolean; formId: string | null; url: string | null;
+    }> = [];
+    const formIdsToCheck = new Set<string>();
+    for (const raw of body.ctas as Array<Record<string, unknown>>) {
+      const atSeconds = Math.floor(Number(raw?.atSeconds));
+      const kind = raw?.kind;
+      const title = typeof raw?.title === 'string' ? raw.title.trim() : '';
+      const bodyText = typeof raw?.body === 'string' ? raw.body.trim() : '';
+      const buttonLabel = typeof raw?.buttonLabel === 'string' ? raw.buttonLabel.trim() : '';
+      const formId = typeof raw?.formId === 'string' && raw.formId ? raw.formId : null;
+      const url = typeof raw?.url === 'string' && raw.url ? raw.url.trim() : null;
+      if (
+        !Number.isFinite(atSeconds) || atSeconds < 0 ||
+        (kind !== 'form' && kind !== 'url') ||
+        !title || title.length > 100 ||
+        bodyText.length > 300 ||
+        !buttonLabel || buttonLabel.length > 50
+      ) {
+        return c.json({ success: false, error: 'invalid_cta' }, 400);
+      }
+      if (kind === 'form') {
+        if (!formId) return c.json({ success: false, error: 'form_id_required' }, 400);
+        formIdsToCheck.add(formId);
+      } else if (!url || !/^https?:\/\//.test(url)) {
+        return c.json({ success: false, error: 'invalid_url' }, 400);
+      }
+      cleaned.push({
+        atSeconds, kind, title, body: bodyText || null, buttonLabel,
+        autoOpen: Boolean(raw?.autoOpen),
+        formId: kind === 'form' ? formId : null,
+        url: kind === 'url' ? url : null,
+      });
+    }
+    const forms = await Promise.all(
+      [...formIdsToCheck].map((fid) => getFormById(c.env.DB, fid)),
+    );
+    if (forms.some((f) => !f)) {
+      return c.json({ success: false, error: 'form_not_found' }, 400);
+    }
+    if (forms.some((f) => f && !f.is_active)) {
+      return c.json({ success: false, error: 'form_inactive' }, 400);
+    }
+    const count = await replaceWebinarCtas(c.env.DB, id, cleaned);
+    return c.json({ success: true, data: { count } });
+  } catch (err) {
+    console.error('PUT /api/webinars/:id/ctas error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
 webinarRoutes.get('/api/webinars/:id/analytics', async (c) => {
   try {
     const id = c.req.param('id');
     const row = await getWebinarById(c.env.DB, id);
     if (!row) return c.json({ success: false, error: 'Not found' }, 404);
-    const [sessions, dropoff] = await Promise.all([
+    const completionThreshold = Math.max(1, Math.floor(row.duration_seconds * 0.9));
+    const [sessions, dropoff, participants, summary, daily] = await Promise.all([
       getWebinarSessionStats(c.env.DB, id),
       getWebinarDropoff(c.env.DB, id),
+      getWebinarParticipantStats(c.env.DB, id, 200),
+      getWebinarAnalyticsSummary(c.env.DB, id, completionThreshold),
+      getWebinarDailyStats(c.env.DB, id),
     ]);
     return c.json({
       success: true,
       data: {
+        summary: {
+          reservations: summary.reservations,
+          viewers: summary.viewers,
+          registeredAndJoined: summary.registered_and_joined,
+          watched5m: summary.watched_5m,
+          watched15m: summary.watched_15m,
+          completed: summary.completed,
+          avgWatchedSeconds: summary.avg_watched_seconds,
+          ctaClicks: summary.cta_clicks,
+          formSubmissions: summary.form_submissions,
+        },
+        daily: daily.map((d) => ({
+          date: d.stat_date,
+          reservations: d.reservations,
+          viewers: d.viewers,
+          ctaClicks: d.cta_clicks,
+          formSubmissions: d.form_submissions,
+        })),
+        participants: participants.map((p) => ({
+          friendId: p.friend_id,
+          friendName: p.friend_name,
+          pictureUrl: p.picture_url,
+          sessions: p.sessions,
+          firstJoinedAt: p.first_joined_at,
+          latestJoinedAt: p.latest_joined_at,
+          maxWatchedSeconds: p.max_watched_seconds,
+          ctaClickedAt: p.cta_clicked_at,
+          registered: Boolean(p.registered),
+          formSubmittedAt: p.form_submitted_at,
+        })),
         sessions: sessions.map((s) => ({
           sessionStartAt: s.session_start_at,
           viewers: s.viewers,
@@ -537,6 +910,7 @@ webinarRoutes.get('/api/webinars/:id/user-comments', async (c) => {
         id: cm.id,
         friendId: cm.friend_id,
         friendName: cm.friend_name ?? null,
+        pictureUrl: cm.picture_url ?? null,
         sessionStartAt: cm.session_start_at,
         atSeconds: cm.at_seconds,
         body: cm.body,

--- a/apps/worker/src/services/activity-digest.test.ts
+++ b/apps/worker/src/services/activity-digest.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'vitest';
+import {
+  getActivityDigest,
+  parseActivityDigestHours,
+} from './activity-digest.js';
+import type { UnansweredInboxResult } from './unanswered-inbox.js';
+
+type ResultsByMarker = Record<string, unknown[]>;
+
+function mockDb(resultsByMarker: ResultsByMarker, bindings: unknown[][]): D1Database {
+  return {
+    prepare(sql: string) {
+      let bound: unknown[] = [];
+      const statement = {
+        bind(...values: unknown[]) {
+          bound = values;
+          return statement;
+        },
+        async all<T>() {
+          bindings.push(bound);
+          const marker = Object.keys(resultsByMarker).find((key) => sql.includes(`activity-digest:${key}`));
+          return { results: (marker ? resultsByMarker[marker] : []) as T[] };
+        },
+      };
+      return statement;
+    },
+  } as unknown as D1Database;
+}
+
+const noUnanswered: UnansweredInboxResult = {
+  total: 0,
+  page: 1,
+  pageSize: 2000,
+  rows: [],
+};
+
+describe('parseActivityDigestHours', () => {
+  test('defaults to three hours', () => {
+    expect(parseActivityDigestHours(undefined)).toBe(3);
+  });
+
+  test('accepts 1..168 and rejects malformed values', () => {
+    expect(parseActivityDigestHours('1')).toBe(1);
+    expect(parseActivityDigestHours('168')).toBe(168);
+    expect(parseActivityDigestHours('0')).toBeNull();
+    expect(parseActivityDigestHours('169')).toBeNull();
+    expect(parseActivityDigestHours('3.5')).toBeNull();
+    expect(parseActivityDigestHours('abc')).toBeNull();
+  });
+});
+
+describe('getActivityDigest', () => {
+  test('aggregates user actions and current unanswered rows', async () => {
+    const bindings: unknown[][] = [];
+    const db = mockDb({
+      friends: [{
+        id: 'friend-1', display_name: '田中', line_account_id: 'account-1',
+        account_name: '本店', created_at: '2026-08-05T17:30:00.000',
+      }],
+      messages: [{
+        id: 'message-1', friend_id: 'friend-1', display_name: '田中',
+        line_account_id: 'account-1', account_name: '本店', message_type: 'text',
+        content: '予約したいです', source: null, created_at: '2026-08-05T17:45:00.000',
+      }],
+      forms: [{
+        id: 'submission-1', form_id: 'form-1', form_name: '相談フォーム',
+        friend_id: 'friend-1', display_name: '田中', line_account_id: 'account-1',
+        account_name: '本店', data: '{"interest":"AI"}',
+        created_at: '2026-08-05T17:50:00.000',
+      }],
+      bookings: [{
+        id: 'booking-1', friend_id: 'friend-1', display_name: '田中',
+        line_account_id: 'account-1', account_name: '本店', menu_name: '初回相談',
+        staff_name: '佐藤', starts_at: '2026-08-06T01:00:00Z', status: 'requested',
+        customer_note: null, requested_at: '2026-08-05T08:55:00Z',
+      }],
+      'event-bookings': [{
+        id: 'event-booking-1', friend_id: 'friend-1', display_name: '田中',
+        line_account_id: 'account-1', account_name: '本店', event_name: 'セミナー',
+        starts_at: '2026-08-10T01:00:00Z', status: 'confirmed', customer_note: '参加希望',
+        requested_at: '2026-08-05T08:58:00Z',
+      }],
+    }, bindings);
+    const unanswered: UnansweredInboxResult = {
+      total: 1,
+      page: 1,
+      pageSize: 2000,
+      rows: [{
+        friendId: 'friend-1', displayName: '田中', pictureUrl: null,
+        accountId: 'account-1', accountName: '本店',
+        lastIncomingAt: '2026-08-05T17:45:00.000+09:00',
+        lastManualAt: null, lastMachineAt: null, lastIncomingType: 'text',
+        lastIncomingContent: '予約したいです',
+      }],
+    };
+
+    const result = await getActivityDigest(db, {
+      hours: 3,
+      now: new Date('2026-08-05T09:00:00Z'),
+      unansweredLoader: async () => unanswered,
+    });
+
+    expect(result.window.since).toBe('2026-08-05T06:00:00.000Z');
+    expect(result.summary).toMatchObject({
+      totalNewActions: 5,
+      newFriends: 1,
+      incomingMessages: 1,
+      formSubmissions: 1,
+      bookingRequests: 1,
+      eventBookingRequests: 1,
+      unansweredTotal: 1,
+    });
+    expect(result.newActions.friends.items[0].occurredAt).toBe('2026-08-05T08:30:00.000Z');
+    expect(result.newActions.formSubmissions.items[0].data).toEqual({ interest: 'AI' });
+    expect(result.summary.newActionsByAccount).toEqual([
+      { accountId: 'account-1', accountName: '本店', count: 5 },
+    ]);
+    expect(result.unanswered.oldestWaitMinutes).toBe(15);
+    expect(bindings).toEqual([
+      ['2026-08-05T15:00:00.000', 501],
+      ['2026-08-05T15:00:00.000', 501],
+      ['2026-08-05T15:00:00.000', 501],
+      ['2026-08-05T06:00:00.000Z', 501],
+      ['2026-08-05T06:00:00.000Z', 501],
+    ]);
+  });
+
+  test('marks a category as truncated without over-counting returned actions', async () => {
+    const messages = Array.from({ length: 501 }, (_, index) => ({
+      id: `message-${index}`,
+      friend_id: 'friend-1',
+      display_name: '田中',
+      line_account_id: 'account-1',
+      account_name: '本店',
+      message_type: 'text',
+      content: String(index),
+      source: null,
+      created_at: '2026-08-05T17:45:00.000',
+    }));
+    const db = mockDb({ messages }, []);
+
+    const result = await getActivityDigest(db, {
+      now: new Date('2026-08-05T09:00:00Z'),
+      unansweredLoader: async () => noUnanswered,
+    });
+
+    expect(result.newActions.incomingMessages.items).toHaveLength(500);
+    expect(result.newActions.incomingMessages.truncated).toBe(true);
+    expect(result.summary.totalNewActions).toBe(500);
+  });
+});

--- a/apps/worker/src/services/activity-digest.ts
+++ b/apps/worker/src/services/activity-digest.ts
@@ -1,0 +1,350 @@
+import {
+  computeUnansweredInbox,
+  type UnansweredInboxResult,
+} from './unanswered-inbox.js';
+
+const DEFAULT_HOURS = 3;
+const MAX_HOURS = 24 * 7;
+const CATEGORY_LIMIT = 500;
+
+export interface ActivityDigestOptions {
+  hours?: number;
+  now?: Date;
+  unansweredLoader?: (
+    db: D1Database,
+    options: { page: number; pageSize: number },
+  ) => Promise<UnansweredInboxResult>;
+}
+
+interface AccountRef {
+  accountId: string | null;
+  accountName: string;
+}
+
+interface RawFriendRow {
+  id: string;
+  display_name: string | null;
+  line_account_id: string | null;
+  account_name: string | null;
+  created_at: string;
+}
+
+interface RawMessageRow {
+  id: string;
+  friend_id: string;
+  display_name: string | null;
+  line_account_id: string | null;
+  account_name: string | null;
+  message_type: string;
+  content: string;
+  source: string | null;
+  created_at: string;
+}
+
+interface RawFormSubmissionRow {
+  id: string;
+  form_id: string;
+  form_name: string;
+  friend_id: string | null;
+  display_name: string | null;
+  line_account_id: string | null;
+  account_name: string | null;
+  data: string;
+  created_at: string;
+}
+
+interface RawBookingRow {
+  id: string;
+  friend_id: string;
+  display_name: string | null;
+  line_account_id: string;
+  account_name: string | null;
+  menu_name: string;
+  staff_name: string;
+  starts_at: string;
+  status: string;
+  customer_note: string | null;
+  requested_at: string;
+}
+
+interface RawEventBookingRow {
+  id: string;
+  friend_id: string;
+  display_name: string | null;
+  line_account_id: string;
+  account_name: string | null;
+  event_name: string;
+  starts_at: string;
+  status: string;
+  customer_note: string | null;
+  requested_at: string;
+}
+
+export function parseActivityDigestHours(value: string | undefined): number | null {
+  if (value === undefined || value === '') return DEFAULT_HOURS;
+  if (!/^\d+$/.test(value)) return null;
+  const hours = Number(value);
+  return Number.isSafeInteger(hours) && hours >= 1 && hours <= MAX_HOURS ? hours : null;
+}
+
+function formatJstSqlTimestamp(date: Date): string {
+  const jst = new Date(date.getTime() + 9 * 60 * 60_000).toISOString();
+  return jst.slice(0, -1);
+}
+
+function normalizeJstTimestamp(value: string): string {
+  if (/Z$|[+-]\d{2}:\d{2}$/.test(value)) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+  }
+  const parsed = new Date(`${value.replace(' ', 'T')}+09:00`);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+}
+
+function normalizeUtcTimestamp(value: string): string {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+}
+
+function parseJsonObject(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function accountRef(row: {
+  line_account_id: string | null;
+  account_name: string | null;
+}): AccountRef {
+  return {
+    accountId: row.line_account_id,
+    accountName: row.account_name ?? '(未分類)',
+  };
+}
+
+function takeCategory<T>(rows: T[]): { items: T[]; truncated: boolean } {
+  return {
+    items: rows.slice(0, CATEGORY_LIMIT),
+    truncated: rows.length > CATEGORY_LIMIT,
+  };
+}
+
+export async function getActivityDigest(
+  db: D1Database,
+  options: ActivityDigestOptions = {},
+) {
+  const hours = options.hours ?? DEFAULT_HOURS;
+  if (!Number.isSafeInteger(hours) || hours < 1 || hours > MAX_HOURS) {
+    throw new RangeError(`hours must be an integer between 1 and ${MAX_HOURS}`);
+  }
+
+  const now = options.now ?? new Date();
+  const since = new Date(now.getTime() - hours * 60 * 60_000);
+  const sinceUtc = since.toISOString();
+  const sinceJst = formatJstSqlTimestamp(since);
+  const queryLimit = CATEGORY_LIMIT + 1;
+  const unansweredLoader = options.unansweredLoader ?? computeUnansweredInbox;
+
+  const [
+    friendsResult,
+    messagesResult,
+    formsResult,
+    bookingsResult,
+    eventBookingsResult,
+    unanswered,
+  ] = await Promise.all([
+    db.prepare(
+      `/* activity-digest:friends */
+       SELECT f.id, f.display_name, f.line_account_id,
+              la.name AS account_name, f.created_at
+         FROM friends f
+         LEFT JOIN line_accounts la ON la.id = f.line_account_id
+        WHERE julianday(f.created_at) >= julianday(?)
+        ORDER BY f.created_at DESC
+        LIMIT ?`,
+    ).bind(sinceJst, queryLimit).all<RawFriendRow>(),
+    db.prepare(
+      `/* activity-digest:messages */
+       SELECT ml.id, ml.friend_id, f.display_name,
+              COALESCE(ml.line_account_id, f.line_account_id) AS line_account_id,
+              la.name AS account_name,
+              ml.message_type, ml.content, ml.source, ml.created_at
+         FROM messages_log ml
+         INNER JOIN friends f ON f.id = ml.friend_id
+         LEFT JOIN line_accounts la
+           ON la.id = COALESCE(ml.line_account_id, f.line_account_id)
+        WHERE ml.direction = 'incoming'
+          AND julianday(ml.created_at) >= julianday(?)
+        ORDER BY ml.created_at DESC
+        LIMIT ?`,
+    ).bind(sinceJst, queryLimit).all<RawMessageRow>(),
+    db.prepare(
+      `/* activity-digest:forms */
+       SELECT fs.id, fs.form_id, fm.name AS form_name,
+              fs.friend_id, f.display_name, f.line_account_id,
+              la.name AS account_name, fs.data, fs.created_at
+         FROM form_submissions fs
+         INNER JOIN forms fm ON fm.id = fs.form_id
+         LEFT JOIN friends f ON f.id = fs.friend_id
+         LEFT JOIN line_accounts la ON la.id = f.line_account_id
+        WHERE julianday(fs.created_at) >= julianday(?)
+        ORDER BY fs.created_at DESC
+        LIMIT ?`,
+    ).bind(sinceJst, queryLimit).all<RawFormSubmissionRow>(),
+    db.prepare(
+      `/* activity-digest:bookings */
+       SELECT b.id, b.friend_id, f.display_name,
+              b.line_account_id, la.name AS account_name,
+              m.name AS menu_name, s.display_name AS staff_name,
+              b.starts_at, b.status, b.customer_note, b.requested_at
+         FROM bookings b
+         INNER JOIN menus m ON m.id = b.menu_id
+         INNER JOIN staff s ON s.id = b.staff_id
+         LEFT JOIN friends f ON f.id = b.friend_id
+         LEFT JOIN line_accounts la ON la.id = b.line_account_id
+        WHERE julianday(b.requested_at) >= julianday(?)
+        ORDER BY b.requested_at DESC
+        LIMIT ?`,
+    ).bind(sinceUtc, queryLimit).all<RawBookingRow>(),
+    db.prepare(
+      `/* activity-digest:event-bookings */
+       SELECT b.id, b.friend_id, f.display_name,
+              b.line_account_id, la.name AS account_name,
+              e.name AS event_name, es.starts_at,
+              b.status, b.customer_note, b.requested_at
+         FROM event_bookings b
+         INNER JOIN events e ON e.id = b.event_id
+         INNER JOIN event_slots es ON es.id = b.slot_id
+         LEFT JOIN friends f ON f.id = b.friend_id
+         LEFT JOIN line_accounts la ON la.id = b.line_account_id
+        WHERE julianday(b.requested_at) >= julianday(?)
+        ORDER BY b.requested_at DESC
+        LIMIT ?`,
+    ).bind(sinceUtc, queryLimit).all<RawEventBookingRow>(),
+    unansweredLoader(db, { page: 1, pageSize: 2000 }),
+  ]);
+
+  const friends = takeCategory((friendsResult.results ?? []).map((row) => ({
+    id: row.id,
+    displayName: row.display_name,
+    ...accountRef(row),
+    occurredAt: normalizeJstTimestamp(row.created_at),
+  })));
+  const incomingMessages = takeCategory((messagesResult.results ?? []).map((row) => ({
+    id: row.id,
+    friendId: row.friend_id,
+    displayName: row.display_name,
+    ...accountRef(row),
+    messageType: row.message_type,
+    content: row.content,
+    source: row.source,
+    occurredAt: normalizeJstTimestamp(row.created_at),
+  })));
+  const formSubmissions = takeCategory((formsResult.results ?? []).map((row) => ({
+    id: row.id,
+    formId: row.form_id,
+    formName: row.form_name,
+    friendId: row.friend_id,
+    displayName: row.display_name,
+    ...accountRef(row),
+    data: parseJsonObject(row.data),
+    occurredAt: normalizeJstTimestamp(row.created_at),
+  })));
+  const bookingRequests = takeCategory((bookingsResult.results ?? []).map((row) => ({
+    id: row.id,
+    friendId: row.friend_id,
+    displayName: row.display_name,
+    ...accountRef(row),
+    menuName: row.menu_name,
+    staffName: row.staff_name,
+    startsAt: normalizeUtcTimestamp(row.starts_at),
+    status: row.status,
+    customerNote: row.customer_note,
+    occurredAt: normalizeUtcTimestamp(row.requested_at),
+  })));
+  const eventBookingRequests = takeCategory((eventBookingsResult.results ?? []).map((row) => ({
+    id: row.id,
+    friendId: row.friend_id,
+    displayName: row.display_name,
+    ...accountRef(row),
+    eventName: row.event_name,
+    startsAt: normalizeUtcTimestamp(row.starts_at),
+    status: row.status,
+    customerNote: row.customer_note,
+    occurredAt: normalizeUtcTimestamp(row.requested_at),
+  })));
+
+  const actionGroups = [
+    friends.items,
+    incomingMessages.items,
+    formSubmissions.items,
+    bookingRequests.items,
+    eventBookingRequests.items,
+  ];
+  const byAccountMap = new Map<string, { accountId: string | null; accountName: string; count: number }>();
+  for (const item of actionGroups.flat()) {
+    const key = item.accountId ?? '__unassigned__';
+    const current = byAccountMap.get(key);
+    if (current) current.count += 1;
+    else byAccountMap.set(key, {
+      accountId: item.accountId,
+      accountName: item.accountName,
+      count: 1,
+    });
+  }
+
+  const unansweredByAccount = new Map<string, { accountId: string; accountName: string; count: number }>();
+  let oldestUnansweredAt: string | null = null;
+  for (const row of unanswered.rows) {
+    const current = unansweredByAccount.get(row.accountId);
+    if (current) current.count += 1;
+    else unansweredByAccount.set(row.accountId, {
+      accountId: row.accountId,
+      accountName: row.accountName,
+      count: 1,
+    });
+    if (oldestUnansweredAt === null || row.lastIncomingAt < oldestUnansweredAt) {
+      oldestUnansweredAt = row.lastIncomingAt;
+    }
+  }
+
+  return {
+    generatedAt: now.toISOString(),
+    window: {
+      hours,
+      since: sinceUtc,
+      until: now.toISOString(),
+    },
+    summary: {
+      totalNewActions: actionGroups.reduce((sum, group) => sum + group.length, 0),
+      newFriends: friends.items.length,
+      incomingMessages: incomingMessages.items.length,
+      formSubmissions: formSubmissions.items.length,
+      bookingRequests: bookingRequests.items.length,
+      eventBookingRequests: eventBookingRequests.items.length,
+      unansweredTotal: unanswered.total,
+      newActionsByAccount: [...byAccountMap.values()].sort((a, b) => b.count - a.count),
+    },
+    newActions: {
+      friends,
+      incomingMessages,
+      formSubmissions,
+      bookingRequests,
+      eventBookingRequests,
+    },
+    unanswered: {
+      total: unanswered.total,
+      rows: unanswered.rows,
+      truncated: unanswered.rows.length < unanswered.total,
+      byAccount: [...unansweredByAccount.values()].sort((a, b) => b.count - a.count),
+      oldestWaitMinutes: oldestUnansweredAt === null
+        ? null
+        : Math.max(0, Math.floor((now.getTime() - new Date(oldestUnansweredAt).getTime()) / 60_000)),
+    },
+  };
+}

--- a/apps/worker/src/services/line-proxy-send.ts
+++ b/apps/worker/src/services/line-proxy-send.ts
@@ -1,0 +1,43 @@
+import type { Message } from '@line-crm/line-sdk';
+
+export type HarnessProxyDispatch = (request: Request) => Promise<Response>;
+
+/**
+ * LINE の push は必ず Harness の互換プロキシを通す。
+ * プロキシ側が送信履歴の記録も担当するため、呼び出し元で messages_log を
+ * 二重に書かないこと。
+ */
+export async function pushViaHarnessProxy(
+  proxyBaseUrl: string,
+  accessToken: string,
+  to: string,
+  messages: Message[],
+  retryKey?: string,
+  dispatch?: HarnessProxyDispatch,
+): Promise<void> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${accessToken}`,
+    'Content-Type': 'application/json',
+  };
+  if (retryKey) headers['X-Line-Retry-Key'] = retryKey;
+
+  const url = `${proxyBaseUrl.replace(/\/$/, '')}/line-api/v2/bot/message/push`;
+  const init: RequestInit = {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ to, messages }),
+  };
+  // Worker 自身の公開 URL へ fetch すると自己接続が失敗する環境がある。
+  // 内部呼び出しは同じ Hono proxy handler へ直接 dispatch し、外部利用時だけ fetch。
+  const response = dispatch ? await dispatch(new Request(url, init)) : await fetch(url, init);
+
+  // 同じ retry key がすでに LINE に受理済みなら、再送の 409 も成功扱い。
+  const alreadyAccepted =
+    response.status === 409 && Boolean(response.headers.get('x-line-accepted-request-id'));
+  if (response.ok || alreadyAccepted) return;
+
+  const body = await response.text().catch(() => '');
+  throw new Error(
+    `LINE Harness proxy error: ${response.status} ${response.statusText} — ${body.slice(0, 500)}`,
+  );
+}

--- a/apps/worker/src/services/local-line-proxy.ts
+++ b/apps/worker/src/services/local-line-proxy.ts
@@ -1,0 +1,11 @@
+import { lineProxy } from '../routes/line-proxy.js';
+import type { Env } from '../index.js';
+
+/** 公開URLへの自己 fetch を避け、Harness proxy の同じ handler をWorker内で実行する。 */
+export function dispatchLineProxyLocally(
+  request: Request,
+  env: Env['Bindings'],
+  executionCtx?: ExecutionContext,
+): Promise<Response> {
+  return Promise.resolve(lineProxy.fetch(request, env, executionCtx as ExecutionContext));
+}

--- a/apps/worker/src/services/webinar-reminders.test.ts
+++ b/apps/worker/src/services/webinar-reminders.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test, beforeEach, vi } from 'vitest';
+
+const dbMocks = {
+  getDueWebinarRegistrations: vi.fn(),
+  markWebinarRegistrationNotified: vi.fn(),
+  getFriendById: vi.fn(),
+  getLineAccountById: vi.fn(),
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+const { processWebinarReminders, sendWebinarRegistrationConfirmation, buildWebinarUrl } =
+  await import('./webinar-reminders.js');
+
+const NOW = 1_800_000_000;
+const REG = {
+  id: 'reg-1', webinar_id: 'w1', friend_id: 'friend-1',
+  session_start_at: NOW + 240, notified_at: null, created_at: 'x',
+  slug: 'test-webinar', title: 'テスト', account_id: 'acc-1', duration_seconds: 1200,
+};
+const OPTIONS = {
+  proxyBaseUrl: 'https://proxy.example.com/',
+  defaultAccessToken: 'default-token',
+  defaultLiffId: '999-def',
+};
+const proxyFetch = vi.fn();
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(NOW * 1000));
+  dbMocks.getFriendById.mockResolvedValue({ id: 'friend-1', line_user_id: 'U1', is_following: 1 });
+  dbMocks.getLineAccountById.mockResolvedValue({
+    id: 'acc-1', channel_access_token: 'tok', liff_id: '111-aaa',
+  });
+  dbMocks.markWebinarRegistrationNotified.mockResolvedValue(true);
+  proxyFetch.mockResolvedValue(new Response(null, { status: 200 }));
+  vi.stubGlobal('fetch', proxyFetch);
+});
+
+describe('processWebinarReminders', () => {
+  test('Harness proxy 経由で送信し、成功後に notified を刻む', async () => {
+    dbMocks.getDueWebinarRegistrations.mockResolvedValue([REG]);
+    const result = await processWebinarReminders({} as D1Database, OPTIONS);
+    expect(result).toEqual({ sent: 1, failed: 0 });
+    expect(dbMocks.markWebinarRegistrationNotified).toHaveBeenCalledWith(expect.anything(), 'reg-1');
+    expect(proxyFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = proxyFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://proxy.example.com/line-api/v2/bot/message/push');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer tok',
+      'X-Line-Retry-Key': 'reg-1',
+    });
+    const body = JSON.parse(String(init.body)) as { to: string; messages: Array<{ text: string }> };
+    expect(body.to).toBe('U1');
+    expect(body.messages[0].text).toContain(
+      buildWebinarUrl('111-aaa', 'test-webinar', REG.session_start_at),
+    );
+    expect(body.messages[0].text).toContain(`sessionStartAt=${REG.session_start_at}`);
+    expect(body.messages[0].text).toContain('何度でも開けます');
+    expect(body.messages[0].text).toContain('まもなく');
+    expect(proxyFetch.mock.invocationCallOrder[0]).toBeLessThan(
+      dbMocks.markWebinarRegistrationNotified.mock.invocationCallOrder[0],
+    );
+  });
+
+  test('proxy 送信失敗時は notified を刻まず、次 tick で再試行できる', async () => {
+    dbMocks.getDueWebinarRegistrations.mockResolvedValue([REG]);
+    proxyFetch.mockResolvedValue(
+      new Response('{"message":"upstream failed"}', { status: 502, statusText: 'Bad Gateway' }),
+    );
+    const result = await processWebinarReminders({} as D1Database, OPTIONS);
+    expect(result).toEqual({ sent: 0, failed: 1 });
+    expect(dbMocks.markWebinarRegistrationNotified).not.toHaveBeenCalled();
+  });
+
+  test('同じ retry key が LINE で受理済みの 409 は成功扱いにして notified を刻む', async () => {
+    dbMocks.getDueWebinarRegistrations.mockResolvedValue([REG]);
+    proxyFetch.mockResolvedValue(
+      new Response(null, {
+        status: 409,
+        headers: { 'x-line-accepted-request-id': 'accepted-1' },
+      }),
+    );
+    const result = await processWebinarReminders({} as D1Database, OPTIONS);
+    expect(result).toEqual({ sent: 1, failed: 0 });
+    expect(dbMocks.markWebinarRegistrationNotified).toHaveBeenCalledWith(expect.anything(), 'reg-1');
+  });
+
+  test('ブロック済み friend は送らず消化する', async () => {
+    dbMocks.getDueWebinarRegistrations.mockResolvedValue([REG]);
+    dbMocks.getFriendById.mockResolvedValue({ id: 'friend-1', line_user_id: 'U1', is_following: 0 });
+    const result = await processWebinarReminders({} as D1Database, OPTIONS);
+    expect(proxyFetch).not.toHaveBeenCalled();
+    expect(dbMocks.markWebinarRegistrationNotified).toHaveBeenCalledWith(expect.anything(), 'reg-1');
+    expect(result).toEqual({ sent: 0, failed: 0 });
+  });
+
+  test('開始済みセッションは「始まりました」文言になる', async () => {
+    dbMocks.getDueWebinarRegistrations.mockResolvedValue([
+      { ...REG, session_start_at: NOW - 30 },
+    ]);
+    await processWebinarReminders({} as D1Database, OPTIONS);
+    const [, init] = proxyFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(init.body)) as { messages: Array<{ text: string }> };
+    expect(body.messages[0].text).toContain('始まりました');
+  });
+});
+
+describe('sendWebinarRegistrationConfirmation', () => {
+  test('予約直後の確認も Harness proxy 経由で送り、履歴化する', async () => {
+    await sendWebinarRegistrationConfirmation(
+      {} as D1Database,
+      { account_id: 'acc-1', title: 'テスト', slug: 'test-webinar' },
+      'friend-1',
+      NOW + 3600,
+      OPTIONS,
+    );
+    expect(proxyFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = proxyFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://proxy.example.com/line-api/v2/bot/message/push');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer tok' });
+    const body = JSON.parse(String(init.body)) as { messages: Array<{ text: string }> };
+    expect(body.messages[0].text).toContain('受付しました');
+    expect(body.messages[0].text).toContain(
+      buildWebinarUrl('111-aaa', 'test-webinar', NOW + 3600),
+    );
+    expect(body.messages[0].text).toContain('専用の入場リンク');
+  });
+});

--- a/apps/worker/src/services/webinar-reminders.ts
+++ b/apps/worker/src/services/webinar-reminders.ts
@@ -1,0 +1,143 @@
+// ウェビナー予約リマインド — 5分毎 cron から実行。
+// セッション選択メニュー (webinar_registrations) で予約した友だちに、開始
+// LEAD_SECONDS 前〜セッション中の間に視聴リンクを1回だけプッシュする。
+// LINE 送信は必ず Harness の /line-api プロキシを通し、messages_log に残す。
+// X-Line-Retry-Key に registration id を使うことで、送信成功後の DB 更新前に
+// worker が落ちても LINE 側で二重送信を防ぎつつ、次 tick で安全に再試行できる。
+
+import {
+  getDueWebinarRegistrations,
+  markWebinarRegistrationNotified,
+  getFriendById,
+  getLineAccountById,
+  type Webinar,
+} from '@line-crm/db';
+import { addJitter, sleep } from './stealth.js';
+import { pushViaHarnessProxy } from './line-proxy-send.js';
+import type { HarnessProxyDispatch } from './line-proxy-send.js';
+
+const LEAD_SECONDS = 300;
+
+export type WebinarProxyDeliveryOptions = {
+  proxyBaseUrl: string;
+  defaultAccessToken: string;
+  defaultLiffId: string | null;
+  proxyDispatch?: HarnessProxyDispatch;
+};
+
+export function buildWebinarUrl(
+  liffId: string,
+  slug: string,
+  sessionStartAt: number,
+): string {
+  return (
+    `https://liff.line.me/${liffId}/?page=webinar&slug=${encodeURIComponent(slug)}` +
+    `&sessionStartAt=${sessionStartAt}&liffId=${liffId}`
+  );
+}
+
+function fmtJstDateTime(epochSeconds: number): string {
+  const d = new Date((epochSeconds + 9 * 3600) * 1000);
+  const days = ['日', '月', '火', '水', '木', '金', '土'];
+  return (
+    `${d.getUTCMonth() + 1}月${d.getUTCDate()}日(${days[d.getUTCDay()]}) ` +
+    `${d.getUTCHours()}:${String(d.getUTCMinutes()).padStart(2, '0')}`
+  );
+}
+
+async function resolveDeliveryConfig(
+  db: D1Database,
+  accountId: string | null,
+  options: WebinarProxyDeliveryOptions,
+): Promise<{ accessToken: string; liffId: string | null }> {
+  if (accountId) {
+    const account = await getLineAccountById(db, accountId);
+    if (account) {
+      return {
+        accessToken: account.channel_access_token,
+        liffId:
+          ((account as unknown as Record<string, string | null>).liff_id as string | null) ??
+          options.defaultLiffId,
+      };
+    }
+  }
+  return {
+    accessToken: options.defaultAccessToken,
+    liffId: options.defaultLiffId,
+  };
+}
+
+export async function processWebinarReminders(
+  db: D1Database,
+  options: WebinarProxyDeliveryOptions,
+): Promise<{ sent: number; failed: number }> {
+  const now = Math.floor(Date.now() / 1000);
+  const due = await getDueWebinarRegistrations(db, now, LEAD_SECONDS);
+  let sent = 0;
+  let failed = 0;
+  for (let i = 0; i < due.length; i++) {
+    const reg = due[i];
+    try {
+      if (i > 0) await sleep(addJitter(50, 200));
+      const friend = await getFriendById(db, reg.friend_id);
+      if (!friend || !friend.is_following) {
+        // ブロック済み等は送らず消化 (毎 tick 積み直さない)
+        await markWebinarRegistrationNotified(db, reg.id);
+        continue;
+      }
+      const { accessToken, liffId } = await resolveDeliveryConfig(db, reg.account_id, options);
+      if (!liffId) {
+        failed++;
+        continue;
+      }
+      const head =
+        reg.session_start_at - now > 60 ? '🔴 まもなくライブ配信が始まります' : '🔴 ライブ配信が始まりました';
+      await pushViaHarnessProxy(options.proxyBaseUrl, accessToken, friend.line_user_id, [
+        {
+          type: 'text',
+          text:
+            `${head}\n\n「${reg.title}」\n${fmtJstDateTime(reg.session_start_at)}〜\n\n` +
+            `こちらから参加してください👇\n${buildWebinarUrl(liffId, reg.slug, reg.session_start_at)}` +
+            `\n\n※この専用リンクは、閉じた後も何度でも開けます。`,
+        },
+      ], reg.id, options.proxyDispatch);
+      // 実送信が成功した後だけ通知済みにする。失敗時は NULL のままなので次 tick で再試行。
+      await markWebinarRegistrationNotified(db, reg.id);
+      sent++;
+    } catch (err) {
+      console.error('webinar reminder error:', reg.id, err);
+      failed++;
+    }
+  }
+  return { sent, failed };
+}
+
+/** 予約直後の受付確認プッシュ (fire-and-forget。失敗しても予約自体は成立) */
+export async function sendWebinarRegistrationConfirmation(
+  db: D1Database,
+  webinar: Pick<Webinar, 'account_id' | 'title' | 'slug'>,
+  friendId: string,
+  sessionStartAt: number,
+  options: WebinarProxyDeliveryOptions,
+): Promise<void> {
+  try {
+    const friend = await getFriendById(db, friendId);
+    if (!friend || !friend.is_following) return;
+    const { accessToken, liffId } = await resolveDeliveryConfig(db, webinar.account_id, options);
+    if (!liffId) return;
+    const admissionUrl = buildWebinarUrl(liffId, webinar.slug, sessionStartAt);
+    await pushViaHarnessProxy(options.proxyBaseUrl, accessToken, friend.line_user_id, [
+      {
+        type: 'text',
+        text:
+          `✅ ${fmtJstDateTime(sessionStartAt)} の回で受付しました\n\n` +
+          `「${webinar.title}」\n\n` +
+          `専用の入場リンクです👇\n${admissionUrl}\n\n` +
+          `開始5分前にも同じリンクをお送りします。` +
+          `閉じた後も何度でも開けます。`,
+      },
+    ], crypto.randomUUID(), options.proxyDispatch);
+  } catch (err) {
+    console.error('webinar registration confirmation error:', err);
+  }
+}

--- a/apps/worker/src/services/webinar-schedule.ts
+++ b/apps/worker/src/services/webinar-schedule.ts
@@ -106,3 +106,15 @@ export function resolveSession(
   }
   return { live: false, sessionStartAt: null, offsetSeconds: null, nextSessionAt: next };
 }
+
+/** now より未来のセッション開始時刻を昇順で最大 count 件返す (セッション選択メニュー用) */
+export function upcomingSessions(
+  rules: ScheduleRule[],
+  durationSeconds: number,
+  nowEpochSeconds: number,
+  count: number,
+): number[] {
+  return candidateStarts(rules, nowEpochSeconds, durationSeconds)
+    .filter((s) => s > nowEpochSeconds)
+    .slice(0, count);
+}

--- a/packages/db/migrations/055_webinar_ctas.sql
+++ b/packages/db/migrations/055_webinar_ctas.sql
@@ -1,0 +1,24 @@
+-- 055: Webinar CTA cards (チャット欄に流れる CTA + インラインフォーム)
+--
+-- ウェビナーの指定秒数でチャット欄に CTA カードを流し込む。kind='form' は
+-- 既存フォーム機能 (forms) をビューア内ボトムシートで開き、離脱なしで回答
+-- させる (送信は既存 POST /api/forms/:id/submit — タグ/シナリオ side effects
+-- がそのまま発火する)。kind='url' は外部 URL を開く (従来 CTA 相当)。
+-- 052-054 は OSS PR (#236/#223/#229) に割当済みのため 055 (line-harness-oss-pr-day)。
+
+CREATE TABLE IF NOT EXISTS webinar_ctas (
+  id TEXT PRIMARY KEY,
+  webinar_id TEXT NOT NULL REFERENCES webinars(id) ON DELETE CASCADE,
+  at_seconds INTEGER NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('form', 'url')),
+  title TEXT NOT NULL,
+  body TEXT,
+  button_label TEXT NOT NULL,
+  auto_open INTEGER NOT NULL DEFAULT 0,
+  form_id TEXT REFERENCES forms(id),
+  url TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_webinar_ctas_webinar
+  ON webinar_ctas (webinar_id, at_seconds);

--- a/packages/db/migrations/056_webinar_registrations.sql
+++ b/packages/db/migrations/056_webinar_registrations.sql
@@ -1,0 +1,20 @@
+-- 056: Webinar session registrations (セッション選択メニューの予約)
+--
+-- 視聴者が「どの回に参加するか」を選ぶと1行入る。session_start_at は
+-- webinar_viewers と同じくセッション開始 epoch 秒。開始5分前までに cron が
+-- 視聴リンクをプッシュし notified_at を刻む (未通知 = NULL)。
+-- 052-054 は OSS PR 割当、055 は webinar_ctas 使用済みのため 056。
+
+CREATE TABLE IF NOT EXISTS webinar_registrations (
+  id TEXT PRIMARY KEY,
+  webinar_id TEXT NOT NULL REFERENCES webinars(id) ON DELETE CASCADE,
+  friend_id TEXT NOT NULL REFERENCES friends(id),
+  session_start_at INTEGER NOT NULL,
+  notified_at TEXT,
+  created_at TEXT NOT NULL,
+  UNIQUE (webinar_id, friend_id, session_start_at)
+);
+CREATE INDEX IF NOT EXISTS idx_webinar_regs_due
+  ON webinar_registrations (notified_at, session_start_at);
+CREATE INDEX IF NOT EXISTS idx_webinar_regs_friend
+  ON webinar_registrations (webinar_id, friend_id);

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -33,6 +33,11 @@ export interface FormSubmission {
   created_at: string;
 }
 
+export interface FriendFormSubmission extends FormSubmission {
+  form_name: string;
+  form_fields: string;
+}
+
 // ── CRUD ─────────────────────────────────────────────────────────────────────
 
 export async function getForms(db: D1Database): Promise<Form[]> {
@@ -251,7 +256,13 @@ export async function updateForm(
 }
 
 export async function deleteForm(db: D1Database, id: string): Promise<void> {
-  await db.prepare(`DELETE FROM forms WHERE id = ?`).bind(id).run();
+  // フォームを参照しているウェビナー CTA カードも同時に削除する。宙吊りの
+  // form_id が残ると、放置運用中のオートウェビナーでカードだけ出続けて
+  // 全タップがエラーになる (D1 は FK 未強制)。
+  await db.batch([
+    db.prepare(`DELETE FROM webinar_ctas WHERE form_id = ?`).bind(id),
+    db.prepare(`DELETE FROM forms WHERE id = ?`).bind(id),
+  ]);
 }
 
 // ── Submissions ───────────────────────────────────────────────────────────────
@@ -268,6 +279,27 @@ export async function getFormSubmissions(
     )
     .bind(formId)
     .all<FormSubmission & { friend_name: string | null }>();
+  return result.results;
+}
+
+/** 友だち詳細欄で使う、フォーム名・質問定義つきの最新回答履歴。 */
+export async function getFormSubmissionsByFriend(
+  db: D1Database,
+  friendId: string,
+  limit = 10,
+): Promise<FriendFormSubmission[]> {
+  const safeLimit = Math.max(1, Math.min(Math.floor(limit), 50));
+  const result = await db
+    .prepare(
+      `SELECT fs.*, f.name AS form_name, f.fields AS form_fields
+       FROM form_submissions fs
+       JOIN forms f ON f.id = fs.form_id
+       WHERE fs.friend_id = ?
+       ORDER BY fs.created_at DESC
+       LIMIT ?`,
+    )
+    .bind(friendId, safeLimit)
+    .all<FriendFormSubmission>();
   return result.results;
 }
 

--- a/packages/db/src/friends.ts
+++ b/packages/db/src/friends.ts
@@ -90,6 +90,27 @@ export async function getFollowingLineUserIdsByTag(
   return (result.results ?? []).map((r) => r.line_user_id);
 }
 
+/**
+ * アカウントスコープ優先の friend 解決。同一プロバイダー配下の複数アカウント
+ * では line_user_id が同一になるため、無指定の先頭一致だと別アカウントの
+ * friend 行に吸われて通知アカウントがズレる。指定アカウントの行を優先し、
+ * 無ければ従来どおり先頭一致にフォールバックする。
+ */
+export async function getFriendByLineUserIdForAccount(
+  db: D1Database,
+  lineUserId: string,
+  lineAccountId: string | null,
+): Promise<Friend | null> {
+  if (lineAccountId) {
+    const scoped = await db
+      .prepare(`SELECT * FROM friends WHERE line_user_id = ? AND line_account_id = ?`)
+      .bind(lineUserId, lineAccountId)
+      .first<Friend>();
+    if (scoped) return scoped;
+  }
+  return getFriendByLineUserId(db, lineUserId);
+}
+
 export async function getFriendByLineUserId(
   db: D1Database,
   lineUserId: string,

--- a/packages/db/src/webinars.ts
+++ b/packages/db/src/webinars.ts
@@ -44,6 +44,7 @@ export interface WebinarUserComment {
   body: string;
   created_at: string;
   friend_name?: string | null;
+  picture_url?: string | null;
 }
 
 export interface WebinarSessionStat {
@@ -51,6 +52,39 @@ export interface WebinarSessionStat {
   viewers: number;
   avg_watched_seconds: number;
   cta_clicks: number;
+}
+
+export interface WebinarParticipantStat {
+  friend_id: string;
+  friend_name: string | null;
+  picture_url: string | null;
+  sessions: number;
+  first_joined_at: string;
+  latest_joined_at: string;
+  max_watched_seconds: number;
+  cta_clicked_at: string | null;
+  registered: number;
+  form_submitted_at: string | null;
+}
+
+export interface WebinarDailyStat {
+  stat_date: string;
+  reservations: number;
+  viewers: number;
+  cta_clicks: number;
+  form_submissions: number;
+}
+
+export interface WebinarAnalyticsSummaryRow {
+  reservations: number;
+  viewers: number;
+  registered_and_joined: number;
+  watched_5m: number;
+  watched_15m: number;
+  completed: number;
+  avg_watched_seconds: number;
+  cta_clicks: number;
+  form_submissions: number;
 }
 
 export interface WebinarCreateInput {
@@ -138,6 +172,7 @@ export async function deleteWebinar(db: D1Database, id: string): Promise<void> {
     db.prepare('DELETE FROM webinar_user_comments WHERE webinar_id = ?').bind(id),
     db.prepare('DELETE FROM webinar_viewers WHERE webinar_id = ?').bind(id),
     db.prepare('DELETE FROM webinar_comments WHERE webinar_id = ?').bind(id),
+    db.prepare('DELETE FROM webinar_ctas WHERE webinar_id = ?').bind(id),
     db.prepare('DELETE FROM webinars WHERE id = ?').bind(id),
   ]);
 }
@@ -271,6 +306,7 @@ export async function getWebinarUserComments(
   const { results } = await db
     .prepare(
       `SELECT wuc.*, f.display_name AS friend_name
+              , f.picture_url
        FROM webinar_user_comments wuc
        LEFT JOIN friends f ON f.id = wuc.friend_id
        WHERE wuc.webinar_id = ?
@@ -315,4 +351,306 @@ export async function getWebinarDropoff(
     .bind(webinarId)
     .all<{ bucket_start: number; viewers: number }>();
   return results ?? [];
+}
+
+/** 参加者を friend 単位にまとめる。再入場・複数セッションは1人として表示する。 */
+export async function getWebinarParticipantStats(
+  db: D1Database,
+  webinarId: string,
+  limit = 200,
+): Promise<WebinarParticipantStat[]> {
+  const { results } = await db
+    .prepare(
+      `SELECT v.friend_id,
+              f.display_name AS friend_name,
+              f.picture_url,
+              COUNT(*) AS sessions,
+              MIN(v.joined_at) AS first_joined_at,
+              MAX(v.joined_at) AS latest_joined_at,
+              MAX(v.last_position_seconds) AS max_watched_seconds,
+              MAX(v.cta_clicked_at) AS cta_clicked_at,
+              CASE WHEN EXISTS (
+                SELECT 1 FROM webinar_registrations r
+                WHERE r.webinar_id = v.webinar_id AND r.friend_id = v.friend_id
+              ) THEN 1 ELSE 0 END AS registered,
+              (
+                SELECT MAX(fs.created_at)
+                FROM form_submissions fs
+                JOIN webinar_ctas wc ON wc.form_id = fs.form_id
+                JOIN webinars wf ON wf.id = wc.webinar_id
+                WHERE wc.webinar_id = v.webinar_id
+                  AND fs.friend_id = v.friend_id
+                  AND fs.created_at >= wf.created_at
+              ) AS form_submitted_at
+       FROM webinar_viewers v
+       LEFT JOIN friends f ON f.id = v.friend_id
+       WHERE v.webinar_id = ?
+       GROUP BY v.webinar_id, v.friend_id, f.display_name, f.picture_url
+       ORDER BY latest_joined_at DESC
+       LIMIT ?`,
+    )
+    .bind(webinarId, limit)
+    .all<WebinarParticipantStat>();
+  return results ?? [];
+}
+
+/** KPI は全参加者で集計し、顔写真付き一覧の表示件数に左右されないようにする。 */
+export async function getWebinarAnalyticsSummary(
+  db: D1Database,
+  webinarId: string,
+  completionThresholdSeconds: number,
+): Promise<WebinarAnalyticsSummaryRow> {
+  const row = await db
+    .prepare(
+      `WITH viewer_rollup AS (
+         SELECT friend_id,
+                MAX(last_position_seconds) AS max_watched_seconds,
+                MAX(CASE WHEN cta_clicked_at IS NOT NULL THEN 1 ELSE 0 END) AS clicked
+         FROM webinar_viewers WHERE webinar_id = ? GROUP BY friend_id
+       ), form_submitters AS (
+         SELECT DISTINCT fs.friend_id
+         FROM form_submissions fs
+         JOIN webinar_ctas wc ON wc.form_id = fs.form_id
+         JOIN webinars w ON w.id = wc.webinar_id
+         WHERE wc.webinar_id = ? AND fs.created_at >= w.created_at
+       )
+       SELECT
+         (SELECT COUNT(DISTINCT friend_id) FROM webinar_registrations
+          WHERE webinar_id = ?) AS reservations,
+         COUNT(*) AS viewers,
+         COALESCE(SUM(CASE WHEN EXISTS (
+           SELECT 1 FROM webinar_registrations r
+           WHERE r.webinar_id = ? AND r.friend_id = vr.friend_id
+         ) THEN 1 ELSE 0 END), 0) AS registered_and_joined,
+         COALESCE(SUM(CASE WHEN vr.max_watched_seconds >= 300 THEN 1 ELSE 0 END), 0) AS watched_5m,
+         COALESCE(SUM(CASE WHEN vr.max_watched_seconds >= 900 THEN 1 ELSE 0 END), 0) AS watched_15m,
+         COALESCE(SUM(CASE WHEN vr.max_watched_seconds >= ? THEN 1 ELSE 0 END), 0) AS completed,
+         COALESCE(CAST(AVG(vr.max_watched_seconds) AS INTEGER), 0) AS avg_watched_seconds,
+         COALESCE(SUM(vr.clicked), 0) AS cta_clicks,
+         COALESCE(SUM(CASE WHEN fs.friend_id IS NOT NULL THEN 1 ELSE 0 END), 0) AS form_submissions
+       FROM viewer_rollup vr
+       LEFT JOIN form_submitters fs ON fs.friend_id = vr.friend_id`,
+    )
+    .bind(
+      webinarId,
+      webinarId,
+      webinarId,
+      webinarId,
+      completionThresholdSeconds,
+    )
+    .first<WebinarAnalyticsSummaryRow>();
+  return row ?? {
+    reservations: 0,
+    viewers: 0,
+    registered_and_joined: 0,
+    watched_5m: 0,
+    watched_15m: 0,
+    completed: 0,
+    avg_watched_seconds: 0,
+    cta_clicks: 0,
+    form_submissions: 0,
+  };
+}
+
+/** 日別の予約→参加→CTA→フォーム推移。日本時間の保存文字列を日付で集計する。 */
+export async function getWebinarDailyStats(
+  db: D1Database,
+  webinarId: string,
+): Promise<WebinarDailyStat[]> {
+  const { results } = await db
+    .prepare(
+      `WITH regs AS (
+         SELECT friend_id, created_at FROM webinar_registrations WHERE webinar_id = ?
+       ), views AS (
+         SELECT friend_id, joined_at, cta_clicked_at FROM webinar_viewers WHERE webinar_id = ?
+       ), submissions AS (
+         SELECT fs.friend_id, fs.created_at
+         FROM form_submissions fs
+         JOIN webinar_ctas wc ON wc.form_id = fs.form_id
+         JOIN webinars w ON w.id = wc.webinar_id
+         WHERE wc.webinar_id = ? AND fs.created_at >= w.created_at
+       ), dates AS (
+         SELECT substr(created_at, 1, 10) AS stat_date FROM regs
+         UNION SELECT substr(joined_at, 1, 10) FROM views
+         UNION SELECT substr(cta_clicked_at, 1, 10) FROM views WHERE cta_clicked_at IS NOT NULL
+         UNION SELECT substr(created_at, 1, 10) FROM submissions
+       )
+       SELECT d.stat_date,
+              (SELECT COUNT(DISTINCT friend_id) FROM regs
+               WHERE substr(created_at, 1, 10) = d.stat_date) AS reservations,
+              (SELECT COUNT(DISTINCT friend_id) FROM views
+               WHERE substr(joined_at, 1, 10) = d.stat_date) AS viewers,
+              (SELECT COUNT(DISTINCT friend_id) FROM views
+               WHERE substr(cta_clicked_at, 1, 10) = d.stat_date) AS cta_clicks,
+              (SELECT COUNT(DISTINCT friend_id) FROM submissions
+               WHERE substr(created_at, 1, 10) = d.stat_date) AS form_submissions
+       FROM dates d
+       WHERE d.stat_date IS NOT NULL AND d.stat_date <> ''
+       ORDER BY d.stat_date ASC`,
+    )
+    .bind(webinarId, webinarId, webinarId)
+    .all<WebinarDailyStat>();
+  return results ?? [];
+}
+
+// ─── Webinar CTA cards ───────────────────────────────────
+
+export interface WebinarCta {
+  id: string;
+  webinar_id: string;
+  at_seconds: number;
+  kind: 'form' | 'url';
+  title: string;
+  body: string | null;
+  button_label: string;
+  auto_open: number;
+  form_id: string | null;
+  url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function getWebinarCtas(
+  db: D1Database,
+  webinarId: string,
+): Promise<WebinarCta[]> {
+  const { results } = await db
+    .prepare('SELECT * FROM webinar_ctas WHERE webinar_id = ? ORDER BY at_seconds ASC')
+    .bind(webinarId)
+    .all<WebinarCta>();
+  return results ?? [];
+}
+
+export async function replaceWebinarCtas(
+  db: D1Database,
+  webinarId: string,
+  ctas: Array<{
+    atSeconds: number;
+    kind: 'form' | 'url';
+    title: string;
+    body: string | null;
+    buttonLabel: string;
+    autoOpen: boolean;
+    formId: string | null;
+    url: string | null;
+  }>,
+): Promise<number> {
+  const now = jstNow();
+  const stmts = [
+    db.prepare('DELETE FROM webinar_ctas WHERE webinar_id = ?').bind(webinarId),
+    ...ctas.map((cta) =>
+      db
+        .prepare(
+          `INSERT INTO webinar_ctas
+             (id, webinar_id, at_seconds, kind, title, body, button_label, auto_open,
+              form_id, url, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(
+          crypto.randomUUID(), webinarId, cta.atSeconds, cta.kind, cta.title, cta.body,
+          cta.buttonLabel, cta.autoOpen ? 1 : 0, cta.formId, cta.url, now, now,
+        ),
+    ),
+  ];
+  await db.batch(stmts);
+  return ctas.length;
+}
+
+// ---- セッション予約 (webinar_registrations) ----
+
+export interface WebinarRegistration {
+  id: string;
+  webinar_id: string;
+  friend_id: string;
+  session_start_at: number;
+  notified_at: string | null;
+  created_at: string;
+}
+
+/** 予約を upsert する (同一 friend×セッションは冪等) */
+export async function upsertWebinarRegistration(
+  db: D1Database,
+  webinarId: string,
+  friendId: string,
+  sessionStartAt: number,
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO webinar_registrations
+         (id, webinar_id, friend_id, session_start_at, notified_at, created_at)
+       VALUES (?, ?, ?, ?, NULL, ?)`,
+    )
+    .bind(crypto.randomUUID(), webinarId, friendId, sessionStartAt, jstNow())
+    .run();
+}
+
+/** friend の未来セッション予約 (直近1件) */
+export async function getUpcomingWebinarRegistration(
+  db: D1Database,
+  webinarId: string,
+  friendId: string,
+  nowEpochSeconds: number,
+): Promise<WebinarRegistration | null> {
+  return db
+    .prepare(
+      `SELECT * FROM webinar_registrations
+       WHERE webinar_id = ? AND friend_id = ? AND session_start_at > ?
+       ORDER BY session_start_at ASC LIMIT 1`,
+    )
+    .bind(webinarId, friendId, nowEpochSeconds)
+    .first<WebinarRegistration>();
+}
+
+/** 特定セッションへの予約行 (ライブ中の本人入場判定用) */
+export async function getWebinarRegistration(
+  db: D1Database,
+  webinarId: string,
+  friendId: string,
+  sessionStartAt: number,
+): Promise<WebinarRegistration | null> {
+  return db
+    .prepare(
+      `SELECT * FROM webinar_registrations
+       WHERE webinar_id = ? AND friend_id = ? AND session_start_at = ?`,
+    )
+    .bind(webinarId, friendId, sessionStartAt)
+    .first<WebinarRegistration>();
+}
+
+/** 開始 leadSeconds 前〜開始後 (セッション継続中) の未通知予約 */
+export async function getDueWebinarRegistrations(
+  db: D1Database,
+  nowEpochSeconds: number,
+  leadSeconds: number,
+  limit = 100,
+): Promise<Array<WebinarRegistration & { slug: string; title: string; account_id: string | null; duration_seconds: number }>> {
+  const { results } = await db
+    .prepare(
+      `SELECT r.*, w.slug, w.title, w.account_id, w.duration_seconds
+       FROM webinar_registrations r
+       JOIN webinars w ON w.id = r.webinar_id
+       WHERE r.notified_at IS NULL
+         AND w.status = 'active'
+         AND r.session_start_at <= ?
+         AND r.session_start_at + w.duration_seconds > ?
+       ORDER BY r.session_start_at ASC
+       LIMIT ?`,
+    )
+    .bind(nowEpochSeconds + leadSeconds, nowEpochSeconds, limit)
+    .all<WebinarRegistration & { slug: string; title: string; account_id: string | null; duration_seconds: number }>();
+  return results ?? [];
+}
+
+/** 通知済みマーク。未通知の場合のみ更新し、更新できたら true (二重送信ガード) */
+export async function markWebinarRegistrationNotified(
+  db: D1Database,
+  id: string,
+): Promise<boolean> {
+  const res = await db
+    .prepare(
+      `UPDATE webinar_registrations SET notified_at = ? WHERE id = ? AND notified_at IS NULL`,
+    )
+    .bind(jstNow(), id)
+    .run();
+  return (res.meta.changes ?? 0) > 0;
 }


### PR DESCRIPTION
Private → OSS sync of the complete auto-webinar feature set, matching the publicly announced functionality.

## Included
- **CTA cards + inline bottom-sheet forms** (migration 055) — zero-exit form flow during playback
- **Session registrations + reminders** (migration 056) — session picker, confirmation push, 5-min-before reminder cron with claim-based dedup
- **Waiting room** — negative at_seconds pre-live comments, countdown
- **iOS mid-join fix** — dynamic EXT-X-START injection via `?at=` on playlists
- **No-midjoin gate** — reserved viewers only during live, next-session booking for walk-ins
- **Account-scoped friend resolution** (webinar routes + /api/liff/link attribution)
- **LINE proxy send services**, activity digest service

Synced via `scripts/sync-oss.sh` (secrets redacted, leak check passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)