### PR TITLE
test: stabilize mileage clock and gate releases on DB tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Build shared workspace packages
         run: pnpm --filter @line-crm/shared --filter @line-crm/line-sdk --filter @line-crm/db --filter @line-harness/update-engine build
 
+      - name: Run unit tests (database, including mileage)
+        run: pnpm --filter @line-crm/db test
+
       - name: Capture build metadata
         id: build-meta
         run: echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"

--- a/packages/db/test/mileage-rules.test.ts
+++ b/packages/db/test/mileage-rules.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Database from 'better-sqlite3';
 import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -18,6 +18,7 @@ import { updateFriendFollowStatus } from '../src/friends.js';
 
 const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const BENIGN = /duplicate column name|already exists/i;
+const FIXED_NOW = new Date('2026-08-10T00:00:00.000+09:00');
 
 function execSafe(db: Database.Database, sql: string) {
   for (const statement of sql.split(/;\s*(?:\r?\n|$)/).map((item) => item.trim()).filter(Boolean)) {
@@ -70,8 +71,15 @@ describe('configurable mileage rules', () => {
   let db: D1Database;
 
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(FIXED_NOW);
     sqlite = setupSqlite();
     db = asD1(sqlite);
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    vi.useRealTimers();
   });
 
   it('enforces the message daily cap across two LINE accounts for one user', async () => {


### PR DESCRIPTION
## Summary

- Freeze the mileage rule test clock at a deterministic JST timestamp and restore it after each test.
- Close the in-memory SQLite database after each mileage test.
- Add the database test suite, including mileage coverage, to the tag-driven Release workflow.

## Why

The mileage tests used fixed processing timestamps on 2026-08-10 while queue rows were created from the real current clock. Running the suite later on the same day could make those queue rows appear to be in the future and produce false zero-mile failures.

Freezing `Date` keeps event creation and processing in a deterministic order, independent of the machine's current time or timezone. Adding the DB suite to the Release workflow prevents a release from shipping when database or mileage behavior regresses.

## Validation

- `TZ=UTC pnpm --filter @line-crm/db test`: 135 passed
- `TZ=America/Los_Angeles pnpm --filter @line-crm/db test`: 135 passed
- Migration safety check: 27 passed
- Release script tests: 37 passed
- Worker tests: 893 passed
- Admin tests: 8 passed
- Admin production build: passed
- LIFF production build: passed
- Worker `wrangler deploy --dry-run`: passed
- `git diff --check`: passed
- Release workflow YAML parse: passed

## Safety

- Test and CI configuration only.
- No runtime behavior, migrations, secrets, or deployment configuration changed.
- Validated entirely in an isolated local sandbox.
