### PR TITLE
sync: add one-time existing-follower import

### DIFF
--- a/apps/web/src/app/accounts/page.tsx
+++ b/apps/web/src/app/accounts/page.tsx
@@ -15,6 +15,7 @@ import {
 import AccountSetupUrls from '@/components/accounts/account-setup-urls'
 import AccountEditModal from '@/components/accounts/account-edit-modal'
 import LinkBaseUrlSetting from '@/components/accounts/link-base-url-setting'
+import FollowerImportButton from '@/components/accounts/follower-import-button'
 
 interface LineAccountListItem {
   id: string
@@ -319,6 +320,7 @@ export default function AccountsPage() {
                 onUpdated={load}
               />
               <TestRecipientsSetting accountId={account.id} />
+              <FollowerImportButton accountId={account.id} onImported={load} />
 
               <div className="flex items-center justify-between mt-3 pt-3 border-t border-gray-100">
                 <p className="text-xs text-gray-400">

--- a/apps/web/src/components/accounts/follower-import-button.tsx
+++ b/apps/web/src/components/accounts/follower-import-button.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { api, type FollowerImportState } from '@/lib/api'
+
+interface Props {
+  accountId: string
+  onImported: () => void
+}
+
+export default function FollowerImportButton({ accountId, onImported }: Props) {
+  const [state, setState] = useState<FollowerImportState | null>(null)
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState('')
+
+  const detect = useCallback(async () => {
+    const res = await api.lineAccounts.detectFollowerImport(accountId)
+    if (!res.success) throw new Error(res.error || '利用可否を確認できませんでした')
+    setState(res.data)
+    return res.data
+  }, [accountId])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await api.lineAccounts.followerImportState(accountId)
+        if (!res.success || cancelled) return
+        let next = res.data
+        // Legacy accounts have no saved capability. Probe once, persist it in
+        // D1, and never repeat on ordinary page loads after that.
+        if (next.capability === 'unknown' && !next.eligibilityCheckedAt) {
+          next = await detect()
+        }
+        if (!cancelled) setState(next)
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : '状態確認に失敗しました')
+      }
+    })()
+    return () => { cancelled = true }
+  }, [accountId, detect])
+
+  const runSteps = async () => {
+    while (true) {
+      const res = await api.lineAccounts.stepFollowerImport(accountId)
+      if (!res.success) throw new Error(res.error || '移行処理に失敗しました')
+      setState(res.data.state)
+      if (res.data.state.lastError) throw new Error(res.data.state.lastError)
+      if (res.data.state.phase === 'completed') return
+      if (res.data.busy) await new Promise((resolve) => setTimeout(resolve, 1000))
+    }
+  }
+
+  const startOrResume = async () => {
+    setRunning(true)
+    setError('')
+    try {
+      const started = await api.lineAccounts.startFollowerImport(accountId)
+      if (!started.success) throw new Error(started.error || '移行を開始できませんでした')
+      setState(started.data)
+      await runSteps()
+      onImported()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '既存友だちの移行に失敗しました')
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  if (!state) return <p className="mt-3 text-[11px] text-gray-400">既存友だち移行を確認中…</p>
+
+  const reflected = state.imported + state.reactivated + state.claimedUnassigned
+  const inProgress = state.phase === 'importing_ids' || state.phase === 'hydrating_profiles'
+
+  return (
+    <div className="mt-3 pt-3 border-t border-gray-100">
+      <p className="text-xs font-medium text-gray-600">既存友だちのワンタイム移行</p>
+
+      {state.capability === 'unavailable' && (
+        <div className="mt-1">
+          <p className="text-[11px] text-gray-400">
+            現在のLINEアカウントでは利用できません。通常運用への負荷や定期処理はありません。
+          </p>
+          <button type="button" onClick={() => detect().catch((e) => setError(String(e)))}
+            className="mt-1 text-[11px] text-blue-600 hover:underline">
+            認証後に利用可否を再確認
+          </button>
+        </div>
+      )}
+
+      {state.capability === 'unknown' && (
+        <button type="button" onClick={() => detect().catch((e) => setError(String(e)))}
+          className="mt-1 text-[11px] text-blue-600 hover:underline">
+          利用可否を確認
+        </button>
+      )}
+
+      {state.capability === 'available' && state.phase !== 'completed' && (
+        <button
+          type="button"
+          onClick={startOrResume}
+          disabled={running}
+          className="mt-2 px-3 py-1.5 rounded-lg bg-green-50 text-green-700 hover:bg-green-100 text-xs font-medium disabled:opacity-50"
+        >
+          {running ? '移行中…' : inProgress ? '移行を再開' : '一度だけ移行を開始'}
+        </button>
+      )}
+
+      {inProgress && (
+        <p className="mt-1 text-xs text-green-700">
+          {state.phase === 'importing_ids'
+            ? `友だちID ${state.received.toLocaleString()}件を確認済み`
+            : `プロフィール ${state.profilesProcessed.toLocaleString()}件を処理済み`}
+        </p>
+      )}
+
+      {state.phase === 'completed' && (
+        <p className="mt-1 text-xs text-green-700">
+          完了: {state.received.toLocaleString()}件確認、{reflected.toLocaleString()}件反映
+          {state.conflicts > 0 ? `、${state.conflicts.toLocaleString()}件保留` : ''}
+        </p>
+      )}
+
+      {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+    </div>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -175,6 +175,26 @@ export type FriendListParams = {
 }
 
 export type FriendWithTags = Friend & { tags: Tag[] }
+export type FollowerImportState = {
+  version: 1
+  capability: 'unknown' | 'available' | 'unavailable'
+  phase: 'not_started' | 'importing_ids' | 'hydrating_profiles' | 'completed'
+  eligibilityCheckedAt: string | null
+  startedAt: string | null
+  completedAt: string | null
+  updatedAt: string
+  received: number
+  imported: number
+  reactivated: number
+  claimedUnassigned: number
+  alreadyPresent: number
+  conflicts: number
+  invalid: number
+  profilesProcessed: number
+  profilesUpdated: number
+  profileErrors: number
+  lastError: string | null
+}
 export type FriendFormSubmission = {
   id: string
   formId: string
@@ -640,6 +660,23 @@ export const api = {
         method: 'PATCH',
         body: JSON.stringify({ ordered }),
       }),
+    followerImportState: (id: string) =>
+      fetchApi<ApiResponse<FollowerImportState>>(`/api/line-accounts/${id}/follower-import`),
+    detectFollowerImport: (id: string) =>
+      fetchApi<ApiResponse<FollowerImportState>>(
+        `/api/line-accounts/${id}/follower-import/detect`,
+        { method: 'POST' },
+      ),
+    startFollowerImport: (id: string) =>
+      fetchApi<ApiResponse<FollowerImportState>>(
+        `/api/line-accounts/${id}/follower-import/start`,
+        { method: 'POST' },
+      ),
+    stepFollowerImport: (id: string) =>
+      fetchApi<ApiResponse<{ state: FollowerImportState; busy: boolean }>>(
+        `/api/line-accounts/${id}/follower-import/step`,
+        { method: 'POST' },
+      ),
   },
   conversions: {
     points: () =>

--- a/apps/worker/src/client/webinar/main.tsx
+++ b/apps/worker/src/client/webinar/main.tsx
@@ -994,35 +994,50 @@ function FormSheet({
   const [error, setError] = useState<string | null>(null);
   const startedRef = useRef(false);
   const completedFieldsRef = useRef(new Set<string>());
+  const bookingRedirectTimerRef = useRef<number | null>(null);
+
+  useEffect(() => () => {
+    if (bookingRedirectTimerRef.current !== null) {
+      window.clearTimeout(bookingRedirectTimerRef.current);
+    }
+  }, []);
+
+  const hasValue = (value: string | string[] | undefined) =>
+    Array.isArray(value) ? value.length > 0 : typeof value === 'string' && value.trim() !== '';
+
+  const requiredFields = sheet.phase === 'form'
+    ? sheet.def.fields.filter((field) => field.required)
+    : [];
+  const completedRequiredCount = requiredFields.filter((field) => hasValue(values[field.name])).length;
+  const remainingRequiredCount = requiredFields.length - completedRequiredCount;
+  const canSubmit = sheet.phase === 'form' && remainingRequiredCount === 0;
 
   const setValue = (name: string, v: string | string[]) => {
     if (!startedRef.current) {
       startedRef.current = true;
       onFunnelEvent('form_start');
     }
+    setError(null);
     setValues((prev) => ({ ...prev, [name]: v }));
   };
 
   const markFieldComplete = (name: string, value: string | string[]) => {
-    const hasValue = Array.isArray(value) ? value.length > 0 : value.trim() !== '';
-    if (!hasValue || completedFieldsRef.current.has(name)) return;
+    if (!hasValue(value) || completedFieldsRef.current.has(name)) return;
     completedFieldsRef.current.add(name);
     onFunnelEvent('field_complete', name);
   };
 
   const submit = async () => {
     if (sheet.phase !== 'form' || submitting) return;
-    onFunnelEvent('submit_attempt');
     const def = sheet.def;
     for (const f of def.fields) {
       const v = values[f.name];
-      const empty = v === undefined || v === '' || (Array.isArray(v) && v.length === 0);
-      if (f.required && empty) {
-        onFunnelEvent('submit_error');
+      if (f.required && !hasValue(v)) {
         setError(`「${f.label}」は必須項目です`);
         return;
       }
     }
+    onFunnelEvent('submit_attempt');
     setSubmitting(true);
     setError(null);
     try {
@@ -1040,6 +1055,16 @@ function FormSheet({
       }
       onFunnelEvent('submit_success');
       onSubmitted(def);
+      const bookingUrl = def.onSubmitMessageContent?.match(/https?:\/\/[^\s]+/)?.[0] ?? null;
+      if (bookingUrl) {
+        // フォーム送信後にもう一度ボタンを押させると、予約画面へ進む前に
+        // 離脱しやすい。同一の in-app browser で予約画面へ自動遷移し、
+        // 完了画面のボタンは自動遷移できなかった場合のフォールバックにする。
+        bookingRedirectTimerRef.current = window.setTimeout(
+          () => window.location.assign(bookingUrl),
+          900,
+        );
+      }
     } catch {
       onFunnelEvent('submit_error');
       setError('送信に失敗しました。通信環境をご確認ください。');
@@ -1058,11 +1083,11 @@ function FormSheet({
 
   const openCompletionUrl = () => {
     if (!completionUrl) return;
-    if (typeof liff !== 'undefined' && liff.isInClient()) {
-      liff.openWindow({ url: completionUrl, external: false });
-    } else {
-      window.open(completionUrl, '_blank', 'noopener');
+    if (bookingRedirectTimerRef.current !== null) {
+      window.clearTimeout(bookingRedirectTimerRef.current);
+      bookingRedirectTimerRef.current = null;
     }
+    window.location.assign(completionUrl);
   };
 
   return (
@@ -1072,7 +1097,7 @@ function FormSheet({
         className="flex-1 bg-black/40"
         onClick={onClose}
       />
-      <div className="mx-auto w-full max-w-md max-h-[75vh] overflow-y-auto rounded-t-2xl bg-white p-5 text-gray-900">
+      <div className="mx-auto flex w-full max-w-md max-h-[75vh] flex-col overflow-hidden rounded-t-2xl bg-white p-5 text-gray-900">
         <div className="mx-auto mb-3 h-1 w-10 rounded bg-gray-300" />
         {sheet.phase === 'loading' && (
           <p className="py-8 text-center text-gray-500">読み込み中...</p>
@@ -1088,16 +1113,16 @@ function FormSheet({
         {sheet.phase === 'done' && (
           <div className="py-6 text-center">
             <p className="text-2xl">🎉</p>
-            <p className="mt-2 text-lg font-bold">あと1ステップで予約完了です</p>
+            <p className="mt-2 text-lg font-bold">回答を送信しました</p>
             <p className="mt-1 text-sm text-gray-500">
-              空いている15分枠を選んでください。
+              予約画面へ移動しています。空いている15分枠を1つ選んでください。
             </p>
             {completionUrl && (
               <button
                 onClick={openCompletionUrl}
                 className="mt-5 w-full rounded-full bg-[#06C755] px-6 py-3 font-bold text-white active:opacity-80"
               >
-                日程を選んで予約を完了する
+                予約画面をすぐ開く
               </button>
             )}
             <button
@@ -1109,13 +1134,14 @@ function FormSheet({
           </div>
         )}
         {sheet.phase === 'form' && (
-          <>
-            <h2 className="text-lg font-bold">{sheet.def.name}</h2>
-            {sheet.def.description && (
-              <p className="mt-1 text-sm text-gray-500">{sheet.def.description}</p>
-            )}
-            <div className="mt-4 space-y-4 pb-2">
-              {sheet.def.fields.map((f) => {
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="min-h-0 flex-1 overflow-y-auto pb-4">
+              <h2 className="text-lg font-bold">{sheet.def.name}</h2>
+              {sheet.def.description && (
+                <p className="mt-1 text-sm text-gray-500">{sheet.def.description}</p>
+              )}
+              <div className="mt-4 space-y-4 pb-2">
+                {sheet.def.fields.map((f) => {
                 const dateMatch = /^meeting_date_(\d+)$/.exec(f.name);
                 const timeMatch = /^meeting_time_(\d+)$/.exec(f.name);
                 if (
@@ -1258,17 +1284,32 @@ function FormSheet({
                   )}
                 </label>
                 );
-              })}
+                })}
+              </div>
+              {error && <p className="mt-2 text-sm font-bold text-red-600">{error}</p>}
             </div>
-            {error && <p className="mt-2 text-sm font-bold text-red-600">{error}</p>}
-            <button
-              onClick={() => void submit()}
-              disabled={submitting}
-              className="mt-4 w-full rounded-full bg-[#06C755] py-3 text-base font-bold text-white shadow disabled:opacity-50 active:opacity-80"
-            >
-              {submitting ? '送信中...' : '送信する'}
-            </button>
-          </>
+            <div className="-mx-5 -mb-5 shrink-0 border-t border-gray-200 bg-white px-5 pb-4 pt-3 shadow-[0_-4px_12px_rgba(0,0,0,0.06)]">
+              <p className="mb-2 text-center text-xs font-bold text-gray-600" aria-live="polite">
+                {canSubmit
+                  ? `${requiredFields.length}項目の回答が完了しました`
+                  : `入力完了 ${completedRequiredCount}/${requiredFields.length}`}
+              </p>
+              <button
+                onClick={() => void submit()}
+                disabled={submitting || !canSubmit}
+                className="w-full rounded-full bg-[#06C755] py-3 text-base font-bold text-white shadow disabled:bg-gray-300 disabled:text-gray-500 disabled:opacity-100 active:opacity-80"
+              >
+                {submitting
+                  ? '送信中...'
+                  : canSubmit
+                    ? '回答を送信して相談日時を選ぶ'
+                    : `あと${remainingRequiredCount}項目を選択`}
+              </button>
+              <p className="mt-2 text-center text-xs text-gray-500">
+                送信後、空いている15分枠を選べます
+              </p>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/apps/worker/src/routes/line-accounts.test.ts
+++ b/apps/worker/src/routes/line-accounts.test.ts
@@ -13,11 +13,15 @@ const dbMocks = {
   updateLineAccountFields: vi.fn(),
   updateLineAccountOrder: vi.fn(),
   deleteLineAccount: vi.fn(),
+  getAccountSetting: vi.fn(),
+  setAccountSetting: vi.fn(),
+  jstNow: vi.fn(() => '2026-08-10T12:00:00.000+09:00'),
 };
 vi.mock('@line-crm/db', () => dbMocks);
 
 const lineClientMocks = {
   getFollowersInsight: vi.fn(),
+  getFollowerIds: vi.fn(),
 };
 vi.mock('@line-crm/line-sdk', () => ({
   LineClient: vi.fn().mockImplementation(() => lineClientMocks),
@@ -79,6 +83,11 @@ const fakeAccount = {
 beforeEach(() => {
   for (const fn of Object.values(dbMocks)) fn.mockReset();
   lineClientMocks.getFollowersInsight.mockReset();
+  lineClientMocks.getFollowerIds.mockReset();
+  dbMocks.getAccountSetting.mockResolvedValue(null);
+  dbMocks.setAccountSetting.mockResolvedValue(undefined);
+  dbMocks.jstNow.mockReturnValue('2026-08-10T12:00:00.000+09:00');
+  lineClientMocks.getFollowerIds.mockResolvedValue({ userIds: [] });
 });
 
 describe('GET /api/line-accounts/:id/follower-insight', () => {

--- a/apps/worker/src/routes/line-accounts.ts
+++ b/apps/worker/src/routes/line-accounts.ts
@@ -11,6 +11,13 @@ import {
 } from '@line-crm/db';
 import type { LineAccount as DbLineAccount } from '@line-crm/db';
 import { requireRole } from '../middleware/role-guard.js';
+import {
+  detectFollowerImportCapability,
+  getFollowerImportState,
+  processFollowerImportStep,
+  startFollowerImport,
+} from '../services/follower-import.js';
+import type { FollowerImportClient } from '../services/follower-import.js';
 import type { Env } from '../index.js';
 
 const lineAccounts = new Hono<Env>();
@@ -162,6 +169,72 @@ lineAccounts.get('/api/line-accounts/:id/follower-insight', async (c) => {
   }
 });
 
+// Existing-follower migration is an explicit, persisted, one-time job.
+// No cron polls LINE: connection/UI performs a one-item capability probe, then
+// operator-approved step requests advance the D1 cursor until completion.
+lineAccounts.get('/api/line-accounts/:id/follower-import', async (c) => {
+  const account = await getLineAccountById(c.env.DB, c.req.param('id')!);
+  if (!account) return c.json({ success: false, error: 'LINE account not found' }, 404);
+  const state = await getFollowerImportState(c.env.DB, account.id);
+  return c.json({ success: true, data: state });
+});
+
+lineAccounts.post(
+  '/api/line-accounts/:id/follower-import/detect',
+  requireRole('owner', 'admin'),
+  async (c) => {
+    try {
+      const account = await getLineAccountById(c.env.DB, c.req.param('id')!);
+      if (!account) return c.json({ success: false, error: 'LINE account not found' }, 404);
+      const client = new LineClient(account.channel_access_token);
+      const state = await detectFollowerImportCapability(
+        c.env.DB,
+        client as unknown as FollowerImportClient,
+        account.id,
+      );
+      return c.json({ success: true, data: state });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('follower import capability detection error:', message);
+      return c.json({ success: false, error: '利用可否の確認に失敗しました' }, 502);
+    }
+  },
+);
+
+lineAccounts.post(
+  '/api/line-accounts/:id/follower-import/start',
+  requireRole('owner', 'admin'),
+  async (c) => {
+    const account = await getLineAccountById(c.env.DB, c.req.param('id')!);
+    if (!account) return c.json({ success: false, error: 'LINE account not found' }, 404);
+    try {
+      const state = await startFollowerImport(c.env.DB, account.id);
+      return c.json({ success: true, data: state });
+    } catch (err) {
+      if (err instanceof Error && err.message === 'FOLLOWER_IMPORT_NOT_AVAILABLE') {
+        return c.json({ success: false, error: 'このアカウントでは既存友だち取得を利用できません' }, 409);
+      }
+      throw err;
+    }
+  },
+);
+
+lineAccounts.post(
+  '/api/line-accounts/:id/follower-import/step',
+  requireRole('owner', 'admin'),
+  async (c) => {
+    const account = await getLineAccountById(c.env.DB, c.req.param('id')!);
+    if (!account) return c.json({ success: false, error: 'LINE account not found' }, 404);
+    const client = new LineClient(account.channel_access_token);
+    const result = await processFollowerImportStep(
+      c.env.DB,
+      client as unknown as FollowerImportClient,
+      account.id,
+    );
+    return c.json({ success: true, data: result });
+  },
+);
+
 // Normalize optional string inputs from the UI:
 //   undefined → undefined (caller skips the column)
 //   null      → null      (explicit clear)
@@ -305,6 +378,19 @@ lineAccounts.post('/api/line-accounts', requireRole('owner'), async (c) => {
       ogDefaultImageUrl: normalizeOptionalString(body.ogDefaultImageUrl) ?? null,
       ogDefaultDescription: normalizeOptionalString(body.ogDefaultDescription) ?? null,
     });
+
+    // One read-only request at connection time records whether this account
+    // can use followers/ids. This never starts the migration and is non-fatal:
+    // a temporary LINE outage must not roll back account registration.
+    try {
+      await detectFollowerImportCapability(
+        c.env.DB,
+        new LineClient(account.channel_access_token) as unknown as FollowerImportClient,
+        account.id,
+      );
+    } catch (err) {
+      console.error('[line-accounts] follower import capability probe failed', err);
+    }
 
     // Auto-enroll new account into the 'main' traffic pool.
     // If migration 039 ran before any LINE accounts existed (fresh tenant),

--- a/apps/worker/src/services/follower-import.test.ts
+++ b/apps/worker/src/services/follower-import.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  detectFollowerImportCapability,
+  getFollowerImportState,
+  processFollowerImportStep,
+  startFollowerImport,
+} from './follower-import.js';
+
+const uid = (hex: string) => `U${hex.repeat(32)}`;
+
+type StoredFriend = {
+  id: string;
+  line_user_id: string;
+  line_account_id: string | null;
+  is_following: number;
+  display_name: string | null;
+  picture_url: string | null;
+  status_message: string | null;
+};
+
+function makeDb(initialFriends: StoredFriend[] = []) {
+  let setting: string | null = null;
+  const friends = new Map(initialFriends.map((f) => [f.line_user_id, { ...f }]));
+
+  const execute = (sql: string, args: unknown[]) => {
+    if (sql.includes('INSERT INTO account_settings')) {
+      setting = args[3] as string;
+      return { meta: { changes: 1 } };
+    }
+    if (sql.includes('UPDATE account_settings')) {
+      if (setting !== args[4]) return { meta: { changes: 0 } };
+      setting = args[0] as string;
+      return { meta: { changes: 1 } };
+    }
+    if (sql.includes('INSERT INTO friends')) {
+      const [id, lineUserId, accountId] = args as [string, string, string];
+      const existing = friends.get(lineUserId);
+      if (!existing) {
+        friends.set(lineUserId, {
+          id,
+          line_user_id: lineUserId,
+          line_account_id: accountId,
+          is_following: 1,
+          display_name: null,
+          picture_url: null,
+          status_message: null,
+        });
+      } else if (existing.line_account_id === null || existing.line_account_id === accountId) {
+        existing.line_account_id = existing.line_account_id ?? accountId;
+        existing.is_following = 1;
+      }
+      return { meta: { changes: 1 } };
+    }
+    if (sql.includes('UPDATE friends') && sql.includes('display_name')) {
+      const [displayName, pictureUrl, statusMessage, , id] = args;
+      const row = [...friends.values()].find((f) => f.id === id);
+      if (row) {
+        row.display_name = displayName as string | null;
+        row.picture_url = pictureUrl as string | null;
+        row.status_message = statusMessage as string | null;
+      }
+      return { meta: { changes: row ? 1 : 0 } };
+    }
+    throw new Error(`Unhandled run SQL: ${sql}`);
+  };
+
+  const db = {
+    prepare: vi.fn((sql: string) => ({
+      bind: (...args: unknown[]) => ({
+        sql,
+        args,
+        first: vi.fn().mockImplementation(async () => {
+          if (sql.includes('SELECT value FROM account_settings')) {
+            return setting === null ? null : { value: setting };
+          }
+          throw new Error(`Unhandled first SQL: ${sql}`);
+        }),
+        all: vi.fn().mockImplementation(async () => {
+          if (sql.includes('WHERE line_user_id IN')) {
+            const requested = new Set(args as string[]);
+            return { results: [...friends.values()].filter((f) => requested.has(f.line_user_id)) };
+          }
+          if (sql.includes('AND display_name IS NULL')) {
+            const [accountId, afterId, limit] = args as [string, string, number];
+            return {
+              results: [...friends.values()]
+                .filter((f) => f.line_account_id === accountId && f.is_following === 1 &&
+                  f.display_name === null && f.id > afterId)
+                .sort((a, b) => a.id.localeCompare(b.id))
+                .slice(0, limit)
+                .map(({ id, line_user_id }) => ({ id, line_user_id })),
+            };
+          }
+          throw new Error(`Unhandled all SQL: ${sql}`);
+        }),
+        run: vi.fn().mockImplementation(async () => execute(sql, args)),
+      }),
+    })),
+    batch: vi.fn().mockImplementation(async (statements: Array<{ sql: string; args: unknown[] }>) =>
+      statements.map((statement) => execute(statement.sql, statement.args))),
+  } as unknown as D1Database;
+
+  return { db, friends, getSetting: () => setting };
+}
+
+describe('persisted one-time follower import', () => {
+  test('detects an unavailable account once and stores the result', async () => {
+    const { db, getSetting } = makeDb();
+    const client = {
+      getFollowerIds: vi.fn().mockRejectedValue(new Error('LINE API error: 403 Forbidden')),
+    };
+
+    const state = await detectFollowerImportCapability(db, client, 'acc-1');
+
+    expect(client.getFollowerIds).toHaveBeenCalledWith(1);
+    expect(state.capability).toBe('unavailable');
+    expect(JSON.parse(getSetting()!).capability).toBe('unavailable');
+  });
+
+  test('resumes bounded steps and cannot restart after completion', async () => {
+    const { db, friends } = makeDb();
+    const lineUserId = uid('a');
+    const client = {
+      getFollowerIds: vi.fn()
+        .mockResolvedValueOnce({ userIds: [] })
+        .mockResolvedValueOnce({ userIds: [lineUserId] }),
+      getProfile: vi.fn().mockResolvedValue({
+        displayName: '移行患者',
+        pictureUrl: 'https://example.com/profile.jpg',
+      }),
+    };
+
+    await detectFollowerImportCapability(db, client, 'acc-1');
+    await startFollowerImport(db, 'acc-1');
+
+    const ids = await processFollowerImportStep(db, client, 'acc-1');
+    expect(ids.state.phase).toBe('hydrating_profiles');
+    expect(ids.state.imported).toBe(1);
+
+    const profiles = await processFollowerImportStep(db, client, 'acc-1');
+    expect(profiles.state.phase).toBe('completed');
+    expect(profiles.state.profilesUpdated).toBe(1);
+    expect(friends.get(lineUserId)?.display_name).toBe('移行患者');
+
+    const completed = await startFollowerImport(db, 'acc-1');
+    expect(completed.phase).toBe('completed');
+    expect(client.getFollowerIds).toHaveBeenCalledTimes(2);
+    expect((await getFollowerImportState(db, 'acc-1')).completedAt).not.toBeNull();
+  });
+});

--- a/apps/worker/src/services/follower-import.ts
+++ b/apps/worker/src/services/follower-import.ts
@@ -1,0 +1,343 @@
+import { getAccountSetting, jstNow, setAccountSetting } from '@line-crm/db';
+
+const LINE_USER_ID_PATTERN = /^U[0-9a-f]{32}$/;
+const LOOKUP_CHUNK_SIZE = 90;
+const WRITE_CHUNK_SIZE = 100;
+const PROFILE_BATCH_SIZE = 25;
+export const FOLLOWER_IMPORT_STATE_KEY = 'follower_import_v1';
+
+export interface FollowerImportClient {
+  getFollowerIds(limit: number, start?: string): Promise<{
+    userIds: string[];
+    next?: string;
+  }>;
+  getProfile(userId: string): Promise<{
+    displayName?: string;
+    pictureUrl?: string;
+    statusMessage?: string;
+  }>;
+}
+
+export type FollowerImportCapability = 'unknown' | 'available' | 'unavailable';
+export type FollowerImportPhase =
+  | 'not_started'
+  | 'importing_ids'
+  | 'hydrating_profiles'
+  | 'completed';
+
+export interface FollowerImportState {
+  version: 1;
+  capability: FollowerImportCapability;
+  phase: FollowerImportPhase;
+  eligibilityCheckedAt: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  updatedAt: string;
+  cursor: string | null;
+  profileCursor: string | null;
+  received: number;
+  imported: number;
+  reactivated: number;
+  claimedUnassigned: number;
+  alreadyPresent: number;
+  conflicts: number;
+  invalid: number;
+  profilesProcessed: number;
+  profilesUpdated: number;
+  profileErrors: number;
+  lastError: string | null;
+  lockToken?: string | null;
+  lockUntil?: string | null;
+}
+
+interface ExistingFriend {
+  line_user_id: string;
+  line_account_id: string | null;
+  is_following: number;
+}
+
+function chunks<T>(items: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < items.length; i += size) result.push(items.slice(i, i + size));
+  return result;
+}
+
+export function emptyFollowerImportState(): FollowerImportState {
+  return {
+    version: 1,
+    capability: 'unknown',
+    phase: 'not_started',
+    eligibilityCheckedAt: null,
+    startedAt: null,
+    completedAt: null,
+    updatedAt: jstNow(),
+    cursor: null,
+    profileCursor: null,
+    received: 0,
+    imported: 0,
+    reactivated: 0,
+    claimedUnassigned: 0,
+    alreadyPresent: 0,
+    conflicts: 0,
+    invalid: 0,
+    profilesProcessed: 0,
+    profilesUpdated: 0,
+    profileErrors: 0,
+    lastError: null,
+  };
+}
+
+export async function getFollowerImportState(
+  db: D1Database,
+  lineAccountId: string,
+): Promise<FollowerImportState> {
+  const raw = await getAccountSetting(db, lineAccountId, FOLLOWER_IMPORT_STATE_KEY);
+  if (!raw) return emptyFollowerImportState();
+  try {
+    return { ...emptyFollowerImportState(), ...JSON.parse(raw) } as FollowerImportState;
+  } catch {
+    return emptyFollowerImportState();
+  }
+}
+
+async function saveState(
+  db: D1Database,
+  lineAccountId: string,
+  state: FollowerImportState,
+): Promise<void> {
+  state.updatedAt = jstNow();
+  await setAccountSetting(
+    db,
+    lineAccountId,
+    FOLLOWER_IMPORT_STATE_KEY,
+    JSON.stringify(state),
+  );
+}
+
+/**
+ * LINE exposes no account-type field in /v2/bot/info. A one-item, read-only
+ * followers request is therefore the authoritative capability probe.
+ */
+export async function detectFollowerImportCapability(
+  db: D1Database,
+  client: Pick<FollowerImportClient, 'getFollowerIds'>,
+  lineAccountId: string,
+): Promise<FollowerImportState> {
+  const state = await getFollowerImportState(db, lineAccountId);
+  try {
+    await client.getFollowerIds(1);
+    state.capability = 'available';
+    state.lastError = null;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/LINE API error:\s*403/i.test(message)) {
+      state.capability = 'unavailable';
+      state.lastError = null;
+    } else {
+      state.capability = 'unknown';
+      state.lastError = '利用可否を確認できませんでした';
+    }
+  }
+  state.eligibilityCheckedAt = jstNow();
+  await saveState(db, lineAccountId, state);
+  return state;
+}
+
+/** Start once or resume an interrupted migration. Completed jobs stay closed. */
+export async function startFollowerImport(
+  db: D1Database,
+  lineAccountId: string,
+): Promise<FollowerImportState> {
+  const state = await getFollowerImportState(db, lineAccountId);
+  if (state.capability !== 'available') {
+    throw new Error('FOLLOWER_IMPORT_NOT_AVAILABLE');
+  }
+  if (state.phase === 'completed') return state;
+  if (state.phase === 'not_started') {
+    const capability = state.capability;
+    const eligibilityCheckedAt = state.eligibilityCheckedAt;
+    Object.assign(state, emptyFollowerImportState(), {
+      capability,
+      eligibilityCheckedAt,
+      phase: 'importing_ids' as const,
+      startedAt: jstNow(),
+    });
+  }
+  state.lastError = null;
+  await saveState(db, lineAccountId, state);
+  return state;
+}
+
+async function importIdPage(
+  db: D1Database,
+  client: Pick<FollowerImportClient, 'getFollowerIds'>,
+  lineAccountId: string,
+  state: FollowerImportState,
+): Promise<void> {
+  const page = await client.getFollowerIds(1000, state.cursor ?? undefined);
+  const receivedIds = Array.isArray(page.userIds) ? page.userIds : [];
+  const validIds = [...new Set(receivedIds.filter((id) => LINE_USER_ID_PATTERN.test(id)))];
+  const invalid = receivedIds.filter((id) => !LINE_USER_ID_PATTERN.test(id)).length;
+
+  const existingById = new Map<string, ExistingFriend>();
+  for (const group of chunks(validIds, LOOKUP_CHUNK_SIZE)) {
+    const placeholders = group.map(() => '?').join(',');
+    const rows = await db
+      .prepare(
+        `SELECT line_user_id, line_account_id, is_following
+           FROM friends
+          WHERE line_user_id IN (${placeholders})`,
+      )
+      .bind(...group)
+      .all<ExistingFriend>();
+    for (const row of rows.results ?? []) existingById.set(row.line_user_id, row);
+  }
+
+  const writableIds: string[] = [];
+  for (const lineUserId of validIds) {
+    const existing = existingById.get(lineUserId);
+    if (!existing) {
+      state.imported += 1;
+      writableIds.push(lineUserId);
+    } else if (existing.line_account_id === null) {
+      state.claimedUnassigned += 1;
+      writableIds.push(lineUserId);
+    } else if (existing.line_account_id !== lineAccountId) {
+      state.conflicts += 1;
+    } else if (existing.is_following === 0) {
+      state.reactivated += 1;
+      writableIds.push(lineUserId);
+    } else {
+      state.alreadyPresent += 1;
+    }
+  }
+
+  const now = jstNow();
+  for (const group of chunks(writableIds, WRITE_CHUNK_SIZE)) {
+    await db.batch(group.map((lineUserId) =>
+      db.prepare(
+        `INSERT INTO friends
+           (id, line_user_id, display_name, picture_url, status_message,
+            is_following, line_account_id, created_at, updated_at)
+         VALUES (?, ?, NULL, NULL, NULL, 1, ?, ?, ?)
+         ON CONFLICT(line_user_id) DO UPDATE SET
+           line_account_id = COALESCE(friends.line_account_id, excluded.line_account_id),
+           is_following = 1,
+           updated_at = excluded.updated_at
+         WHERE (friends.line_account_id IS NULL OR friends.line_account_id = excluded.line_account_id)
+           AND (friends.line_account_id IS NULL OR friends.is_following != 1)`,
+      ).bind(crypto.randomUUID(), lineUserId, lineAccountId, now, now),
+    ));
+  }
+
+  state.received += receivedIds.length;
+  state.invalid += invalid;
+  state.cursor = typeof page.next === 'string' && page.next ? page.next : null;
+  if (!state.cursor) state.phase = 'hydrating_profiles';
+}
+
+async function hydrateProfilePage(
+  db: D1Database,
+  client: Pick<FollowerImportClient, 'getProfile'>,
+  lineAccountId: string,
+  state: FollowerImportState,
+): Promise<void> {
+  const rows = await db.prepare(
+    `SELECT id, line_user_id
+       FROM friends
+      WHERE line_account_id = ?
+        AND is_following = 1
+        AND display_name IS NULL
+        AND id > ?
+      ORDER BY id
+      LIMIT ?`,
+  ).bind(lineAccountId, state.profileCursor ?? '', PROFILE_BATCH_SIZE)
+    .all<{ id: string; line_user_id: string }>();
+  const batch = rows.results ?? [];
+
+  for (const group of chunks(batch, 5)) {
+    await Promise.all(group.map(async (row) => {
+      try {
+        const profile = await client.getProfile(row.line_user_id);
+        await db.prepare(
+          `UPDATE friends
+              SET display_name = ?, picture_url = ?, status_message = ?, updated_at = ?
+            WHERE id = ?`,
+        ).bind(
+          profile.displayName ?? null,
+          profile.pictureUrl ?? null,
+          profile.statusMessage ?? null,
+          jstNow(),
+          row.id,
+        ).run();
+        state.profilesUpdated += 1;
+      } catch {
+        state.profileErrors += 1;
+      }
+      state.profilesProcessed += 1;
+    }));
+  }
+
+  if (batch.length > 0) state.profileCursor = batch[batch.length - 1].id;
+  if (batch.length < PROFILE_BATCH_SIZE) {
+    state.phase = 'completed';
+    state.completedAt = jstNow();
+  }
+}
+
+export interface FollowerImportStepResult {
+  state: FollowerImportState;
+  busy: boolean;
+}
+
+/**
+ * Process one bounded unit. State/cursors live in D1, so closing the browser
+ * only pauses the job; the next request resumes it. No cron is involved.
+ */
+export async function processFollowerImportStep(
+  db: D1Database,
+  client: FollowerImportClient,
+  lineAccountId: string,
+): Promise<FollowerImportStepResult> {
+  let state = await getFollowerImportState(db, lineAccountId);
+  if (state.phase === 'not_started' || state.phase === 'completed') {
+    return { state, busy: false };
+  }
+
+  const nowMs = Date.now();
+  if (state.lockUntil && new Date(state.lockUntil).getTime() > nowMs) {
+    return { state, busy: true };
+  }
+
+  const lockToken = crypto.randomUUID();
+  const lockUntil = new Date(nowMs + 60_000).toISOString();
+  const oldRaw = await getAccountSetting(db, lineAccountId, FOLLOWER_IMPORT_STATE_KEY);
+  if (!oldRaw) return { state, busy: true };
+  const locked = { ...state, lockToken, lockUntil, updatedAt: jstNow() };
+  const claim = await db.prepare(
+    `UPDATE account_settings
+        SET value = ?, updated_at = ?
+      WHERE line_account_id = ? AND key = ? AND value = ?`,
+  ).bind(
+    JSON.stringify(locked), locked.updatedAt, lineAccountId,
+    FOLLOWER_IMPORT_STATE_KEY, oldRaw,
+  ).run();
+  if ((claim.meta.changes ?? 0) === 0) return { state, busy: true };
+  state = locked;
+
+  try {
+    if (state.phase === 'importing_ids') {
+      await importIdPage(db, client, lineAccountId, state);
+    } else if (state.phase === 'hydrating_profiles') {
+      await hydrateProfilePage(db, client, lineAccountId, state);
+    }
+    state.lastError = null;
+  } catch (err) {
+    state.lastError = err instanceof Error ? err.message : '移行処理に失敗しました';
+  } finally {
+    state.lockToken = null;
+    state.lockUntil = null;
+    await saveState(db, lineAccountId, state);
+  }
+  return { state, busy: false };
+}

--- a/apps/worker/src/services/webinar-followups.test.ts
+++ b/apps/worker/src/services/webinar-followups.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, test } from 'vitest';
-import { buildJourneyFollowupText } from './webinar-followups.js';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  getFriendById: vi.fn(),
+  getLineAccountById: vi.fn(),
+  jstNow: vi.fn(() => '2026-08-10T20:00:00+09:00'),
+}));
+vi.mock('@line-crm/db', () => dbMocks);
+
+const { buildJourneyFollowupText, processWebinarFollowups } =
+  await import('./webinar-followups.js');
 
 describe('buildJourneyFollowupText', () => {
   const pickerUrl = 'https://liff.line.me/123/?page=webinar&slug=demo';
@@ -29,5 +38,70 @@ describe('buildJourneyFollowupText', () => {
     expect(text).toContain('回答の送信は完了');
     expect(text).toContain(bookingUrl);
     expect(text).not.toContain(pickerUrl);
+  });
+});
+
+describe('processWebinarFollowups', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('ブロック済みfriendを候補から除外し、選択後のブロックもpendingに残さない', async () => {
+    const preparedSql: string[] = [];
+    const updates: Array<{ sql: string; values: unknown[] }> = [];
+    const candidate = {
+      webinar_id: 'webinar-1',
+      account_id: 'account-1',
+      friend_id: 'friend-1',
+      slug: 'demo',
+      form_id: 'form-1',
+      cta_clicked_at: '2026-08-10T19:00:00+09:00',
+    };
+    const db = {
+      prepare(sql: string) {
+        preparedSql.push(sql);
+        let values: unknown[] = [];
+        return {
+          bind(...bound: unknown[]) {
+            values = bound;
+            return this;
+          },
+          async all() {
+            if (sql.includes('FROM clicks c')) {
+              return { results: values[1] === 'after_30m' ? [candidate] : [] };
+            }
+            return { results: [] };
+          },
+          async first() {
+            if (sql.includes('SELECT id, retry_key, status FROM webinar_followups')) {
+              return { id: 'followup-1', retry_key: 'retry-1', status: 'pending' };
+            }
+            return null;
+          },
+          async run() {
+            updates.push({ sql, values });
+            return { success: true };
+          },
+        };
+      },
+    } as unknown as D1Database;
+    dbMocks.getFriendById.mockResolvedValue({
+      id: 'friend-1', line_user_id: 'U1', is_following: 0,
+    });
+
+    const result = await processWebinarFollowups(db, {
+      proxyBaseUrl: 'https://proxy.example.com',
+      defaultAccessToken: 'token',
+      defaultLiffId: 'liff-1',
+    });
+
+    expect(result).toEqual({ sent: 0, failed: 0 });
+    expect(preparedSql.some((sql) =>
+      sql.includes('JOIN friends f ON f.id = c.friend_id AND f.is_following = 1'),
+    )).toBe(true);
+    expect(updates).toContainEqual(expect.objectContaining({
+      sql: expect.stringContaining("last_error = 'not_following'"),
+      values: ['2026-08-10T20:00:00+09:00', 'followup-1'],
+    }));
   });
 });

--- a/apps/worker/src/services/webinar-followups.ts
+++ b/apps/worker/src/services/webinar-followups.ts
@@ -131,6 +131,7 @@ async function candidates(
              ORDER BY wc.at_seconds ASC LIMIT 1) AS form_id
      FROM clicks c
      JOIN webinars w ON w.id = c.webinar_id
+     JOIN friends f ON f.id = c.friend_id AND f.is_following = 1
      JOIN webinar_followup_configs cfg ON cfg.webinar_id = w.id AND cfg.is_active = 1
      WHERE datetime(c.cta_clicked_at) >= datetime(cfg.enabled_at)
        AND datetime(c.cta_clicked_at, '+' || cfg.${delayColumn} || ' minutes') <= datetime(?)
@@ -398,7 +399,18 @@ export async function processWebinarFollowups(
     if (followup.status === 'sent') continue;
     try {
       const friend = await getFriendById(db, candidate.friend_id);
-      if (!friend?.is_following) continue;
+      if (!friend?.is_following) {
+        // Candidate selection and delivery are separate operations. A friend can
+        // block the account between them, so consume the row as a terminal
+        // non-delivery instead of leaving it pending forever. If they follow
+        // again later, candidates() can select this failed row for a retry.
+        const skippedAt = jstNow();
+        await db.prepare(
+          `UPDATE webinar_followups
+           SET status = 'failed', last_error = 'not_following', updated_at = ? WHERE id = ?`,
+        ).bind(skippedAt, followup.id).run();
+        continue;
+      }
       const delivery = await deliveryConfig(db, candidate.account_id, options);
       if (!delivery.liffId) throw new Error('LIFF ID not configured');
       const url = formUrl(delivery.liffId, candidate.form_id);

--- a/packages/line-sdk/src/client.ts
+++ b/packages/line-sdk/src/client.ts
@@ -18,6 +18,11 @@ export interface FollowersInsight {
   blocks?: number;
 }
 
+export interface FollowerIdsPage {
+  userIds: string[];
+  next?: string;
+}
+
 export class LineClient {
   constructor(private readonly channelAccessToken: string) {}
 
@@ -281,5 +286,23 @@ export class LineClient {
       `/v2/bot/insight/followers?date=${encodeURIComponent(date)}`,
     );
     return data as FollowersInsight;
+  }
+
+  /**
+   * Get one page of users who currently follow the LINE Official Account.
+   * Verified/premium accounts only. Pass the returned `next` value as
+   * `start` until `next` is absent to retrieve the full audience.
+   */
+  async getFollowerIds(
+    limit = 1000,
+    start?: string,
+  ): Promise<FollowerIdsPage> {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (start) params.set('start', start);
+    const { data } = await this.request(
+      'GET',
+      `/v2/bot/followers/ids?${params.toString()}`,
+    );
+    return data as FollowerIdsPage;
   }
 }


### PR DESCRIPTION
## Summary

- add a persisted, resumable one-time import using the LINE followers/ids API
- detect eligibility once at account connection or once for legacy accounts
- keep unavailable normal accounts idle with no cron polling
- sync the pending production webinar continuation fixes

## Safety

- no database migration
- no new cron job
- no automatic LINE message send
- owner/admin role required for detection and import mutations
- D1 cursor and lock make the job resumable and bounded
- private production Worker and Admin deploys completed successfully

## Validation

- sync dry-run and private-value redaction/leak check passed
- DB: 135 tests passed
- Worker: typecheck and 896 tests passed
- Worker, Admin Web, and LIFF production builds passed
- git diff --check passed