### PR TITLE
sync: production broadcast personalization safety

### DIFF
--- a/apps/web/src/components/broadcasts/broadcast-form.tsx
+++ b/apps/web/src/components/broadcasts/broadcast-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { Tag } from '@line-crm/shared'
 import { api, eventsApi, type ApiBroadcast, type EventListItem } from '@/lib/api'
 import { useAccount } from '@/contexts/account-context'
@@ -35,6 +35,8 @@ interface FormState {
 
 export default function BroadcastForm({ tags, onSuccess, onCancel }: BroadcastFormProps) {
   const { selectedAccountId } = useAccount()
+  // Network timeout後の再クリックでも同じ作成要求として扱い、二重予約を防ぐ。
+  const createIdempotencyKey = useRef(crypto.randomUUID())
   // 「リンクするイベント」セレクタ用: 公開中の events を取得して
   // 選択された event の LIFF URL (テンプレ) を message に挿入する。
   const [linkableEvents, setLinkableEvents] = useState<EventListItem[]>([])
@@ -101,7 +103,7 @@ export default function BroadcastForm({ tags, onSuccess, onCancel }: BroadcastFo
         scheduledAt: form.sendNow || !form.scheduledAt
           ? null
           : form.scheduledAt + ':00.000+09:00',
-      })
+      }, { idempotencyKey: createIdempotencyKey.current })
       if (res.success) {
         onSuccess()
       } else {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -453,9 +453,12 @@ export const api = {
       accountIds?: string[]
       dedupPriority?: string[]
       trackLinks?: boolean
-    }) =>
+    }, options?: { idempotencyKey?: string }) =>
       fetchApi<ApiResponse<ApiBroadcast>>('/api/broadcasts', {
         method: 'POST',
+        headers: options?.idempotencyKey
+          ? { 'Idempotency-Key': options.idempotencyKey }
+          : undefined,
         body: JSON.stringify(data),
       }),
     update: (

--- a/apps/worker/src/routes/broadcasts-idempotency.test.ts
+++ b/apps/worker/src/routes/broadcasts-idempotency.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { Hono } from 'hono';
+
+const dbMocks = {
+  getBroadcasts: vi.fn(),
+  getBroadcastById: vi.fn(),
+  createBroadcast: vi.fn(),
+  updateBroadcast: vi.fn(),
+  deleteBroadcast: vi.fn(),
+  getLineAccountById: vi.fn(),
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+const { broadcasts } = await import('./broadcasts.js');
+
+const KEY = '11111111-2222-4333-8444-555555555555';
+const requestBody = {
+  title: '朝のお知らせ',
+  messageType: 'text',
+  messageContent: '{{name}}さん、おはようございます',
+  targetType: 'all',
+  scheduledAt: '2026-08-12T09:00:00.000+09:00',
+  lineAccountId: 'account-1',
+  trackLinks: true,
+};
+
+const row = {
+  id: KEY,
+  title: requestBody.title,
+  message_type: requestBody.messageType,
+  message_content: requestBody.messageContent,
+  target_type: requestBody.targetType,
+  target_tag_id: null,
+  status: 'scheduled',
+  scheduled_at: requestBody.scheduledAt,
+  sent_at: null,
+  total_count: 0,
+  success_count: 0,
+  created_at: '2026-08-11T12:00:00.000+09:00',
+  account_ids: null,
+  dedup_priority: null,
+  failed_account_ids: null,
+  dedup_progress: null,
+  batch_lock_at: null,
+  track_links: 1,
+  line_account_id: requestBody.lineAccountId,
+  alt_text: null,
+};
+
+function setupApp() {
+  const app = new Hono<{ Bindings: { DB: D1Database } }>();
+  app.use('*', async (c, next) => {
+    c.env = { DB: {} as D1Database };
+    await next();
+  });
+  app.route('/', broadcasts);
+  return app;
+}
+
+beforeEach(() => {
+  for (const fn of Object.values(dbMocks)) fn.mockReset();
+});
+describe('POST /api/broadcasts idempotency', () => {
+  test('creates with the idempotency key as the stable broadcast id', async () => {
+    dbMocks.getBroadcastById.mockResolvedValueOnce(null);
+    dbMocks.createBroadcast.mockResolvedValueOnce(row);
+
+    const response = await setupApp().request('/api/broadcasts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Idempotency-Key': KEY },
+      body: JSON.stringify(requestBody),
+    });
+
+    expect(response.status).toBe(201);
+    expect(dbMocks.createBroadcast).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      id: KEY,
+      lineAccountId: 'account-1',
+      messageContent: requestBody.messageContent,
+    }));
+  });
+
+  test('returns the original row without creating a duplicate on replay', async () => {
+    dbMocks.getBroadcastById.mockResolvedValueOnce(row);
+
+    const response = await setupApp().request('/api/broadcasts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Idempotency-Key': KEY },
+      body: JSON.stringify(requestBody),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Idempotency-Replayed')).toBe('true');
+    expect(dbMocks.createBroadcast).not.toHaveBeenCalled();
+    expect((await response.json() as { data: { id: string } }).data.id).toBe(KEY);
+  });
+
+  test('rejects reuse of the same key for different content', async () => {
+    dbMocks.getBroadcastById.mockResolvedValueOnce(row);
+
+    const response = await setupApp().request('/api/broadcasts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Idempotency-Key': KEY },
+      body: JSON.stringify({ ...requestBody, messageContent: '別の内容' }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(dbMocks.createBroadcast).not.toHaveBeenCalled();
+  });
+
+  test('rejects a malformed key before touching the database', async () => {
+    const response = await setupApp().request('/api/broadcasts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Idempotency-Key': 'not-a-uuid' },
+      body: JSON.stringify(requestBody),
+    });
+
+    expect(response.status).toBe(400);
+    expect(dbMocks.getBroadcastById).not.toHaveBeenCalled();
+    expect(dbMocks.createBroadcast).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/routes/broadcasts.ts
+++ b/apps/worker/src/routes/broadcasts.ts
@@ -14,8 +14,23 @@ import { processSegmentSend } from '../services/segment-send.js';
 import type { SegmentCondition } from '../services/segment-query.js';
 import { getLineAccountById } from '@line-crm/db';
 import type { Env } from '../index.js';
+import {
+  assertNoUnresolvedBroadcastVariables,
+  getUnsupportedBroadcastVariables,
+  hasRecipientVariables,
+  renderBroadcastMessageContent,
+} from '../services/render-message.js';
 
 const broadcasts = new Hono<Env>();
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function unsupportedVariablesError(content: string): string | null {
+  const unsupported = getUnsupportedBroadcastVariables(content);
+  return unsupported.length > 0
+    ? `Unsupported broadcast variables: ${unsupported.map((v) => `{{${v}}}`).join(', ')}`
+    : null;
+}
 
 /**
  * Parse a D1 JSON-array column. Returns:
@@ -34,6 +49,36 @@ function parseJsonArray(s: unknown): string[] | null {
   } catch {
     return null;
   }
+}
+
+type CreateBroadcastBody = {
+  title: string;
+  messageType: BroadcastMessageType;
+  messageContent: string;
+  targetType: BroadcastTargetType;
+  targetTagId?: string | null;
+  scheduledAt?: string | null;
+  lineAccountId?: string | null;
+  altText?: string | null;
+  accountIds?: string[];
+  dedupPriority?: string[];
+  trackLinks?: boolean;
+};
+
+function sameCreateRequest(existing: DbBroadcast, body: CreateBroadcastBody): boolean {
+  const existingAccountIds = parseJsonArray(existing.account_ids) ?? [];
+  const existingPriority = parseJsonArray(existing.dedup_priority) ?? [];
+  return existing.title === body.title
+    && existing.message_type === body.messageType
+    && existing.message_content === body.messageContent
+    && existing.target_type === body.targetType
+    && existing.target_tag_id === (body.targetTagId ?? null)
+    && existing.scheduled_at === (body.scheduledAt ?? null)
+    && (existing.line_account_id ?? null) === (body.lineAccountId ?? null)
+    && (existing.alt_text ?? null) === (body.altText ?? null)
+    && JSON.stringify(existingAccountIds) === JSON.stringify(body.accountIds ?? [])
+    && JSON.stringify(existingPriority) === JSON.stringify(body.dedupPriority ?? [])
+    && existing.track_links === (body.trackLinks === false ? 0 : 1);
 }
 
 function serializeBroadcast(row: DbBroadcast) {
@@ -261,25 +306,23 @@ broadcasts.get('/api/broadcasts/:id/per-account-stats', async (c) => {
 // POST /api/broadcasts - create
 broadcasts.post('/api/broadcasts', async (c) => {
   try {
-    const body = await c.req.json<{
-      title: string;
-      messageType: BroadcastMessageType;
-      messageContent: string;
-      targetType: BroadcastTargetType;
-      targetTagId?: string | null;
-      scheduledAt?: string | null;
-      lineAccountId?: string | null;
-      altText?: string | null;
-      accountIds?: string[];
-      dedupPriority?: string[];
-      trackLinks?: boolean;
-    }>();
+    const body = await c.req.json<CreateBroadcastBody>();
+    const idempotencyKey = c.req.header('Idempotency-Key')?.trim();
+
+    if (idempotencyKey && !UUID_PATTERN.test(idempotencyKey)) {
+      return c.json({ success: false, error: 'Idempotency-Key must be a UUID' }, 400);
+    }
 
     if (!body.title || !body.messageType || !body.messageContent || !body.targetType) {
       return c.json(
         { success: false, error: 'title, messageType, messageContent, and targetType are required' },
         400,
       );
+    }
+
+    const variableError = unsupportedVariablesError(body.messageContent);
+    if (variableError) {
+      return c.json({ success: false, error: variableError }, 400);
     }
 
     if (body.targetType === 'tag' && !body.targetTagId) {
@@ -301,27 +344,45 @@ broadcasts.post('/api/broadcasts', async (c) => {
         typeof id === 'string' && body.accountIds!.includes(id));
     }
 
-    const broadcast = await createBroadcast(c.env.DB, {
-      title: body.title,
-      messageType: body.messageType,
-      messageContent: body.messageContent,
-      targetType: body.targetType,
-      targetTagId: body.targetTagId ?? null,
-      scheduledAt: body.scheduledAt ?? null,
-      accountIds: body.accountIds,
-      dedupPriority: body.dedupPriority,
-      trackLinks: body.trackLinks,
-    });
+    if (idempotencyKey) {
+      const existing = await getBroadcastById(c.env.DB, idempotencyKey);
+      if (existing) {
+        if (!sameCreateRequest(existing, body)) {
+          return c.json({ success: false, error: 'Idempotency-Key was already used with a different request' }, 409);
+        }
+        c.header('Idempotency-Replayed', 'true');
+        return c.json({ success: true, data: serializeBroadcast(existing) }, 200);
+      }
+    }
 
-    // Save line_account_id and alt_text if provided
-    const updates: string[] = [];
-    const binds: unknown[] = [];
-    if (body.lineAccountId) { updates.push('line_account_id = ?'); binds.push(body.lineAccountId); }
-    if (body.altText) { updates.push('alt_text = ?'); binds.push(body.altText); }
-    if (updates.length > 0) {
-      binds.push(broadcast.id);
-      await c.env.DB.prepare(`UPDATE broadcasts SET ${updates.join(', ')} WHERE id = ?`)
-        .bind(...binds).run();
+    let broadcast: DbBroadcast;
+    try {
+      broadcast = await createBroadcast(c.env.DB, {
+        id: idempotencyKey,
+        title: body.title,
+        messageType: body.messageType,
+        messageContent: body.messageContent,
+        targetType: body.targetType,
+        targetTagId: body.targetTagId ?? null,
+        scheduledAt: body.scheduledAt ?? null,
+        accountIds: body.accountIds,
+        dedupPriority: body.dedupPriority,
+        trackLinks: body.trackLinks,
+        lineAccountId: body.lineAccountId ?? null,
+        altText: body.altText ?? null,
+      });
+    } catch (createError) {
+      // Concurrent retries may both pass the SELECT above. The primary key makes
+      // only one INSERT win; the loser is returned as an idempotent replay.
+      const existing = idempotencyKey
+        ? await getBroadcastById(c.env.DB, idempotencyKey)
+        : null;
+      if (!existing) throw createError;
+      if (!sameCreateRequest(existing, body)) {
+        return c.json({ success: false, error: 'Idempotency-Key was already used with a different request' }, 409);
+      }
+      c.header('Idempotency-Replayed', 'true');
+      return c.json({ success: true, data: serializeBroadcast(existing) }, 200);
     }
 
     return c.json({ success: true, data: serializeBroadcast(broadcast) }, 201);
@@ -354,6 +415,13 @@ broadcasts.put('/api/broadcasts/:id', async (c) => {
       scheduledAt?: string | null;
       trackLinks?: boolean;
     }>();
+
+    if (body.messageContent !== undefined) {
+      const variableError = unsupportedVariablesError(body.messageContent);
+      if (variableError) {
+        return c.json({ success: false, error: variableError }, 400);
+      }
+    }
 
     // Keep status in sync with scheduledAt changes
     let statusUpdate: 'draft' | 'scheduled' | undefined;
@@ -437,6 +505,82 @@ broadcasts.post('/api/broadcasts/:id/send', async (c) => {
       return c.json({ success: false, error: 'Broadcast not found' }, 404);
     }
 
+    const variableError = unsupportedVariablesError(existing.message_content);
+    if (variableError) {
+      return c.json({ success: false, error: variableError }, 400);
+    }
+
+    // LINE's multicast/broadcast endpoints accept one shared Message object;
+    // recipient-name variables therefore require per-friend push delivery.
+    // Queue these even for a small audience so they run within Worker limits.
+    if (hasRecipientVariables(existing.message_content)
+      && existing.target_type !== 'multi-account-dedup') {
+      const rawExisting = existing as unknown as Record<string, unknown>;
+      const accountId = rawExisting.line_account_id as string | null;
+      const where: string[] = ['f.is_following = 1'];
+      const binds: unknown[] = [];
+      if (accountId) {
+        where.push('f.line_account_id = ?');
+        binds.push(accountId);
+      }
+      if (existing.target_type === 'tag') {
+        if (!existing.target_tag_id) {
+          return c.json({ success: false, error: 'targetTagId is required for tag delivery' }, 400);
+        }
+        where.push('EXISTS (SELECT 1 FROM friend_tags ft WHERE ft.friend_id = f.id AND ft.tag_id = ?)');
+        binds.push(existing.target_tag_id);
+      }
+
+      const audience = await c.env.DB.prepare(
+        `SELECT COUNT(*) AS total,
+                SUM(CASE WHEN f.display_name IS NULL OR trim(f.display_name) = '' THEN 1 ELSE 0 END) AS missing_name
+           FROM friends f
+          WHERE ${where.join(' AND ')}`,
+      ).bind(...binds).first<{ total: number; missing_name: number | null }>();
+      const total = Number(audience?.total ?? 0);
+      const missingName = Number(audience?.missing_name ?? 0);
+      if (missingName > 0) {
+        return c.json({
+          success: false,
+          error: `Cannot personalize broadcast: ${missingName} recipient(s) have no display name`,
+        }, 400);
+      }
+
+      const conditions: SegmentCondition = existing.target_type === 'tag'
+        ? { operator: 'AND', rules: [
+            { type: 'is_following', value: true },
+            { type: 'tag_exists', value: existing.target_tag_id! },
+          ] }
+        : { operator: 'AND', rules: [{ type: 'is_following', value: true }] };
+      const lockResult = await c.env.DB.prepare(
+        `UPDATE broadcasts
+            SET status = 'sending', batch_offset = 0, total_count = ?, segment_conditions = ?
+          WHERE id = ? AND status IN ('draft','scheduled')`,
+      ).bind(total, JSON.stringify(conditions), id).run();
+      if (!lockResult.meta.changes) {
+        return c.json({ success: false, error: 'Broadcast is already sent or sending' }, 409);
+      }
+
+      try {
+        const ctx = c.executionCtx as ExecutionContext;
+        const defaultClient = new LineClient(c.env.LINE_CHANNEL_ACCESS_TOKEN);
+        ctx.waitUntil(
+          processQueuedBroadcasts(c.env.DB, defaultClient, c.env.WORKER_URL).catch((err) => {
+            console.error('[personalized-broadcast] background queue processing failed:', err);
+          }),
+        );
+      } catch (kickErr) {
+        console.warn('[personalized-broadcast] waitUntil unavailable, falling back to cron:', kickErr);
+      }
+
+      return c.json({
+        success: true,
+        data: { id, status: 'sending', totalCount: total },
+        queued: true,
+        message: 'Personalized broadcast queued for per-recipient delivery',
+      }, 202);
+    }
+
     // multi-account-dedup は常にキュー方式 — Worker の30秒制限を超えるため
     if (existing.target_type === 'multi-account-dedup') {
       // Always queue — never run inline. The executor walks per-account multicast
@@ -461,10 +605,20 @@ broadcasts.post('/api/broadcasts/:id/send', async (c) => {
       // inactive 分も含めた全件を返すため、ここでアカウント状態を引き直して
       // active 分だけ集計する。これで confirm/progress UI と実送信数が一致する。
       let projectedTotal = 0;
+      let missingDisplayNames = 0;
       const { getLineAccountById } = await import('@line-crm/db');
       for (const a of preview.perAccount) {
         const account = await getLineAccountById(c.env.DB, a.accountId);
-        if (account && account.is_active) projectedTotal += a.recipients.length;
+        if (account && account.is_active) {
+          projectedTotal += a.recipients.length;
+          missingDisplayNames += a.recipients.filter((r) => !r.displayName?.trim()).length;
+        }
+      }
+      if (hasRecipientVariables(existing.message_content) && missingDisplayNames > 0) {
+        return c.json({
+          success: false,
+          error: `Cannot personalize broadcast: ${missingDisplayNames} recipient(s) have no display name`,
+        }, 400);
       }
 
       const lockResult = await c.env.DB.prepare(
@@ -590,6 +744,36 @@ broadcasts.post('/api/broadcasts/:id/send-segment', async (c) => {
         { success: false, error: 'conditions with operator and rules array is required' },
         400,
       );
+    }
+
+    const variableError = unsupportedVariablesError(existing.message_content);
+    if (variableError) {
+      return c.json({ success: false, error: variableError }, 400);
+    }
+
+    if (hasRecipientVariables(existing.message_content)) {
+      const { buildSegmentQuery } = await import('../services/segment-query.js');
+      const { sql, bindings } = buildSegmentQuery(body.conditions);
+      const accountId = (existing as unknown as Record<string, unknown>).line_account_id as string | null;
+      let audienceSql = `SELECT COUNT(*) AS total,
+                                SUM(CASE WHEN q.display_name IS NULL OR trim(q.display_name) = '' THEN 1 ELSE 0 END) AS missing_name
+                           FROM (${sql}) q`;
+      const audienceBindings = [...bindings];
+      if (accountId) {
+        audienceSql = `SELECT COUNT(*) AS total,
+                              SUM(CASE WHEN q.display_name IS NULL OR trim(q.display_name) = '' THEN 1 ELSE 0 END) AS missing_name
+                         FROM (${sql.replace('WHERE', 'WHERE f.line_account_id = ? AND')}) q`;
+        audienceBindings.unshift(accountId);
+      }
+      const audience = await c.env.DB.prepare(audienceSql)
+        .bind(...audienceBindings)
+        .first<{ total: number; missing_name: number | null }>();
+      if (Number(audience?.missing_name ?? 0) > 0) {
+        return c.json({
+          success: false,
+          error: `Cannot personalize broadcast: ${audience!.missing_name} recipient(s) have no display name`,
+        }, 400);
+      }
     }
 
     // Atomic lock: status='draft'|'scheduled' のときだけ status='sending' に遷移
@@ -830,8 +1014,8 @@ broadcasts.post('/api/broadcasts/:id/test-send', async (c) => {
 
     const placeholders = friendIds.map(() => '?').join(',');
     const friends = await c.env.DB.prepare(
-      `SELECT id, line_user_id FROM friends WHERE id IN (${placeholders})`
-    ).bind(...friendIds).all<{ id: string; line_user_id: string }>();
+      `SELECT id, line_user_id, display_name FROM friends WHERE id IN (${placeholders})`
+    ).bind(...friendIds).all<{ id: string; line_user_id: string; display_name: string | null }>();
 
     const account = await getLineAccountById(c.env.DB, accountId);
     if (!account) return c.json({ success: false, error: 'LINE account not found' }, 400);
@@ -853,8 +1037,7 @@ broadcasts.post('/api/broadcasts/:id/test-send', async (c) => {
     }
 
     const { extractFlexAltText } = await import('../utils/flex-alt-text.js');
-    const altText = raw.alt_text as string || (tracked.messageType === 'flex' ? extractFlexAltText(tracked.content) : undefined);
-    const message = buildMessage(tracked.messageType, tracked.content, altText);
+    const liffId = (account as unknown as { liff_id?: string | null }).liff_id ?? null;
 
     let sent = 0;
     let failed = 0;
@@ -862,12 +1045,20 @@ broadcasts.post('/api/broadcasts/:id/test-send', async (c) => {
 
     for (const friend of friends.results) {
       try {
+        const renderedContent = renderBroadcastMessageContent(tracked.messageType, tracked.content, {
+          liffId,
+          displayName: friend.display_name,
+        });
+        assertNoUnresolvedBroadcastVariables(renderedContent);
+        const altText = raw.alt_text as string
+          || (tracked.messageType === 'flex' ? extractFlexAltText(renderedContent) : undefined);
+        const message = buildMessage(tracked.messageType, renderedContent, altText);
         await lineClient.pushMessage(friend.line_user_id, [message]);
         sent++;
         await c.env.DB.prepare(
           `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, delivery_type, source, created_at)
            VALUES (?, ?, 'outgoing', ?, ?, NULL, 'test', 'broadcast', ?)`
-        ).bind(crypto.randomUUID(), friend.id, broadcast.message_type, messageContent, now).run();
+        ).bind(crypto.randomUUID(), friend.id, tracked.messageType, renderedContent, now).run();
       } catch (err) {
         console.error(`Test send to ${friend.id} failed:`, err);
         failed++;

--- a/apps/worker/src/services/broadcast-retry-key.test.ts
+++ b/apps/worker/src/services/broadcast-retry-key.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest';
+import { createBroadcastRetryKey } from './broadcast-retry-key.js';
+
+describe('createBroadcastRetryKey', () => {
+  test('is stable, UUID-shaped, and changes with delivery content', async () => {
+    const first = await createBroadcastRetryKey('broadcast-1', 'friend-1', 'hello');
+    const retry = await createBroadcastRetryKey('broadcast-1', 'friend-1', 'hello');
+    const edited = await createBroadcastRetryKey('broadcast-1', 'friend-1', 'hello again');
+
+    expect(first).toBe(retry);
+    expect(first).not.toBe(edited);
+    expect(first).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+});

--- a/apps/worker/src/services/broadcast-retry-key.ts
+++ b/apps/worker/src/services/broadcast-retry-key.ts
@@ -1,0 +1,14 @@
+/**
+ * Produce a stable RFC 4122 UUID-shaped retry key from the logical delivery.
+ * LINE accepts a retry of the same push/multicast without delivering it twice
+ * when the same X-Line-Retry-Key is reused.
+ */
+export async function createBroadcastRetryKey(...parts: string[]): Promise<string> {
+  const input = new TextEncoder().encode(`line-harness:broadcast:${parts.join('\u001f')}`);
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', input));
+  const bytes = digest.slice(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/apps/worker/src/services/broadcast.ts
+++ b/apps/worker/src/services/broadcast.ts
@@ -14,8 +14,16 @@ import type { Broadcast } from '@line-crm/db';
 import type { LineClient } from '@line-crm/line-sdk';
 import type { Message } from '@line-crm/line-sdk';
 import { calculateStaggerDelay, sleep, addMessageVariation } from './stealth.js';
+import {
+  assertNoUnresolvedBroadcastVariables,
+  getUnsupportedBroadcastVariables,
+  hasRecipientVariables,
+  renderBroadcastMessageContent,
+} from './render-message.js';
+import { createBroadcastRetryKey } from './broadcast-retry-key.js';
 
 const MULTICAST_BATCH_SIZE = 500;
+const PERSONALIZED_PUSH_BATCH_SIZE = 10;
 
 export async function processBroadcastSend(
   db: D1Database,
@@ -29,6 +37,53 @@ export async function processBroadcastSend(
   const broadcast = await getBroadcastById(db, broadcastId);
   if (!broadcast) {
     throw new Error(`Broadcast ${broadcastId} not found`);
+  }
+
+  const unsupportedVariables = getUnsupportedBroadcastVariables(broadcast.message_content);
+  if (unsupportedVariables.length > 0) {
+    throw new Error(
+      `Unsupported broadcast variables: ${unsupportedVariables.map((v) => `{{${v}}}`).join(', ')}`,
+    );
+  }
+
+  // A recipient variable cannot be delivered through LINE broadcast or
+  // multicast because those endpoints accept one shared Message object.
+  // Convert scheduled/direct sends into the resumable queue path.
+  if (hasRecipientVariables(broadcast.message_content)
+    && broadcast.target_type !== 'multi-account-dedup') {
+    const raw = broadcast as unknown as Record<string, unknown>;
+    const accountId = raw.line_account_id as string | null;
+    const where: string[] = ['f.is_following = 1'];
+    const binds: unknown[] = [];
+    if (accountId) {
+      where.push('f.line_account_id = ?');
+      binds.push(accountId);
+    }
+    if (broadcast.target_type === 'tag') {
+      if (!broadcast.target_tag_id) throw new Error('target_tag_id is required for personalized tag broadcast');
+      where.push('EXISTS (SELECT 1 FROM friend_tags ft WHERE ft.friend_id = f.id AND ft.tag_id = ?)');
+      binds.push(broadcast.target_tag_id);
+    }
+    const audience = await db.prepare(
+      `SELECT COUNT(*) AS total,
+              SUM(CASE WHEN f.display_name IS NULL OR trim(f.display_name) = '' THEN 1 ELSE 0 END) AS missing_name
+         FROM friends f WHERE ${where.join(' AND ')}`,
+    ).bind(...binds).first<{ total: number; missing_name: number | null }>();
+    if (Number(audience?.missing_name ?? 0) > 0) {
+      throw new Error(`Cannot personalize broadcast: ${audience!.missing_name} recipient(s) have no display name`);
+    }
+    const conditions = broadcast.target_type === 'tag'
+      ? { operator: 'AND', rules: [
+          { type: 'is_following', value: true },
+          { type: 'tag_exists', value: broadcast.target_tag_id },
+        ] }
+      : { operator: 'AND', rules: [{ type: 'is_following', value: true }] };
+    await db.prepare(
+      `UPDATE broadcasts
+          SET status = 'sending', batch_offset = 0, total_count = ?, segment_conditions = ?
+        WHERE id = ?`,
+    ).bind(Number(audience?.total ?? 0), JSON.stringify(conditions), broadcast.id).run();
+    return (await getBroadcastById(db, broadcastId))!;
   }
 
   // multi-account-dedup は inline 送信せず cron queue (processQueuedBroadcasts) に委譲する。
@@ -77,9 +132,9 @@ export async function processBroadcastSend(
     const { getLineAccountById: getLA } = await import('@line-crm/db');
     const acct = await getLA(db, broadcastAccountId);
     const liffId = (acct as unknown as { liff_id?: string | null } | null)?.liff_id ?? null;
-    const { renderMessageContent } = await import('./render-message.js');
-    finalContent = renderMessageContent(finalContent, liffId);
+    finalContent = renderBroadcastMessageContent(finalType, finalContent, { liffId });
   }
+  assertNoUnresolvedBroadcastVariables(finalContent);
   const altText = (broadcast as unknown as Record<string, unknown>).alt_text as string | undefined;
   const message = buildMessage(finalType, finalContent, altText || undefined);
   let totalCount = 0;
@@ -88,7 +143,13 @@ export async function processBroadcastSend(
   try {
     if (broadcast.target_type === 'all') {
       // Use LINE broadcast API (sends to all followers)
-      const { requestId } = await lineClient.broadcast([message]);
+      const retryKey = await createBroadcastRetryKey(
+        broadcast.id,
+        'broadcast',
+        finalType,
+        finalContent,
+      );
+      const { requestId } = await lineClient.broadcast([message], retryKey);
       await updateBroadcastLineRequestId(db, broadcast.id, requestId, null);
       // We don't have exact count for broadcast API, set as 0 (unknown)
       totalCount = 0;
@@ -124,7 +185,13 @@ export async function processBroadcastSend(
         }
 
         try {
-          await lineClient.multicast(lineUserIds, [batchMessage], [unit]);
+          const retryKey = await createBroadcastRetryKey(
+            broadcast.id,
+            'multicast',
+            ...batch.map((f) => f.id),
+            JSON.stringify(batchMessage),
+          );
+          await lineClient.multicast(lineUserIds, [batchMessage], [unit], retryKey);
           successCount += batch.length;
 
           // Log only successfully sent messages (batch insert for performance)
@@ -295,8 +362,7 @@ async function processQueuedBroadcastBatches(
     const { getLineAccountById: getLA } = await import('@line-crm/db');
     const acct = await getLA(db, queuedAccountId);
     const liffId = (acct as unknown as { liff_id?: string | null } | null)?.liff_id ?? null;
-    const { renderMessageContent } = await import('./render-message.js');
-    finalContent = renderMessageContent(finalContent, liffId);
+    finalContent = renderBroadcastMessageContent(finalType, finalContent, { liffId });
   }
   const altText = raw.alt_text as string | undefined;
   const message = buildMessage(finalType, finalContent, altText || undefined);
@@ -329,7 +395,7 @@ async function processQueuedBroadcastBatches(
 
   // 対象ユーザーリストを取得（アカウントで絞り込む）
   const accountId = raw.line_account_id as string | null;
-  let friends: Array<{ id: string; line_user_id: string }>;
+  let friends: Array<{ id: string; line_user_id: string; display_name: string | null }>;
   if (segmentConditionsStr) {
     const { buildSegmentQuery } = await import('./segment-query.js');
     const condition = JSON.parse(segmentConditionsStr);
@@ -341,15 +407,29 @@ async function processQueuedBroadcastBatches(
       accountSql = sql.replace('WHERE', 'WHERE f.line_account_id = ? AND');
       accountBindings.unshift(accountId);
     }
-    const result = await db.prepare(accountSql).bind(...accountBindings).all<{ id: string; line_user_id: string }>();
+    const result = await db.prepare(accountSql).bind(...accountBindings).all<{
+      id: string;
+      line_user_id: string;
+      display_name: string | null;
+    }>();
     friends = result.results ?? [];
   } else if (broadcast.target_tag_id) {
     const { getFriendsByTag } = await import('@line-crm/db');
     const tagFriends = await getFriendsByTag(db, broadcast.target_tag_id);
-    friends = tagFriends.filter(f => f.is_following).map(f => ({ id: f.id, line_user_id: f.line_user_id }));
+    friends = tagFriends.filter(f => f.is_following).map(f => ({
+      id: f.id,
+      line_user_id: f.line_user_id,
+      display_name: f.display_name,
+    }));
   } else {
     // target_type='all' でキューに入ることはないが、念のため
-    const { requestId } = await lineClient.broadcast([message]);
+    const retryKey = await createBroadcastRetryKey(
+      broadcast.id,
+      'queued-broadcast',
+      finalType,
+      finalContent,
+    );
+    const { requestId } = await lineClient.broadcast([message], retryKey);
     await updateBroadcastLineRequestId(db, broadcast.id, requestId, null);
     await createBroadcastInsight(db, broadcast.id);
     await updateBroadcastStatus(db, broadcast.id, 'sent', { totalCount: 0, successCount: 0 });
@@ -363,15 +443,104 @@ async function processQueuedBroadcastBatches(
   }
 
   const now = jstNow();
-  const unit = `bcast_${broadcast.id.slice(0, 8)}`;
+  const unit = `bcast_${broadcast.id.slice(0, 8).replace(/[^a-zA-Z0-9_]/g, '_')}`;
   let currentOffset = batchOffset;
-  const totalBatches = Math.ceil(friends.length / MULTICAST_BATCH_SIZE);
+  const personalized = hasRecipientVariables(finalContent);
+  const unsupportedVariables = getUnsupportedBroadcastVariables(finalContent);
+  if (unsupportedVariables.length > 0) {
+    await updateBroadcastBatchProgress(db, broadcast.id, batchOffset, 0);
+    throw new Error(
+      `Unsupported broadcast variables: ${unsupportedVariables.map((v) => `{{${v}}}`).join(', ')}`,
+    );
+  }
+  if (!personalized) {
+    try {
+      assertNoUnresolvedBroadcastVariables(finalContent);
+    } catch (err) {
+      await updateBroadcastBatchProgress(db, broadcast.id, batchOffset, 0);
+      throw err;
+    }
+  }
+  const deliveryBatchSize = personalized ? PERSONALIZED_PUSH_BATCH_SIZE : MULTICAST_BATCH_SIZE;
+  const totalBatches = Math.ceil(friends.length / deliveryBatchSize);
 
   // 1回のCron実行で全バッチを処理（タイムアウトしない範囲で）
   while (currentOffset < friends.length) {
-    const batch = friends.slice(currentOffset, currentOffset + MULTICAST_BATCH_SIZE);
+    const batch = friends.slice(currentOffset, currentOffset + deliveryBatchSize);
     const lineUserIds = batch.map(f => f.line_user_id);
-    const batchIndex = Math.floor(currentOffset / MULTICAST_BATCH_SIZE);
+    const batchIndex = Math.floor(currentOffset / deliveryBatchSize);
+
+    if (personalized) {
+      for (const friend of batch) {
+        const alreadyLogged = await db.prepare(
+          `SELECT 1 FROM messages_log
+            WHERE broadcast_id = ? AND friend_id = ? AND direction = 'outgoing'
+              AND COALESCE(delivery_type, '') != 'test'
+            LIMIT 1`,
+        ).bind(broadcast.id, friend.id).first();
+        if (alreadyLogged) {
+          currentOffset++;
+          continue;
+        }
+
+        try {
+          const renderedContent = renderBroadcastMessageContent(finalType, finalContent, {
+            displayName: friend.display_name,
+          });
+          assertNoUnresolvedBroadcastVariables(renderedContent);
+          const personalizedMessage = buildMessage(finalType, renderedContent, altText || undefined);
+          const retryKey = await createBroadcastRetryKey(
+            broadcast.id,
+            'personalized-push',
+            friend.id,
+            finalType,
+            renderedContent,
+          );
+          await lineClient.pushMessage(friend.line_user_id, [personalizedMessage], retryKey, [unit]);
+
+          await db.prepare(
+            `INSERT INTO messages_log
+              (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, line_account_id, created_at)
+             VALUES (?, ?, 'outgoing', ?, ?, ?, NULL, 'broadcast', ?, ?)`,
+          ).bind(
+            crypto.randomUUID(),
+            friend.id,
+            finalType,
+            renderedContent,
+            broadcast.id,
+            accountId,
+            now,
+          ).run();
+          currentOffset++;
+        } catch (err) {
+          console.error(`Personalized broadcast recipient ${friend.id} failed:`, err);
+          await db.prepare(
+            `UPDATE broadcasts
+                SET batch_offset = ?, batch_lock_at = NULL,
+                    success_count = (
+                      SELECT COUNT(*) FROM messages_log
+                       WHERE broadcast_id = ? AND direction = 'outgoing'
+                         AND COALESCE(delivery_type, '') != 'test'
+                    )
+              WHERE id = ?`,
+          ).bind(currentOffset, broadcast.id, broadcast.id).run();
+          return;
+        }
+      }
+
+      await db.prepare(
+        `UPDATE broadcasts
+            SET batch_offset = ?, batch_lock_at = NULL,
+                success_count = (
+                  SELECT COUNT(*) FROM messages_log
+                   WHERE broadcast_id = ? AND direction = 'outgoing'
+                     AND COALESCE(delivery_type, '') != 'test'
+                )
+          WHERE id = ?`,
+      ).bind(currentOffset, broadcast.id, broadcast.id).run();
+      if (currentOffset < friends.length) return;
+      break;
+    }
 
     // ステルス遅延（最初のバッチ以外）
     if (batchIndex > 0) {
@@ -386,7 +555,13 @@ async function processQueuedBroadcastBatches(
     }
 
     try {
-      await lineClient.multicast(lineUserIds, [batchMessage], [unit]);
+      const retryKey = await createBroadcastRetryKey(
+        broadcast.id,
+        'queued-multicast',
+        ...batch.map((f) => f.id),
+        JSON.stringify(batchMessage),
+      );
+      await lineClient.multicast(lineUserIds, [batchMessage], [unit], retryKey);
     } catch (err) {
       console.error(`Queued broadcast batch ${batchIndex} send failed:`, err);
       // 送信失敗: ロック解除 + offsetを保存して次のCronで再開
@@ -403,7 +578,7 @@ async function processQueuedBroadcastBatches(
         db.prepare(
           `INSERT INTO messages_log (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, line_account_id, created_at)
            VALUES (?, ?, 'outgoing', ?, ?, ?, NULL, 'broadcast', ?, ?)`,
-        ).bind(crypto.randomUUID(), friend.id, broadcast.message_type, broadcast.message_content, broadcast.id, queuedBroadcastAccount, now),
+        ).bind(crypto.randomUUID(), friend.id, finalType, finalContent, broadcast.id, queuedBroadcastAccount, now),
       );
       await db.batch(stmts);
     } catch (logErr) {

--- a/apps/worker/src/services/dedup-broadcast.test.ts
+++ b/apps/worker/src/services/dedup-broadcast.test.ts
@@ -287,7 +287,12 @@ describe('computeDedupBroadcastPreview', () => {
       ['acc1', 'acc2'], ['acc1', 'acc2'],
     );
     const acc1 = result.perAccount.find((p) => p.accountId === 'acc1')!;
-    expect(acc1.recipients).toEqual([{ friendId: 'f1', lineUserId: 'u1', identKey: 'f1' }]);
+    expect(acc1.recipients).toEqual([{
+      friendId: 'f1',
+      lineUserId: 'u1',
+      identKey: 'f1',
+      displayName: null,
+    }]);
   });
 });
 
@@ -329,6 +334,10 @@ class MockLineClient {
     }
     return { data: {}, requestId: 'mock-req' };
   }
+  async pushMessage(to: string, messages: unknown[], retryKey?: string, units?: string[]) {
+    this.calls.push({ method: 'push', args: [to, messages, retryKey, units, this.token] });
+    return {};
+  }
 }
 
 // fakeDb for send-side: handles `db.prepare(...).bind(...).run()` for the
@@ -338,7 +347,13 @@ class MockLineClient {
 // caller seeded).
 function makeSendDb(opts: {
   selectedCounts?: Array<{ line_account_id: string; cnt: number }>;
-  rankedRows?: Array<{ friend_id: string; line_user_id: string; line_account_id: string; ident_key?: string }>;
+  rankedRows?: Array<{
+    friend_id: string;
+    line_user_id: string;
+    line_account_id: string;
+    ident_key?: string;
+    display_name?: string | null;
+  }>;
   accountMeta?: Array<{ id: string; name: string; country: string | null }>;
 }) {
   const updates: Record<string, unknown> = {};
@@ -696,6 +711,43 @@ describe('processMultiAccountDedupBroadcast', () => {
     expect(last.sentIdentKeys[500]).toBe('f500');
   });
 
+  it('renders {{name}} per recipient and uses individual push requests', async () => {
+    const { db } = makeSendDb({
+      selectedCounts: [{ line_account_id: 'acc1', cnt: 2 }],
+      rankedRows: [
+        { friend_id: 'f1', line_user_id: 'u1', line_account_id: 'acc1', display_name: 'Alice' },
+        { friend_id: 'f2', line_user_id: 'u2', line_account_id: 'acc1', display_name: 'Bob' },
+      ],
+      accountMeta: [{ id: 'acc1', name: 'A1', country: 'JP' }],
+    });
+    vi.mocked(getLineAccountById).mockResolvedValue({
+      id: 'acc1', channel_access_token: 'tok1', is_active: 1, liff_id: 'LIFF-1',
+    } as never);
+    const client = new MockLineClient('tok1');
+
+    const result = await processMultiAccountDedupBroadcast(
+      db,
+      {
+        id: 'b-personalized',
+        account_ids: '["acc1"]',
+        dedup_priority: '["acc1"]',
+        message_type: 'text',
+        message_content: '{{name}}さん https://liff.line.me/{{liff_id}}',
+      },
+      () => client as unknown as LineClient,
+    );
+
+    expect(result.successCount).toBe(2);
+    expect(client.calls.map((call) => call.method)).toEqual(['push', 'push']);
+    expect(client.calls[0].args[1]).toEqual([{
+      type: 'text', text: 'Aliceさん https://liff.line.me/LIFF-1',
+    }]);
+    expect(client.calls[1].args[1]).toEqual([{
+      type: 'text', text: 'Bobさん https://liff.line.me/LIFF-1',
+    }]);
+    expect(client.calls[0].args[2]).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
   // ---- 分割送信 (chunking) ----
   // 1 実行が時間バジェット(maxRunMs)を超えたら、残りは次の cron tick に回して yield する。
   // これで 5000 人配信でも 1 実行が短く終わり、Worker 時間制限で stall しなくなる。
@@ -743,7 +795,7 @@ describe('processMultiAccountDedupBroadcast', () => {
   });
 
   it('within time budget: sends all batches and reports complete=true', async () => {
-    const N = 1000; // 2 batches
+    const N = 1000; // 20 batches
     const { db } = makeSendDb({
       selectedCounts: [{ line_account_id: 'acc1', cnt: N }],
       rankedRows: Array.from({ length: N }, (_, i) => ({
@@ -770,7 +822,7 @@ describe('processMultiAccountDedupBroadcast', () => {
 
     expect(result.complete).toBe(true);
     const c = clients.find((x) => x.token === 'tok1');
-    expect(c?.calls.length).toBe(2); // 両 batch 送信
+    expect(c?.calls.length).toBe(2); // 500人ずつ全 batch を送信
     expect(result.successCount).toBe(1000);
   });
 });

--- a/apps/worker/src/services/dedup-broadcast.ts
+++ b/apps/worker/src/services/dedup-broadcast.ts
@@ -11,7 +11,12 @@ export interface DedupPreviewPerAccount {
   // resume 時の send 済判定に使う。lineUserId はプロバイダ単位のID なので、
   // 同じ論理人物が別 LINE 公式アカウント (別プロバイダ) にいる場合に二重配信
   // する事故を防ぐため、cross-account でユニークな identKey を採用する。
-  recipients: Array<{ friendId: string; lineUserId: string; identKey: string }>;
+  recipients: Array<{
+    friendId: string;
+    lineUserId: string;
+    identKey: string;
+    displayName: string | null;
+  }>;
 }
 
 export interface DedupPreviewResult {
@@ -27,6 +32,7 @@ interface RankedRow {
   line_user_id: string;
   line_account_id: string;
   ident_key: string;
+  display_name: string | null;
 }
 
 /**
@@ -103,6 +109,7 @@ export async function computeDedupBroadcastPreview(
       SELECT
         f.id            AS friend_id,
         f.line_user_id,
+        f.display_name,
         f.line_account_id,
         f.created_at,
         COALESCE(${URL_TOKEN_SQL}, 'uid:'||f.user_id, 'solo:'||f.id) AS ident_key
@@ -120,7 +127,7 @@ export async function computeDedupBroadcastPreview(
         ) AS rn
       FROM selected
     )
-    SELECT friend_id, line_user_id, line_account_id, ident_key
+    SELECT friend_id, line_user_id, line_account_id, ident_key, display_name
     FROM ranked
     WHERE rn = 1
     ORDER BY line_account_id, created_at
@@ -175,6 +182,7 @@ export async function computeDedupBroadcastPreview(
         friendId: w.friend_id,
         lineUserId: w.line_user_id,
         identKey: w.ident_key,
+        displayName: w.display_name ?? null,
       })),
     };
   });
@@ -185,10 +193,16 @@ export async function computeDedupBroadcastPreview(
 import { LineClient, type Message } from '@line-crm/line-sdk';
 import { getLineAccountById, jstNow, updateBroadcastLineRequestId } from '@line-crm/db';
 import { calculateStaggerDelay, sleep, addMessageVariation } from './stealth.js';
-import { renderMessageContent } from './render-message.js';
+import {
+  assertNoUnresolvedBroadcastVariables,
+  hasRecipientVariables,
+  renderBroadcastMessageContent,
+} from './render-message.js';
 import { buildMessage } from './broadcast.js';
+import { createBroadcastRetryKey } from './broadcast-retry-key.js';
 
 const MULTICAST_BATCH_SIZE = 500;
+const PERSONALIZED_PUSH_BATCH_SIZE = 10;
 
 export interface ProcessMultiAccountDedupResult {
   totalCount: number;
@@ -354,21 +368,27 @@ export async function processMultiAccountDedupBroadcast(
     if (remaining.length === 0) continue; // このアカに残作業なし
 
     const client = lineClientFactory(account.channel_access_token);
-    const totalBatches = Math.ceil(remaining.length / MULTICAST_BATCH_SIZE);
+    const accountContent = renderBroadcastMessageContent(
+      broadcast.message_type,
+      broadcast.message_content,
+      { liffId: (account as unknown as { liff_id?: string | null }).liff_id ?? null },
+    );
+    const personalized = hasRecipientVariables(accountContent);
+    if (!personalized) assertNoUnresolvedBroadcastVariables(accountContent);
+    const deliveryBatchSize = personalized ? PERSONALIZED_PUSH_BATCH_SIZE : MULTICAST_BATCH_SIZE;
+    const totalBatches = Math.ceil(remaining.length / deliveryBatchSize);
 
     // Per-account の liff_id でテンプレ変数 ({{liff_id}}) を置換してから
     // buildMessage する。これで 1 broadcast から複数アカへ配信する際、
     // 友だちの所属アカに対応した LIFF URL が届く (events の運用要件)。
-    const renderedContent = renderMessageContent(
-      broadcast.message_content,
-      (account as unknown as { liff_id?: string | null }).liff_id ?? null,
-    );
-    const message = buildMessage(broadcast.message_type, renderedContent, broadcast.alt_text ?? undefined);
+    const message = personalized
+      ? null
+      : buildMessage(broadcast.message_type, accountContent, broadcast.alt_text ?? undefined);
 
     try {
-      for (let i = 0; i < remaining.length; i += MULTICAST_BATCH_SIZE) {
-        const batchIdx = Math.floor(i / MULTICAST_BATCH_SIZE);
-        const batch = remaining.slice(i, i + MULTICAST_BATCH_SIZE);
+      for (let i = 0; i < remaining.length; i += deliveryBatchSize) {
+        const batchIdx = Math.floor(i / deliveryBatchSize);
+        const batch = remaining.slice(i, i + deliveryBatchSize);
 
         // 時間バジェットを超えたら、残りは次の cron tick に回して yield する。
         // ただし最低 1 batch は必ず送る (sentAnyBatch ガード) ことで毎 tick 前進を保証。
@@ -381,15 +401,62 @@ export async function processMultiAccountDedupBroadcast(
           await sleep(calculateStaggerDelay(remaining.length, batchIdx));
         }
 
-        let batchMessage = message;
-        if (message.type === 'text' && totalBatches > 1) {
-          batchMessage = { ...message, text: addMessageVariation(message.text, batchIdx) } as Message;
+        const delivered = [] as Array<{
+          recipient: (typeof batch)[number];
+          messageType: string;
+          content: string;
+        }>;
+        let batchDeliveryError: unknown = null;
+        if (personalized) {
+          for (const recipient of batch) {
+            try {
+              const content = renderBroadcastMessageContent(broadcast.message_type, accountContent, {
+                displayName: recipient.displayName,
+              });
+              assertNoUnresolvedBroadcastVariables(content);
+              const recipientMessage = buildMessage(
+                broadcast.message_type,
+                content,
+                broadcast.alt_text ?? undefined,
+              );
+              const retryKey = await createBroadcastRetryKey(
+                broadcast.id,
+                'dedup-personalized-push',
+                recipient.friendId,
+                broadcast.message_type,
+                content,
+              );
+              await client.pushMessage(recipient.lineUserId, [recipientMessage], retryKey, [unit]);
+              delivered.push({ recipient, messageType: broadcast.message_type, content });
+            } catch (err) {
+              batchDeliveryError = err;
+              break;
+            }
+          }
+        } else {
+          let batchMessage = message!;
+          if (batchMessage.type === 'text' && totalBatches > 1) {
+            batchMessage = { ...batchMessage, text: addMessageVariation(batchMessage.text, batchIdx) } as Message;
+          }
+          const retryKey = await createBroadcastRetryKey(
+            broadcast.id,
+            'dedup-multicast',
+            account.id,
+            ...batch.map((r) => r.identKey),
+            JSON.stringify(batchMessage),
+          );
+          await client.multicast(batch.map((r) => r.lineUserId), [batchMessage], [unit], retryKey);
+          for (const recipient of batch) {
+            delivered.push({
+              recipient,
+              messageType: broadcast.message_type,
+              content: accountContent,
+            });
+          }
         }
 
-        await client.multicast(batch.map((r) => r.lineUserId), [batchMessage], [unit]);
-
         // multicast 成功直後に identKey を sent set へ追加。
-        for (const r of batch) {
+        for (const { recipient: r } of delivered) {
           progress.sentIdentKeys.push(r.identKey);
           sentSet.add(r.identKey);
         }
@@ -400,12 +467,12 @@ export async function processMultiAccountDedupBroadcast(
         // DB 進捗未更新」になって resume 時に同 batch を再送 → 重複配信事故が起きる。
         // db.batch は D1 で transaction として扱われ、まとめて成否が決まる。
         const stmts = [
-          ...batch.map((r) =>
+          ...delivered.map(({ recipient: r, messageType, content }) =>
             db.prepare(
               `INSERT INTO messages_log
                 (id, friend_id, direction, message_type, content, broadcast_id, scenario_step_id, source, line_account_id, created_at)
                VALUES (?, ?, 'outgoing', ?, ?, ?, NULL, 'broadcast', ?, ?)`,
-            ).bind(crypto.randomUUID(), r.friendId, broadcast.message_type, broadcast.message_content, broadcast.id, account.id, now),
+            ).bind(crypto.randomUUID(), r.friendId, messageType, content, broadcast.id, account.id, now),
           ),
           // success_count は absolute (`= ?`) で書いて double-counting を防ぐ。
           db.prepare(
@@ -414,6 +481,7 @@ export async function processMultiAccountDedupBroadcast(
         ];
         await db.batch(stmts);
         sentAnyBatch = true; // 1 batch 以上 durable に記録した → 前進保証 & yield 可
+        if (batchDeliveryError) throw batchDeliveryError;
       }
     } catch (err) {
       console.error(`[multi-account-dedup] account ${account.id} failed:`, err);

--- a/apps/worker/src/services/line-sdk-retry.test.ts
+++ b/apps/worker/src/services/line-sdk-retry.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { LineClient } from '@line-crm/line-sdk';
+
+describe('LineClient retry keys', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  test('sends X-Line-Retry-Key for push and omits undefined body fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new LineClient('token');
+    await client.pushMessage('U1', [{ type: 'text', text: 'hello' }], '123e4567-e89b-12d3-a456-426614174000');
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)['X-Line-Retry-Key'])
+      .toBe('123e4567-e89b-12d3-a456-426614174000');
+    expect(JSON.parse(init.body as string)).toEqual({
+      to: 'U1',
+      messages: [{ type: 'text', text: 'hello' }],
+    });
+  });
+
+  test('treats retry-key 409 as an already-accepted success', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{"message":"conflict"}', {
+      status: 409,
+      headers: { 'Content-Type': 'application/json' },
+    })));
+
+    const client = new LineClient('token');
+    await expect(client.pushMessage(
+      'U1',
+      [{ type: 'text', text: 'hello' }],
+      '123e4567-e89b-12d3-a456-426614174000',
+    )).resolves.toEqual({ retryAccepted: true });
+  });
+});

--- a/apps/worker/src/services/render-message.test.ts
+++ b/apps/worker/src/services/render-message.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest';
-import { renderMessageContent } from './render-message.js';
+import {
+  assertNoUnresolvedBroadcastVariables,
+  getUnsupportedBroadcastVariables,
+  hasRecipientVariables,
+  renderBroadcastMessageContent,
+  renderMessageContent,
+} from './render-message.js';
 
 describe('renderMessageContent', () => {
   test('replaces {{liff_id}} with given liffId', () => {
@@ -29,5 +35,46 @@ describe('renderMessageContent', () => {
     expect(renderMessageContent(tpl, 'LIFF-9999')).toBe(
       'イベント詳細→ https://liff.line.me/LIFF-9999/?page=event&id=evt-1',
     );
+  });
+
+  test('replaces recipient display name when supplied', () => {
+    expect(renderMessageContent('{{name}}さん、こんにちは', { displayName: 'Michi' }))
+      .toBe('Michiさん、こんにちは');
+    expect(renderMessageContent('{{ name }}さん', { displayName: 'Michi' }))
+      .toBe('Michiさん');
+  });
+
+  test('keeps {{name}} unresolved when display name is unavailable', () => {
+    expect(renderMessageContent('{{name}}さん', { displayName: null })).toBe('{{name}}さん');
+  });
+
+  test('safely escapes quotes, backslashes, and newlines in Flex JSON names', () => {
+    const template = JSON.stringify({
+      type: 'bubble',
+      body: { type: 'box', contents: [{ type: 'text', text: '{{name}}さん' }] },
+    });
+    const rendered = renderBroadcastMessageContent('flex', template, {
+      displayName: 'A "quoted" \\ name\nnext',
+    });
+
+    expect(JSON.parse(rendered)).toMatchObject({
+      body: { contents: [{ text: 'A "quoted" \\ name\nnextさん' }] },
+    });
+  });
+
+  test('does not JSON-normalize ordinary text messages', () => {
+    expect(renderBroadcastMessageContent('text', '  {{name}}  ', { displayName: 'Michi' }))
+      .toBe('  Michi  ');
+  });
+
+  test('detects recipient and unsupported variables', () => {
+    expect(hasRecipientVariables('{{name}} {{liff_id}}')).toBe(true);
+    expect(getUnsupportedBroadcastVariables('{{name}} {{coupon}}')).toEqual(['coupon']);
+  });
+
+  test('fails closed when any variable remains unresolved', () => {
+    expect(() => assertNoUnresolvedBroadcastVariables('hello {{name}}'))
+      .toThrow('Unresolved broadcast variables: {{name}}');
+    expect(() => assertNoUnresolvedBroadcastVariables('hello Michi')).not.toThrow();
   });
 });

--- a/apps/worker/src/services/render-message.ts
+++ b/apps/worker/src/services/render-message.ts
@@ -1,11 +1,74 @@
-// broadcast 配信時に message_content 内のテンプレ変数を置換する純関数。
-// 配信先 LINE アカウントに対応した liff_id を埋め込むのが目的:
-// 1 broadcast から複数アカへ multi-account-dedup で配信する際、メッセージ
-// 内の URL を各友だちの所属アカに合わせて差し替える。
-//
-// 将来テンプレ変数 (display_name, user_id, ...) を追加する場合はこの
-// 関数を拡張する。
-export function renderMessageContent(content: string, liffId: string | null): string {
-  if (!liffId) return content;
-  return content.replaceAll('{{liff_id}}', liffId);
+// Broadcast template variables are expanded by LINE Harness before calling
+// the Messaging API. LINE's official textV2.substitution supports mentions
+// and LINE emoji only; it does not provide arbitrary recipient-name strings.
+export const SUPPORTED_BROADCAST_VARIABLES = new Set(['name', 'liff_id']);
+
+const BROADCAST_VARIABLE_RE = /\{\{\s*([^{}]+?)\s*\}\}/g;
+
+export function getBroadcastVariables(content: string): string[] {
+  return [...new Set([...content.matchAll(BROADCAST_VARIABLE_RE)].map((m) => m[1].trim()))];
+}
+
+export function getUnsupportedBroadcastVariables(content: string): string[] {
+  return getBroadcastVariables(content).filter((name) => !SUPPORTED_BROADCAST_VARIABLES.has(name));
+}
+
+export function hasRecipientVariables(content: string): boolean {
+  return getBroadcastVariables(content).includes('name');
+}
+
+export interface BroadcastRenderContext {
+  liffId?: string | null;
+  displayName?: string | null;
+}
+
+export function renderMessageContent(
+  content: string,
+  liffIdOrContext: string | null | BroadcastRenderContext,
+): string {
+  const context: BroadcastRenderContext = typeof liffIdOrContext === 'object'
+    ? liffIdOrContext ?? {}
+    : { liffId: liffIdOrContext };
+
+  let result = content;
+  if (context.liffId) result = result.replace(/\{\{\s*liff_id\s*\}\}/g, context.liffId);
+  if (context.displayName) result = result.replace(/\{\{\s*name\s*\}\}/g, context.displayName);
+  return result;
+}
+
+function renderJsonValue(value: unknown, context: BroadcastRenderContext): unknown {
+  if (typeof value === 'string') return renderMessageContent(value, context);
+  if (Array.isArray(value)) return value.map((item) => renderJsonValue(item, context));
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        renderMessageContent(key, context),
+        renderJsonValue(item, context),
+      ]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Flex content is JSON. Replacing raw bytes would break the JSON when a LINE
+ * display name contains a quote, backslash, or newline, so render parsed string
+ * values and serialize them again. Text content remains unchanged except for
+ * the requested variables.
+ */
+export function renderBroadcastMessageContent(
+  messageType: string,
+  content: string,
+  context: BroadcastRenderContext,
+): string {
+  if (messageType !== 'flex') return renderMessageContent(content, context);
+  const parsed = JSON.parse(content) as unknown;
+  return JSON.stringify(renderJsonValue(parsed, context));
+}
+
+export function assertNoUnresolvedBroadcastVariables(content: string): void {
+  const unresolved = getBroadcastVariables(content);
+  if (unresolved.length > 0) {
+    throw new Error(`Unresolved broadcast variables: ${unresolved.map((v) => `{{${v}}}`).join(', ')}`);
+  }
 }

--- a/apps/worker/src/services/segment-query.ts
+++ b/apps/worker/src/services/segment-query.ts
@@ -93,7 +93,7 @@ export function buildSegmentQuery(condition: SegmentCondition): { sql: string; b
 
   const separator = condition.operator === 'AND' ? ' AND ' : ' OR '
   const where = clauses.length > 0 ? clauses.join(separator) : '1=1'
-  const sql = `SELECT f.id, f.line_user_id FROM friends f WHERE ${where}`
+  const sql = `SELECT f.id, f.line_user_id, f.display_name FROM friends f WHERE ${where} ORDER BY f.created_at ASC, f.id ASC`
 
   return { sql, bindings }
 }

--- a/packages/db/src/broadcasts.ts
+++ b/packages/db/src/broadcasts.ts
@@ -22,6 +22,8 @@ export interface Broadcast {
   dedup_progress: string | null;
   batch_lock_at: string | null;
   track_links: number;
+  line_account_id?: string | null;
+  alt_text?: string | null;
 }
 
 export async function getBroadcasts(db: D1Database, accountId?: string): Promise<Broadcast[]> {
@@ -76,6 +78,7 @@ WHERE b.id = ?`,
 }
 
 export interface CreateBroadcastInput {
+  id?: string;
   title: string;
   messageType: BroadcastMessageType;
   messageContent: string;
@@ -85,13 +88,15 @@ export interface CreateBroadcastInput {
   accountIds?: string[];
   dedupPriority?: string[];
   trackLinks?: boolean;
+  lineAccountId?: string | null;
+  altText?: string | null;
 }
 
 export async function createBroadcast(
   db: D1Database,
   input: CreateBroadcastInput,
 ): Promise<Broadcast> {
-  const id = crypto.randomUUID();
+  const id = input.id ?? crypto.randomUUID();
   const now = jstNow();
 
   const initialStatus: BroadcastStatus = input.scheduledAt ? 'scheduled' : 'draft';
@@ -99,8 +104,8 @@ export async function createBroadcast(
   await db
     .prepare(
       `INSERT INTO broadcasts
-         (id, title, message_type, message_content, target_type, target_tag_id, status, scheduled_at, sent_at, total_count, success_count, account_ids, dedup_priority, track_links, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, 0, 0, ?, ?, ?, ?)`,
+         (id, title, message_type, message_content, target_type, target_tag_id, status, scheduled_at, sent_at, total_count, success_count, account_ids, dedup_priority, track_links, line_account_id, alt_text, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, 0, 0, ?, ?, ?, ?, ?, ?)`,
     )
     .bind(
       id,
@@ -114,6 +119,8 @@ export async function createBroadcast(
       input.accountIds ? JSON.stringify(input.accountIds) : null,
       input.dedupPriority ? JSON.stringify(input.dedupPriority) : null,
       input.trackLinks === false ? 0 : 1,
+      input.lineAccountId ?? null,
+      input.altText ?? null,
       now,
     )
     .run();
@@ -408,6 +415,24 @@ export async function recoverStalledBroadcasts(db: D1Database): Promise<void> {
        AND sent_at IS NULL
        AND target_type = 'multi-account-dedup'
        AND success_count > 0 AND dedup_progress IS NOT NULL
+       AND batch_lock_at IS NOT NULL
+       AND julianday('now', '+9 hours') - julianday(batch_lock_at) > ${STALL_LOCK_REVOKE_DAYS_RESUMABLE}`,
+    )
+    .run();
+
+  // 3) Personalized standard broadcasts are also safely resumable. They use
+  // one stable LINE retry key per broadcast+friend+rendered content and check
+  // messages_log before each push. Restarting from offset 0 is intentional:
+  // logged recipients are skipped, while a push accepted just before a crash
+  // is acknowledged by LINE as retry-key 409 and then logged once.
+  await db
+    .prepare(
+      `UPDATE broadcasts SET batch_offset = 0, batch_lock_at = NULL
+       WHERE status = 'sending' AND batch_offset = -1
+       AND sent_at IS NULL
+       AND target_type != 'multi-account-dedup'
+       AND segment_conditions IS NOT NULL
+       AND instr(replace(message_content, ' ', ''), '{{name}}') > 0
        AND batch_lock_at IS NOT NULL
        AND julianday('now', '+9 hours') - julianday(batch_lock_at) > ${STALL_LOCK_REVOKE_DAYS_RESUMABLE}`,
     )

--- a/packages/db/test/broadcasts.test.ts
+++ b/packages/db/test/broadcasts.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createBroadcast } from '../src/broadcasts.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function asD1(sqlite: Database.Database): D1Database {
+  return {
+    prepare(query: string) {
+      const stmt = sqlite.prepare(query);
+      return {
+        bind(...params: unknown[]) {
+          return {
+            async run() {
+              const info = stmt.run(...params);
+              return { results: [], success: true, meta: { changes: info.changes } };
+            },
+            async first<T>() {
+              return (stmt.get(...params) as T) ?? null;
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+describe('createBroadcast', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:');
+    sqlite.exec(readFileSync(join(__dirname, '../schema.sql'), 'utf8'));
+    // schema.sql is the historical base schema; these production migrations
+    // add the columns createBroadcast writes atomically today.
+    sqlite.exec('ALTER TABLE broadcasts ADD COLUMN line_account_id TEXT');
+    sqlite.exec('ALTER TABLE broadcasts ADD COLUMN alt_text TEXT');
+    db = asD1(sqlite);
+  });
+
+  test('persists a caller-supplied stable id and account fields atomically', async () => {
+    const id = '11111111-2222-4333-8444-555555555555';
+    const result = await createBroadcast(db, {
+      id,
+      title: 'Personalized notice',
+      messageType: 'text',
+      messageContent: '{{name}}さんへ',
+      targetType: 'all',
+      scheduledAt: '2026-08-12T09:00:00.000+09:00',
+      lineAccountId: 'account-1',
+      altText: '通知',
+    });
+
+    expect(result.id).toBe(id);
+    expect(result.status).toBe('scheduled');
+    expect(result.line_account_id).toBe('account-1');
+    expect(result.alt_text).toBe('通知');
+  });
+
+  test('the same stable id cannot create a second row', async () => {
+    const input = {
+      id: '11111111-2222-4333-8444-555555555555',
+      title: 'Notice',
+      messageType: 'text' as const,
+      messageContent: 'hello',
+      targetType: 'all' as const,
+    };
+
+    await createBroadcast(db, input);
+    await expect(createBroadcast(db, input)).rejects.toThrow(/UNIQUE constraint failed/);
+    expect(sqlite.prepare('SELECT COUNT(*) AS count FROM broadcasts').get()).toEqual({ count: 1 });
+  });
+});

--- a/packages/line-sdk/src/client.ts
+++ b/packages/line-sdk/src/client.ts
@@ -32,6 +32,7 @@ export class LineClient {
     method: string,
     path: string,
     body?: unknown,
+    requestHeaders: Record<string, string> = {},
   ): Promise<{ data: unknown; headers: Headers }> {
     const url = `${LINE_API_BASE}${path}`;
 
@@ -40,6 +41,7 @@ export class LineClient {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${this.channelAccessToken}`,
+        ...requestHeaders,
       },
     };
 
@@ -48,6 +50,13 @@ export class LineClient {
     }
 
     const res = await fetch(url, options);
+
+    // LINE returns 409 when a request with the same X-Line-Retry-Key was
+    // already accepted. For a caller retrying the exact same operation this
+    // is a successful idempotent outcome, not a delivery failure.
+    if (res.status === 409 && requestHeaders['X-Line-Retry-Key']) {
+      return { data: { retryAccepted: true }, headers: res.headers };
+    }
 
     if (!res.ok) {
       const text = await res.text().catch(() => '');
@@ -80,9 +89,19 @@ export class LineClient {
 
   // ─── Messaging ───────────────────────────────────────────────────────────
 
-  async pushMessage(to: string, messages: Message[]): Promise<unknown> {
-    const body: PushMessageRequest = { to, messages };
-    const { data } = await this.request('POST', '/v2/bot/message/push', body);
+  async pushMessage(
+    to: string,
+    messages: Message[],
+    retryKey?: string,
+    customAggregationUnits?: string[],
+  ): Promise<unknown> {
+    const body: PushMessageRequest = { to, messages, customAggregationUnits };
+    const { data } = await this.request(
+      'POST',
+      '/v2/bot/message/push',
+      body,
+      retryKey ? { 'X-Line-Retry-Key': retryKey } : {},
+    );
     return data;
   }
 
@@ -90,6 +109,7 @@ export class LineClient {
     to: string[],
     messages: Message[],
     customAggregationUnits?: string[],
+    retryKey?: string,
   ): Promise<{ data: unknown; requestId: string | null }> {
     const body: Record<string, unknown> = { to, messages };
     if (customAggregationUnits) {
@@ -99,18 +119,21 @@ export class LineClient {
       'POST',
       '/v2/bot/message/multicast',
       body,
+      retryKey ? { 'X-Line-Retry-Key': retryKey } : {},
     );
     return { data, requestId: headers.get('x-line-request-id') };
   }
 
   async broadcast(
     messages: Message[],
+    retryKey?: string,
   ): Promise<{ data: unknown; requestId: string | null }> {
     const body: BroadcastRequest = { messages };
     const { data, headers } = await this.request(
       'POST',
       '/v2/bot/message/broadcast',
       body,
+      retryKey ? { 'X-Line-Retry-Key': retryKey } : {},
     );
     return { data, requestId: headers.get('x-line-request-id') };
   }

--- a/packages/line-sdk/src/types.ts
+++ b/packages/line-sdk/src/types.ts
@@ -271,6 +271,7 @@ export interface RichMenuObject {
 export interface PushMessageRequest {
   to: string;
   messages: Message[];
+  customAggregationUnits?: string[];
 }
 
 export interface MulticastRequest {

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -21,8 +21,8 @@ export class HttpClient {
     return this.request<T>('GET', path)
   }
 
-  async post<T = unknown>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>('POST', path, body)
+  async post<T = unknown>(path: string, body?: unknown, headers?: Record<string, string>): Promise<T> {
+    return this.request<T>('POST', path, body, headers)
   }
 
   async put<T = unknown>(path: string, body?: unknown): Promise<T> {
@@ -37,11 +37,12 @@ export class HttpClient {
     return this.request<T>('DELETE', path)
   }
 
-  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async request<T>(method: string, path: string, body?: unknown, extraHeaders?: Record<string, string>): Promise<T> {
     const url = `${this.baseUrl}${path}`
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
       'Content-Type': 'application/json',
+      ...extraHeaders,
     }
 
     const options: RequestInit = {

--- a/packages/sdk/src/resources/broadcasts.ts
+++ b/packages/sdk/src/resources/broadcasts.ts
@@ -19,12 +19,18 @@ export class BroadcastsResource {
     return res.data
   }
 
-  async create(input: CreateBroadcastInput & { lineAccountId?: string }): Promise<Broadcast> {
-    const body = { ...input }
+  async create(input: CreateBroadcastInput & { lineAccountId?: string; idempotencyKey?: string }): Promise<Broadcast> {
+    const { idempotencyKey, ...body } = input
     if (!body.lineAccountId && this.defaultAccountId) {
       body.lineAccountId = this.defaultAccountId
     }
-    const res = await this.http.post<ApiResponse<Broadcast>>('/api/broadcasts', body)
+    const res = idempotencyKey
+      ? await this.http.post<ApiResponse<Broadcast>>(
+          '/api/broadcasts',
+          body,
+          { 'Idempotency-Key': idempotencyKey },
+        )
+      : await this.http.post<ApiResponse<Broadcast>>('/api/broadcasts', body)
     return res.data
   }
 

--- a/packages/sdk/tests/http.test.ts
+++ b/packages/sdk/tests/http.test.ts
@@ -54,6 +54,30 @@ describe('HttpClient', () => {
     vi.unstubAllGlobals()
   })
 
+  it('merges caller-supplied POST headers with authentication headers', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, data: { id: '1' } }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await http.post('/api/broadcasts', { title: 'Notice' }, {
+      'Idempotency-Key': '11111111-2222-4333-8444-555555555555',
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example.com/api/broadcasts',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-key',
+          'Content-Type': 'application/json',
+          'Idempotency-Key': '11111111-2222-4333-8444-555555555555',
+        }),
+      }),
+    )
+    vi.unstubAllGlobals()
+  })
+
   it('throws LineHarnessError on 4xx/5xx', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/sdk/tests/resources/broadcasts.test.ts
+++ b/packages/sdk/tests/resources/broadcasts.test.ts
@@ -87,6 +87,33 @@ describe('BroadcastsResource', () => {
     expect(result).toEqual(broadcast)
   })
 
+  it('create(input) sends idempotency key as a header, not in the JSON body', async () => {
+    const http = mockHttp({ post: vi.fn().mockResolvedValue({
+      success: true,
+      data: { id: 'bc-stable' },
+    }) })
+    const resource = new BroadcastsResource(http)
+
+    await resource.create({
+      title: 'Personalized notice',
+      messageType: 'text',
+      messageContent: '{{name}}さんへ',
+      targetType: 'all',
+      idempotencyKey: '11111111-2222-4333-8444-555555555555',
+    })
+
+    expect(http.post).toHaveBeenCalledWith(
+      '/api/broadcasts',
+      {
+        title: 'Personalized notice',
+        messageType: 'text',
+        messageContent: '{{name}}さんへ',
+        targetType: 'all',
+      },
+      { 'Idempotency-Key': '11111111-2222-4333-8444-555555555555' },
+    )
+  })
+
   it('update(id, input) calls PUT /api/broadcasts/:id with input', async () => {
     const updatedBroadcast = {
       id: 'bc-1',

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,7 +1,9 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    environment: 'node',
+    globals: false,
     include: ['tests/**/*.test.ts'],
   },
-});
+})


### PR DESCRIPTION
## Summary
- sync the production-safe `{{name}}` broadcast rendering path
- add idempotent creation and retry keys to prevent duplicate delivery
- preserve Flex JSON structure while rendering recipient variables
- add worker, DB, and SDK regression coverage

## Verification
- known private-value scan: clean
- extended secret scan: clean
- worker/db/sdk typechecks: pass
- full workspace tests: 1,314 passed
- Worker, LIFF, Web, and package builds: pass

Source of truth: private production commit `97e941440d8de54d6cc0f641bd8243b9441b16c3`.