### PR TITLE
seo: 公式ガイドへの導線を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>LINE Harness — L社やU社の上位互換を、なぜ0円で公開するのか</title>
 <meta name="description" content="LINE公式アカウント運用の全機能を完全無料で。ステップ配信・セグメント・リッチメニュー・決済・自動化をオープンソースで提供。">
+<link rel="canonical" href="https://the-harness.com/line-harness/">
 
 <!-- OGP / Open Graph -->
 <meta property="og:title" content="LINE Harness — L社やU社の上位互換を、なぜ0円で公開するのか">
@@ -817,6 +818,7 @@
         全機能を使う（0円）
       </a>
       <span class="cta-sub">オープンソース・すべて無料</span>
+      <a href="https://the-harness.com/line-harness/" style="display:inline-block;margin-top:14px;color:var(--text-muted);font-size:14px;text-underline-offset:4px;">機能・料金・使い方を見る — LINE Harness公式ガイド</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## 概要

既存のGitHub Pagesランディングから、The HarnessドメインのLINE Harness公式ガイドへ一次情報の導線を追加します。

## 変更

- canonicalを `https://the-harness.com/line-harness/` に設定
- ファーストビューCTA下に機能・料金・使い方の公式ガイドリンクを追加

## 確認

- `git diff --check`
- リンク先はHTTP 200確認済み
