### PR TITLE
fix(liff): upsert friend in /api/liff/link to survive the follow-webhook race

### DIFF
--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -1185,11 +1185,25 @@ liffRoutes.post('/api/liff/link', async (c) => {
     const matchedAccount = matchedLoginChannelId
       ? dbAccounts.find((a) => a.login_channel_id === matchedLoginChannelId) ?? null
       : null;
-    const friend = await getFriendByLineUserIdForAccount(
+    let friend = await getFriendByLineUserIdForAccount(
       db, lineUserId, matchedAccount?.id ?? null,
     );
     if (!friend) {
-      return c.json({ success: false, error: 'Friend not found' }, 404);
+      // Follow-webhook race: on a first-ever friend add, LINE-side friendship
+      // already exists when the LIFF loads, but the follow event may not have
+      // reached this Worker yet (measured 6s behind in production). Returning
+      // 404 here silently dropped the ref attribution — the entry-route tag /
+      // scenario push for that visit never fired, and the follow handler's
+      // ~1s ref_code retry window had nothing to read because this endpoint
+      // is the one that writes it. Create the row ourselves — exactly what
+      // /auth/callback already does via upsertFriend — and let the follow
+      // webhook wire line_account_id when it arrives.
+      friend = await upsertFriend(db, {
+        lineUserId,
+        displayName: body.displayName ?? verified.name ?? 'Unknown',
+        pictureUrl: null,
+        statusMessage: null,
+      });
     }
 
     let linkedUserId = (friend as unknown as Record<string, unknown>).user_id as string | null;


### PR DESCRIPTION
## 問題 / Problem

初回の友だち追加（卓上QR → LIFF → `bot_prompt=aggressive`）で、`/api/liff/link` が follow webhook より先に Worker に到達すると `404 Friend not found` で終了し、**ref のアトリビューション（entry_route のタグ付与・シナリオ push）が無言で失われます**。follow ハンドラ側の `ref_code` リトライ（約1秒）も、`ref_code` を書くのがこのエンドポイント自身のため空振りします。

実運用（v0.20.0 / 飲食店の卓上QR）での実測ログ:

```
11:50:12  POST /api/liff/link     -> 404 (friend 行がまだ無い)
11:50:18  POST /webhook [follow]  -> 行が作られるが ref_code は NULL
結果: 初回スキャンは友だち追加のみで配信されず、2回目のスキャンで届く
```

エンドユーザーからの報告も「1度目は友達追加して終わり、2度目の読み取りでメッセージが届いた」でした。

## 修正 / Fix

friend 行が見つからない場合に `upsertFriend` でフォールバック作成します。**`/auth/callback` が同じレースに対して既に行っている処理と同一**で、LIFF が開けている時点で LINE 側の友だち関係は成立しているため、直後の push は正常に配信されます。`line_account_id` は従来どおり後着の follow webhook が配線します。

- 変更は `/api/liff/link` の1箇所のみ（+16/-2）
- `upsertFriend` は既に import 済み
- 既存テスト `liff-offer-attribution.test.ts`（already-linked 分岐）: **5/5 passed**

## 検証 / Verification

本番インストール（Cloudflare Workers / D1, v0.20.0 ベース）にこのパッチを当ててデプロイし、新規ユーザーの初回スキャンで entry_route のタグ付与・シナリオ push・ref_tracking 記録がすべて1回目で成立することを確認済みです（複数ユーザー・複数 entry_route で確認）。

## 備考 / Notes

- OAuth 経路（`/auth/callback`）と LIFF 経路の非対称の解消であり、新しい挙動の追加ではありません
- 友だち追加をチェックオフしてログインだけしたユーザーの場合、作成された行への push が失敗し既存の pause 機構に乗りますが、これは OAuth 経路の既存挙動と同一です

🤖 Generated with [Claude Code](https://claude.com/claude-code)