### PR TITLE
sync: release v0.21.1 webinar analytics fixes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/web/src/app/webinars/edit/page.tsx
+++ b/apps/web/src/app/webinars/edit/page.tsx
@@ -516,7 +516,12 @@ function AnalyticsTab({ webinarId, durationSeconds }: { webinarId: string; durat
                 <tbody className="divide-y divide-slate-100">
                   {recentParticipants.map((p) => {
                     const name = p.friendName ?? `友だち ${p.friendId.slice(0, 6)}`
-                    const watchedRate = Math.min(100, Math.round((p.maxWatchedSeconds / Math.max(1, durationSeconds)) * 100))
+                    const watchedSeconds = typeof p.latestWatchedSeconds === 'number'
+                      ? p.latestWatchedSeconds
+                      : typeof p.maxWatchedSeconds === 'number'
+                        ? p.maxWatchedSeconds
+                        : 0
+                    const watchedRate = Math.min(100, Math.round((watchedSeconds / Math.max(1, durationSeconds)) * 100))
                     return (
                       <tr key={p.friendId} className="hover:bg-blue-50/30">
                         <td className="px-5 py-3.5">
@@ -531,7 +536,7 @@ function AnalyticsTab({ webinarId, durationSeconds }: { webinarId: string; durat
                         <td className="px-4 py-3.5 text-xs text-slate-600">{compactDateTime(p.latestJoinedAt)}</td>
                         <td className="w-48 px-4 py-3.5">
                           <div className="flex items-center justify-between text-[11px] text-slate-500">
-                            <span>{fmtSec(p.maxWatchedSeconds)}</span><span>{watchedRate}%</span>
+                            <span>{fmtSec(watchedSeconds)}</span><span>{watchedRate}%</span>
                           </div>
                           <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-slate-100">
                             <div className="h-full rounded-full bg-blue-500" style={{ width: `${watchedRate}%` }} />
@@ -560,12 +565,17 @@ function AnalyticsTab({ webinarId, durationSeconds }: { webinarId: string; durat
             <div className="divide-y divide-slate-100 md:hidden">
               {recentParticipants.map((p) => {
                 const name = p.friendName ?? `友だち ${p.friendId.slice(0, 6)}`
+                const watchedSeconds = typeof p.latestWatchedSeconds === 'number'
+                  ? p.latestWatchedSeconds
+                  : typeof p.maxWatchedSeconds === 'number'
+                    ? p.maxWatchedSeconds
+                    : 0
                 return (
                   <Link key={p.friendId} href={`/chats?friend=${p.friendId}`} className="flex items-center gap-3 p-4 active:bg-slate-50">
                     <ParticipantAvatar name={name} pictureUrl={p.pictureUrl} size="lg" />
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-sm font-semibold text-slate-900">{name}</div>
-                      <div className="mt-1 text-[11px] text-slate-500">{compactDateTime(p.latestJoinedAt)} · {fmtSec(p.maxWatchedSeconds)}視聴</div>
+                      <div className="mt-1 text-[11px] text-slate-500">{compactDateTime(p.latestJoinedAt)} · {fmtSec(watchedSeconds)}視聴</div>
                     </div>
                     <span className={`h-2.5 w-2.5 rounded-full ${p.formSubmittedAt ? 'bg-emerald-500' : p.ctaClickedAt ? 'bg-violet-500' : 'bg-slate-300'}`} />
                   </Link>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2093,7 +2093,9 @@ export type WebinarAnalytics = {
     sessions: number
     firstJoinedAt: string
     latestJoinedAt: string
-    maxWatchedSeconds: number
+    latestWatchedSeconds?: number
+    /** 旧Worker/旧管理画面とのローリングデプロイ互換。 */
+    maxWatchedSeconds?: number
     ctaClickedAt: string | null
     registered: boolean
     formSubmittedAt: string | null

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/worker/src/client/form.ts
+++ b/apps/worker/src/client/form.ts
@@ -21,7 +21,7 @@ declare const liff: {
 };
 
 const UUID_STORAGE_KEY = 'lh_uuid';
-const FORM_VERSION = '2.0.0'; // cache buster
+const FORM_VERSION = '2.1.0'; // cache buster
 
 interface FormField {
   name: string;
@@ -45,6 +45,38 @@ interface FormDef {
   webhookGateId: string | null;
   onSubmitMessageContent?: string | null;
   onSubmitWebhookFailMessage?: string | null;
+  consultationWebinarSlug?: string | null;
+}
+
+interface ConsultationSlot {
+  date: string;
+  start: string;
+  end: string;
+  startsAt: string;
+}
+
+interface ConsultationAvailability {
+  calendarReady: boolean;
+  fallbackUrl: string | null;
+  menu: { id: string; name: string; durationMinutes: number };
+  staff: { id: string; name: string };
+  slots: ConsultationSlot[];
+  existingBooking: {
+    bookingId: string;
+    status: string;
+    startsAt: string;
+    meetUrl: string | null;
+  } | null;
+}
+
+interface BookedConsultation {
+  bookingId: string;
+  status: 'confirmed';
+  startsAt: string;
+  endsAt: string;
+  meetUrl: string;
+  externalEventId: string;
+  created: boolean;
 }
 
 interface XFollowerSuggestion {
@@ -371,6 +403,30 @@ function injectStyles(): void {
     .form-success .check { width: 64px; height: 64px; border-radius: 50%; background: #06C755; color: #fff; font-size: 32px; line-height: 64px; margin: 0 auto 16px; }
     .form-success h2 { font-size: 20px; color: #06C755; margin-bottom: 12px; }
     .form-success p { font-size: 14px; color: #666; line-height: 1.6; }
+    .consultation-card { background:#fff; border-radius:16px; padding:20px; box-shadow:0 1px 4px rgba(0,0,0,.1); }
+    .consultation-head { text-align:center; margin-bottom:20px; }
+    .consultation-head .calendar-icon { font-size:32px; line-height:1; }
+    .consultation-head h2 { margin:8px 0 6px; font-size:21px; color:#1f2937; }
+    .consultation-head p { margin:0; font-size:13px; line-height:1.6; color:#6b7280; }
+    .consultation-date { margin-top:18px; }
+    .consultation-date h3 { margin:0 0 8px; font-size:14px; color:#374151; }
+    .consultation-grid { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; }
+    .slot-btn { border:1.5px solid #06C755; border-radius:9px; padding:11px 4px; background:#fff; color:#049f45; font-size:14px; font-weight:700; cursor:pointer; }
+    .slot-btn:active { background:#ecfdf3; }
+    .slot-btn:disabled { opacity:.45; cursor:not-allowed; }
+    .consultation-status { margin:14px 0 0; text-align:center; font-size:13px; color:#dc2626; font-weight:600; }
+    .consultation-loading { text-align:center; padding:44px 20px; }
+    .consultation-loading h2 { margin:14px 0 6px; font-size:20px; color:#1f2937; }
+    .consultation-loading p { margin:0; color:#6b7280; font-size:14px; }
+    .consultation-spinner { width:30px; height:30px; margin:0 auto; border:3px solid #d1fae5; border-top-color:#06C755; border-radius:50%; animation:x-spin .8s linear infinite; }
+    .consultation-empty { margin:16px 0 0; padding:18px; border-radius:12px; background:#f9fafb; text-align:center; color:#6b7280; font-size:14px; }
+    .consultation-primary { display:block; width:100%; box-sizing:border-box; margin-top:16px; padding:13px 16px; border:0; border-radius:999px; background:#06C755; color:#fff; text-align:center; text-decoration:none; font-size:15px; font-weight:700; cursor:pointer; }
+    .consultation-secondary { display:block; margin:14px auto 0; border:0; background:transparent; color:#6b7280; font-size:13px; text-decoration:underline; cursor:pointer; }
+    .consultation-confirmed { text-align:center; }
+    .consultation-confirmed .check { font-size:38px; }
+    .consultation-confirmed h2 { margin:8px 0; color:#1f2937; font-size:21px; }
+    .consultation-confirmed .time { margin:14px 0; padding:13px; border-radius:12px; background:#ecfdf3; color:#166534; font-size:17px; font-weight:700; }
+    .consultation-confirmed .note { color:#6b7280; font-size:12px; line-height:1.6; }
   `;
   document.head.appendChild(style);
 }
@@ -623,6 +679,221 @@ function renderSuccess(): void {
   }
 }
 
+function consultationDateTime(startsAt: string): string {
+  return new Date(startsAt).toLocaleString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function consultationDateLabel(date: string): string {
+  return new Date(`${date}T00:00:00+09:00`).toLocaleDateString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    month: 'numeric',
+    day: 'numeric',
+    weekday: 'short',
+  });
+}
+
+function safeHttpsUrl(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function closeFormWindow(): void {
+  if (liff.isInClient()) {
+    liff.closeWindow();
+  } else {
+    window.close();
+  }
+}
+
+function renderConsultationConfirmed(booking: BookedConsultation): void {
+  const app = getApp();
+  const meetUrl = safeHttpsUrl(booking.meetUrl);
+  app.innerHTML = `
+    <div class="form-page">
+      <div class="consultation-card consultation-confirmed">
+        <div class="check">✅</div>
+        <h2>個別相談が確定しました</h2>
+        <div class="time">${escapeHtml(consultationDateTime(booking.startsAt))}</div>
+        ${meetUrl ? `<a class="consultation-primary" href="${escapeHtml(meetUrl)}" target="_blank" rel="noreferrer">Google Meetを確認する</a>` : ''}
+        <p class="note">LINEにも参加リンクを送りました。前日と開始1時間前にもお知らせします。</p>
+        <button class="consultation-secondary" id="closeConsultationBtn">閉じる</button>
+      </div>
+    </div>
+  `;
+  document.getElementById('closeConsultationBtn')?.addEventListener('click', closeFormWindow);
+  window.scrollTo(0, 0);
+}
+
+function renderConsultationFallback(
+  webinarSlug: string,
+  message: string,
+  fallbackUrl: string | null = null,
+): void {
+  const app = getApp();
+  const safeFallbackUrl = safeHttpsUrl(fallbackUrl);
+  app.innerHTML = `
+    <div class="form-page">
+      <div class="consultation-card">
+        <div class="consultation-head">
+          <div class="calendar-icon">📅</div>
+          <h2>回答を受け付けました</h2>
+          <p>${escapeHtml(message)}</p>
+        </div>
+        ${safeFallbackUrl ? `<a class="consultation-primary" href="${escapeHtml(safeFallbackUrl)}">予約カレンダーを開く</a>` : '<button class="consultation-primary" id="retryConsultationBtn">空き枠を再読み込み</button>'}
+        <button class="consultation-secondary" id="closeConsultationBtn">あとで予約する</button>
+      </div>
+    </div>
+  `;
+  document.getElementById('retryConsultationBtn')?.addEventListener('click', () => {
+    void renderConsultationBooking(webinarSlug);
+  });
+  document.getElementById('closeConsultationBtn')?.addEventListener('click', closeFormWindow);
+  window.scrollTo(0, 0);
+}
+
+function renderConsultationSlots(
+  webinarSlug: string,
+  availability: ConsultationAvailability,
+): void {
+  const existing = availability.existingBooking;
+  if (existing?.status === 'confirmed' && existing.meetUrl) {
+    renderConsultationConfirmed({
+      bookingId: existing.bookingId,
+      status: 'confirmed',
+      startsAt: existing.startsAt,
+      endsAt: '',
+      meetUrl: existing.meetUrl,
+      externalEventId: '',
+      created: false,
+    });
+    return;
+  }
+
+  if (!availability.calendarReady) {
+    renderConsultationFallback(
+      webinarSlug,
+      '空き枠を自動取得できませんでした。予約カレンダーから日時を選んでください。',
+      availability.fallbackUrl,
+    );
+    return;
+  }
+
+  const grouped = availability.slots.reduce<Record<string, ConsultationSlot[]>>((all, slot) => {
+    (all[slot.date] ??= []).push(slot);
+    return all;
+  }, {});
+  const slotHtml = Object.entries(grouped).map(([date, slots]) => `
+    <section class="consultation-date">
+      <h3>${escapeHtml(consultationDateLabel(date))}</h3>
+      <div class="consultation-grid">
+        ${slots.map((slot) => `<button class="slot-btn" data-starts-at="${escapeHtml(slot.startsAt)}">${escapeHtml(slot.start)}</button>`).join('')}
+      </div>
+    </section>
+  `).join('');
+
+  const app = getApp();
+  app.innerHTML = `
+    <div class="form-page">
+      <div class="consultation-card">
+        <div class="consultation-head">
+          <div class="calendar-icon">📅</div>
+          <h2>このまま相談日時を確定</h2>
+          <p>空いている15分枠だけを表示しています。<br>選ぶとGoogle Meetまで自動発行されます。</p>
+        </div>
+        ${slotHtml || '<div class="consultation-empty">現在、選べる枠がありません。</div>'}
+        <p class="consultation-status" id="consultationStatus" hidden></p>
+        <button class="consultation-secondary" id="closeConsultationBtn">あとで予約する</button>
+      </div>
+    </div>
+  `;
+
+  document.querySelectorAll<HTMLButtonElement>('.slot-btn').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const startsAt = button.dataset.startsAt;
+      if (!startsAt) return;
+      const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('.slot-btn'));
+      const status = document.getElementById('consultationStatus');
+      buttons.forEach((item) => { item.disabled = true; });
+      const original = button.textContent;
+      button.textContent = '確定中...';
+      if (status) status.hidden = true;
+      try {
+        const response = await apiCall(
+          `/api/liff/webinars/${encodeURIComponent(webinarSlug)}/consultation-book`,
+          { method: 'POST', body: JSON.stringify({ startsAt }) },
+        );
+        const json = await response.json() as {
+          ok?: boolean;
+          data?: BookedConsultation;
+          error?: string;
+        };
+        if (!response.ok || !json.ok || !json.data) {
+          if (response.status === 409) {
+            await renderConsultationBooking(webinarSlug);
+            return;
+          }
+          throw new Error(json.error || '日程を確定できませんでした');
+        }
+        renderConsultationConfirmed(json.data);
+      } catch {
+        buttons.forEach((item) => { item.disabled = false; });
+        button.textContent = original;
+        if (status) {
+          status.textContent = '日程を確定できませんでした。もう一度お試しください。';
+          status.hidden = false;
+        }
+      }
+    });
+  });
+  document.getElementById('closeConsultationBtn')?.addEventListener('click', closeFormWindow);
+  window.scrollTo(0, 0);
+}
+
+async function renderConsultationBooking(webinarSlug: string): Promise<void> {
+  const app = getApp();
+  app.innerHTML = `
+    <div class="form-page">
+      <div class="consultation-card consultation-loading">
+        <div class="consultation-spinner"></div>
+        <h2>回答を受け付けました</h2>
+        <p>実際の空き枠を確認しています...</p>
+      </div>
+    </div>
+  `;
+  window.scrollTo(0, 0);
+  try {
+    const response = await apiCall(
+      `/api/liff/webinars/${encodeURIComponent(webinarSlug)}/consultation-slots`,
+    );
+    const json = await response.json() as {
+      ok?: boolean;
+      data?: ConsultationAvailability;
+      error?: string;
+    };
+    if (!response.ok || !json.ok || !json.data) {
+      throw new Error(json.error || 'availability_failed');
+    }
+    renderConsultationSlots(webinarSlug, json.data);
+  } catch {
+    renderConsultationFallback(
+      webinarSlug,
+      '空き枠を読み込めませんでした。通信環境を確認して、もう一度お試しください。',
+    );
+  }
+}
+
 function renderFormError(message: string): void {
   const app = getApp();
   app.innerHTML = `
@@ -819,7 +1090,11 @@ async function submitForm(): Promise<void> {
       throw new Error(`${res.status}: ${errMsg}`);
     }
 
-    renderSuccess();
+    if (state.formDef.consultationWebinarSlug) {
+      await renderConsultationBooking(state.formDef.consultationWebinarSlug);
+    } else {
+      renderSuccess();
+    }
   } catch (err) {
     state.submitting = false;
     if (submitBtn) {

--- a/apps/worker/src/routes/forms.security.test.ts
+++ b/apps/worker/src/routes/forms.security.test.ts
@@ -68,7 +68,8 @@ const baseForm = {
 
 function env() {
   const run = vi.fn(async () => ({ success: true }));
-  const bind = vi.fn((..._args: unknown[]) => ({ run }));
+  const first = vi.fn(async () => null as { slug: string } | null);
+  const bind = vi.fn((..._args: unknown[]) => ({ run, first }));
   const prepare = vi.fn((_sql: string) => ({ bind }));
   return {
     bindings: {
@@ -79,6 +80,7 @@ function env() {
     } as Env['Bindings'],
     prepare,
     bind,
+    first,
   };
 }
 
@@ -131,6 +133,16 @@ describe('public form representation', () => {
     expect(body.data).not.toHaveProperty('onSubmitTagId');
     expect(body.data).not.toHaveProperty('onSubmitScenarioId');
     expect(JSON.stringify(body.data)).not.toContain('Bearer secret');
+  });
+
+  test('returns the active webinar consultation route for the LIFF form', async () => {
+    const { bindings, first } = env();
+    first.mockResolvedValue({ slug: 'ritz-voice-1-l1b' });
+    const res = await app().request('/api/forms/form-1', {}, bindings);
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { data: Record<string, unknown> };
+    expect(body.data.consultationWebinarSlug).toBe('ritz-voice-1-l1b');
   });
 
   test('keeps the full representation for an authenticated admin', async () => {

--- a/apps/worker/src/routes/forms.ts
+++ b/apps/worker/src/routes/forms.ts
@@ -102,7 +102,10 @@ function publicWebhookConfig(row: DbForm): {
   }
 }
 
-function serializePublicForm(row: DbForm) {
+function serializePublicForm(
+  row: DbForm,
+  consultationWebinarSlug: string | null = null,
+) {
   return {
     id: row.id,
     name: row.name,
@@ -111,8 +114,37 @@ function serializePublicForm(row: DbForm) {
     isActive: Boolean(row.is_active),
     onSubmitMessageContent: row.on_submit_message_content,
     onSubmitWebhookFailMessage: row.on_submit_webhook_fail_message,
+    // When this form belongs to an active webinar consultation funnel, the
+    // LIFF form can switch directly to the same slot picker used by the live
+    // CTA. The slug is public routing information; menu/staff IDs remain
+    // server-side authorities and are never accepted from the browser.
+    consultationWebinarSlug,
     ...publicWebhookConfig(row),
   };
+}
+
+async function consultationWebinarSlugForForm(
+  db: D1Database,
+  formId: string,
+): Promise<string | null> {
+  const row = await db
+    .prepare(
+      `SELECT w.slug
+         FROM webinar_ctas wc
+         INNER JOIN webinars w
+           ON w.id = wc.webinar_id AND w.status = 'active'
+         INNER JOIN webinar_followup_configs cfg
+           ON cfg.webinar_id = w.id
+          AND cfg.is_active = 1
+          AND cfg.booking_menu_id IS NOT NULL
+        WHERE wc.form_id = ?
+        ORDER BY datetime(COALESCE(cfg.stage_enabled_at, cfg.enabled_at)) DESC,
+                 datetime(w.updated_at) DESC
+        LIMIT 1`,
+    )
+    .bind(formId)
+    .first<{ slug: string }>();
+  return row?.slug ?? null;
 }
 
 function serializeSubmission(row: DbFormSubmission & { friend_name?: string | null }) {
@@ -153,7 +185,12 @@ forms.get('/api/forms/:id', async (c) => {
     if (!form) {
       return c.json({ success: false, error: 'Form not found' }, 404);
     }
-    const data = c.get('staff') ? serializeForm(form) : serializePublicForm(form);
+    const data = c.get('staff')
+      ? serializeForm(form)
+      : serializePublicForm(
+          form,
+          await consultationWebinarSlugForForm(c.env.DB, id),
+        );
     return c.json({ success: true, data });
   } catch (err) {
     console.error('GET /api/forms/:id error:', err);

--- a/apps/worker/src/routes/webinars.test.ts
+++ b/apps/worker/src/routes/webinars.test.ts
@@ -885,14 +885,14 @@ describe('admin CRUD', () => {
       {
         friend_id: 'friend-1', friend_name: '山田太郎', picture_url: 'https://example.com/u.jpg',
         sessions: 2, first_joined_at: '2026-08-05T10:00:00+09:00',
-        latest_joined_at: '2026-08-06T10:00:00+09:00', max_watched_seconds: 6500,
+        latest_joined_at: '2026-08-06T10:00:00+09:00', latest_watched_seconds: 6500,
         cta_clicked_at: '2026-08-06T11:00:00+09:00', registered: 1,
         form_submitted_at: '2026-08-06T11:01:00+09:00',
       },
       {
         friend_id: 'friend-2', friend_name: '佐藤花子', picture_url: null,
         sessions: 1, first_joined_at: '2026-08-06T10:00:00+09:00',
-        latest_joined_at: '2026-08-06T10:00:00+09:00', max_watched_seconds: 600,
+        latest_joined_at: '2026-08-06T10:00:00+09:00', latest_watched_seconds: 600,
         cta_clicked_at: null, registered: 0, form_submitted_at: null,
       },
     ]);
@@ -942,6 +942,7 @@ describe('admin CRUD', () => {
     expect(body.data.participants[0]).toMatchObject({
       friendId: 'friend-1', friendName: '山田太郎', registered: true,
       pictureUrl: 'https://example.com/u.jpg', formSubmittedAt: '2026-08-06T11:01:00+09:00',
+      latestWatchedSeconds: 6500, maxWatchedSeconds: 6500,
     });
     expect(body.data.formFunnel).toEqual({
       ctaImpressions: 10,

--- a/apps/worker/src/routes/webinars.ts
+++ b/apps/worker/src/routes/webinars.ts
@@ -1058,7 +1058,9 @@ webinarRoutes.get('/api/webinars/:id/analytics', async (c) => {
           sessions: p.sessions,
           firstJoinedAt: p.first_joined_at,
           latestJoinedAt: p.latest_joined_at,
-          maxWatchedSeconds: p.max_watched_seconds,
+          latestWatchedSeconds: p.latest_watched_seconds,
+          // デプロイ中に旧管理画面が残っていても NaN にしない互換フィールド。
+          maxWatchedSeconds: p.latest_watched_seconds,
           ctaClickedAt: p.cta_clicked_at,
           registered: Boolean(p.registered),
           formSubmittedAt: p.form_submitted_at,

--- a/docs/wiki/Release-Notes.md
+++ b/docs/wiki/Release-Notes.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## v0.21.1 (2026-08-14)
+
+### Fixed — Webinar analytics and registration delivery
+
+- The recent-participants table now keeps the all-time session count while showing watch progress, CTA activity, and form completion from the participant's latest session only.
+- Worker and Admin remain compatible during rolling updates, preventing `NaN:NaN` and `NaN%` when either side still uses the previous analytics field name.
+- Repeated taps or retried requests for the same webinar session no longer send duplicate LINE registration confirmations.
+- Added regression coverage for latest-session analytics and idempotent registration delivery.
+
+### Database
+
+- No migration required.
+
 ## v0.21.0 (2026-08-14)
 
 ### Added — Live CTA consultation booking

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "line-oss-crm",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "private": true,
   "description": "Open-source LINE Official Account CRM/marketing automation",
   "scripts": {

--- a/packages/db/src/webinars.ts
+++ b/packages/db/src/webinars.ts
@@ -61,7 +61,7 @@ export interface WebinarParticipantStat {
   sessions: number;
   first_joined_at: string;
   latest_joined_at: string;
-  max_watched_seconds: number;
+  latest_watched_seconds: number;
   cta_clicked_at: string | null;
   registered: number;
   form_submitted_at: string | null;
@@ -481,7 +481,11 @@ export async function getWebinarDropoff(
   return results ?? [];
 }
 
-/** 参加者を friend 単位にまとめる。再入場・複数セッションは1人として表示する。 */
+/**
+ * 参加者を friend 単位にまとめる。
+ * 参加回数は全セッション、視聴位置・CTA・フォームは最新セッションだけを返す。
+ * 過去回の完走やCTAを最新回の参加日時と混在させない。
+ */
 export async function getWebinarParticipantStats(
   db: D1Database,
   webinarId: string,
@@ -489,14 +493,29 @@ export async function getWebinarParticipantStats(
 ): Promise<WebinarParticipantStat[]> {
   const { results } = await db
     .prepare(
-      `SELECT v.friend_id,
+      `WITH ranked_viewers AS (
+         SELECT v.*,
+                COUNT(*) OVER (
+                  PARTITION BY v.webinar_id, v.friend_id
+                ) AS sessions,
+                MIN(v.joined_at) OVER (
+                  PARTITION BY v.webinar_id, v.friend_id
+                ) AS first_joined_at,
+                ROW_NUMBER() OVER (
+                  PARTITION BY v.webinar_id, v.friend_id
+                  ORDER BY datetime(v.joined_at) DESC, v.session_start_at DESC, v.id DESC
+                ) AS recency_rank
+         FROM webinar_viewers v
+         WHERE v.webinar_id = ?
+       )
+       SELECT v.friend_id,
               f.display_name AS friend_name,
               f.picture_url,
-              COUNT(*) AS sessions,
-              MIN(v.joined_at) AS first_joined_at,
-              MAX(v.joined_at) AS latest_joined_at,
-              MAX(v.last_position_seconds) AS max_watched_seconds,
-              MAX(v.cta_clicked_at) AS cta_clicked_at,
+              v.sessions,
+              v.first_joined_at,
+              v.joined_at AS latest_joined_at,
+              v.last_position_seconds AS latest_watched_seconds,
+              v.cta_clicked_at,
               CASE WHEN EXISTS (
                 SELECT 1 FROM webinar_registrations r
                 WHERE r.webinar_id = v.webinar_id AND r.friend_id = v.friend_id
@@ -508,13 +527,12 @@ export async function getWebinarParticipantStats(
                 JOIN webinars wf ON wf.id = wc.webinar_id
                 WHERE wc.webinar_id = v.webinar_id
                   AND fs.friend_id = v.friend_id
-                  AND fs.created_at >= wf.created_at
+                  AND datetime(fs.created_at) >= datetime(v.joined_at)
               ) AS form_submitted_at
-       FROM webinar_viewers v
+       FROM ranked_viewers v
        LEFT JOIN friends f ON f.id = v.friend_id
-       WHERE v.webinar_id = ?
-       GROUP BY v.webinar_id, v.friend_id, f.display_name, f.picture_url
-       ORDER BY latest_joined_at DESC
+       WHERE v.recency_rank = 1
+       ORDER BY datetime(v.joined_at) DESC
        LIMIT ?`,
     )
     .bind(webinarId, limit)

--- a/packages/db/test/webinar-participants.test.ts
+++ b/packages/db/test/webinar-participants.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { getWebinarParticipantStats } from '../src/webinars.js';
+
+function asD1(sqlite: Database.Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          const statement = sqlite.prepare(sql);
+          return {
+            async all<T>() {
+              return { success: true, results: statement.all(...params) as T[], meta: {} };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+describe('getWebinarParticipantStats', () => {
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:');
+    sqlite.exec(`
+      CREATE TABLE friends (
+        id TEXT PRIMARY KEY, display_name TEXT, picture_url TEXT
+      );
+      CREATE TABLE webinars (
+        id TEXT PRIMARY KEY, created_at TEXT NOT NULL
+      );
+      CREATE TABLE webinar_viewers (
+        id TEXT PRIMARY KEY, webinar_id TEXT NOT NULL, friend_id TEXT NOT NULL,
+        session_start_at INTEGER NOT NULL, joined_at TEXT NOT NULL,
+        last_position_seconds INTEGER NOT NULL DEFAULT 0, cta_clicked_at TEXT
+      );
+      CREATE TABLE webinar_registrations (
+        id TEXT PRIMARY KEY, webinar_id TEXT NOT NULL, friend_id TEXT NOT NULL
+      );
+      CREATE TABLE webinar_ctas (
+        id TEXT PRIMARY KEY, webinar_id TEXT NOT NULL, form_id TEXT
+      );
+      CREATE TABLE form_submissions (
+        id TEXT PRIMARY KEY, form_id TEXT NOT NULL, friend_id TEXT, created_at TEXT NOT NULL
+      );
+
+      INSERT INTO friends VALUES ('friend-shu', 'Shu', 'https://example.com/shu.jpg');
+      INSERT INTO webinars VALUES ('webinar-1', '2026-08-01T00:00:00+09:00');
+      INSERT INTO webinar_registrations VALUES ('reg-1', 'webinar-1', 'friend-shu');
+      INSERT INTO webinar_ctas VALUES ('cta-1', 'webinar-1', 'form-1');
+
+      INSERT INTO webinar_viewers VALUES
+        ('old', 'webinar-1', 'friend-shu', 100,
+         '2026-08-06T09:30:01+09:00', 1263, '2026-08-06T09:36:00+09:00'),
+        ('latest', 'webinar-1', 'friend-shu', 200,
+         '2026-08-14T01:32:06+09:00', 276, NULL);
+
+      INSERT INTO form_submissions VALUES
+        ('old-form', 'form-1', 'friend-shu', '2026-08-06T09:37:00+09:00');
+    `);
+  });
+
+  afterEach(() => sqlite.close());
+
+  it('参加回数は全期間だが視聴・CTA・フォームは最新回だけを返す', async () => {
+    const participants = await getWebinarParticipantStats(asD1(sqlite), 'webinar-1', 200);
+
+    expect(participants).toEqual([
+      expect.objectContaining({
+        friend_id: 'friend-shu',
+        sessions: 2,
+        first_joined_at: '2026-08-06T09:30:01+09:00',
+        latest_joined_at: '2026-08-14T01:32:06+09:00',
+        latest_watched_seconds: 276,
+        cta_clicked_at: null,
+        registered: 1,
+        form_submitted_at: null,
+      }),
+    ]);
+  });
+});

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/mcp-server",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "MCP server for LINE Harness — operate a LINE official account from AI agents over MCP",
   "type": "module",
   "bin": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/sdk",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "AI-native SDK for LINE Harness — programmatic LINE official account automation",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- show watch progress, CTA, and form completion from each participant's latest webinar session
- keep old/new analytics field compatibility to prevent NaN during rolling updates
- make duplicate webinar registration requests idempotent for LINE confirmations
- sync the improved mobile meeting-date input flow already present upstream
- bump OSS update version to v0.21.1

## Verification
- migration policy check: passed
- script tests: 37 passed
- DB tests: 139 passed
- Worker tests: 949 passed
- Web tests: 10 passed
- workspace typechecks: passed
- known private-value scan: passed

No database migration is required.