### PR TITLE
feat(web): 自動更新の共通基盤 + チャット画面のリアルタイム新着反映

### DIFF
--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -10,6 +10,7 @@ import CcPromptButton from '@/components/cc-prompt-button'
 import FlexPreviewComponent from '@/components/flex-preview'
 import FriendInfoSidebar from '@/components/chats/friend-info-sidebar'
 import ImageUploader, { type ImageUploaderValue } from '@/components/shared/image-uploader'
+import { useAutoRefresh } from '@/hooks/use-auto-refresh'
 
 interface Chat {
   id: string
@@ -61,6 +62,9 @@ const SHOW_LOADING_PREF_KEY = 'lh_chat_show_loading_indicator'
 const CHAT_PAGE_SIZE = 300
 const LOADING_SECONDS_PREF_KEY = 'lh_chat_loading_seconds'
 const LOADING_REFRESH_INTERVAL_MS = 4000
+// チャット一覧・スレッドの自動更新間隔。Webhook 受信や MCP / API 経由の送信を
+// リロードなしで反映する (仕組みは hooks/use-auto-refresh.ts を参照)。
+const CHAT_POLL_INTERVAL_MS = 10_000
 
 function StickerMessageImage({ content }: { content: string }) {
   const [failed, setFailed] = useState(false)
@@ -153,19 +157,32 @@ function DirectMessagePanel({ friendId, friend, onBack, onSent }: {
   const isComposingRef = useRef(false)
   const sendLockRef = useRef(false)
 
-  useEffect(() => {
-    const loadMessages = async () => {
-      setLoadingMessages(true)
-      try {
-        const res = await fetchApi<{ success: boolean; data: MessageLog[] }>(
-          `/api/friends/${friendId}/messages`
-        )
-        if (res.success) setMessages(res.data)
-      } catch { /* silent */ }
-      setLoadingMessages(false)
-    }
-    loadMessages()
+  const loadMessages = useCallback(async (opts?: { silent?: boolean }) => {
+    if (!opts?.silent) setLoadingMessages(true)
+    try {
+      const res = await fetchApi<{ success: boolean; data: MessageLog[] }>(
+        `/api/friends/${friendId}/messages`
+      )
+      if (res.success) {
+        // silent 更新では、送信直後の楽観追加より少ない件数 (send より前に
+        // 発行された古いレスポンス) を捨て、送ったばかりのメッセージが
+        // 一瞬消える現象を防ぐ。
+        setMessages((prev) => (opts?.silent && res.data.length < prev.length) ? prev : res.data)
+      }
+    } catch { /* silent */ }
+    if (!opts?.silent) setLoadingMessages(false)
   }, [friendId])
+
+  useEffect(() => {
+    void loadMessages()
+  }, [loadMessages])
+
+  // 新着 (webhook 受信 / MCP・API 経由の送信) をリロードなしで反映する
+  useAutoRefresh(() => loadMessages({ silent: true }), {
+    intervalMs: CHAT_POLL_INTERVAL_MS,
+    // 送信中は楽観更新と競合するためスキップ
+    isPaused: () => sendLockRef.current,
+  })
 
   const handleSend = async () => {
     if (!message.trim() || sending || sendLockRef.current) return
@@ -487,6 +504,60 @@ export default function ChatsPage() {
     loadChats()
   }, [loadChats])
 
+  // --- 自動更新 (ポーリング) ---
+  // loadChats / loadChatDetail はローディング表示を伴うため、ポーリングでは
+  // スピナーを出さない silent 版を使う。楽観更新済みの state を古いレスポンスで
+  // 巻き戻さないよう、適用前に件数・末尾 id を比較する。
+  const refreshChatsSilently = useCallback(async () => {
+    try {
+      const chatRes = await api.chats.list(buildListParams(null))
+      if (!chatRes.success) return
+      const rows = chatRes.data as unknown as Chat[]
+      // 1ページ目をサーバの並びで先頭に置き、「さらに読み込む」で取得済みの
+      // 古い行は末尾に残す (重複は除外)。
+      setChats((prev) => {
+        const fetched = new Set(rows.map((c) => c.id))
+        return [...rows, ...prev.filter((c) => !fetched.has(c.id))]
+      })
+    } catch { /* silent — 次回のポーリングで再試行 */ }
+  }, [buildListParams])
+
+  const refreshChatDetailSilently = useCallback(async (chatId: string) => {
+    try {
+      const res = await api.chats.get(chatId)
+      if (!res.success) return
+      const next = res.data as unknown as ChatDetail
+      setChatDetail((prev) => {
+        // 選択が変わっていたら破棄
+        if (!prev || prev.id !== next.id) return prev
+        const prevMsgs = prev.messages ?? []
+        const nextMsgs = next.messages ?? []
+        // 楽観更新より少ない件数 (送信前に発行された古いレスポンス) は捨てて、
+        // 送ったばかりのメッセージが一瞬消える現象を防ぐ
+        if (nextMsgs.length < prevMsgs.length) return prev
+        const prevLast = prevMsgs[prevMsgs.length - 1]
+        const nextLast = nextMsgs[nextMsgs.length - 1]
+        // 変化なしなら同じ参照を返して再レンダーさせない
+        if (
+          nextMsgs.length === prevMsgs.length &&
+          prevLast?.id === nextLast?.id &&
+          prev.status === next.status
+        ) return prev
+        return next
+      })
+    } catch { /* silent — 次回のポーリングで再試行 */ }
+  }, [])
+
+  useAutoRefresh(async () => {
+    const tasks: Promise<void>[] = [refreshChatsSilently()]
+    if (selectedChatId) tasks.push(refreshChatDetailSilently(selectedChatId))
+    await Promise.allSettled(tasks)
+  }, {
+    intervalMs: CHAT_POLL_INTERVAL_MS,
+    // 送信中は楽観更新と競合するためスキップ
+    isPaused: () => sendLockRef.current,
+  })
+
   // Deep-link from other pages (e.g. /form-submissions): ?friend=<friendId>
   // chat list returns id = friend_id, so selectedChatId === friendId is correct.
   // If no chat exists yet, loadChatDetail will fail and the user can fall back to
@@ -543,21 +614,34 @@ export default function ChatsPage() {
   // 詳細が新しくロードされたら最下部（＝最新メッセージ）までスクロールする。
   // そこから上にスクロールすれば過去のメッセージを辿れる（LINE受信画面と同じUX）。
   // ユーザーが手動でスクロールしたら delayed auto-scroll は発動させない。
+  // ポーリングによる新着追加時は、下端付近にいるときだけ追従スクロールする
+  // （過去ログを読んでいる途中に最下部へ飛ばされないように）。
+  const isNearBottomRef = useRef(true)
+  const prevScrollChatIdRef = useRef<string | null>(null)
   useEffect(() => {
     if (!chatDetail?.messages || chatDetail.messages.length === 0) return
     const el = messagesScrollRef.current
     if (!el) return
-    el.scrollTop = el.scrollHeight
     let userScrolled = false
     const onScroll = () => {
       if (!messagesScrollRef.current) return
       const current = messagesScrollRef.current
+      const distanceFromBottom = current.scrollHeight - current.scrollTop - current.clientHeight
+      isNearBottomRef.current = distanceFromBottom <= 20
       // 下端から一定以上離れたらユーザー操作とみなす
-      if (current.scrollHeight - current.scrollTop - current.clientHeight > 20) {
+      if (distanceFromBottom > 20) {
         userScrolled = true
       }
     }
     el.addEventListener('scroll', onScroll, { passive: true })
+    const isChatSwitch = prevScrollChatIdRef.current !== chatDetail.id
+    prevScrollChatIdRef.current = chatDetail.id
+    if (!isChatSwitch && !isNearBottomRef.current) {
+      // ポーリング新着だが過去ログ閲覧中 — スクロール位置は動かさない
+      return () => el.removeEventListener('scroll', onScroll)
+    }
+    el.scrollTop = el.scrollHeight
+    isNearBottomRef.current = true
     // 画像/Flex の表示後に高さが増える場合に追従するフォロワー（ユーザーがスクロール済みなら発動させない）
     const id = window.setTimeout(() => {
       if (userScrolled || !messagesScrollRef.current) return

--- a/apps/web/src/app/duplicates/page.tsx
+++ b/apps/web/src/app/duplicates/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import Header from '@/components/layout/header'
 import { api } from '@/lib/api'
+import { useAutoRefresh } from '@/hooks/use-auto-refresh'
 
 interface PerAccountStat {
   accountId: string
@@ -76,12 +77,10 @@ export default function DuplicatesPage() {
 
   // Tick once a minute so the "○分前に計算" label keeps refreshing while
   // the operator leaves the page open. setNow reads Date.now() implicitly
-  // on the next render via formatRelative.
+  // on the next render via formatRelative. (タブ非表示中は止まり、復帰時に
+  // 即時 tick するのでラベルが古いまま見えることはない)
   const [, setTick] = useState(0)
-  useEffect(() => {
-    const interval = setInterval(() => setTick((t) => t + 1), 60_000)
-    return () => clearInterval(interval)
-  }, [])
+  useAutoRefresh(() => setTick((t) => t + 1), { intervalMs: 60_000 })
 
   return (
     <div className="space-y-8">

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -6,6 +6,7 @@ import InboxFilters from '@/components/inbox/inbox-filters'
 import InboxList from '@/components/inbox/inbox-list'
 import InboxSummaryBar from '@/components/inbox/inbox-summary-bar'
 import { api } from '@/lib/api'
+import { useAutoRefresh } from '@/hooks/use-auto-refresh'
 import type { InboxRowData } from '@/components/inbox/inbox-row'
 
 const PAGE_SIZE = 50
@@ -87,9 +88,11 @@ export default function InboxPage() {
 
   useEffect(() => {
     loadAll()
-    const id = setInterval(loadAll, POLL_INTERVAL_MS)
-    return () => clearInterval(id)
   }, [loadAll])
+
+  // 新着の未対応 (webhook 受信) をリロードなしで反映する。
+  // タブ非表示中は停止し、復帰時に即時更新する (use-auto-refresh 側の共通挙動)。
+  useAutoRefresh(loadAll, { intervalMs: POLL_INTERVAL_MS })
 
   // ── client-side filter ──
   const filteredRows = useMemo(() => {

--- a/apps/web/src/components/broadcasts/broadcast-detail.tsx
+++ b/apps/web/src/components/broadcasts/broadcast-detail.tsx
@@ -10,6 +10,7 @@ import TestSendSection from '@/components/broadcasts/test-send-section'
 import ProgressBar from '@/components/broadcasts/progress-bar'
 import SendConfirmDialog from '@/components/broadcasts/send-confirm-dialog'
 import SegmentBuilder from '@/components/broadcasts/segment-builder'
+import { useAutoRefresh } from '@/hooks/use-auto-refresh'
 import type { Tag } from '@line-crm/shared'
 
 interface BroadcastDetailProps {
@@ -88,26 +89,21 @@ export default function BroadcastDetail({ broadcastId }: BroadcastDetailProps) {
 
   useEffect(() => { load() }, [load])
 
-  // Poll progress while sending
-  useEffect(() => {
-    if (broadcast?.status !== 'sending') return
-    const interval = setInterval(async () => {
-      const res = await api.broadcasts.getProgress(id)
-      if (res.success && res.data) {
-        setBroadcast(prev => prev ? {
-          ...prev,
-          status: res.data!.status as ApiBroadcast['status'],
-          totalCount: res.data!.totalCount,
-          successCount: res.data!.successCount,
-        } : prev)
-        if (res.data.status === 'sent') {
-          clearInterval(interval)
-          load()
-        }
-      }
-    }, 3000)
-    return () => clearInterval(interval)
-  }, [broadcast?.status, id, load])
+  // Poll progress while sending — status が 'sent' になると enabled が false に
+  // なり自動停止する。MCP / API 経由で開始された配信でも、この画面を開いて
+  // いれば進捗が追従する。
+  useAutoRefresh(async () => {
+    const res = await api.broadcasts.getProgress(id)
+    if (res.success && res.data) {
+      setBroadcast(prev => prev ? {
+        ...prev,
+        status: res.data!.status as ApiBroadcast['status'],
+        totalCount: res.data!.totalCount,
+        successCount: res.data!.successCount,
+      } : prev)
+      if (res.data.status === 'sent') load()
+    }
+  }, { intervalMs: 3000, enabled: broadcast?.status === 'sending' })
 
   // Load insight for sent broadcasts
   useEffect(() => {
@@ -121,34 +117,27 @@ export default function BroadcastDetail({ broadcastId }: BroadcastDetailProps) {
   // multi-account-dedup 以外の broadcast でも 1 行返るので最終的にテーブル表示するかは
   // 描画側で targetType チェックして判断する。送信完了時は LINE Insight が
   // each account token で fetch されるので時間かかる (3-5 秒/アカ) — fire-and-forget。
+  const fetchPerAccountStats = useCallback(() => {
+    const requestId = id
+    return api.broadcasts.perAccountStats(requestId).then((r) => {
+      // race guard: 別 broadcast に navigate していたら捨てる (response の遅延上書きを防止)
+      if (requestId !== latestIdRef.current) return
+      if (r.success && r.data) setPerAccountStats(r.data)
+    }).catch(() => {/* ignore */})
+  }, [id])
+
   useEffect(() => {
     const status = broadcast?.status
     if (status !== 'sending' && status !== 'sent') return
+    void fetchPerAccountStats()
+  }, [broadcast?.status, fetchPerAccountStats])
 
-    let cancelled = false
-    const requestId = id
-
-    const fetchStats = () => {
-      api.broadcasts.perAccountStats(requestId).then((r) => {
-        // race guard: 別 broadcast に navigate していたら捨てる (response の遅延上書きを防止)
-        if (cancelled || requestId !== latestIdRef.current) return
-        if (r.success && r.data) setPerAccountStats(r.data)
-      }).catch(() => {/* ignore */})
-    }
-
-    fetchStats()
-
-    // 送信中は 3s ごとに再 fetch して per-account 進捗を更新する。
-    // 既存の successCount poll と同期させる目的。送信完了 (sent) では再 fetch 不要。
-    if (status === 'sending') {
-      const interval = setInterval(fetchStats, 3000)
-      return () => {
-        cancelled = true
-        clearInterval(interval)
-      }
-    }
-    return () => { cancelled = true }
-  }, [broadcast?.status, id])
+  // 送信中は 3s ごとに再 fetch して per-account 進捗を更新する。
+  // 既存の successCount poll と同期させる目的。送信完了 (sent) では再 fetch 不要。
+  useAutoRefresh(fetchPerAccountStats, {
+    intervalMs: 3000,
+    enabled: broadcast?.status === 'sending',
+  })
 
   const handleSend = async () => {
     setShowConfirm(false)

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useAccount } from '@/contexts/account-context'
 import type { AccountWithStats } from '@/contexts/account-context'
 import { countryFlag } from '@/lib/country-flag'
 import { UNANSWERED_REFRESH_EVENT } from '@/lib/events'
+import { useAutoRefresh } from '@/hooks/use-auto-refresh'
 
 const appVersion = process.env.APP_VERSION || '0.0.0'
 const appCommitSha = process.env.APP_COMMIT_SHA || 'local'
@@ -214,31 +215,30 @@ export default function Sidebar() {
   // チャット画面での status 変更・手動返信直後は UNANSWERED_REFRESH_EVENT で
   // 即時再取得する (ポーリング待ちだと操作してもバッジが減らないと感じるため)。
   const [unansweredCount, setUnansweredCount] = useState<number>(0)
-  useEffect(() => {
-    let cancelled = false
-    // 連続操作で fetch が並走した際、遅い古いレスポンスが新しい値を上書きしない
-    // ように発行順 seq でガードする。
-    let seq = 0
-    const fetchCount = async () => {
-      const mySeq = ++seq
-      try {
-        const { api } = await import('@/lib/api')
-        const res = await api.inbox.unanswered.count()
-        if (!cancelled && mySeq === seq && res.success) setUnansweredCount(res.data.total)
-      } catch {
-        // サイレント失敗
-      }
-    }
-    fetchCount()
-    const id = setInterval(fetchCount, 5 * 60_000)
-    const onRefresh = () => { void fetchCount() }
-    window.addEventListener(UNANSWERED_REFRESH_EVENT, onRefresh)
-    return () => {
-      cancelled = true
-      clearInterval(id)
-      window.removeEventListener(UNANSWERED_REFRESH_EVENT, onRefresh)
+  // 連続操作で fetch が並走した際、遅い古いレスポンスが新しい値を上書きしない
+  // ように発行順 seq でガードする。
+  const unansweredSeqRef = useRef(0)
+  const fetchCount = useCallback(async () => {
+    const mySeq = ++unansweredSeqRef.current
+    try {
+      const { api } = await import('@/lib/api')
+      const res = await api.inbox.unanswered.count()
+      if (mySeq === unansweredSeqRef.current && res.success) setUnansweredCount(res.data.total)
+    } catch {
+      // サイレント失敗
     }
   }, [])
+
+  useEffect(() => { void fetchCount() }, [fetchCount])
+  const { refresh: refreshUnanswered } = useAutoRefresh(fetchCount, { intervalMs: 5 * 60_000 })
+
+  // チャット画面での status 変更・手動返信直後は即時再取得する
+  // (ポーリング待ちだと操作してもバッジが減らないと感じるため)。
+  useEffect(() => {
+    const onRefresh = () => { void refreshUnanswered() }
+    window.addEventListener(UNANSWERED_REFRESH_EVENT, onRefresh)
+    return () => window.removeEventListener(UNANSWERED_REFRESH_EVENT, onRefresh)
+  }, [refreshUnanswered])
 
   useEffect(() => { setIsOpen(false) }, [pathname])
   useEffect(() => {

--- a/apps/web/src/hooks/use-auto-refresh.ts
+++ b/apps/web/src/hooks/use-auto-refresh.ts
@@ -1,0 +1,80 @@
+'use client'
+
+/**
+ * 自動更新 (ポーリング) の React フック。実体は lib/auto-refresh.ts の
+ * 共通スケジューラで、このフックはライフサイクル管理だけを担う。
+ *
+ * 使い方:
+ *
+ *   // 10 秒ごとに一覧を再取得 (タブ非表示中は停止、復帰時に即時更新)
+ *   useAutoRefresh(reload, { intervalMs: 10_000 })
+ *
+ *   // 送信中だけ 3 秒ごとに進捗を追う (完了したら自動停止)
+ *   useAutoRefresh(fetchProgress, { intervalMs: 3000, enabled: status === 'sending' })
+ *
+ *   // アプリ内イベントから手動で即時更新
+ *   const { refresh } = useAutoRefresh(fetchCount, { intervalMs: 5 * 60_000 })
+ *
+ * `refresh` / `isPaused` は最新のクロージャが ref 経由で呼ばれるため、
+ * 呼び出し側で useCallback で固定する必要はない (依存が変わっても
+ * インターバルは張り直されない)。
+ */
+
+import { useCallback, useEffect, useRef } from 'react'
+import { startAutoRefresh, type AutoRefreshHandle } from '@/lib/auto-refresh'
+
+export interface UseAutoRefreshOptions {
+  /** ポーリング間隔 (ms)。対象 API の重さに応じて画面側で決める。 */
+  intervalMs: number
+  /** false の間はポーリングしない (条件付きポーリング用。既定 true)。 */
+  enabled?: boolean
+  /** true を返す間は tick をスキップする (例: 送信中は楽観更新と競合させない)。 */
+  isPaused?: () => boolean
+  /** タブ非表示中も tick する (既定 false = 停止)。 */
+  runWhenHidden?: boolean
+  /** タブが表示に戻った瞬間に 1 回 tick する (既定 true)。 */
+  refreshOnVisible?: boolean
+}
+
+export function useAutoRefresh(
+  refresh: () => void | Promise<void>,
+  options: UseAutoRefreshOptions,
+): { refresh: () => Promise<void> } {
+  const { intervalMs, enabled = true, runWhenHidden, refreshOnVisible } = options
+
+  // 最新のコールバックを ref に保持し、インターバルを張り直さずに
+  // 常に最新の state / props を参照できるようにする (stale closure 対策)。
+  const refreshRef = useRef(refresh)
+  useEffect(() => { refreshRef.current = refresh })
+  const isPausedRef = useRef(options.isPaused)
+  useEffect(() => { isPausedRef.current = options.isPaused })
+
+  const handleRef = useRef<AutoRefreshHandle | null>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+    const handle = startAutoRefresh(() => refreshRef.current(), {
+      intervalMs,
+      runWhenHidden,
+      refreshOnVisible,
+      isPaused: () => isPausedRef.current?.() ?? false,
+    })
+    handleRef.current = handle
+    return () => {
+      handleRef.current = null
+      handle.stop()
+    }
+  }, [intervalMs, enabled, runWhenHidden, refreshOnVisible])
+
+  // 手動即時更新。ポーリング停止中 (enabled: false) でも動くように、
+  // ハンドルが無ければコールバックを直接呼ぶ。
+  const manualRefresh = useCallback(async () => {
+    if (handleRef.current) {
+      await handleRef.current.refresh()
+    } else {
+      await refreshRef.current()
+    }
+  }, [])
+
+  return { refresh: manualRefresh }
+}

--- a/apps/web/src/lib/auto-refresh.test.ts
+++ b/apps/web/src/lib/auto-refresh.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startAutoRefresh, type VisibilityDocument } from './auto-refresh'
+
+/** visibilitychange を発火できるテスト用 document。 */
+function createFakeDoc(initialHidden = false) {
+  let hidden = initialHidden
+  const listeners = new Set<() => void>()
+  const doc: VisibilityDocument = {
+    get hidden() {
+      return hidden
+    },
+    addEventListener: (_type, listener) => {
+      listeners.add(listener)
+    },
+    removeEventListener: (_type, listener) => {
+      listeners.delete(listener)
+    },
+  }
+  return {
+    doc,
+    listenerCount: () => listeners.size,
+    setHidden(next: boolean) {
+      hidden = next
+      for (const l of [...listeners]) l()
+    },
+  }
+}
+
+describe('startAutoRefresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('intervalMs ごとに refresh を呼ぶ', async () => {
+    const refresh = vi.fn()
+    const handle = startAutoRefresh(refresh, { intervalMs: 1000, doc: null })
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(refresh).toHaveBeenCalledTimes(3)
+    handle.stop()
+  })
+
+  it('前回の refresh が完了するまで次の tick をスキップする', async () => {
+    let resolve!: () => void
+    const refresh = vi.fn(
+      () => new Promise<void>((r) => { resolve = r }),
+    )
+    const handle = startAutoRefresh(refresh, { intervalMs: 1000, doc: null })
+
+    // 3 interval 経過しても、最初の呼び出しが pending の間は 1 回のまま
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    // 完了したら次の interval から再開する
+    resolve()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(refresh).toHaveBeenCalledTimes(2)
+    handle.stop()
+  })
+
+  it('isPaused が true の間は tick をスキップする', async () => {
+    let paused = true
+    const refresh = vi.fn()
+    const handle = startAutoRefresh(refresh, {
+      intervalMs: 1000,
+      isPaused: () => paused,
+      doc: null,
+    })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(refresh).not.toHaveBeenCalled()
+
+    paused = false
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(refresh).toHaveBeenCalledTimes(1)
+    handle.stop()
+  })
+
+  it('タブ非表示中は tick をスキップし、表示に戻った瞬間に 1 回実行する', async () => {
+    const fake = createFakeDoc(true)
+    const refresh = vi.fn()
+    const handle = startAutoRefresh(refresh, { intervalMs: 1000, doc: fake.doc })
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(refresh).not.toHaveBeenCalled()
+
+    fake.setHidden(false)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh).toHaveBeenCalledTimes(1)
+    handle.stop()
+  })
+
+  it('refreshOnVisible: false なら表示復帰時に実行しない', async () => {
+    const fake = createFakeDoc(true)
+    const refresh = vi.fn()
+    const handle = startAutoRefresh(refresh, {
+      intervalMs: 1000,
+      refreshOnVisible: false,
+      doc: fake.doc,
+    })
+    fake.setHidden(false)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(refresh).not.toHaveBeenCalled()
+
+    // 通常の interval では実行される
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(refresh).toHaveBeenCalledTimes(1)
+    handle.stop()
+  })
+
+  it('runWhenHidden: true ならタブ非表示中も実行する', async () => {
+    const fake = createFakeDoc(true)
+    const refresh = vi.fn()
+    const handle = startAutoRefresh(refresh, {
+      intervalMs: 1000,
+      runWhenHidden: true,
+      doc: fake.doc,
+    })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(refresh).toHaveBeenCalledTimes(2)
+    handle.stop()
+  })
+
+  it('stop 後は tick も手動 refresh も実行されず、リスナーが解除される', async () => {
+    const fake = createFakeDoc(false)
+    const refresh = vi.fn()
+    const handle = startAutoRefresh(refresh, { intervalMs: 1000, doc: fake.doc })
+    expect(fake.listenerCount()).toBe(1)
+
+    handle.stop()
+    expect(fake.listenerCount()).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(3000)
+    await handle.refresh()
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('手動 refresh は hidden / isPaused でも実行される', async () => {
+    const fake = createFakeDoc(true)
+    const refresh = vi.fn()
+    const handle = startAutoRefresh(refresh, {
+      intervalMs: 1000,
+      isPaused: () => true,
+      doc: fake.doc,
+    })
+    await handle.refresh()
+    expect(refresh).toHaveBeenCalledTimes(1)
+    handle.stop()
+  })
+
+  it('手動 refresh も実行中は重複しない', async () => {
+    let resolve!: () => void
+    const refresh = vi.fn(
+      () => new Promise<void>((r) => { resolve = r }),
+    )
+    const handle = startAutoRefresh(refresh, { intervalMs: 1000, doc: null })
+
+    const first = handle.refresh()
+    const second = handle.refresh() // busy 中 — no-op
+    resolve()
+    await Promise.all([first, second])
+    expect(refresh).toHaveBeenCalledTimes(1)
+    handle.stop()
+  })
+
+  it('refresh が reject してもポーリングは継続する', async () => {
+    const refresh = vi
+      .fn<[], Promise<void>>()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValue(undefined)
+    const handle = startAutoRefresh(refresh, { intervalMs: 1000, doc: null })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(refresh).toHaveBeenCalledTimes(2)
+    handle.stop()
+  })
+})

--- a/apps/web/src/lib/auto-refresh.ts
+++ b/apps/web/src/lib/auto-refresh.ts
@@ -1,0 +1,115 @@
+/**
+ * 自動更新 (ポーリング) の共通スケジューラ。
+ *
+ * 管理画面は Cloudflare Pages 上の静的 SPA で、Webhook 受信や MCP / API 経由の
+ * アクションはサーバ側 (Workers) だけで起こるため、開きっぱなしの画面には
+ * 手動リロードするまで反映されない。SSE / WebSocket を Workers で提供するには
+ * Durable Objects が必要になるため、まずは各画面が軽量なポーリングで新着を
+ * 追従する。ここはその共通実装で、画面ごとに再実装されがちな以下を一元化する:
+ *
+ * - タブ非表示中の停止 (見ていない画面のために API を叩かない)
+ * - タブ復帰時の即時更新 (最大ポーリング間隔ぶんの表示遅延を解消)
+ * - 実行中 tick の重複防止 (レスポンス遅延時にリクエストを並走させない)
+ * - 呼び出し側都合の一時停止 (送信中の楽観更新と競合させない等)
+ *
+ * React コンポーネントからは `useAutoRefresh` (hooks/use-auto-refresh.ts) を使う。
+ * このモジュール自体は DOM グローバルに直接依存しない (visibility は注入可能)
+ * ので、Node 環境の vitest でそのままテストできる。
+ */
+
+/** `document` のうちスケジューラが使う可視性まわりだけを切り出した型 (テスト注入用)。 */
+export interface VisibilityDocument {
+  readonly hidden: boolean
+  addEventListener(type: 'visibilitychange', listener: () => void): void
+  removeEventListener(type: 'visibilitychange', listener: () => void): void
+}
+
+export interface AutoRefreshOptions {
+  /** ポーリング間隔 (ms)。対象 API の重さに応じて画面側で決める。 */
+  intervalMs: number
+  /**
+   * true を返す間は tick をスキップする。
+   * 例: メッセージ送信中に楽観更新をサーバの古いレスポンスで巻き戻さない。
+   */
+  isPaused?: () => boolean
+  /** タブ非表示中も tick する (既定 false = 停止)。 */
+  runWhenHidden?: boolean
+  /** タブが表示に戻った瞬間に 1 回 tick する (既定 true)。 */
+  refreshOnVisible?: boolean
+  /** visibility の取得元。省略時はグローバル document (SSR/テストでは null 可)。 */
+  doc?: VisibilityDocument | null
+}
+
+export interface AutoRefreshHandle {
+  /**
+   * 手動で即時更新する。ユーザー操作やアプリ内イベント起点の更新に使うため、
+   * hidden / isPaused のガードは通さない (重複実行ガードだけ効く)。
+   */
+  refresh: () => Promise<void>
+  /** ポーリングを停止しリスナーを解除する。以後 refresh() も no-op。 */
+  stop: () => void
+}
+
+function defaultDoc(): VisibilityDocument | null {
+  return typeof document === 'undefined' ? null : document
+}
+
+/**
+ * ポーリングを開始する。戻り値の `stop()` で必ず後始末すること
+ * (React からは `useAutoRefresh` が effect cleanup として面倒を見る)。
+ *
+ * `refresh` が reject してもポーリングは継続する (一時的なネットワーク断で
+ * 自動更新が死なないように)。エラー表示が必要な画面は `refresh` 側で処理する。
+ */
+export function startAutoRefresh(
+  refresh: () => void | Promise<void>,
+  options: AutoRefreshOptions,
+): AutoRefreshHandle {
+  const {
+    intervalMs,
+    isPaused,
+    runWhenHidden = false,
+    refreshOnVisible = true,
+    doc = defaultDoc(),
+  } = options
+
+  let stopped = false
+  let busy = false
+
+  // busy ガードを通した 1 回分の実行。tick / 手動 refresh の両方がここを通る
+  // ので、ポーリングと手動更新が並走してもリクエストは常に 1 本に保たれる。
+  const run = async (): Promise<void> => {
+    if (stopped || busy) return
+    busy = true
+    try {
+      await refresh()
+    } catch {
+      // 呼び出し側で処理される想定。ここでは次回の tick を止めないことが責務。
+    } finally {
+      busy = false
+    }
+  }
+
+  const tick = (): void => {
+    if (stopped) return
+    if (doc && doc.hidden && !runWhenHidden) return
+    if (isPaused?.()) return
+    void run()
+  }
+
+  const intervalId = setInterval(tick, intervalMs)
+
+  const onVisibilityChange = (): void => {
+    if (refreshOnVisible && doc && !doc.hidden) tick()
+  }
+  doc?.addEventListener('visibilitychange', onVisibilityChange)
+
+  return {
+    refresh: () => run(),
+    stop: () => {
+      stopped = true
+      clearInterval(intervalId)
+      doc?.removeEventListener('visibilitychange', onVisibilityChange)
+    },
+  }
+}


### PR DESCRIPTION
## 概要

管理画面に「自動更新 (ポーリング) の共通基盤」を追加し、それを使ってオペレーターチャット画面に新着メッセージのリアルタイム反映を実装しました。あわせて、既存の 4 箇所のバラバラな `setInterval` 実装を共通基盤へ移行しました。

## 動機

- 管理画面は静的 SPA のため、**Webhook 受信 (友だちからのメッセージ) や MCP / API 経由の送信が、手動リロードするまで画面に反映されません**。チャット画面を開いたまま友だちの新着を待つオペレーターにとって大きな不便でした。
- 一方で、既存コードには `setInterval` によるポーリングが 5 箇所 (notifications / duplicates / sidebar / broadcast-detail / use-update-notification) に個別実装されており、「タブ非表示時に止める」「実行中の tick を重複させない」「タブ復帰時に即時更新する」といった挙動が画面ごとにバラバラでした。

SSE / WebSocket を Workers で提供するには Durable Objects が必要になりインフラ構成が変わるため、まずは既存構成のまま動く軽量ポーリングを共通化しました (将来 push 型に置き換える場合も、このフックの実装を差し替えるだけで全画面に効きます)。

## 変更内容

### 新規: 共通基盤

- `apps/web/src/lib/auto-refresh.ts` — フレームワーク非依存のスケジューラ
  - タブ非表示中の停止 (見ていない画面のために API を叩かない)
  - タブ復帰時の即時更新 (最大ポーリング間隔ぶんの表示遅延を解消)
  - 実行中 tick の重複防止 (レスポンス遅延時にリクエストを並走させない)
  - `isPaused` による呼び出し側都合の一時停止 (送信中の楽観更新と競合させない等)
  - visibility を注入可能にしてあり、Node 環境の vitest でテスト可能 (**unit test 10 件同梱**)
- `apps/web/src/hooks/use-auto-refresh.ts` — React ラッパー
  - `enabled` オプションで条件付きポーリング (例: 配信中のみ進捗を追う → 完了で自動停止)
  - 手動 `refresh()` を返し、アプリ内イベント起点の即時更新にも使える
  - latest-ref パターンで stale closure を防止 (呼び出し側の useCallback 固定は不要)

### 新機能: チャット画面の自動更新 (10 秒間隔)

- 一覧・開いているスレッド・個別送信パネルを silent 更新 (スピナーを出さない)
- 楽観更新との競合ガード: 送信中は tick をスキップし、適用前に件数・末尾 id を比較して古いレスポンスでの巻き戻りを防止
- 過去ログを読んでいる間 (スクロール位置が下端から離れている間) は新着が来ても自動スクロールしない。チャット切替時は従来どおり最下部へ
- 「さらに読み込む」で取得済みのページング行はポーリング後も保持

### 移行: 既存ポーリングの共通基盤化 (挙動は維持)

- `notifications/page.tsx` — 30 秒ポーリングを移行 (+ 非表示時停止)
- `duplicates/page.tsx` — 「○分前に計算」ラベルの 60 秒 tick を移行
- `layout/sidebar.tsx` — 未対応バッジの 5 分ポーリング + `UNANSWERED_REFRESH_EVENT` の即時更新を移行 (seq ガードは維持)
- `broadcasts/broadcast-detail.tsx` — 送信中のみの 3 秒進捗ポーリング×2 を `enabled` で表現 (送信完了で自動停止)

`use-update-notification.ts` は localStorage の TTL キャッシュと絡むため今回のスコープ外としました (follow-up 候補)。

## 検証

- `npx tsc --noEmit` パス
- `pnpm test` 20 件パス (新規 10 件含む)
- `next build` (lint + 型チェック含む) パス
- 実環境 (v0.21.1 セットアップ + 本パッチ) にデプロイし、MCP `send_message` で送ったメッセージがチャット画面にリロードなしで反映されること、友だちからの受信が一覧・スレッドに追従することを確認

## 環境

- LINE Harness v0.21.1 / Node.js v22 / wrangler 4.77.0 / Cloudflare Pages + Workers

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbeW9gKz7DQtH8AXbsaRUi
