### PR TITLE
release: v0.21.2 rich menu and Admin update fixes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/web/src/app/rich-menus/edit/page.tsx
+++ b/apps/web/src/app/rich-menus/edit/page.tsx
@@ -27,6 +27,7 @@ type Group = {
   size: 'large' | 'compact'
   defaultPageId: string | null
   isDefaultForAll: boolean
+  selected: boolean
   status: 'draft' | 'published'
   publishingAt: string | null
   pages: Page[]
@@ -90,6 +91,7 @@ function Editor({
   // isDefaultForAll はこの画面では編集しない (ON/OFF は「友だちに表示」モーダルから)。
   // ただし persistDraft で送信値を一致させるため、現在値を保持する。
   const [isDefaultForAll, setIsDefaultForAll] = useState(false)
+  const [selected, setSelected] = useState(false)
 
   const [saving, setSaving] = useState(false)
   const [publishing, setPublishing] = useState(false)
@@ -110,6 +112,7 @@ function Editor({
       setName(g.name)
       setChatBarText(g.chatBarText)
       setIsDefaultForAll(g.isDefaultForAll)
+      setSelected(g.selected)
       setPages(g.pages)
       setActivePageId((prev) =>
         prev && g.pages.some((p) => p.id === prev) ? prev : (g.pages[0]?.id ?? null),
@@ -218,6 +221,7 @@ function Editor({
       name,
       chatBarText,
       isDefaultForAll,
+      selected,
       pages: pages.map((p, i) => ({
         // 既存 page (UUID) は id を渡す。新規 page (`tmp-*` プレフィックス) は
         // id を渡さず Worker 側で新 UUID を発行させる。
@@ -516,6 +520,22 @@ function Editor({
                 className="mt-1 block w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
               />
               <p className="mt-1 text-[11px] text-gray-500">14 文字以内 (友だちのトーク画面でメニューを開く前に表示)</p>
+            </label>
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={selected}
+                onChange={(e) => setSelected(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>
+                <span className="block text-xs font-medium text-gray-700">
+                  トークを開いたときにメニューを表示する
+                </span>
+                <span className="block mt-1 text-[11px] text-gray-500">
+                  変更後は「LINE に登録」をやり直すと反映されます。
+                </span>
+              </span>
             </label>
           </section>
 

--- a/apps/web/src/app/rich-menus/new/page.tsx
+++ b/apps/web/src/app/rich-menus/new/page.tsx
@@ -13,6 +13,7 @@ export default function NewRichMenuPage() {
   const { selectedAccount } = useAccount()
   const [name, setName] = useState('')
   const [chatBarText, setChatBarText] = useState('メニュー')
+  const [selected, setSelected] = useState(true)
   const [templateKey, setTemplateKey] = useState(TEMPLATES[0].key)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -37,6 +38,7 @@ export default function NewRichMenuPage() {
         name: name.trim(),
         chatBarText: chatBarText.trim(),
         size: tmpl.size,
+        selected,
         pages: [
           { name: 'ページ 1', orderIndex: 0, areas: templateToAreas(tmpl) },
         ],
@@ -90,6 +92,25 @@ export default function NewRichMenuPage() {
           <p className="mt-1 text-xs text-gray-500">
             ユーザーがトーク画面でメニューを開く前に表示される文言。
           </p>
+        </div>
+
+        <div>
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={selected}
+              onChange={(e) => setSelected(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="block text-sm font-medium text-gray-700">
+                トークを開いたときにメニューを表示する
+              </span>
+              <span className="block mt-1 text-xs text-gray-500">
+                ON にすると、友だちがトーク画面を開いた直後からリッチメニューを展開します。
+              </span>
+            </span>
+          </label>
         </div>
 
         <div>

--- a/apps/web/src/app/rich-menus/page.tsx
+++ b/apps/web/src/app/rich-menus/page.tsx
@@ -14,6 +14,7 @@ type RichMenuGroupListItem = {
   size: 'large' | 'compact'
   status: 'draft' | 'published'
   isDefaultForAll: boolean
+  selected: boolean
   thumbnailR2Key: string | null
   updatedAt: string
 }
@@ -34,6 +35,7 @@ type LineMenu = {
   richMenuId: string
   name: string
   chatBarText: string
+  selected: boolean
   size: { width: number; height: number }
   areasCount: number
   isCurrentDefault: boolean
@@ -271,6 +273,7 @@ export default function RichMenusListPage() {
                     {g.isDefaultForAll && (
                       <span className="text-blue-600 font-medium">★ 全員のデフォルト</span>
                     )}
+                    <span>{g.selected ? '初期表示: 開く' : '初期表示: 閉じる'}</span>
                   </div>
                 </div>
               </Link>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1253,6 +1253,7 @@ export const api = {
         size: 'large' | 'compact';
         defaultPageId: string | null;
         isDefaultForAll: boolean;
+        selected: boolean;
         status: 'draft' | 'published';
         publishingAt: string | null;
         thumbnailR2Key: string | null;
@@ -1269,6 +1270,7 @@ export const api = {
         size: 'large' | 'compact';
         defaultPageId: string | null;
         isDefaultForAll: boolean;
+        selected: boolean;
         status: 'draft' | 'published';
         publishingAt: string | null;
         createdAt: string;
@@ -1298,6 +1300,7 @@ export const api = {
       name: string;
       chatBarText: string;
       size: 'large' | 'compact';
+      selected: boolean;
       pages: Array<{
         id?: string;
         name: string;
@@ -1321,6 +1324,7 @@ export const api = {
       name?: string;
       chatBarText?: string;
       isDefaultForAll?: boolean;
+      selected?: boolean;
       pages?: Array<{
         id?: string;
         name: string;
@@ -1365,6 +1369,7 @@ export const api = {
           richMenuId: string;
           name: string;
           chatBarText: string;
+          selected: boolean;
           size: { width: number; height: number };
           areasCount: number;
           isCurrentDefault: boolean;

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/worker/src/lib/rich-menu-publisher.test.ts
+++ b/apps/worker/src/lib/rich-menu-publisher.test.ts
@@ -127,7 +127,7 @@ describe('publishRichMenuGroup', () => {
     const r2 = makeMockR2();
     const result = await publishRichMenuGroup(
       {
-        id: 'gid12345-aaaa', size: 'large', chatBarText: 'menu', isDefaultForAll: false,
+        id: 'gid12345-aaaa', size: 'large', chatBarText: 'menu', isDefaultForAll: false, selected: false,
         pages: [{
           id: 'p1', orderIndex: 0, name: 'p1',
           imageR2Key: 'rich-menus/test/p1.png', imageContentType: 'image/png',
@@ -151,7 +151,7 @@ describe('publishRichMenuGroup', () => {
     const r2 = makeMockR2();
     const result = await publishRichMenuGroup(
       {
-        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false,
+        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false, selected: false,
         pages: [
           { id: 'p1', orderIndex: 0, name: 'p1', imageR2Key: 'a.png', imageContentType: 'image/png', lineRichMenuId: null, areas: [] },
           { id: 'p2', orderIndex: 1, name: 'p2', imageR2Key: 'b.png', imageContentType: 'image/png', lineRichMenuId: null, areas: [] },
@@ -170,7 +170,7 @@ describe('publishRichMenuGroup', () => {
     const r2 = makeMockR2();
     await publishRichMenuGroup(
       {
-        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: true,
+        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: true, selected: true,
         pages: [{
           id: 'p1', orderIndex: 0, name: 'p1',
           imageR2Key: 'a.png', imageContentType: 'image/png',
@@ -183,6 +183,7 @@ describe('publishRichMenuGroup', () => {
     expect(line.calls).toContain('set-default');
     // 有効化時は clear-default を呼ばない
     expect(line.calls).not.toContain('clear-default');
+    expect(line.createRichMenu).toHaveBeenCalledWith(expect.objectContaining({ selected: true }));
   });
 
   it('isDefaultForAll=false かつ LINE current default が own page と一致 → clear-default を呼ぶ (Round 2 P1)', async () => {
@@ -191,7 +192,7 @@ describe('publishRichMenuGroup', () => {
     const r2 = makeMockR2();
     await publishRichMenuGroup(
       {
-        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false,
+        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false, selected: false,
         pages: [{
           id: 'p1', orderIndex: 0, name: 'p1',
           imageR2Key: 'a.png', imageContentType: 'image/png',
@@ -212,7 +213,7 @@ describe('publishRichMenuGroup', () => {
     const r2 = makeMockR2();
     await publishRichMenuGroup(
       {
-        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false,
+        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false, selected: false,
         pages: [{
           id: 'p1', orderIndex: 0, name: 'p1',
           imageR2Key: 'a.png', imageContentType: 'image/png',
@@ -234,7 +235,7 @@ describe('publishRichMenuGroup', () => {
     const r2 = makeMockR2();
     const result = await publishRichMenuGroup(
       {
-        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false,
+        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false, selected: false,
         pages: [{
           id: 'p1', orderIndex: 0, name: 'p1',
           imageR2Key: 'a.png', imageContentType: 'image/png',
@@ -254,7 +255,7 @@ describe('publishRichMenuGroup', () => {
     await expect(
       publishRichMenuGroup(
         {
-          id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false,
+          id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false, selected: false,
           pages: [{
             id: 'p1', orderIndex: 0, name: 'p1',
             imageR2Key: 'missing.png', imageContentType: 'image/png',
@@ -273,7 +274,7 @@ describe('publishRichMenuGroup', () => {
     await expect(
       publishRichMenuGroup(
         {
-          id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false,
+          id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false, selected: false,
           pages: [{
             id: 'p1', orderIndex: 0, name: 'p1',
             imageR2Key: null, imageContentType: null,
@@ -292,7 +293,7 @@ describe('unpublishRichMenuGroup', () => {
     const line = makeMockLineClient({ currentDefault: 'lm-old-1' });
     const result = await unpublishRichMenuGroup(
       {
-        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: true,
+        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: true, selected: true,
         pages: [
           { id: 'p1', orderIndex: 0, name: 'p1', imageR2Key: null, imageContentType: null, lineRichMenuId: 'lm-old-1', areas: [] },
           { id: 'p2', orderIndex: 1, name: 'p2', imageR2Key: null, imageContentType: null, lineRichMenuId: 'lm-old-2', areas: [] },
@@ -316,7 +317,7 @@ describe('unpublishRichMenuGroup', () => {
     const line = makeMockLineClient({ currentDefault: 'lm-other-group' });
     await unpublishRichMenuGroup(
       {
-        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false,
+        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false, selected: false,
         pages: [
           { id: 'p1', orderIndex: 0, name: 'p1', imageR2Key: null, imageContentType: null, lineRichMenuId: 'lm-mine', areas: [] },
         ],
@@ -333,7 +334,7 @@ describe('unpublishRichMenuGroup', () => {
     });
     const result = await unpublishRichMenuGroup(
       {
-        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false,
+        id: 'gid12345-aaaa', size: 'large', chatBarText: 'm', isDefaultForAll: false, selected: false,
         pages: [
           { id: 'p1', orderIndex: 0, name: 'p1', imageR2Key: null, imageContentType: null, lineRichMenuId: null, areas: [] },
         ],

--- a/apps/worker/src/lib/rich-menu-publisher.ts
+++ b/apps/worker/src/lib/rich-menu-publisher.ts
@@ -35,6 +35,7 @@ export type GroupInput = {
   size: 'large' | 'compact';
   chatBarText: string;
   isDefaultForAll: boolean;
+  selected: boolean;
   pages: PageInput[];
 };
 
@@ -122,7 +123,7 @@ export async function publishRichMenuGroup(
     // 1. richmenu 作成
     const created = await line.createRichMenu({
       size: dimensions,
-      selected: false,
+      selected: group.selected,
       name: `${group.id.slice(0, 8)} - ${page.name}`,
       chatBarText: group.chatBarText,
       areas: page.areas.map((a) => ({

--- a/apps/worker/src/routes/rich-menu-groups.test.ts
+++ b/apps/worker/src/routes/rich-menu-groups.test.ts
@@ -103,7 +103,7 @@ describe('GET /api/rich-menu-groups', () => {
     dbMocks.getRichMenuGroups.mockResolvedValue([
       {
         id: 'g1', account_id: 'acc-1', name: 'メイン', chat_bar_text: 'メニュー',
-        size: 'large', default_page_id: 'p1', is_default_for_all: 1,
+        size: 'large', default_page_id: 'p1', is_default_for_all: 1, selected: 1,
         status: 'published', publishing_at: null,
         created_at: '2026-05-08T00:00:00.000', updated_at: '2026-05-08T01:00:00.000',
       },
@@ -113,7 +113,7 @@ describe('GET /api/rich-menu-groups', () => {
     const body = (await res.json()) as { data: any[] };
     expect(body.data[0]).toMatchObject({
       id: 'g1', accountId: 'acc-1', chatBarText: 'メニュー',
-      isDefaultForAll: true, status: 'published',
+      isDefaultForAll: true, selected: true, status: 'published',
     });
   });
 });
@@ -269,7 +269,7 @@ describe('POST /api/rich-menu-groups', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        accountId: 'a', name: 'x', chatBarText: 'バー', size: 'large',
+        accountId: 'a', name: 'x', chatBarText: 'バー', size: 'large', selected: true,
         pages: [{ name: 'p1', orderIndex: 0, areas: [] }],
       }),
     });
@@ -277,7 +277,7 @@ describe('POST /api/rich-menu-groups', () => {
     expect(dbMocks.createRichMenuGroup).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        accountId: 'a', name: 'x', chatBarText: 'バー', size: 'large',
+        accountId: 'a', name: 'x', chatBarText: 'バー', size: 'large', selected: true,
         pages: [expect.objectContaining({ name: 'p1', orderIndex: 0 })],
       }),
     );
@@ -309,11 +309,11 @@ describe('PATCH /api/rich-menu-groups/:groupId', () => {
     const res = await app.request('/api/rich-menu-groups/g1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: 'new', isDefaultForAll: true }),
+      body: JSON.stringify({ name: 'new', isDefaultForAll: true, selected: true }),
     });
     expect(res.status).toBe(200);
     expect(dbMocks.updateRichMenuGroupMeta).toHaveBeenCalledWith(expect.anything(), 'g1', {
-      name: 'new', isDefaultForAll: true,
+      name: 'new', isDefaultForAll: true, selected: true,
     });
     expect(dbMocks.replaceRichMenuPages).not.toHaveBeenCalled();
   });

--- a/apps/worker/src/routes/rich-menu-groups.ts
+++ b/apps/worker/src/routes/rich-menu-groups.ts
@@ -47,6 +47,7 @@ function serializeGroup(row: RichMenuGroup) {
     size: row.size,
     defaultPageId: row.default_page_id,
     isDefaultForAll: row.is_default_for_all === 1,
+    selected: row.selected === 1,
     status: row.status,
     publishingAt: row.publishing_at,
     createdAt: row.created_at,
@@ -196,6 +197,9 @@ function parseCreateBody(raw: unknown): Parsed<CreateRichMenuGroupInput> {
     return { ok: false, error: 'chatBarText required (1..14 chars)' };
   }
   if (typeof r.size !== 'string' || !VALID_SIZES.has(r.size)) return { ok: false, error: 'size must be large or compact' };
+  if (r.selected !== undefined && typeof r.selected !== 'boolean') {
+    return { ok: false, error: 'selected must be boolean' };
+  }
   const pages = parsePages(r.pages);
   if (!pages.ok) return pages;
   return {
@@ -205,6 +209,7 @@ function parseCreateBody(raw: unknown): Parsed<CreateRichMenuGroupInput> {
       name: r.name,
       chatBarText: r.chatBarText,
       size: r.size as 'large' | 'compact',
+      selected: r.selected === true,
       pages: pages.value,
     },
   };
@@ -227,6 +232,10 @@ function parsePatchBody(raw: unknown): Parsed<{ meta: UpdateRichMenuGroupMetaInp
   if (r.isDefaultForAll !== undefined) {
     if (typeof r.isDefaultForAll !== 'boolean') return { ok: false, error: 'isDefaultForAll must be boolean' };
     meta.isDefaultForAll = r.isDefaultForAll;
+  }
+  if (r.selected !== undefined) {
+    if (typeof r.selected !== 'boolean') return { ok: false, error: 'selected must be boolean' };
+    meta.selected = r.selected;
   }
   let pages: RichMenuPageInput[] | undefined;
   if (r.pages !== undefined) {
@@ -320,6 +329,7 @@ richMenuGroups.post('/api/rich-menu-groups/import', async (c) => {
   const detail = (await detailRes.json()) as {
     name: string;
     chatBarText: string;
+    selected: boolean;
     size: { width: number; height: number };
     areas: LineArea[];
   };
@@ -409,6 +419,7 @@ richMenuGroups.post('/api/rich-menu-groups/import', async (c) => {
     name: detail.name,
     chatBarText: detail.chatBarText,
     size,
+    selected: detail.selected,
     pages: [
       {
         name: 'ページ 1',
@@ -517,6 +528,7 @@ richMenuGroups.get('/api/rich-menu-groups/external', async (c) => {
           richMenuId: m.richMenuId,
           name: m.name,
           chatBarText: m.chatBarText,
+          selected: m.selected,
           size: m.size,
           areasCount: Array.isArray(m.areas) ? m.areas.length : 0,
           isCurrentDefault: currentDefault === m.richMenuId,
@@ -862,6 +874,7 @@ richMenuGroups.post('/api/rich-menu-groups/:groupId/publish', async (c) => {
       size: group.size,
       chatBarText: group.chat_bar_text,
       isDefaultForAll: group.is_default_for_all === 1,
+      selected: group.selected === 1,
       pages: group.pages.map((p) => ({
         id: p.id,
         orderIndex: p.order_index,
@@ -908,6 +921,7 @@ richMenuGroups.post('/api/rich-menu-groups/:groupId/unpublish', async (c) => {
     size: group.size,
     chatBarText: group.chat_bar_text,
     isDefaultForAll: group.is_default_for_all === 1,
+    selected: group.selected === 1,
     pages: group.pages.map((p) => ({
       id: p.id,
       orderIndex: p.order_index,

--- a/docs/wiki/Release-Notes.md
+++ b/docs/wiki/Release-Notes.md
@@ -1,5 +1,22 @@
 # Release Notes
 
+## v0.21.2 (2026-08-14)
+
+### Added — Rich menu initial display
+
+- Rich menus can now choose whether LINE opens the menu automatically when a friend enters the chat.
+- The setting is available on both the new-menu and edit screens and is applied the next time the menu is registered with LINE.
+- Existing menus retain the previous OFF behavior; newly created menus default to ON in the Admin UI.
+
+### Fixed — Admin update uploads
+
+- Cloudflare Pages asset uploads now use the same top-level JSON array format as Wrangler, fixing opaque HTTP 500 failures when the Admin update contains uncached assets.
+- Upload batches are bounded by both file count and 40 MiB of source data, with up to five retries for HTTP 429 and 5xx responses.
+
+### Database
+
+- Additive migration `069_rich_menu_selected.sql` stores the LINE rich-menu `selected` setting.
+
 ## v0.21.1 (2026-08-14)
 
 ### Fixed — Webinar analytics and registration delivery

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "line-oss-crm",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "description": "Open-source LINE Official Account CRM/marketing automation",
   "scripts": {

--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Set up LINE Harness — AI-operated LINE CRM — with one command",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@line-harness/update-engine": "workspace:^0.0.7",
+    "@line-harness/update-engine": "workspace:^0.0.8",
     "execa": "^9.5.2",
     "picocolors": "^1.1.1"
   },

--- a/packages/db/bootstrap-meta.json
+++ b/packages/db/bootstrap-meta.json
@@ -72,7 +72,8 @@
     "065_following_loyalty_mileage.sql",
     "066_referral_quality_mileage.sql",
     "067_mileage_keyword_auto_reply.sql",
-    "068_media_inquiries.sql"
+    "068_media_inquiries.sql",
+    "069_rich_menu_selected.sql"
   ],
-  "migrationCount": 73
+  "migrationCount": 74
 }

--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -807,6 +807,7 @@ CREATE TABLE rich_menu_groups (
   size               TEXT NOT NULL CHECK (size IN ('large','compact')),
   default_page_id    TEXT,
   is_default_for_all INTEGER NOT NULL DEFAULT 0,
+  selected           INTEGER NOT NULL DEFAULT 0,
   status             TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','published')),
   publishing_at      TEXT,
   created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),

--- a/packages/db/migrations/069_rich_menu_selected.sql
+++ b/packages/db/migrations/069_rich_menu_selected.sql
@@ -1,0 +1,3 @@
+-- LINE の rich menu 作成時に、トークを開いた直後からメニューを展開するかを保持する。
+-- 既存メニューは従来動作 (false) を維持する。
+ALTER TABLE rich_menu_groups ADD COLUMN selected INTEGER NOT NULL DEFAULT 0;

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -1097,6 +1097,7 @@ CREATE TABLE IF NOT EXISTS rich_menu_groups (
   size               TEXT NOT NULL CHECK (size IN ('large','compact')),
   default_page_id    TEXT,
   is_default_for_all INTEGER NOT NULL DEFAULT 0,
+  selected           INTEGER NOT NULL DEFAULT 0,
   status             TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft','published')),
   publishing_at      TEXT,
   created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),

--- a/packages/db/src/rich-menus.ts
+++ b/packages/db/src/rich-menus.ts
@@ -20,6 +20,7 @@ export interface RichMenuGroup {
   size: 'large' | 'compact';
   default_page_id: string | null;
   is_default_for_all: number;
+  selected: number;
   status: 'draft' | 'published';
   publishing_at: string | null;
   created_at: string;
@@ -77,6 +78,7 @@ export interface CreateRichMenuGroupInput {
   name: string;
   chatBarText: string;
   size: 'large' | 'compact';
+  selected: boolean;
   pages: RichMenuPageInput[];
 }
 
@@ -84,6 +86,7 @@ export interface UpdateRichMenuGroupMetaInput {
   name?: string;
   chatBarText?: string;
   isDefaultForAll?: boolean;
+  selected?: boolean;
 }
 
 export interface RichMenuPageWithAreas extends RichMenuPage {
@@ -185,8 +188,8 @@ export async function createRichMenuGroup(
       .prepare(
         `INSERT INTO rich_menu_groups
            (id, account_id, name, chat_bar_text, size, default_page_id,
-            is_default_for_all, status, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, 0, 'draft', ?, ?)`,
+            is_default_for_all, selected, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, 0, ?, 'draft', ?, ?)`,
       )
       .bind(
         groupId,
@@ -195,6 +198,7 @@ export async function createRichMenuGroup(
         input.chatBarText,
         input.size,
         defaultPageId,
+        input.selected ? 1 : 0,
         now,
         now,
       ),
@@ -258,6 +262,10 @@ export async function updateRichMenuGroupMeta(
   if (patch.isDefaultForAll !== undefined) {
     sets.push('is_default_for_all = ?');
     vals.push(patch.isDefaultForAll ? 1 : 0);
+  }
+  if (patch.selected !== undefined) {
+    sets.push('selected = ?');
+    vals.push(patch.selected ? 1 : 0);
   }
   if (sets.length === 0) return;
   sets.push('updated_at = ?');

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/mcp-server",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "MCP server for LINE Harness — operate a LINE official account from AI agents over MCP",
   "type": "module",
   "bin": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/sdk",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "AI-native SDK for LINE Harness — programmatic LINE official account automation",
   "type": "module",
   "exports": {

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/update-engine",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Self-update engine for LINE Harness — shared between Worker (cloud-side self-update) and CLI (npx create-line-harness update)",
   "type": "module",
   "exports": {

--- a/packages/update-engine/src/cf-api/pages.ts
+++ b/packages/update-engine/src/cf-api/pages.ts
@@ -112,13 +112,15 @@ interface UploadEntry {
   base64: true;
 }
 
-// Wrangler also uploads Pages assets in bounded batches. Keeping each
-// request small avoids oversized JSON/base64 payloads causing the Pages
-// upload Worker to fail, while sequential batches keep memory and API load
-// predictable for the CLI and Worker-side updater.
+// Keep batches small by count. A count cap is useful for Admin bundles with
+// many tiny chunks; the byte cap below handles a few unusually large assets.
 const ASSET_UPLOAD_BATCH_SIZE = 50;
-const ASSET_UPLOAD_MAX_ATTEMPTS = 3;
-const ASSET_UPLOAD_RETRY_BASE_MS = 250;
+// Match Wrangler's Pages uploader: a bucket contains at most 40 MiB of raw
+// file data. Base64 expands this on the wire, but the API limit is defined in
+// terms of the source files Wrangler buckets.
+const ASSET_UPLOAD_MAX_RAW_BYTES = 40 * 1024 * 1024;
+const ASSET_UPLOAD_MAX_ATTEMPTS = 5;
+const ASSET_UPLOAD_RETRY_BASE_MS = 1000;
 
 function isRetryableUploadStatus(status: number): boolean {
   return status === 429 || status >= 500;
@@ -132,7 +134,7 @@ function delay(ms: number): Promise<void> {
  * Push a batch of missing assets to CF. The payload is `key → base64
  * content` plus a small metadata blob (just the Content-Type for now).
  * Callers must skip this entirely when the missing-hashes list is
- * empty — the API errors on an empty `payload` array.
+ * empty — the API errors on an empty top-level array.
  */
 async function uploadAssets(
   jwt: string,
@@ -147,7 +149,10 @@ async function uploadAssets(
           ...authHeader(jwt),
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ payload: entries }),
+        // Pages expects the upload entries as the top-level JSON array.
+        // `{ payload: entries }` is not the Direct Upload wire format and can
+        // surface as an opaque HTTP 500 from the assets Worker.
+        body: JSON.stringify(entries),
       },
     );
     if (res.ok) return;
@@ -237,8 +242,26 @@ export async function deployPagesProject(opts: {
         base64: true,
       });
     }
-    for (let i = 0; i < entries.length; i += ASSET_UPLOAD_BATCH_SIZE) {
-      await uploadAssets(jwt, entries.slice(i, i + ASSET_UPLOAD_BATCH_SIZE));
+    let batch: UploadEntry[] = [];
+    let batchRawBytes = 0;
+    for (const entry of entries) {
+      // Derive the original byte count from base64 without decoding it.
+      const padding = entry.value.endsWith('==') ? 2 : entry.value.endsWith('=') ? 1 : 0;
+      const rawBytes = Math.floor((entry.value.length * 3) / 4) - padding;
+      if (
+        batch.length > 0 &&
+        (batch.length >= ASSET_UPLOAD_BATCH_SIZE ||
+          batchRawBytes + rawBytes > ASSET_UPLOAD_MAX_RAW_BYTES)
+      ) {
+        await uploadAssets(jwt, batch);
+        batch = [];
+        batchRawBytes = 0;
+      }
+      batch.push(entry);
+      batchRawBytes += rawBytes;
+    }
+    if (batch.length > 0) {
+      await uploadAssets(jwt, batch);
     }
   }
 

--- a/packages/update-engine/test/cf-api/pages.test.ts
+++ b/packages/update-engine/test/cf-api/pages.test.ts
@@ -181,9 +181,9 @@ describe('deployPagesProject', () => {
 
     const [, uploadInit] = fetchMock.mock.calls[2] as [string, RequestInit];
     const uploadBody = JSON.parse(uploadInit.body as string);
-    expect(Array.isArray(uploadBody.payload)).toBe(true);
-    expect(uploadBody.payload).toHaveLength(1);
-    const entry = uploadBody.payload[0];
+    expect(Array.isArray(uploadBody)).toBe(true);
+    expect(uploadBody).toHaveLength(1);
+    const entry = uploadBody[0];
     expect(entry.key).toBe(hash);
     expect(entry.value).toBe(content.toString('base64'));
     expect(entry.base64).toBe(true);
@@ -224,8 +224,8 @@ describe('deployPagesProject', () => {
 
     const [, firstUpload] = fetchMock.mock.calls[2] as [string, RequestInit];
     const [, secondUpload] = fetchMock.mock.calls[3] as [string, RequestInit];
-    expect(JSON.parse(firstUpload.body as string).payload).toHaveLength(50);
-    expect(JSON.parse(secondUpload.body as string).payload).toHaveLength(1);
+    expect(JSON.parse(firstUpload.body as string)).toHaveLength(50);
+    expect(JSON.parse(secondUpload.body as string)).toHaveLength(1);
     expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,7 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@line-harness/update-engine':
-        specifier: workspace:^0.0.7
+        specifier: workspace:^0.0.8
         version: link:../update-engine
       execa:
         specifier: ^9.5.2


### PR DESCRIPTION
## Summary
- make the rich-menu initial display (`selected`) configurable in Admin
- pass the configured value to the LINE rich-menu publisher
- fix Cloudflare Pages Admin asset uploads and add batching/retries
- prepare v0.21.2 release metadata and package versions

## Verification
- 1,341 tests passed across the workspace
- all available builds and typechecks passed
- release migration safety passed for all 30 migrations
- Worker production deployment applied migration 069 successfully
- Admin and Worker production deployments succeeded