### PR TITLE
feat: reorganize booking management view

### DIFF
--- a/apps/web/src/app/booking/bookings/booking-view.test.ts
+++ b/apps/web/src/app/booking/bookings/booking-view.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { BookingRequest } from '@/lib/api'
+import {
+  getBookingTimeGroup,
+  isRecentlyReceived,
+  matchesTimeFilter,
+  sortBookings,
+} from './booking-view'
+
+const now = new Date('2026-08-15T06:00:00.000Z') // JST 15:00
+
+function booking(id: string, startsAt: string, requestedAt: string): BookingRequest {
+  return {
+    id,
+    friend_id: `friend-${id}`,
+    starts_at: startsAt,
+    ends_at: startsAt,
+    status: 'confirmed',
+    customer_note: null,
+    internal_note: null,
+    price_at_booking: 0,
+    menu_name: '相談',
+    staff_name: '担当者',
+    friend_name: '顧客',
+    requested_at: requestedAt,
+  }
+}
+
+describe('booking view helpers', () => {
+  it('JST の日付で今日・今後・過去を分類する', () => {
+    expect(getBookingTimeGroup('2026-08-14T15:30:00.000Z', now)).toBe('today')
+    expect(getBookingTimeGroup('2026-08-15T15:00:00.000Z', now)).toBe('future')
+    expect(getBookingTimeGroup('2026-08-14T14:59:59.000Z', now)).toBe('past')
+  })
+
+  it('今日以降フィルターは今日と未来だけを含む', () => {
+    expect(matchesTimeFilter('2026-08-14T15:00:00.000Z', 'upcoming', now)).toBe(true)
+    expect(matchesTimeFilter('2026-08-16T00:00:00.000Z', 'upcoming', now)).toBe(true)
+    expect(matchesTimeFilter('2026-08-14T14:59:59.000Z', 'upcoming', now)).toBe(false)
+  })
+
+  it('予定順では今後を昇順、過去を降順に並べる', () => {
+    const older = booking('older', '2026-08-16T01:00:00.000Z', '2026-08-10T00:00:00.000Z')
+    const newer = booking('newer', '2026-08-17T01:00:00.000Z', '2026-08-14T00:00:00.000Z')
+    expect(sortBookings([newer, older], 'schedule', 'future').map((b) => b.id)).toEqual(['older', 'newer'])
+    expect(sortBookings([older, newer], 'schedule', 'past').map((b) => b.id)).toEqual(['newer', 'older'])
+    expect(sortBookings([older, newer], 'received', 'future').map((b) => b.id)).toEqual(['newer', 'older'])
+  })
+
+  it('72時間以内の受付を新着と判定する', () => {
+    expect(isRecentlyReceived('2026-08-13T06:00:00.000Z', now)).toBe(true)
+    expect(isRecentlyReceived('2026-08-11T06:00:00.000Z', now)).toBe(false)
+  })
+})

--- a/apps/web/src/app/booking/bookings/booking-view.ts
+++ b/apps/web/src/app/booking/bookings/booking-view.ts
@@ -1,0 +1,67 @@
+import type { BookingRequest } from '@/lib/api'
+
+export type BookingTimeFilter = 'upcoming' | 'today' | 'future' | 'past' | 'all'
+export type BookingSort = 'schedule' | 'received'
+export type BookingTimeGroup = 'today' | 'future' | 'past'
+
+const JST_DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  timeZone: 'Asia/Tokyo',
+})
+
+function jstDateKey(value: string | Date): string {
+  const parts = JST_DATE_FORMATTER.formatToParts(
+    typeof value === 'string' ? new Date(value) : value,
+  )
+  const year = parts.find((part) => part.type === 'year')?.value ?? ''
+  const month = parts.find((part) => part.type === 'month')?.value ?? ''
+  const day = parts.find((part) => part.type === 'day')?.value ?? ''
+  return `${year}-${month}-${day}`
+}
+
+export function getBookingTimeGroup(
+  startsAt: string,
+  now: Date = new Date(),
+): BookingTimeGroup {
+  const bookingDate = jstDateKey(startsAt)
+  const today = jstDateKey(now)
+  if (bookingDate === today) return 'today'
+  return bookingDate > today ? 'future' : 'past'
+}
+
+export function matchesTimeFilter(
+  startsAt: string,
+  filter: BookingTimeFilter,
+  now: Date = new Date(),
+): boolean {
+  if (filter === 'all') return true
+  const group = getBookingTimeGroup(startsAt, now)
+  if (filter === 'upcoming') return group === 'today' || group === 'future'
+  return group === filter
+}
+
+export function sortBookings(
+  bookings: BookingRequest[],
+  sort: BookingSort,
+  group: BookingTimeGroup,
+): BookingRequest[] {
+  return [...bookings].sort((a, b) => {
+    if (sort === 'received') {
+      return new Date(b.requested_at).getTime() - new Date(a.requested_at).getTime()
+    }
+
+    const direction = group === 'past' ? -1 : 1
+    return direction * (new Date(a.starts_at).getTime() - new Date(b.starts_at).getTime())
+  })
+}
+
+export function isRecentlyReceived(
+  requestedAt: string,
+  now: Date = new Date(),
+  withinHours = 72,
+): boolean {
+  const elapsed = now.getTime() - new Date(requestedAt).getTime()
+  return elapsed >= 0 && elapsed <= withinHours * 60 * 60 * 1000
+}

--- a/apps/web/src/app/booking/bookings/page.tsx
+++ b/apps/web/src/app/booking/bookings/page.tsx
@@ -1,32 +1,51 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import Header from '@/components/layout/header'
 import { bookingApi, type BookingRequest } from '@/lib/api'
 import { useAccount } from '@/contexts/account-context'
+import {
+  getBookingTimeGroup,
+  isRecentlyReceived,
+  matchesTimeFilter,
+  sortBookings,
+  type BookingSort,
+  type BookingTimeFilter,
+  type BookingTimeGroup,
+} from './booking-view'
 
-const STATUS_TABS: Array<{ key: string; label: string }> = [
+const STATUS_FILTERS: Array<{ key: string; label: string }> = [
+  { key: 'all', label: 'すべて' },
   { key: 'requested', label: '未承認' },
   { key: 'confirmed', label: '確定' },
+  { key: 'completed', label: '完了' },
+  { key: 'cancelled', label: 'キャンセル' },
   { key: 'rejected', label: '拒否' },
   { key: 'expired', label: '期限切れ' },
-  { key: 'cancelled', label: 'キャンセル' },
-  { key: 'all', label: '全件' },
+  { key: 'no_show', label: '無断' },
+]
+
+const TIME_FILTERS: Array<{ key: BookingTimeFilter; label: string }> = [
+  { key: 'upcoming', label: '今日以降' },
+  { key: 'today', label: '今日' },
+  { key: 'future', label: '明日以降' },
+  { key: 'past', label: '過去' },
+  { key: 'all', label: '全期間' },
 ]
 
 const statusBadgeColor: Record<string, string> = {
-  requested: 'bg-yellow-100 text-yellow-800',
-  confirmed: 'bg-green-100 text-green-800',
-  rejected: 'bg-gray-100 text-gray-700',
-  expired: 'bg-gray-100 text-gray-600',
-  cancelled: 'bg-gray-100 text-gray-600',
-  completed: 'bg-blue-100 text-blue-800',
-  no_show: 'bg-red-100 text-red-800',
+  requested: 'bg-amber-100 text-amber-800 ring-amber-200',
+  confirmed: 'bg-emerald-100 text-emerald-800 ring-emerald-200',
+  rejected: 'bg-gray-100 text-gray-700 ring-gray-200',
+  expired: 'bg-gray-100 text-gray-600 ring-gray-200',
+  cancelled: 'bg-gray-100 text-gray-600 ring-gray-200',
+  completed: 'bg-blue-100 text-blue-800 ring-blue-200',
+  no_show: 'bg-red-100 text-red-800 ring-red-200',
 }
 
 const statusLabel: Record<string, string> = {
-  requested: 'リクエスト',
+  requested: '未承認',
   confirmed: '確定',
   rejected: '拒否',
   expired: '期限切れ',
@@ -43,33 +62,40 @@ const actionLabel: Record<string, string> = {
   complete: '完了',
 }
 
-function formatJpDateTime(iso: string): string {
-  return new Date(iso).toLocaleString('ja-JP', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    timeZone: 'Asia/Tokyo',
-  })
-}
+const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
+  month: 'numeric',
+  day: 'numeric',
+  weekday: 'short',
+  timeZone: 'Asia/Tokyo',
+})
+
+const timeFormatter = new Intl.DateTimeFormat('ja-JP', {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: 'Asia/Tokyo',
+})
+
+const receivedFormatter = new Intl.DateTimeFormat('ja-JP', {
+  month: 'numeric',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: 'Asia/Tokyo',
+})
 
 export default function BookingsPage() {
   const { selectedAccountId, selectedAccount } = useAccount()
-  const [tab, setTab] = useState<string>('requested')
+  const [statusFilter, setStatusFilter] = useState('all')
+  const [timeFilter, setTimeFilter] = useState<BookingTimeFilter>('upcoming')
+  const [sort, setSort] = useState<BookingSort>('schedule')
   const [items, setItems] = useState<BookingRequest[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  // copied 状態は URL 単位で持つ。アカウント切替で shareUrl が変わると
-  // 自動で「コピー済」が消えるので、A の URL をコピーしたまま B 画面で
-  // 「B フォームと思い込んで送信」する事故を防ぐ。
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null)
 
   const liffId = selectedAccount?.liffId ?? null
-  // Worker `/o` は ref 解決・追跡なしで liffId を直接受けるラップ URL。
-  // `liff.line.me` を直貼りすると OpenChat / IG DM 等で削除されるため、
-  // LINE 内配信も SNS 配信もこの 1 本で完結させる。/o は LINE 内 UA でも
-  // 「LINEで開く」ボタン経由で Universal Link → LIFF を起動する。
   const workerBase = process.env.NEXT_PUBLIC_API_URL ?? ''
   const shareUrl = workerBase && liffId
     ? `${workerBase}/o?liffId=${encodeURIComponent(liffId)}&page=salon-book`
@@ -82,7 +108,7 @@ export default function BookingsPage() {
       await navigator.clipboard.writeText(url)
       setCopiedUrl(url)
       setTimeout(() => {
-        setCopiedUrl((cur) => (cur === url ? null : cur))
+        setCopiedUrl((current) => (current === url ? null : current))
       }, 2000)
     } catch {
       window.prompt('コピーしてください:', url)
@@ -90,27 +116,32 @@ export default function BookingsPage() {
   }
 
   const load = useCallback(async () => {
-    if (!selectedAccountId) return
+    if (!selectedAccountId) {
+      setItems([])
+      setLoading(false)
+      return
+    }
     setLoading(true)
     setError(null)
-    // タブ/アカウント切り替えで先に list をクリア。fetch 失敗時に前タブの行が
-    // 残ってしまい、誤って別ステータスの予約を操作してしまう事故を防ぐ。
     setItems([])
     try {
-      const r = await bookingApi.listRequests(selectedAccountId, tab)
-      setItems(r.requests)
+      const response = await bookingApi.listRequests(selectedAccountId, 'all')
+      setItems(response.requests)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     } finally {
       setLoading(false)
     }
-  }, [selectedAccountId, tab])
+  }, [selectedAccountId])
 
   useEffect(() => {
     load()
   }, [load])
 
-  async function handleDecide(id: string, action: 'approve' | 'reject' | 'cancel' | 'no_show' | 'complete') {
+  async function handleDecide(
+    id: string,
+    action: 'approve' | 'reject' | 'cancel' | 'no_show' | 'complete',
+  ) {
     if (!selectedAccountId) return
     if (!confirm(`この予約を「${actionLabel[action]}」しますか？`)) return
     try {
@@ -121,145 +152,457 @@ export default function BookingsPage() {
     }
   }
 
+  const counts = useMemo(() => {
+    const referenceNow = new Date()
+    return {
+      requested: items.filter((item) => item.status === 'requested').length,
+      today: items.filter((item) => getBookingTimeGroup(item.starts_at, referenceNow) === 'today').length,
+      future: items.filter((item) => getBookingTimeGroup(item.starts_at, referenceNow) === 'future').length,
+      past: items.filter((item) => getBookingTimeGroup(item.starts_at, referenceNow) === 'past').length,
+    }
+  }, [items])
+
+  const statusCounts = useMemo(() => {
+    const result: Record<string, number> = { all: items.length }
+    for (const item of items) result[item.status] = (result[item.status] ?? 0) + 1
+    return result
+  }, [items])
+
+  const groupedItems = useMemo(() => {
+    const referenceNow = new Date()
+    const groups: Record<BookingTimeGroup, BookingRequest[]> = {
+      today: [],
+      future: [],
+      past: [],
+    }
+    for (const item of items) {
+      if (statusFilter !== 'all' && item.status !== statusFilter) continue
+      if (!matchesTimeFilter(item.starts_at, timeFilter, referenceNow)) continue
+      groups[getBookingTimeGroup(item.starts_at, referenceNow)].push(item)
+    }
+    groups.today = sortBookings(groups.today, sort, 'today')
+    groups.future = sortBookings(groups.future, sort, 'future')
+    groups.past = sortBookings(groups.past, sort, 'past')
+    return groups
+  }, [items, sort, statusFilter, timeFilter])
+
+  const visibleCount = groupedItems.today.length + groupedItems.future.length + groupedItems.past.length
+
+  function showRequested() {
+    setStatusFilter('requested')
+    setTimeFilter('all')
+    setSort('received')
+  }
+
+  function showTime(filter: BookingTimeFilter) {
+    setStatusFilter('all')
+    setTimeFilter(filter)
+    setSort('schedule')
+  }
+
   return (
     <div>
       <Header
         title="予約管理"
-        description="顧客からの予約リクエストを承認・拒否します"
+        description="今日の予定と新しい予約を、ここから確認・対応できます"
       />
 
       {selectedAccountId && (
-        <div className="mb-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
-          <div className="flex items-center gap-2 text-sm font-medium text-blue-900 mb-2">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M13.828 10.172a4 4 0 015.656 0l1.414 1.414a4 4 0 010 5.656l-3 3a4 4 0 01-5.656 0L10 18.343M10.172 13.828a4 4 0 01-5.656 0L3.1 12.414a4 4 0 010-5.656l3-3a4 4 0 015.656 0L14 5.657"
-              />
-            </svg>
-            お客様向け 予約フォーム LIFF URL
+        <div className="mb-5 rounded-xl border border-blue-200 bg-blue-50 p-4">
+          <div className="mb-2 flex items-center gap-2 text-sm font-medium text-blue-900">
+            <LinkIcon />
+            お客様向け 予約フォーム URL
           </div>
           {shareUrl ? (
             <>
-              <div className="flex gap-2 items-center">
+              <div className="flex items-center gap-2">
                 <input
                   readOnly
                   value={shareUrl}
                   onFocus={(e) => e.currentTarget.select()}
-                  className="flex-1 border border-blue-200 rounded-lg px-3 py-2 text-xs bg-white font-mono"
+                  className="min-w-0 flex-1 rounded-lg border border-blue-200 bg-white px-3 py-2 text-xs font-mono"
                 />
                 <button
                   type="button"
                   onClick={() => copyUrl(shareUrl)}
-                  className="px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+                  className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
                 >
                   {copied ? 'コピー済' : 'コピー'}
                 </button>
               </div>
-              <p className="text-xs text-blue-700 mt-2">
-                LINE / OpenChat / IG DM どこでも貼れます。受信者がタップすると LINE で予約画面が開きます。
+              <p className="mt-2 text-xs text-blue-700">
+                LINE / OpenChat / IG DM で共有できます。タップすると LINE の予約画面が開きます。
               </p>
             </>
           ) : (
             <p className="text-xs text-amber-700">
               このアカウントには LIFF ID が未設定です。
-              <a href="/accounts" className="underline ml-1">アカウント設定</a> で LIFF ID を登録してください。
+              <a href="/accounts" className="ml-1 underline">アカウント設定</a> で登録してください。
             </p>
           )}
         </div>
       )}
 
       {error && (
-        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
           {error}
         </div>
       )}
 
-      <div className="mb-4 flex flex-wrap gap-2">
-        {STATUS_TABS.map(({ key, label }) => (
-          <button
-            key={key}
-            onClick={() => setTab(key)}
-            className={`px-3 py-1.5 text-xs font-medium rounded-full transition-colors ${
-              tab === key ? 'text-white' : 'text-gray-600 bg-gray-100 hover:bg-gray-200'
-            }`}
-            style={tab === key ? { backgroundColor: '#06C755' } : undefined}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
+      {selectedAccountId && !loading && (
+        <div className="mb-5 grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <SummaryCard
+            label="要対応"
+            count={counts.requested}
+            helper="未承認の予約"
+            tone="amber"
+            active={statusFilter === 'requested'}
+            onClick={showRequested}
+          />
+          <SummaryCard
+            label="今日"
+            count={counts.today}
+            helper="本日の予約"
+            tone="blue"
+            active={timeFilter === 'today' && statusFilter === 'all'}
+            onClick={() => showTime('today')}
+          />
+          <SummaryCard
+            label="今後"
+            count={counts.future}
+            helper="明日以降"
+            tone="green"
+            active={timeFilter === 'future' && statusFilter === 'all'}
+            onClick={() => showTime('future')}
+          />
+          <SummaryCard
+            label="過去"
+            count={counts.past}
+            helper="終了した日程"
+            tone="gray"
+            active={timeFilter === 'past' && statusFilter === 'all'}
+            onClick={() => showTime('past')}
+          />
+        </div>
+      )}
 
-      {!selectedAccountId ? (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center text-sm text-gray-500">
-          サイドバーでアカウントを選択してください
-        </div>
-      ) : loading ? (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center text-sm text-gray-500">
-          読み込み中…
-        </div>
-      ) : items.length === 0 ? (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center text-sm text-gray-500">
-          該当する予約はありません
-        </div>
-      ) : (
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[800px]">
-              <thead>
-                <tr className="bg-gray-50 border-b border-gray-200">
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">日時</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">顧客</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">メニュー</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">担当</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">要望</th>
-                  <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase">料金</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">状態</th>
-                  <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase">操作</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {items.map((b) => (
-                  <tr key={b.id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 text-sm whitespace-nowrap">{formatJpDateTime(b.starts_at)}</td>
-                    <td className="px-4 py-3 text-sm">
-                      <Link
-                        href={`/chats?friend=${b.friend_id}`}
-                        className="text-blue-600 hover:underline"
-                      >
-                        {b.friend_name ?? '-'}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-3 text-sm">{b.menu_name}</td>
-                    <td className="px-4 py-3 text-sm">{b.staff_name}</td>
-                    <td className="px-4 py-3 text-sm text-gray-600 max-w-xs truncate" title={b.customer_note ?? ''}>
-                      {b.customer_note ?? '-'}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-right tabular-nums">¥{b.price_at_booking.toLocaleString()}</td>
-                    <td className="px-4 py-3 text-sm">
-                      <span className={`inline-block px-2 py-0.5 rounded text-xs ${statusBadgeColor[b.status] ?? 'bg-gray-100'}`}>
-                        {statusLabel[b.status] ?? b.status}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <ActionButtons status={b.status} onAction={(a) => handleDecide(b.id, a)} />
-                    </td>
-                  </tr>
+      {selectedAccountId && !loading && (
+        <div className="mb-4 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+            <div className="space-y-3">
+              <FilterGroup label="期間">
+                {TIME_FILTERS.map(({ key, label }) => (
+                  <FilterButton
+                    key={key}
+                    active={timeFilter === key}
+                    onClick={() => setTimeFilter(key)}
+                  >
+                    {label}
+                  </FilterButton>
                 ))}
-              </tbody>
-            </table>
+              </FilterGroup>
+              <FilterGroup label="状態">
+                {STATUS_FILTERS.map(({ key, label }) => (
+                  <FilterButton
+                    key={key}
+                    active={statusFilter === key}
+                    onClick={() => setStatusFilter(key)}
+                  >
+                    {label}
+                    <span className="ml-1 opacity-60">{statusCounts[key] ?? 0}</span>
+                  </FilterButton>
+                ))}
+              </FilterGroup>
+            </div>
+            <label className="flex shrink-0 items-center gap-2 text-xs font-medium text-gray-500">
+              並び順
+              <select
+                value={sort}
+                onChange={(e) => setSort(e.target.value as BookingSort)}
+                className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800"
+              >
+                <option value="schedule">予約日時が近い順</option>
+                <option value="received">受付が新しい順</option>
+              </select>
+            </label>
           </div>
         </div>
       )}
+
+      {!selectedAccountId ? (
+        <EmptyPanel>サイドバーでアカウントを選択してください</EmptyPanel>
+      ) : loading ? (
+        <EmptyPanel>読み込み中…</EmptyPanel>
+      ) : visibleCount === 0 ? (
+        <EmptyPanel>
+          <div className="font-medium text-gray-700">条件に合う予約はありません</div>
+          <button
+            type="button"
+            onClick={() => {
+              setStatusFilter('all')
+              setTimeFilter('all')
+            }}
+            className="mt-2 text-sm font-medium text-blue-600 hover:underline"
+          >
+            絞り込みを解除
+          </button>
+        </EmptyPanel>
+      ) : (
+        <div className="space-y-5">
+          {groupedItems.today.length > 0 && (
+            <BookingSection
+              title="今日の予約"
+              helper="まず確認する予定"
+              tone="blue"
+              items={groupedItems.today}
+              onAction={handleDecide}
+            />
+          )}
+          {groupedItems.future.length > 0 && (
+            <BookingSection
+              title="今後の予約"
+              helper="明日以降の予定"
+              tone="green"
+              items={groupedItems.future}
+              onAction={handleDecide}
+            />
+          )}
+          {groupedItems.past.length > 0 && (
+            <BookingSection
+              title="過去の予約"
+              helper="新しい日付から表示"
+              tone="gray"
+              items={groupedItems.past}
+              onAction={handleDecide}
+              collapsible={timeFilter === 'all'}
+            />
+          )}
+        </div>
+      )}
     </div>
+  )
+}
+
+function SummaryCard({
+  label,
+  count,
+  helper,
+  tone,
+  active,
+  onClick,
+}: {
+  label: string
+  count: number
+  helper: string
+  tone: 'amber' | 'blue' | 'green' | 'gray'
+  active: boolean
+  onClick: () => void
+}) {
+  const tones = {
+    amber: 'border-amber-200 bg-amber-50 text-amber-900',
+    blue: 'border-blue-200 bg-blue-50 text-blue-900',
+    green: 'border-emerald-200 bg-emerald-50 text-emerald-900',
+    gray: 'border-gray-200 bg-gray-50 text-gray-800',
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-xl border p-4 text-left transition hover:-translate-y-0.5 hover:shadow-sm ${tones[tone]} ${active ? 'ring-2 ring-blue-500 ring-offset-1' : ''}`}
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-sm font-semibold">{label}</span>
+        <span className="text-2xl font-bold tabular-nums">{count}</span>
+      </div>
+      <div className="mt-1 text-xs opacity-70">{helper}</div>
+    </button>
+  )
+}
+
+function FilterGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-3">
+      <span className="w-8 shrink-0 pt-1.5 text-xs font-semibold text-gray-400">{label}</span>
+      <div className="flex flex-wrap gap-2">{children}</div>
+    </div>
+  )
+}
+
+function FilterButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+        active
+          ? 'bg-gray-900 text-white'
+          : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function BookingSection({
+  title,
+  helper,
+  tone,
+  items,
+  onAction,
+  collapsible = false,
+}: {
+  title: string
+  helper: string
+  tone: 'blue' | 'green' | 'gray'
+  items: BookingRequest[]
+  onAction: (
+    id: string,
+    action: 'approve' | 'reject' | 'cancel' | 'no_show' | 'complete',
+  ) => void
+  collapsible?: boolean
+}) {
+  const dotColor = {
+    blue: 'bg-blue-500',
+    green: 'bg-emerald-500',
+    gray: 'bg-gray-400',
+  }[tone]
+  const heading = (
+    <div className="flex items-center gap-3">
+      <span className={`h-2.5 w-2.5 rounded-full ${dotColor}`} />
+      <div>
+        <h2 className="text-sm font-bold text-gray-900">
+          {title} <span className="ml-1 font-normal text-gray-400">{items.length}件</span>
+        </h2>
+        <p className="text-xs text-gray-500">{helper}</p>
+      </div>
+    </div>
+  )
+  const cards = (
+    <div className="mt-3 space-y-2">
+      {items.map((booking) => (
+        <BookingCard key={booking.id} booking={booking} onAction={onAction} />
+      ))}
+    </div>
+  )
+
+  if (collapsible) {
+    return (
+      <details className="group rounded-xl border border-gray-200 bg-gray-50 p-4">
+        <summary className="flex cursor-pointer list-none items-center justify-between">
+          {heading}
+          <ChevronIcon />
+        </summary>
+        {cards}
+      </details>
+    )
+  }
+
+  return (
+    <section>
+      <div className="px-1">{heading}</div>
+      {cards}
+    </section>
+  )
+}
+
+function BookingCard({
+  booking,
+  onAction,
+}: {
+  booking: BookingRequest
+  onAction: (
+    id: string,
+    action: 'approve' | 'reject' | 'cancel' | 'no_show' | 'complete',
+  ) => void
+}) {
+  const startsAt = new Date(booking.starts_at)
+  const recentlyReceived = isRecentlyReceived(booking.requested_at)
+
+  return (
+    <article className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:border-gray-300">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center">
+        <div className="flex shrink-0 items-center gap-3 lg:w-36">
+          <div className="flex h-14 w-14 shrink-0 flex-col items-center justify-center rounded-xl bg-gray-900 text-white">
+            <span className="text-xs leading-none opacity-70">{dateFormatter.format(startsAt)}</span>
+            <span className="mt-1 text-base font-bold leading-none">{timeFormatter.format(startsAt)}</span>
+          </div>
+          <div className="lg:hidden">
+            <StatusAndNew status={booking.status} recentlyReceived={recentlyReceived} />
+          </div>
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <Link
+              href={`/chats?friend=${booking.friend_id}`}
+              className="font-bold text-gray-900 hover:text-blue-600 hover:underline"
+            >
+              {booking.friend_name ?? '名前未取得'}
+            </Link>
+            <span className="hidden lg:inline-flex">
+              <StatusAndNew status={booking.status} recentlyReceived={recentlyReceived} />
+            </span>
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600">
+            <span>{booking.menu_name}</span>
+            <span className="text-gray-300">•</span>
+            <span>担当: {booking.staff_name}</span>
+            {booking.price_at_booking > 0 && (
+              <>
+                <span className="text-gray-300">•</span>
+                <span className="tabular-nums">¥{booking.price_at_booking.toLocaleString()}</span>
+              </>
+            )}
+          </div>
+          <div className="mt-1 text-xs text-gray-400">
+            {receivedFormatter.format(new Date(booking.requested_at))} 受付
+          </div>
+          {booking.customer_note && (
+            <details className="group/note mt-2 rounded-lg bg-amber-50 px-3 py-2 text-sm text-gray-700">
+              <summary className="cursor-pointer list-none font-medium text-amber-800">
+                <span className="group-open/note:hidden">要望を見る</span>
+                <span className="hidden group-open/note:inline">要望を閉じる</span>
+                <span className="ml-2 font-normal text-amber-700/70">{booking.customer_note.slice(0, 45)}{booking.customer_note.length > 45 ? '…' : ''}</span>
+              </summary>
+              <p className="mt-2 whitespace-pre-wrap border-t border-amber-200 pt-2 leading-6">
+                {booking.customer_note}
+              </p>
+            </details>
+          )}
+        </div>
+
+        <div className="shrink-0 border-t border-gray-100 pt-3 lg:border-l lg:border-t-0 lg:pl-4 lg:pt-0">
+          <ActionButtons
+            status={booking.status}
+            onAction={(action) => onAction(booking.id, action)}
+          />
+        </div>
+      </div>
+    </article>
+  )
+}
+
+function StatusAndNew({ status, recentlyReceived }: { status: string; recentlyReceived: boolean }) {
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1.5">
+      <span className={`rounded-md px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${statusBadgeColor[status] ?? 'bg-gray-100 text-gray-700 ring-gray-200'}`}>
+        {statusLabel[status] ?? status}
+      </span>
+      {recentlyReceived && (
+        <span className="rounded-md bg-fuchsia-100 px-2 py-0.5 text-[10px] font-bold tracking-wide text-fuchsia-700">
+          NEW
+        </span>
+      )}
+    </span>
   )
 }
 
@@ -268,21 +611,22 @@ function ActionButtons({
   onAction,
 }: {
   status: string
-  onAction: (a: 'approve' | 'reject' | 'cancel' | 'no_show' | 'complete') => void
+  onAction: (action: 'approve' | 'reject' | 'cancel' | 'no_show' | 'complete') => void
 }) {
   if (status === 'requested') {
     return (
-      <div className="inline-flex gap-1">
+      <div className="flex gap-2 lg:flex-col">
         <button
+          type="button"
           onClick={() => onAction('approve')}
-          className="px-3 py-1 text-xs font-medium text-white rounded-md transition-opacity hover:opacity-90"
-          style={{ backgroundColor: '#06C755' }}
+          className="flex-1 rounded-lg bg-[#06C755] px-4 py-2 text-xs font-bold text-white hover:opacity-90 lg:w-24"
         >
           承認
         </button>
         <button
+          type="button"
           onClick={() => onAction('reject')}
-          className="px-3 py-1 text-xs font-medium text-red-700 bg-red-50 hover:bg-red-100 rounded-md"
+          className="flex-1 rounded-lg bg-red-50 px-4 py-2 text-xs font-medium text-red-700 hover:bg-red-100 lg:w-24"
         >
           拒否
         </button>
@@ -291,27 +635,54 @@ function ActionButtons({
   }
   if (status === 'confirmed') {
     return (
-      <div className="inline-flex gap-1">
+      <div className="flex flex-wrap gap-1.5 lg:w-28 lg:flex-col">
         <button
+          type="button"
           onClick={() => onAction('complete')}
-          className="px-3 py-1 text-xs font-medium text-blue-700 bg-blue-50 hover:bg-blue-100 rounded-md"
+          className="flex-1 rounded-lg bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100"
         >
           完了
         </button>
         <button
+          type="button"
           onClick={() => onAction('no_show')}
-          className="px-3 py-1 text-xs font-medium text-orange-700 bg-orange-50 hover:bg-orange-100 rounded-md"
+          className="flex-1 rounded-lg bg-orange-50 px-3 py-1.5 text-xs font-medium text-orange-700 hover:bg-orange-100"
         >
           無断
         </button>
         <button
+          type="button"
           onClick={() => onAction('cancel')}
-          className="px-3 py-1 text-xs font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-md"
+          className="flex-1 rounded-lg bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200"
         >
           取消
         </button>
       </div>
     )
   }
-  return <span className="text-xs text-gray-400">-</span>
+  return <span className="text-xs text-gray-400">操作なし</span>
+}
+
+function EmptyPanel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-12 text-center text-sm text-gray-500 shadow-sm">
+      {children}
+    </div>
+  )
+}
+
+function LinkIcon() {
+  return (
+    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13.8 10.2a4 4 0 0 1 5.7 0l1.4 1.4a4 4 0 0 1 0 5.7l-3 3a4 4 0 0 1-5.7 0L10 18.3m.2-4.5a4 4 0 0 1-5.7 0l-1.4-1.4a4 4 0 0 1 0-5.7l3-3a4 4 0 0 1 5.7 0L14 5.7" />
+    </svg>
+  )
+}
+
+function ChevronIcon() {
+  return (
+    <svg className="h-5 w-5 text-gray-400 transition group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+    </svg>
+  )
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1698,6 +1698,7 @@ export interface BookingRequest {
   menu_name: string;
   staff_name: string;
   friend_name: string | null;
+  requested_at: string;
 }
 
 export interface BookingAvailabilityRule {

--- a/apps/worker/src/routes/booking.ts
+++ b/apps/worker/src/routes/booking.ts
@@ -553,7 +553,7 @@ booking.get('/api/liff/booking/me', async (c) => {
          INNER JOIN staff s ON s.id = b.staff_id
         WHERE b.friend_id = ? AND b.line_account_id = ?
           AND (b.status NOT IN ('requested','confirmed') OR b.starts_at < ?)
-        ORDER BY b.starts_at DESC
+        ORDER BY b.requested_at DESC
         LIMIT 50`,
     )
     .bind(friendId, accountId, new Date().toISOString())
@@ -1530,8 +1530,8 @@ booking.get('/api/booking/admin/requests', async (c) => {
          INNER JOIN staff s ON s.id = b.staff_id
          LEFT JOIN friends f ON f.id = b.friend_id
         WHERE b.line_account_id = ?
-        ORDER BY b.starts_at ASC
-        LIMIT 200`
+        ORDER BY b.requested_at DESC
+        LIMIT 500`
     : `SELECT b.*,
               m.name AS menu_name,
               s.display_name AS staff_name,
@@ -1541,8 +1541,8 @@ booking.get('/api/booking/admin/requests', async (c) => {
          INNER JOIN staff s ON s.id = b.staff_id
          LEFT JOIN friends f ON f.id = b.friend_id
         WHERE b.line_account_id = ? AND b.status = ?
-        ORDER BY b.starts_at ASC
-        LIMIT 200`;
+        ORDER BY b.starts_at DESC
+        LIMIT 500`;
   const stmt = c.env.DB.prepare(sql);
   const rows = await (status === 'all' || !status
     ? (status === 'all' ? stmt.bind(accountId) : stmt.bind(accountId, 'requested'))


### PR DESCRIPTION
## Summary

- replace the long booking table with grouped booking cards
- add at-a-glance counts for pending, today, upcoming, and past bookings
- add time/status filters and received-at sorting
- mark recently received bookings and collapse long notes / past history
- fetch the latest 500 bookings by requested time

## Safety

- generated from the private source-of-truth repository on a dedicated OSS branch
- `scripts/sync-oss.sh --dry-run` and `--apply` completed
- OSS secret redaction and leak checks passed
- OSS-only files and workflows were preserved
- no migration, auth, messaging, webhook, or LINE delivery behavior changes

## Verification

- `pnpm --filter web test` (14 tests passed)
- `NEXT_PUBLIC_API_URL=https://line-crm-worker.line-crm-api.workers.dev pnpm --filter web build`
- `pnpm --filter worker test -- booking-admin.test.ts` (14 tests passed)
- production Admin Panel and Worker deployments succeeded before OSS sync
- rollback: revert commit `24775cb5`

Private source commit: `08b2a8f`