### PR TITLE
LICENSEファイル(MIT)の復活

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shudesu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 概要

`1efa40d` で追加された LICENSE ファイル(MIT)が、v0.6.0 の sync コミット `2884ca5` の変更に含まれて削除されたままになっています。

README と各パッケージの package.json は引き続き MIT を明記しているため、当時のファイルを**内容そのまま**(Copyright (c) 2026 Shudesu)復活させるPRです。

LICENSE ファイルがリポジトリ直下にあると、GitHub のライセンス表示やツール類にも正しく認識されます。ご確認よろしくお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GvJ6UBEuopHz9QYBxVDE9v