### PR TITLE
ci: publish update CLI with npm trusted publishing

### DIFF
--- a/.github/workflows/publish-update-cli.yml
+++ b/.github/workflows/publish-update-cli.yml
@@ -1,0 +1,62 @@
+name: Publish Update CLI
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-update-cli
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      # npm Trusted Publishing requires npm CLI 11.5.1 or later.
+      - name: Install dependencies and current npm CLI
+        run: |
+          npm install --global npm@11
+          pnpm install --frozen-lockfile
+
+      - name: Test and build publishable packages
+        run: |
+          pnpm --filter @line-harness/update-engine test
+          pnpm --filter @line-harness/update-engine build
+          pnpm --filter create-line-harness test
+          pnpm --filter create-line-harness build
+
+      - name: Pack and publish with npm OIDC
+        run: |
+          pack_dir="$RUNNER_TEMP/line-harness-packs"
+          mkdir -p "$pack_dir"
+
+          update_version=$(node -p "require('./packages/update-engine/package.json').version")
+          cli_version=$(node -p "require('./packages/create-line-harness/package.json').version")
+
+          pnpm --dir packages/update-engine pack --pack-destination "$pack_dir"
+          pnpm --dir packages/create-line-harness pack --pack-destination "$pack_dir"
+
+          if npm view "@line-harness/update-engine@$update_version" version >/dev/null 2>&1; then
+            echo "@line-harness/update-engine@$update_version is already published"
+          else
+            npm publish "$pack_dir/line-harness-update-engine-$update_version.tgz" --access public
+          fi
+
+          if npm view "create-line-harness@$cli_version" version >/dev/null 2>&1; then
+            echo "create-line-harness@$cli_version is already published"
+          else
+            npm publish "$pack_dir/create-line-harness-$cli_version.tgz" --access public
+          fi

--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -26,7 +26,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Shudesu/line-harness.git",
+    "url": "https://github.com/Shudesu/line-harness-oss.git",
     "directory": "packages/create-line-harness"
   },
   "license": "MIT",

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -2,6 +2,11 @@
   "name": "@line-harness/update-engine",
   "version": "0.0.9",
   "description": "Self-update engine for LINE Harness — shared between Worker (cloud-side self-update) and CLI (npx create-line-harness update)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shudesu/line-harness-oss.git",
+    "directory": "packages/update-engine"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- add a manual GitHub Actions workflow for token-free npm publishing via OIDC
- publish update-engine before create-line-harness
- make reruns idempotent when one package was already published
- correct npm package repository metadata for Trusted Publishing verification

This replaces interactive OTP publishing with npm Trusted Publishing.

Official setup: configure both npm packages for `Shudesu/line-harness-oss` and workflow `publish-update-cli.yml`.
