### PR TITLE
fix: slash-prefix Worker Assets manifest paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v0.21.3 (2026-08-15)
 
+### Worker Assetsアップロードの修正（2026-08-16）
+
+- Cloudflare Workers Assets APIへ送るmanifestキーを必須の`/`始まりへ修正
+- migration完了後、Assets upload session作成時にHTTP 400（code 10304）で停止する問題を解消
+- 修正版CLI `create-line-harness@0.2.8` / update engine `0.0.10`を公開
+
 ### 安全なアップデート経路
 
 - Worker本体と `apps/worker/dist/client` のWorker Assetsを同じリリースbundleに同梱し、一体で更新

--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Set up LINE Harness — AI-operated LINE CRM — with one command",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@line-harness/update-engine": "workspace:^0.0.9",
+    "@line-harness/update-engine": "workspace:^0.0.10",
     "execa": "^9.5.2",
     "picocolors": "^1.1.1"
   },

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/update-engine",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Self-update engine for LINE Harness — shared between Worker (cloud-side self-update) and CLI (npx create-line-harness update)",
   "repository": {
     "type": "git",

--- a/packages/update-engine/src/cf-api/assets.ts
+++ b/packages/update-engine/src/cf-api/assets.ts
@@ -109,7 +109,10 @@ function normalizeAssetPath(path: string): string {
   if (!normalized || normalized.split('/').includes('..')) {
     throw new Error(`invalid Workers Asset path: ${path}`);
   }
-  return normalized;
+  // Cloudflare's Workers Assets upload-session API requires every manifest
+  // key to be an absolute URL path. Bundle entries are stored relative to
+  // worker-assets/, so add the leading slash only at the API boundary.
+  return `/${normalized}`;
 }
 
 function contentTypeFor(path: string): string {

--- a/packages/update-engine/test/cf-api/assets.test.ts
+++ b/packages/update-engine/test/cf-api/assets.test.ts
@@ -43,10 +43,38 @@ describe('Workers Assets upload', () => {
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toContain('/workers/scripts/worker/assets-upload-session');
     const body = JSON.parse(init.body as string);
-    expect(body.manifest['index.html']).toEqual({
+    expect(body.manifest['/index.html']).toEqual({
       hash: 'a2b82584e50075886b08927390f2f573',
       size: 5,
     });
+    expect(body.manifest['index.html']).toBeUndefined();
+  });
+
+  it('normalizes every manifest key to a slash-prefixed URL path', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ result: { buckets: [], jwt: 'session-jwt' } }),
+    } as Response);
+
+    await uploadWorkerAssets({
+      creds,
+      scriptName: 'worker',
+      files: new Map([
+        ['./index.html', Buffer.from('index')],
+        ['assets\\app.js', Buffer.from('app')],
+        ['/assets/app.css', Buffer.from('css')],
+      ]),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(Object.keys(body.manifest).sort()).toEqual([
+      '/assets/app.css',
+      '/assets/app.js',
+      '/index.html',
+    ]);
   });
 
   it('uploads requested hashes as base64 and returns the completion JWT', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@line-harness/update-engine':
-        specifier: workspace:^0.0.9
+        specifier: workspace:^0.0.10
         version: link:../update-engine
       execa:
         specifier: ^9.5.2


### PR DESCRIPTION
## 問題

`v0.19.0 → v0.21.3` の実更新で、Cloudflare Workers Assets upload session APIがmanifestキーをHTTP 400 / code 10304で拒否しました。

## 原因

manifestキーが `index.html` 形式で、API必須の `/index.html` 形式ではありませんでした。

## 修正

- API境界で全manifestキーを `/` 始まりへ正規化
- relative / Windows / slash-prefixed各入力の回帰テスト
- update-engine `0.0.10`、CLI `0.2.8`

## 検証

- update-engine: 191 tests passed
- create-line-harness: 49 tests passed
- both packages build and pack successfully