### PR TITLE
fix: use Wrangler-compatible Pages asset hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Cloudflare Workers Assets APIへ送るmanifestキーを必須の`/`始まりへ修正
 - migration完了後、Assets upload session作成時にHTTP 400（code 10304）で停止する問題を解消
 - 修正版CLI `create-line-harness@0.2.8` / update engine `0.0.10`を公開
+- Cloudflare Pagesのasset keyをWrangler互換BLAKE3へ修正し、deploy成功後に全パスHTTP 500となる問題を解消
+- Adminのみを安全に再同期する修正版CLI `create-line-harness@0.2.9` / update engine `0.0.11`を公開
 
 ### 安全なアップデート経路
 

--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Set up LINE Harness — AI-operated LINE CRM — with one command",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@line-harness/update-engine": "workspace:^0.0.10",
+    "@line-harness/update-engine": "workspace:^0.0.11",
     "execa": "^9.5.2",
     "picocolors": "^1.1.1"
   },

--- a/packages/create-line-harness/src/commands/update.ts
+++ b/packages/create-line-harness/src/commands/update.ts
@@ -14,6 +14,7 @@ import {
   putWorkerScript,
   listWorkerBindings,
   deployPagesProject,
+  verifyPagesDeploymentUrl,
   materializeAdminFiles,
   findResidualPlaceholders,
   applyD1Migrations,
@@ -980,6 +981,7 @@ async function deployAdminFromBundle(
       projectName: cfg.adminProject,
       files,
     });
+    await verifyPagesDeploymentUrl(r.url);
     s.stop(`Admin デプロイ完了 (${r.deploymentId.slice(0, 8)})`);
     if (residual.length > 0) {
       p.log.warn(
@@ -1009,6 +1011,7 @@ async function deployLiffFromBundle(
       projectName: cfg.liffProject,
       files: bundle.liffFiles,
     });
+    await verifyPagesDeploymentUrl(r.url);
     s.stop(`LIFF デプロイ完了 (${r.deploymentId.slice(0, 8)})`);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/update-engine",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Self-update engine for LINE Harness — shared between Worker (cloud-side self-update) and CLI (npx create-line-harness update)",
   "repository": {
     "type": "git",

--- a/packages/update-engine/src/cf-api/pages.ts
+++ b/packages/update-engine/src/cf-api/pages.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'node:crypto';
 import type { CfApiCreds } from '../types.js';
 import { authHeader, pagesProjectApiBase, throwHttpError } from './_shared.js';
+import { hashWorkerAsset } from './assets.js';
 
 /**
  * Cloudflare Pages Direct Upload API.
@@ -16,16 +16,14 @@ import { authHeader, pagesProjectApiBase, throwHttpError } from './_shared.js';
  * Step 3 is skipped entirely when the server already has every file hash —
  * common for incremental redeploys where only a handful of bundles changed.
  *
- * CF docs reference blake3 for the missing-files check, but SHA-256 works
- * too and is available in every JS runtime we care about (Node, Workers).
- * We pick SHA-256 for portability.
+ * Pages asset keys must match Wrangler byte-for-byte: the first 32 hex
+ * characters of BLAKE3(base64(file bytes) + extension). The API can accept a
+ * deployment manifest containing other-looking hashes and still mark the
+ * deploy stage successful, but the resulting deployment returns HTTP 500
+ * because those keys do not resolve to uploaded assets.
  */
 
 import type { Buffer as NodeBuffer } from 'node:buffer';
-
-function sha256Hex(buf: NodeBuffer): string {
-  return createHash('sha256').update(buf).digest('hex');
-}
 
 /**
  * Map a file path to a sensible Content-Type for upload metadata. CF uses
@@ -121,6 +119,8 @@ const ASSET_UPLOAD_BATCH_SIZE = 50;
 const ASSET_UPLOAD_MAX_RAW_BYTES = 40 * 1024 * 1024;
 const ASSET_UPLOAD_MAX_ATTEMPTS = 5;
 const ASSET_UPLOAD_RETRY_BASE_MS = 1000;
+const DEPLOYMENT_VERIFY_ATTEMPTS = 3;
+const DEPLOYMENT_VERIFY_DELAY_MS = 3000;
 
 function isRetryableUploadStatus(status: number): boolean {
   return status === 429 || status >= 500;
@@ -128,6 +128,40 @@ function isRetryableUploadStatus(status: number): boolean {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Confirm that a newly-created Pages deployment actually serves files.
+ *
+ * The Pages deployment API can report a successful deploy stage even when
+ * the manifest refers to asset keys that were never stored; that deployment
+ * then returns HTTP 500 for every path. CLI callers use this before reporting
+ * Admin/LIFF success to the operator.
+ */
+export async function verifyPagesDeploymentUrl(
+  url: string,
+  options: { attempts?: number; delayMs?: number } = {},
+): Promise<void> {
+  const attempts = options.attempts ?? DEPLOYMENT_VERIFY_ATTEMPTS;
+  const delayMs = options.delayMs ?? DEPLOYMENT_VERIFY_DELAY_MS;
+  let last: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        redirect: 'follow',
+        headers: { 'Cache-Control': 'no-cache' },
+      });
+      if (response.ok) return;
+      last = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      last = error;
+    }
+    if (attempt < attempts) await delay(delayMs);
+  }
+
+  const reason = last instanceof Error ? last.message : String(last);
+  throw new Error(`Pages deployment health check failed: ${reason} (${url})`);
 }
 
 /**
@@ -210,7 +244,10 @@ export async function deployPagesProject(opts: {
   const byHash = new Map<string, { path: string; content: NodeBuffer }>();
   const pathToHash = new Map<string, string>();
   for (const [path, content] of files) {
-    const hash = sha256Hex(content);
+    // Pages and Workers Assets deliberately share Wrangler's asset-key
+    // algorithm. The extension is part of the hash input, so the path must be
+    // provided even when two files have identical bytes.
+    const hash = hashWorkerAsset(path, content);
     pathToHash.set(path, hash);
     // First-write wins if two files share a hash — same content, doesn't matter which we pick.
     if (!byHash.has(hash)) {

--- a/packages/update-engine/test/cf-api/pages.test.ts
+++ b/packages/update-engine/test/cf-api/pages.test.ts
@@ -1,20 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createHash } from 'node:crypto';
 import {
   deployPagesProject,
   getLatestDeployment,
   rollbackPagesDeployment,
+  verifyPagesDeploymentUrl,
 } from '../../src/cf-api/pages.js';
+import { hashWorkerAsset } from '../../src/cf-api/assets.js';
 import type { CfApiCreds } from '../../src/types.js';
 
 const creds: CfApiCreds = {
   accountId: 'acct123',
   apiToken: 'tok_abc',
 };
-
-function sha256Hex(buf: Buffer): string {
-  return createHash('sha256').update(buf).digest('hex');
-}
 
 describe('deployPagesProject', () => {
   const originalFetch = globalThis.fetch;
@@ -31,8 +28,8 @@ describe('deployPagesProject', () => {
   it('runs full happy path: 4 calls in order, returns { deploymentId, url }', async () => {
     const indexHtml = Buffer.from('<html>hi</html>');
     const appJs = Buffer.from('console.log("ok")');
-    const hashIndex = sha256Hex(indexHtml);
-    const hashApp = sha256Hex(appJs);
+    const hashIndex = hashWorkerAsset('index.html', indexHtml);
+    const hashApp = hashWorkerAsset('app.js', appJs);
 
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     fetchMock
@@ -89,6 +86,14 @@ describe('deployPagesProject', () => {
     expect(url3).toBe(
       'https://api.cloudflare.com/client/v4/pages/assets/check-missing',
     );
+    const [, checkMissingInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(JSON.parse(checkMissingInit.body as string)).toEqual({
+      hashes: [
+        // Wrangler-compatible BLAKE3(base64(bytes) + extension), not SHA-256.
+        'c7c80743d6c079822f72f66347942cee',
+        '6b3bb7f1a2e692baf095ebe8cd936e88',
+      ],
+    });
 
     // Step 4 URL
     const [url4] = fetchMock.mock.calls[2] as [string, RequestInit];
@@ -148,7 +153,7 @@ describe('deployPagesProject', () => {
 
   it('base64-encodes file content in upload payload', async () => {
     const content = Buffer.from('binary\x00\x01\x02data');
-    const hash = sha256Hex(content);
+    const hash = hashWorkerAsset('bin.dat', content);
 
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     fetchMock
@@ -197,7 +202,7 @@ describe('deployPagesProject', () => {
     for (let i = 0; i < 51; i++) {
       const content = Buffer.from(`file-${i}`);
       files.set(`asset-${i}.txt`, content);
-      hashes.push(sha256Hex(content));
+      hashes.push(hashWorkerAsset(`asset-${i}.txt`, content));
     }
 
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
@@ -231,7 +236,7 @@ describe('deployPagesProject', () => {
 
   it('retries a transient Pages asset upload 5xx', async () => {
     const content = Buffer.from('retry me');
-    const hash = sha256Hex(content);
+    const hash = hashWorkerAsset('index.html', content);
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     fetchMock
       .mockResolvedValueOnce({
@@ -271,8 +276,8 @@ describe('deployPagesProject', () => {
   it('sends manifest with /{path} → hash mapping in final FormData', async () => {
     const indexHtml = Buffer.from('<html/>');
     const appJs = Buffer.from('x');
-    const hashIndex = sha256Hex(indexHtml);
-    const hashApp = sha256Hex(appJs);
+    const hashIndex = hashWorkerAsset('index.html', indexHtml);
+    const hashApp = hashWorkerAsset('assets/app.js', appJs);
 
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     fetchMock
@@ -319,7 +324,7 @@ describe('deployPagesProject', () => {
 
   it('uses JWT for check-missing & upload, API token for token & deployment calls', async () => {
     const content = Buffer.from('a');
-    const hash = sha256Hex(content);
+    const hash = hashWorkerAsset('a.txt', content);
 
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     fetchMock
@@ -400,6 +405,49 @@ describe('deployPagesProject', () => {
       }),
     ).rejects.toThrow(/invalid path/);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('verifyPagesDeploymentUrl', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('retries an initially broken deployment until the asset tree serves', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200 } as Response);
+
+    await expect(
+      verifyPagesDeploymentUrl('https://deployment.pages.dev/', {
+        attempts: 3,
+        delayMs: 0,
+      }),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects a deploy stage that remains HTTP 500', async () => {
+    const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({ ok: false, status: 500 } as Response);
+
+    await expect(
+      verifyPagesDeploymentUrl('https://broken.pages.dev/', {
+        attempts: 3,
+        delayMs: 0,
+      }),
+    ).rejects.toThrow(
+      'Pages deployment health check failed: HTTP 500 (https://broken.pages.dev/)',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/packages/update-engine/test/phases/apply.test.ts
+++ b/packages/update-engine/test/phases/apply.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createHash } from 'node:crypto';
 import { runApply } from '../../src/phases/apply.js';
 import { createEventEmitter } from '../../src/events.js';
+import { hashWorkerAsset } from '../../src/cf-api/assets.js';
 import type { ParsedBundle } from '../../src/bundle.js';
 import type {
   UpdateContext,
@@ -213,17 +213,17 @@ function makeRouter(routes: RouterRoutes): ReturnType<typeof vi.fn> {
   }) as unknown as ReturnType<typeof vi.fn>;
 }
 
-function sha256Hex(buf: Buffer): string {
-  return createHash('sha256').update(buf).digest('hex');
-}
-
 /**
  * Reasonable defaults that let the entire apply phase pass. Individual
  * tests can spread + override only what they need.
  */
 function defaultRoutes(bundle: ParsedBundle): RouterRoutes {
-  const adminHashes = Array.from(bundle.adminFiles.values()).map(sha256Hex);
-  const liffHashes = Array.from(bundle.liffFiles.values()).map(sha256Hex);
+  const adminHashes = Array.from(bundle.adminFiles).map(([path, content]) =>
+    hashWorkerAsset(path, content),
+  );
+  const liffHashes = Array.from(bundle.liffFiles).map(([path, content]) =>
+    hashWorkerAsset(path, content),
+  );
   return {
     d1: { defaults: { ok: true, status: 200, body: { success: true, result: [] } } },
     bindings: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,7 +189,7 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@line-harness/update-engine':
-        specifier: workspace:^0.0.10
+        specifier: workspace:^0.0.11
         version: link:../update-engine
       execa:
         specifier: ^9.5.2


### PR DESCRIPTION
## 実環境での症状

`v0.19.0 → v0.21.3` 更新後、Pages deployment APIはsuccessを返す一方、Adminのroot/login/favicon/個別deployment URLがすべてHTTP 500。旧deploymentは正常。

## 原因

Pages asset keyにSHA-256を使用していました。Cloudflare Wranglerは `BLAKE3(base64(bytes) + extension)` の先頭32 hexを使います。誤ったkeyのmanifestでもdeployment stageはsuccessになり得ますが、assetが解決できず全パス500になります。

## 修正

- Pages asset keyをWranglerと同一アルゴリズムへ変更
- check-missing/upload/deployment manifestのkeyを統一
- 個別deployment URLの2xx確認を追加し、500を成功扱いしない
- Admin-only recovery用CLI `0.2.9` / engine `0.0.11`

## 検証

- update-engine: 193 tests passed
- create-line-harness: 49 tests passed
- build/pack passed
- known Wrangler hash vectorsを固定値で検証