### PR TITLE
fix: normalize calendar booking range comparisons

### DIFF
--- a/packages/db/src/calendar.ts
+++ b/packages/db/src/calendar.ts
@@ -127,8 +127,13 @@ export async function updateCalendarBookingEventId(db: D1Database, id: string, e
 /** 空きスロット計算用: 指定日範囲の予約一覧を取得 */
 export async function getBookingsInRange(db: D1Database, connectionId: string, startAt: string, endAt: string): Promise<CalendarBookingRow[]> {
   const result = await db
-    .prepare(`SELECT * FROM calendar_bookings WHERE connection_id = ? AND start_at >= ? AND end_at <= ? AND status != 'cancelled' ORDER BY start_at ASC`)
-    .bind(connectionId, startAt, endAt)
+    .prepare(`SELECT * FROM calendar_bookings
+              WHERE connection_id = ?
+                AND datetime(start_at) < datetime(?)
+                AND datetime(end_at) > datetime(?)
+                AND status != 'cancelled'
+              ORDER BY datetime(start_at) ASC`)
+    .bind(connectionId, endAt, startAt)
     .all<CalendarBookingRow>();
   return result.results;
 }

--- a/packages/db/test/calendar-bookings-range.test.ts
+++ b/packages/db/test/calendar-bookings-range.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { getBookingsInRange } from '../src/calendar.js';
+
+function asD1(sqlite: Database.Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          const statement = sqlite.prepare(sql);
+          return {
+            async all<T>() {
+              return { success: true, results: statement.all(...params) as T[], meta: {} };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+describe('getBookingsInRange', () => {
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:');
+    sqlite.exec(`
+      CREATE TABLE calendar_bookings (
+        id TEXT PRIMARY KEY,
+        connection_id TEXT NOT NULL,
+        friend_id TEXT,
+        event_id TEXT,
+        title TEXT NOT NULL,
+        start_at TEXT NOT NULL,
+        end_at TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'confirmed',
+        metadata TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      INSERT INTO calendar_bookings
+        (id, connection_id, title, start_at, end_at, status, created_at, updated_at)
+      VALUES
+        ('crosses-start', 'calendar-1', 'Crosses start',
+         '2026-08-16T23:30:00Z', '2026-08-17T00:30:00Z', 'confirmed', '', ''),
+        ('jst', 'calendar-1', 'JST booking',
+         '2026-08-17T10:00:00+09:00', '2026-08-17T11:00:00+09:00', 'confirmed', '', ''),
+        ('utc', 'calendar-1', 'UTC booking',
+         '2026-08-17T02:00:00Z', '2026-08-17T03:00:00Z', 'confirmed', '', ''),
+        ('at-end', 'calendar-1', 'Starts at range end',
+         '2026-08-17T09:00:00Z', '2026-08-17T10:00:00Z', 'confirmed', '', ''),
+        ('cancelled', 'calendar-1', 'Cancelled',
+         '2026-08-17T04:00:00Z', '2026-08-17T05:00:00Z', 'cancelled', '', ''),
+        ('other-calendar', 'calendar-2', 'Other calendar',
+         '2026-08-17T04:00:00Z', '2026-08-17T05:00:00Z', 'confirmed', '', '');
+    `);
+  });
+
+  afterEach(() => sqlite.close());
+
+  it('normalizes UTC and JST timestamps and returns every overlapping booking', async () => {
+    const bookings = await getBookingsInRange(
+      asD1(sqlite),
+      'calendar-1',
+      '2026-08-17T09:00:00+09:00',
+      '2026-08-17T18:00:00+09:00',
+    );
+
+    expect(bookings.map((booking) => booking.id)).toEqual([
+      'crosses-start',
+      'jst',
+      'utc',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize stored booking timestamps with SQLite `datetime()` before range comparison
- use overlap semantics so bookings crossing the requested range boundary are not omitted
- add regression coverage for mixed UTC/JST timestamps, cancellation, calendar isolation, and boundary behavior

## Verification
- `pnpm --filter @line-crm/db test` (140 tests passed)
- `pnpm --filter @line-crm/db typecheck`

Reported from a production LINE Harness user after a double-booking caused by mixed timestamp formats.