### PR TITLE
fix(update): group progress modal rows by step

### DIFF
--- a/apps/web/src/components/update/progress-modal.tsx
+++ b/apps/web/src/components/update/progress-modal.tsx
@@ -1,16 +1,26 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { openUpdateStream, getUpdateStatus } from '@/lib/update-client'
 import type { UpdateEvent } from '@line-harness/update-engine'
+import { buildProgressRows } from './progress-rows'
 
 /**
  * ProgressModal — live timeline for an in-flight update.
  *
  * Subscribes to `GET /admin/update/stream/:id` (SSE) via the update-client
- * helper and renders each `progress` event as a row. When a `complete` frame
- * lands the modal pivots to a terminal panel (success / rolled_back / failed)
+ * helper and renders the event log as rows. When a `complete` frame lands
+ * the modal pivots to a terminal panel (success / rolled_back / failed)
  * with a 閉じる button that calls `onClose`.
+ *
+ * Row grouping
+ * ------------
+ * The raw log is one event per state change, so rendering it verbatim gave
+ * two lines per step and 2N lines for an N-migration release. `buildProgressRows`
+ * folds it: one line per step, completed migrations collapsed into a count,
+ * and the informational `requires_secrets` event attached to the Pre-flight
+ * line instead of occupying one of its own. Grouping is display-only — the
+ * polling/SSE transport and the terminal-state decision are untouched.
  *
  * Fallback to polling
  * -------------------
@@ -43,6 +53,7 @@ export function ProgressModal({
   const [events, setEvents] = useState<UpdateEvent[]>([])
   const [final, setFinal] = useState<FinalState | null>(null)
   const [mode, setMode] = useState<'sse' | 'polling'>('sse')
+  const rows = useMemo(() => buildProgressRows(events), [events])
 
   useEffect(() => {
     let es: EventSource | null = null
@@ -123,19 +134,34 @@ export function ProgressModal({
           )}
         </h2>
         <ul className="space-y-1 font-mono text-sm">
-          {events.length === 0 && (
+          {rows.length === 0 && (
             <li className="text-gray-500">接続中...</li>
           )}
-          {events.map((e, i) => (
-            <li key={i} className="flex items-center gap-2">
-              <span className="w-5 inline-block">{iconFor(e.status)}</span>
-              <span>
-                {labelFor(e.step)}
-                {e.name ? ` — ${e.name}` : ''}
-                {e.error ? ` (${e.error})` : ''}
-              </span>
-            </li>
-          ))}
+          {rows.map((row) =>
+            row.kind === 'migration-summary' ? (
+              <li key={row.key} className="flex items-center gap-2">
+                <span className="w-5 inline-block">{iconFor('done')}</span>
+                <span>
+                  {labelFor('migration')} — {row.total}件完了
+                  {row.skipped > 0 && `(${row.skipped}件は適用済みスキップ)`}
+                </span>
+              </li>
+            ) : (
+              <li key={row.key} className="flex items-start gap-2">
+                <span className="w-5 inline-block">{iconFor(row.status)}</span>
+                <span>
+                  {labelFor(row.step)}
+                  {row.name ? ` — ${row.name}` : ''}
+                  {row.error ? ` (${row.error})` : ''}
+                  {row.secrets && row.secrets.length > 0 && (
+                    <span className="block text-xs text-gray-600">
+                      新しく必要になるsecret: {row.secrets.join(', ')}
+                    </span>
+                  )}
+                </span>
+              </li>
+            ),
+          )}
         </ul>
         {final && (
           <div className="mt-4 p-3 rounded bg-gray-50">

--- a/apps/web/src/components/update/progress-rows.test.ts
+++ b/apps/web/src/components/update/progress-rows.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest';
+import type { ProgressRow } from './progress-rows.js';
+import { buildProgressRows } from './progress-rows.js';
+
+function labels(rows: ProgressRow[]): string[] {
+  return rows.map((r) =>
+    r.kind === 'migration-summary'
+      ? `migration-summary:${r.total}/${r.skipped}`
+      : `${r.step}:${r.status}${r.name ? `:${r.name}` : ''}`,
+  );
+}
+
+describe('buildProgressRows', () => {
+  test('running and done fold into one row per step, in first-seen order', () => {
+    const rows = buildProgressRows([
+      { step: 'worker', status: 'running' },
+      { step: 'admin', status: 'running' },
+      { step: 'worker', status: 'done' },
+      { step: 'admin', status: 'done' },
+    ]);
+    expect(labels(rows)).toEqual(['worker:done', 'admin:done']);
+  });
+
+  test('completed migrations collapse into one row, skip marker included', () => {
+    const rows = buildProgressRows([
+      { step: 'migration', status: 'running', name: '001_a.sql' },
+      { step: 'migration', status: 'done', name: '001_a.sql (already applied)' },
+      { step: 'migration', status: 'running', name: '002_b.sql' },
+      { step: 'migration', status: 'done', name: '002_b.sql' },
+    ]);
+    expect(rows).toEqual([
+      {
+        kind: 'migration-summary',
+        key: 'migration-summary',
+        total: 2,
+        skipped: 1,
+      },
+    ]);
+  });
+
+  test('running and failed migrations keep an individual row', () => {
+    const rows = buildProgressRows([
+      { step: 'migration', status: 'running', name: '001_a.sql' },
+      { step: 'migration', status: 'failed', name: '001_a.sql', error: 'blip' },
+      { step: 'migration', status: 'running', name: '001_a.sql' },
+      { step: 'migration', status: 'done', name: '001_a.sql' },
+      { step: 'migration', status: 'running', name: '002_b.sql' },
+      { step: 'migration', status: 'failed', name: '003_c.sql', error: 'boom' },
+    ]);
+    expect(labels(rows)).toEqual([
+      'migration-summary:1/0',
+      'migration:running:002_b.sql',
+      'migration:failed:003_c.sql',
+    ]);
+    expect(rows[2]).toMatchObject({ error: 'boom' });
+  });
+
+  test('requires_secrets joins the Pre-flight row without moving its status', () => {
+    const rows = buildProgressRows([
+      { step: 'preflight', status: 'running' },
+      { step: 'preflight', status: 'done' },
+      {
+        step: 'preflight',
+        status: 'running',
+        name: 'requires_secrets:ADMIN_ORIGIN,LIFF_ID',
+      },
+    ]);
+    expect(labels(rows)).toEqual(['preflight:done']);
+    expect(rows[0]).toMatchObject({ secrets: ['ADMIN_ORIGIN', 'LIFF_ID'] });
+  });
+
+  test('rollback keeps the cause it reported on the running event', () => {
+    const rows = buildProgressRows([
+      { step: 'rollback', status: 'running', error: 'health probe 503' },
+      { step: 'rollback', status: 'done' },
+    ]);
+    expect(labels(rows)).toEqual(['rollback:done']);
+    expect(rows[0]).toMatchObject({ error: 'health probe 503' });
+  });
+});

--- a/apps/web/src/components/update/progress-rows.ts
+++ b/apps/web/src/components/update/progress-rows.ts
@@ -1,0 +1,140 @@
+import type { UpdateEvent } from '@line-harness/update-engine'
+
+/**
+ * Folds the raw update event log into display rows: one row per step
+ * instead of one per state change, completed migrations collapsed into a
+ * single count, and the informational `requires_secrets` event attached to
+ * the Pre-flight row. Rows keep the order in which they first appeared.
+ */
+
+export const REQUIRES_SECRETS_PREFIX = 'requires_secrets:'
+const ALREADY_APPLIED_SUFFIX = ' (already applied)'
+const SUMMARY_KEY = 'migration-summary'
+
+export type ProgressRow =
+  | {
+      kind: 'step'
+      key: string
+      step: UpdateEvent['step']
+      status: UpdateEvent['status']
+      name?: string
+      error?: string
+      secrets?: string[]
+    }
+  | { kind: 'migration-summary'; key: string; total: number; skipped: number }
+
+type StepRow = Extract<ProgressRow, { kind: 'step' }>
+
+interface MigrationEntry {
+  kind: 'migration'
+  key: string
+  name: string
+  status: UpdateEvent['status']
+  error?: string
+  alreadyApplied: boolean
+}
+
+type Entry = StepRow | MigrationEntry
+
+const rowKey = (step: UpdateEvent['step'], name: string) =>
+  JSON.stringify([step, name])
+
+export function buildProgressRows(
+  events: readonly UpdateEvent[],
+): ProgressRow[] {
+  const order: Entry[] = []
+  const byKey = new Map<string, Entry>()
+
+  const ensure = <T extends Entry>(key: string, create: () => T): T => {
+    const found = byKey.get(key)
+    if (found) return found as T
+    const created = create()
+    byKey.set(key, created)
+    order.push(created)
+    return created
+  }
+
+  for (const e of events) {
+    if (e.step === 'preflight' && e.name?.startsWith(REQUIRES_SECRETS_PREFIX)) {
+      const key = rowKey('preflight', '')
+      const entry = ensure<StepRow>(key, () => ({
+        kind: 'step',
+        key,
+        step: 'preflight',
+        status: e.status,
+      }))
+      const incoming = e.name
+        .slice(REQUIRES_SECRETS_PREFIX.length)
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+      entry.secrets = [...new Set([...(entry.secrets ?? []), ...incoming])]
+      continue
+    }
+
+    if (e.step === 'migration') {
+      // Coupled to apply.ts: `running` reports the bare name and `done`
+      // appends this marker for skips, so both have to key on the base name.
+      const raw = e.name ?? ''
+      const alreadyApplied = raw.endsWith(ALREADY_APPLIED_SUFFIX)
+      const name = alreadyApplied
+        ? raw.slice(0, -ALREADY_APPLIED_SUFFIX.length)
+        : raw
+      const key = rowKey('migration', name)
+      const entry = ensure<MigrationEntry>(key, () => ({
+        kind: 'migration',
+        key,
+        name,
+        status: e.status,
+        alreadyApplied: false,
+      }))
+      entry.status = e.status
+      if (alreadyApplied) entry.alreadyApplied = true
+      if (e.error) entry.error = e.error
+      continue
+    }
+
+    const key = rowKey(e.step, e.name ?? '')
+    const entry = ensure<StepRow>(key, () => ({
+      kind: 'step',
+      key,
+      step: e.step,
+      status: e.status,
+      name: e.name,
+    }))
+    entry.status = e.status
+    if (e.name) entry.name = e.name
+    // Last non-empty error wins rather than the newest event: rollback
+    // reports its cause on `running` and carries none on `done`.
+    if (e.error) entry.error = e.error
+  }
+
+  const rows: ProgressRow[] = []
+  let summary: Extract<ProgressRow, { kind: 'migration-summary' }> | null = null
+
+  for (const entry of order) {
+    if (entry.kind === 'step') {
+      rows.push(entry)
+      continue
+    }
+    if (entry.status !== 'done') {
+      rows.push({
+        kind: 'step',
+        key: entry.key,
+        step: 'migration',
+        status: entry.status,
+        name: entry.name,
+        error: entry.error,
+      })
+      continue
+    }
+    if (!summary) {
+      summary = { kind: SUMMARY_KEY, key: SUMMARY_KEY, total: 0, skipped: 0 }
+      rows.push(summary)
+    }
+    summary.total += 1
+    if (entry.alreadyApplied) summary.skipped += 1
+  }
+
+  return rows
+}


### PR DESCRIPTION
## 問題

GUIからUpdateを実行すると、進捗モーダルが80行を超え、表示しきれないため最下部の閉じるボタンが押せなくなりました。

実際の表示の抜粋:

```
⏳ Pre-flight
⏳ Pre-flight — requires_secrets:ADMIN_ORIGIN,ADMIN_ALLOW_CROSS_SITE,...
✓ Pre-flight
⏳ Migration — 037_event_booking.sql
✓ Migration — 037_event_booking.sql (already applied)
⏳ Migration — 037_scenario_delivery_mode.sql
✓ Migration — 037_scenario_delivery_mode.sql (already applied)
…(同じ形がmigration 41件ぶん続く)
⏳ Worker デプロイ
✓ Worker デプロイ
```

問題は3つあります。

1. 同じステップが「実行中」と「完了」の2行に分かれ、両方とも画面に残る
2. スキップされただけのmigrationが1件につき2行、41件で80行以上を占める
3. `requires_secrets:...` という機械向けの文字列がそのまま1行になる

その結果、Workerデプロイやヘルスチェックなどオペレータが本当に見たい行がノイズに埋まり、行が縦に積み上がったぶんモーダル下部の「閉じる」ボタンが画面外へ押し出されて押せなくなります。

## 原因

`progress-modal.tsx` がイベントログを `events.map` でそのまま行にしているためです。エンジンは1つのステップにつき「実行中」と「完了」のイベントを別々に発行するので、表示側でまとめない限り必ず2行になります。

## 修正(表示部分のみ)

イベントログを表示用の行へまとめる純関数 `buildProgressRows` を追加し、モーダルはその結果を描画するようにしました。

- 同じステップは1行にまとまり、アイコンが ⏳ → ✓ へその場で切り替わる
- 完了したmigrationは「Migration — N件完了(M件は適用済みスキップ)」の1行に集約。実行中・失敗したmigrationは従来どおり個別の行で出る(進行の見え方と失敗箇所の特定は変わらない)
- `requires_secrets` は独立した行ではなく、Pre-flight行の下の補足「新しく必要になるsecret: A, B, C」として表示する

同じ更新のイベント列を通した結果:

```
✓ Pre-flight
    新しく必要になるsecret: ADMIN_ORIGIN, ADMIN_ALLOW_CROSS_SITE, ...
✓ Migration — 40件完了(40件は適用済みスキップ)
⏳ Migration — 041_xxx.sql
⏳ Worker デプロイ
```

まとめる際の注意点が1つ: エラーメッセージは「最後の空でない値」を残します。rollbackは原因を実行中イベントに載せ、完了イベントには載せないため、単純に最新イベントで上書きすると原因の表示が消えるからです。

## 検証

- 新規テスト5ケース(行の統合と順序保持、migration集約と `(already applied)` の扱い、実行中・失敗migrationの個別行、requires_secretsの吸収、rollbackの原因保持)
- `tsc --noEmit` エラーなし
- 補足: apps/webには `main` のクリーンな状態でも落ちる既存テストが3件あります(`form-list.test.ts` 1件、`update-client.test.ts` 2件)。本PRと無関係であることを `main` 単体で確認済みです
