### PR TITLE
fix(db): make bootstrap check line-ending stable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# SQL files must stay LF in the working tree on every platform.
+#
+# packages/db/scripts/generate-bootstrap.mjs embeds SQL text read from
+# schema.sql / migrations into bootstrap.sql and compares the result
+# byte-for-byte. With core.autocrlf=true a Windows checkout rewrites these
+# files to CRLF, which makes `generate-bootstrap.mjs --check` (and the
+# bootstrap.sql sync test) fail even with no real schema drift.
+*.sql text eol=lf

--- a/packages/db/scripts/generate-bootstrap.mjs
+++ b/packages/db/scripts/generate-bootstrap.mjs
@@ -23,6 +23,15 @@ function isBenignSqliteError(error) {
   return error instanceof Error && BENIGN_SQLITE_ERROR.test(error.message);
 }
 
+/**
+ * Windows の checkout (core.autocrlf) では schema.sql / migrations が CRLF になり、
+ * sqlite_master 経由で CR が bootstrap.sql に混入する。
+ * 生成物も比較対象も LF に揃え、checkout 設定に依存しないようにする。
+ */
+function normalizeEol(text) {
+  return text.replace(/\r\n/g, "\n");
+}
+
 function splitSqlStatements(sql) {
   return sql
     .split(/;\s*(?:\r?\n|$)/)
@@ -132,7 +141,7 @@ function buildBootstrapSql() {
     const builtinSeeds = buildBuiltinAutoReplySeeds(db);
 
     return {
-      sql: `${header}${body}${builtinSeeds ? `\n\n${builtinSeeds}` : ""}\n`,
+      sql: normalizeEol(`${header}${body}${builtinSeeds ? `\n\n${builtinSeeds}` : ""}\n`),
       meta: {
         includedMigrations: migrationFiles,
         migrationCount: migrationFiles.length,
@@ -157,10 +166,10 @@ if (wantsStdout) {
 
 if (wantsCheck) {
   const current = existsSync(BOOTSTRAP_PATH)
-    ? readFileSync(BOOTSTRAP_PATH, "utf8")
+    ? normalizeEol(readFileSync(BOOTSTRAP_PATH, "utf8"))
     : "";
   const currentMeta = existsSync(BOOTSTRAP_META_PATH)
-    ? readFileSync(BOOTSTRAP_META_PATH, "utf8")
+    ? normalizeEol(readFileSync(BOOTSTRAP_META_PATH, "utf8"))
     : "";
   const nextMeta = `${JSON.stringify(generated.meta, null, 2)}\n`;
   if (current !== generated.sql || currentMeta !== nextMeta) {


### PR DESCRIPTION
## Summary

On Windows, `packages/db/test/bootstrap.test.ts` → `bootstrap.sql > stays in sync with schema.sql + migrations` fails on a clean checkout even when there is no schema drift at all.

**Root cause:** `core.autocrlf=true` combined with the absence of a `.gitattributes` means the working tree is checked out with CRLF. `scripts/generate-bootstrap.mjs` embeds SQL text read from `schema.sql` / `migrations/*.sql` (via `sqlite_master`) into `bootstrap.sql` and then compares it byte-for-byte in `--check`. The CR bytes enter the two sides of that comparison asymmetrically, so the check always reports "out of date".

**Worth noting:** the committed content is *not* CRLF-polluted. Measured byte-exact, the stored Git blobs for both `bootstrap.sql` and `schema.sql` contain **0 CR bytes** — they are pure LF. The CRLF is introduced only at checkout time. So no renormalization of the committed SQL was necessary, and none was done.

**Fix (two complementary parts):**

1. `.gitattributes` pinning `*.sql text eol=lf` — removes the root cause in every contributor's working tree.
2. `generate-bootstrap.mjs` normalizes the end-of-line form of both the generated SQL and the read-back current file before comparing — so `--check` is stable regardless of anyone's local checkout configuration.

The companion test `matches the schema produced by replaying all migrations` already passed before this change, which confirms the failure was a line-ending artifact rather than real schema drift. Linux CI was never affected.

## Files changed

Exactly 2 files:

- `.gitattributes` (new)
- `packages/db/scripts/generate-bootstrap.mjs`

## Validation

Environment: Windows 11, Node 20, pnpm 9.15.4, `core.autocrlf=true`.

| Scenario | Result |
| --- | --- |
| Baseline on pristine upstream tree (0 tracked changes, this PR's edits stashed) | 138 passed / **1 failed** — the failure is exactly `bootstrap.sql > stays in sync with schema.sql + migrations` |
| After the fix | **139 passed / 0 failed** |
| `pnpm --filter @line-crm/db typecheck` | exit 0 |
| Genuine schema drift (extra table temporarily added to `schema.sql`) | `--check` **exit 1** — real drift is still detected |
| Faithful full-CRLF simulation: all 76 tracked `.sql` files converted to CRLF, i.e. as if `.gitattributes` were absent | **139 passed** — the generator-side normalization alone is sufficient |
| Working-tree `bootstrap.sql` CR bytes | 1423 → **0** |

The baseline failure was reproduced on an unmodified upstream checkout before any of this PR's changes were applied, so the regression is demonstrably pre-existing and not introduced here.

## Scope

- `bootstrap.sql` is **not** modified and was **not** regenerated
- no schema semantic changes
- no migration changes
- no generated artifacts committed
- no dependency or lockfile changes
- no CI config changes
- no production DB, deployment, or runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
