### PR TITLE
fix(db): align broadcast timestamp default with migration

### DIFF
--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -130,7 +130,20 @@ CREATE TABLE IF NOT EXISTS broadcasts (
   aggregation_unit  TEXT,
   batch_offset    INTEGER NOT NULL DEFAULT 0,
   segment_conditions TEXT,
-  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  -- NOTE: この DEFAULT だけ他テーブルの JST ISO-8601 形式ではなく UTC の datetime('now')。
+  -- 029_account_management_v2.sql がテーブルを再構築した際に datetime('now') で
+  -- 宣言しており、029 は schema.sql より後に適用されるため、replay 後の実効値は
+  -- UTC 側になる。
+  -- ここは「意図」ではなく「実際に出来上がる DDL」を書いている（schema.sql と
+  -- bootstrap.sql / migrated schema の乖離を防ぐため）。
+  -- 現時点で実害はない: broadcasts への INSERT は src/broadcasts.ts の 1 箇所のみで、
+  -- created_at を明示列挙して jstNow() をバインドしているため DEFAULT は発火しない。
+  -- created_at を省略する INSERT を新設する場合は、必ず jstNow() を明示バインドすること。
+  -- 揃えるには SQLite の仕様上テーブル再構築が必要で、未使用の DEFAULT のために
+  -- 既存テーブルを作り直すのは割に合わないと判断した。
+  -- 同様に UTC DEFAULT のままの列は test/timestamp-defaults.test.ts の
+  -- KNOWN_UTC_DEFAULTS に列挙してある（新規追加はテストが失敗する）。
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   account_ids        TEXT CHECK (account_ids IS NULL OR json_valid(account_ids)),
   dedup_priority     TEXT CHECK (dedup_priority IS NULL OR json_valid(dedup_priority)),
   failed_account_ids TEXT CHECK (failed_account_ids IS NULL OR json_valid(failed_account_ids)),

--- a/packages/db/test/timestamp-defaults.test.ts
+++ b/packages/db/test/timestamp-defaults.test.ts
@@ -1,0 +1,167 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+// =============================================================================
+// created_at / updated_at の DEFAULT 式ドリフト検知
+// =============================================================================
+//
+// このリポジトリのタイムスタンプ列は JST ISO-8601（ミリ秒付き）で保存する規約。
+// 一方 SQLite の datetime('now') は「UTC・スペース区切り・ミリ秒なし」を返すため、
+// 両者が混ざると文字列比較の順序・境界判定が壊れる。
+// （実際に一度踏んでいる: src/affiliate-report.ts の "Task 4 boundary-bug lesson"
+//   コメント参照。あちらは julianday() で読み側を防御している。）
+//
+// ドリフトが起きる典型は「テーブル再構築マイグレーション」で、schema.sql 側の
+// 宣言と食い違っても replay 後は後勝ちで気付けない。実例として
+// 029_account_management_v2.sql が broadcasts を datetime('now') で作り直している。
+//
+// そこで replay 後の *実効 DDL* を PRAGMA table_info で読み、DEFAULT 式が
+// 正準形か既知の例外かを検査する。PRAGMA を使うのは、空白や改行の差で
+// 誤検知しない正規化済みの値が得られるため。
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = join(__dirname, '..');
+const MIGRATIONS_DIR = join(PKG_ROOT, 'migrations');
+const BOOTSTRAP_PATH = join(PKG_ROOT, 'bootstrap.sql');
+
+const BENIGN_SQLITE_ERROR = /duplicate column name|already exists/i;
+
+/** 全テーブル共通の正準 DEFAULT 式（JST ISO-8601, ミリ秒付き）。 */
+const CANONICAL_JST_DEFAULT = "strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')";
+
+/** UTC を返す非正準式。 */
+const UTC_DEFAULT = "datetime('now')";
+
+// 既知の UTC DEFAULT。SQLite は DEFAULT の変更にテーブル再構築を要するため、
+// 「現時点で DEFAULT が発火していない（INSERT が created_at を明示している）」
+// 列については、既存テーブルの作り直しを避けて現状を追認している。
+//
+// このリストは ratchet として機能する:
+//   * 新しく UTC DEFAULT の列が増えたらテストが落ちる（＝ドリフトの新規流入を止める）
+//   * 逆にここの列を正準形へ直したら、リストから消すまでテストが落ちる
+//
+// 追加する場合は「なぜ DEFAULT が発火しないか」を必ず確認すること。
+// DEFAULT に依存する INSERT を書くなら、ここに足すのではなく jstNow() を明示バインドする。
+const KNOWN_UTC_DEFAULTS = new Set([
+  'broadcasts.created_at',
+  'entry_routes.created_at',
+  'entry_routes.updated_at',
+  'form_submissions.created_at',
+  'forms.created_at',
+  'forms.updated_at',
+  'media_inquiries.created_at',
+  'media_inquiries.updated_at',
+  'message_templates.created_at',
+  'message_templates.updated_at',
+  'pool_accounts.created_at',
+  'ref_tracking.created_at',
+  'tracked_links.created_at',
+  'tracked_links.updated_at',
+  'webinar_funnel_events.created_at',
+]);
+
+function splitSqlStatements(sql: string): string[] {
+  return sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+}
+
+function applyMigrationReplay(db: Database.Database): void {
+  db.exec(readFileSync(join(PKG_ROOT, 'schema.sql'), 'utf8'));
+  const migrationFiles = readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+
+  for (const file of migrationFiles) {
+    const sql = readFileSync(join(MIGRATIONS_DIR, file), 'utf8');
+    for (const statement of splitSqlStatements(sql)) {
+      try {
+        db.exec(statement);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!BENIGN_SQLITE_ERROR.test(message)) {
+          throw new Error(`${file}: ${message}`);
+        }
+      }
+    }
+  }
+}
+
+/** `table.column` -> DEFAULT 式（DEFAULT 無しの列は含めない）。 */
+function collectTimestampDefaults(db: Database.Database): Map<string, string> {
+  const found = new Map<string, string>();
+  const tables = db
+    .prepare(
+      `SELECT name FROM sqlite_master
+        WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+        ORDER BY name`,
+    )
+    .all() as Array<{ name: string }>;
+
+  for (const { name } of tables) {
+    const columns = db.prepare(`PRAGMA table_info("${name}")`).all() as Array<{
+      name: string;
+      dflt_value: string | null;
+    }>;
+    for (const column of columns) {
+      if (column.name !== 'created_at' && column.name !== 'updated_at') continue;
+      if (column.dflt_value === null) continue;
+      found.set(`${name}.${column.name}`, column.dflt_value);
+    }
+  }
+  return found;
+}
+
+function replayedDefaults(): Map<string, string> {
+  const db = new Database(':memory:');
+  try {
+    applyMigrationReplay(db);
+    return collectTimestampDefaults(db);
+  } finally {
+    db.close();
+  }
+}
+
+describe('created_at / updated_at DEFAULT expressions', () => {
+  it('uses the canonical JST expression except for known UTC columns', () => {
+    const defaults = replayedDefaults();
+    expect(defaults.size).toBeGreaterThan(0);
+
+    const offenders = [...defaults]
+      .filter(([key, expr]) => expr !== CANONICAL_JST_DEFAULT && !KNOWN_UTC_DEFAULTS.has(key))
+      .map(([key, expr]) => `${key} => ${expr}`);
+
+    expect(offenders).toEqual([]);
+  });
+
+  // KNOWN_UTC_DEFAULTS が現実とズレたら落とす。片方向の抑制リストにすると
+  // 直したあともリストが残り、次のドリフトを隠してしまうため。
+  it('keeps KNOWN_UTC_DEFAULTS exactly in sync with reality', () => {
+    const defaults = replayedDefaults();
+    const actualUtc = [...defaults]
+      .filter(([, expr]) => expr === UTC_DEFAULT)
+      .map(([key]) => key)
+      .sort();
+
+    expect(actualUtc).toEqual([...KNOWN_UTC_DEFAULTS].sort());
+  });
+
+  // 新規インストールは bootstrap.sql から作られるので、replay と一致していないと
+  // 「移行済み DB と新規 DB でタイムスタンプ形式が違う」事故になる。
+  it('bootstrap.sql agrees with the migration replay', () => {
+    const bootstrapDb = new Database(':memory:');
+    try {
+      bootstrapDb.exec(readFileSync(BOOTSTRAP_PATH, 'utf8'));
+      const fromBootstrap = collectTimestampDefaults(bootstrapDb);
+      expect(Object.fromEntries([...fromBootstrap].sort())).toEqual(
+        Object.fromEntries([...replayedDefaults()].sort()),
+      );
+    } finally {
+      bootstrapDb.close();
+    }
+  });
+});


### PR DESCRIPTION
### Problem

`packages/db/schema.sql` declares `broadcasts.created_at` with the canonical JST default used by every other table:

```sql
created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
```

but the schema you actually get after applying the migrations uses `datetime('now')` — UTC, space-separated, no milliseconds.

### Cause

`migrations/029_account_management_v2.sql` rebuilds the table (`CREATE broadcasts_new` / `DROP broadcasts` / `RENAME`) and redeclares the column as `datetime('now')`. Because 029 is applied after the base schema definition, the migrated schema's effective default is the UTC form, and `schema.sql` no longer describes the DDL that results.

I replayed `schema.sql` + all 74 migrations into SQLite and read the defaults back via `PRAGMA table_info`: **81 columns use the canonical JST expression, 15 use `datetime('now')`**. Of those 15, `broadcasts.created_at` is the **only** one where `schema.sql` and the replayed DDL actually disagree — the other 14 either declare the UTC form in `schema.sql` too, or belong to tables created by migrations and absent from `schema.sql`.

No migration after 029 rebuilds `broadcasts`; 030 / 031 / 046 are `ALTER TABLE ADD COLUMN` only, so 029's declaration is the final one.

### Fix

The drift is latent rather than active: the sole `INSERT INTO broadcasts` (`packages/db/src/broadcasts.ts`) lists `created_at` explicitly and binds `jstNow()`, so the default never fires. Realigning it to the JST form would require a full SQLite table rebuild for a default nothing writes through, which did not seem like a good trade.

So this PR takes the low-risk option:

1. **`packages/db/schema.sql`** — `broadcasts.created_at` now declares the DDL that actually results, with a comment explaining why it differs, that the default never fires today, and that any future INSERT which omits `created_at` must bind `jstNow()` instead of relying on it.
2. **`packages/db/test/timestamp-defaults.test.ts`** (new) — a regression test so this class of drift is caught automatically.

The test replays `schema.sql` + all migrations and asserts every `created_at` / `updated_at` default is either the canonical JST expression or listed in an explicit `KNOWN_UTC_DEFAULTS` allowlist. The allowlist is a **two-way ratchet**: newly introduced drift fails, *and* fixing a listed column also fails until it is removed from the list — so it cannot quietly rot into a blanket suppression. A third assertion checks that `bootstrap.sql` agrees with the replay, so freshly bootstrapped and migrated databases cannot diverge on these columns.

I confirmed the test actually detects drift by injecting a probe migration with a `datetime('now')` default; all three assertions failed and named the offending column. The probe was removed and is not part of this PR.

### Validation

- `pnpm --dir packages/db test timestamp-defaults` — **3/3 pass**
- `pnpm --dir packages/db test` — **141 passed, 1 failed**
- `pnpm --dir packages/db typecheck` — **pass**

The one failure is `bootstrap.test.ts > stays in sync with schema.sql + migrations`, and it is **pre-existing and unrelated to this change**. It reproduces on a pristine checkout of `main` with zero tracked modifications. It is a Windows line-ending artifact: the committed `bootstrap.sql` is CRLF while the generator emits mixed LF/CRLF, so `--check`'s string comparison fails even though the content is byte-identical once line endings are normalized. I have left it alone here rather than mixing an unrelated fix into this PR.

`bootstrap.sql` is deliberately **not** regenerated. The generator emits `sqlite_master` after replaying the migrations, so 029 overrides `schema.sql` regardless — I verified the generated output is byte-identical before and after this change.

### Scope

- no migration added or changed
- no changes to `bootstrap.sql` / `bootstrap-meta.json` or any generated artifact
- no application source changes
- no dependency or lockfile changes
- no CI or deployment configuration changes

Happy to switch to a forward migration that rebuilds the table and normalizes the default instead, if you would rather have the schema fully consistent — I went with the documentation-only option because the default is currently unreachable. Likewise glad to fold the new test into `bootstrap.test.ts` if you prefer it there rather than as a separate per-concern file.
