### PR TITLE
fix(admin): remove QR display from dashboard friend-add card

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -77,7 +77,6 @@ function StatCard({ title, value, loading, icon, href, accentColor = '#06C755' }
 function FriendAddLinkCard() {
   const { selectedAccount } = useAccount()
   const [copied, setCopied] = useState(false)
-  const [showQr, setShowQr] = useState(false)
   const base = (process.env.NEXT_PUBLIC_API_URL ?? '').replace(/\/$/, '')
   const link = selectedAccount
     ? `${base}/auth/line?account=${encodeURIComponent(selectedAccount.channelId)}`
@@ -104,13 +103,6 @@ function FriendAddLinkCard() {
               : 'デフォルトアカウントへの追加リンク (UUID計測つき)'}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => setShowQr((v) => !v)}
-          className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 hover:bg-gray-50 font-medium text-gray-600"
-        >
-          {showQr ? 'QRを隠す' : 'QR表示'}
-        </button>
       </div>
       <div className="flex items-stretch gap-2">
         <input
@@ -128,18 +120,6 @@ function FriendAddLinkCard() {
           {copied ? 'コピーしました ✓' : 'コピー'}
         </button>
       </div>
-      {showQr && (
-        <div className="mt-3 flex justify-center">
-          {/* eslint-disable-next-line @next/next/no-img-element -- worker QR proxy, not a static asset */}
-          <img
-            src={`${base}/api/qr?data=${encodeURIComponent(link)}&size=240x240`}
-            alt="友だち追加QRコード"
-            width={240}
-            height={240}
-            className="border border-gray-200 rounded-lg"
-          />
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
private main [f87d57e] の単発同期。

## 変更内容
管理ダッシュボードの「友だち追加リンク」カードから QR 表示トグルと QR 画像を削除(20行削除のみ)。

**理由:** 240px の QR を余白ゼロ + `rounded-lg` の角丸クリップで直貼りしていたため、QR の quiet zone が確保されずファインダーパターンの角が欠け、スマホカメラで読み取れない。PC ユーザーには `/auth/line` の QR ランディングページ(24px パディングで可読)が引き続き機能するため、カードはリンクコピー専用に戻す。

## 注記
全体 rsync 同期ではなく単発パッチ適用。OSS 側で先行している #273〜#276 等が private に未逆マージのため、全体同期はそれらを巻き戻すリスクがあり別途対応(逆マージ → 全体同期)が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)