### PR TITLE
feat(links): friend-add links go app-first — /r ?account= + /r/dashboard

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -71,16 +71,19 @@ function StatCard({ title, value, loading, icon, href, accentColor = '#06C755' }
   )
 }
 
-// 友だち追加リンクの即時取得カード。/auth/line は UUID 付与・アカウント解決・
-// PC では QR ランディング表示までやる正規の流入口なので、共有リンクは常に
-// これを配る (公式の lin.ee 直リンクだと計測も UUID 紐づけも失われる)。
+// 友だち追加リンクの即時取得カード。/r/dashboard は OS 対応ランディング経由で
+// LINE アプリを直接開く流入口（モバイル: LIFF Universal Link / PC: QR）。
+// UUID 付与・アカウント解決は LIFF 側 /api/liff/link が担い、ref=dashboard が
+// friends.ref_code に流入元として記録される。/auth/line?account= を配らないのは
+// モバイルブラウザで Web 版 LINE ログインが挟まり離脱を生むため
+// (公式の lin.ee 直リンクだと計測も UUID 紐づけも失われるのは従来どおり)。
 function FriendAddLinkCard() {
   const { selectedAccount } = useAccount()
   const [copied, setCopied] = useState(false)
   const base = (process.env.NEXT_PUBLIC_API_URL ?? '').replace(/\/$/, '')
   const link = selectedAccount
-    ? `${base}/auth/line?account=${encodeURIComponent(selectedAccount.channelId)}`
-    : `${base}/auth/line`
+    ? `${base}/r/dashboard?account=${encodeURIComponent(selectedAccount.channelId)}`
+    : `${base}/r/dashboard`
 
   const onCopy = async () => {
     try {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -8,6 +8,7 @@ import {
   getRandomPoolAccount,
   getPoolAccounts,
   getEntryRouteByRefCode,
+  getLineAccountByChannelId,
   getLineAccountById,
   getAffiliateLinkByRefCode,
   incrementAffiliateLinkClick,
@@ -274,11 +275,28 @@ app.get('/r/:ref', async (c) => {
   const formId = c.req.query('form') || '';
 
   // Resolve LIFF URL — priority:
+  //   0. URL query ?account= (explicit single-account pin — admin-issued
+  //      per-account links must never be re-routed by a colliding ref_code)
   //   1. entry_route.pool_id (if ref maps to a referral link)
   //   2. URL query ?pool=
   //   3. 'main' fallback
   let liffUrl = c.env.LIFF_URL;
   let pool: Awaited<ReturnType<typeof getTrafficPoolBySlug>> | null = null;
+
+  // 0. ?account= pins the destination account and wins over any ref-derived
+  // pool/affiliate resolution. The ref still rides through to LIFF below, so
+  // attribution (friends.ref_code / ref_tracking via /api/liff/link) keeps
+  // working; only the account choice is fixed. Unknown channel_id or an
+  // account without liff_id falls through to the normal resolution chain.
+  const accountParam = c.req.query('account') || '';
+  let accountResolved = false;
+  if (accountParam) {
+    const account = await getLineAccountByChannelId(c.env.DB, accountParam);
+    if (account?.liff_id) {
+      liffUrl = `https://liff.line.me/${account.liff_id}`;
+      accountResolved = true;
+    }
+  }
 
   // 1. entry_route lookup. getTrafficPoolById (unlike getTrafficPoolBySlug)
   // does not filter on is_active, so we ignore disabled pools explicitly to
@@ -290,7 +308,7 @@ app.get('/r/:ref', async (c) => {
   // double-count every successful click in getEntryRouteFunnel. Landing-page
   // drop-off (clicks that never reach OAuth) is therefore not visible in the
   // funnel; that limitation is intentional pending a dedicated click table.
-  const route = await getEntryRouteByRefCode(c.env.DB, ref);
+  const route = accountResolved ? null : await getEntryRouteByRefCode(c.env.DB, ref);
   if (route?.pool_id) {
     const candidate = await getTrafficPoolById(c.env.DB, route.pool_id);
     if (candidate?.is_active) pool = candidate;
@@ -306,7 +324,7 @@ app.get('/r/:ref', async (c) => {
   // through to LIFF state below so the existing ref_tracking flow attributes
   // the eventual friend-add via /auth/callback + /api/liff/link.
   let affiliateResolved = false;
-  if (!route) {
+  if (!route && !accountResolved) {
     const affiliateLink = await getAffiliateLinkByRefCode(c.env.DB, ref);
     if (affiliateLink) {
       await incrementAffiliateLinkClick(c.env.DB, ref);
@@ -322,7 +340,7 @@ app.get('/r/:ref', async (c) => {
   // 2 / 3. fallback to URL query or 'main'. Skipped for affiliate refs, whose
   // account is already resolved above; falling through to the 'main' pool would
   // override the affiliate's chosen account.
-  if (!pool && !affiliateResolved) {
+  if (!pool && !affiliateResolved && !accountResolved) {
     const poolSlug = c.req.query('pool') || 'main';
     pool = await getTrafficPoolBySlug(c.env.DB, poolSlug);
   }
@@ -345,6 +363,8 @@ app.get('/r/:ref', async (c) => {
   if (liffIdMatch) liffParams.set('liffId', liffIdMatch[1]);
   if (ref) liffParams.set('ref', ref);
   if (formId) liffParams.set('form', formId);
+  // Parity with /auth/line's qrParams — keeps the account hint on the LIFF URL.
+  if (accountParam) liffParams.set('account', accountParam);
   const gate = c.req.query('gate');
   if (gate) liffParams.set('gate', gate);
   const xh = c.req.query('xh');

--- a/apps/worker/src/lib/reserved-refs.ts
+++ b/apps/worker/src/lib/reserved-refs.ts
@@ -1,0 +1,16 @@
+/**
+ * Ref codes handed out by the product itself (not tenant campaigns).
+ *
+ * 'dashboard' is what the admin dashboard's friend-add card rides as the
+ * provenance marker (/r/dashboard?account=...). Reserved refs are:
+ *   - rejected at entry-route create/update (routes/entry-routes.ts)
+ *   - excluded from campaign attribution side effects (applyRefAttribution)
+ *     while still being written to friends.ref_code / ref_tracking, so
+ *     provenance survives but a pre-existing colliding campaign row can
+ *     never fire its tags/scenarios from a dashboard-copied link.
+ */
+export const RESERVED_REF_CODES = new Set(['dashboard']);
+
+export function isReservedRef(ref: string): boolean {
+  return RESERVED_REF_CODES.has(ref.toLowerCase());
+}

--- a/apps/worker/src/routes/entry-routes.ts
+++ b/apps/worker/src/routes/entry-routes.ts
@@ -9,6 +9,7 @@ import {
 } from '@line-crm/db';
 import type { EntryRoute } from '@line-crm/db';
 import type { Env } from '../index.js';
+import { isReservedRef } from '../lib/reserved-refs.js';
 
 const entryRoutes = new Hono<Env>();
 
@@ -53,6 +54,10 @@ entryRoutes.get('/api/entry-routes/:id', async (c) => {
   }
 });
 
+// Reserved product refs — see lib/reserved-refs.ts for the full contract.
+const reservedRefError = (code: string) =>
+  `「${code}」は予約済みの ref コードです（管理画面の友だち追加リンクが使用）。別の ref コードを指定してください`;
+
 // POST /api/entry-routes — create
 entryRoutes.post('/api/entry-routes', async (c) => {
   try {
@@ -69,6 +74,9 @@ entryRoutes.post('/api/entry-routes', async (c) => {
     }>();
     if (!body.refCode || !body.name) {
       return c.json({ success: false, error: 'refCode and name are required' }, 400);
+    }
+    if (isReservedRef(body.refCode)) {
+      return c.json({ success: false, error: reservedRefError(body.refCode) }, 400);
     }
     const row = await createEntryRoute(c.env.DB, body);
     return c.json({ success: true, data: serialize(row) }, 201);
@@ -95,6 +103,9 @@ entryRoutes.patch('/api/entry-routes/:id', async (c) => {
         isActive: boolean;
       }>
     >();
+    if (body.refCode && isReservedRef(body.refCode)) {
+      return c.json({ success: false, error: reservedRefError(body.refCode) }, 400);
+    }
     const row = await updateEntryRoute(c.env.DB, id, body);
     if (!row) return c.json({ success: false, error: 'Not found' }, 404);
     return c.json({ success: true, data: serialize(row) });

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -32,6 +32,7 @@ import { notifyAffiliateFriendAdd } from '../services/affiliate-notifier.js';
 import { verifyCallerLineUserId } from '../services/liff-auth.js';
 import { awardActivityMileage } from '../services/activity-mileage.js';
 import { safeRedirectTarget } from '../lib/safe-redirect.js';
+import { isReservedRef } from '../lib/reserved-refs.js';
 import type { Env } from '../index.js';
 import { verifyCrossAccountToken } from '../lib/cross-account-token.js';
 
@@ -201,6 +202,11 @@ async function applyRefAttribution(
   options?: { accountChannelId?: string | null; isNewFriend?: boolean },
 ): Promise<void> {
   if (!ref || ref.startsWith('xh:')) return;
+  // Reserved product refs (e.g. 'dashboard') are provenance markers, never
+  // campaigns — skip route/tracked-link/affiliate side effects even when a
+  // tenant has a pre-existing row with that ref_code. friends.ref_code and
+  // ref_tracking writes happen in the callers and are unaffected.
+  if (isReservedRef(ref)) return;
   const db = c.env.DB;
 
   const route = await getEntryRouteByRefCode(db, ref);
@@ -329,28 +335,19 @@ liffRoutes.get('/auth/line', async (c) => {
 
   // Multi-account: resolve LINE Login channel + LIFF
   // Priority:
-  //   1. entry_route.pool_id (when ref resolves to a referral link)
-  //   2. ?account= explicit single-account override
+  //   1. ?account= explicit single-account pin — wins over ref-derived pools
+  //      so an admin-issued per-account link is never re-routed by a
+  //      colliding ref_code (the ref still rides along for attribution)
+  //   2. entry_route.pool_id (when ref resolves to a referral link)
   //   3. ?pool= explicit override
   //   4. 'main' traffic pool fallback
   //   5. env default
   let channelId = c.env.LINE_LOGIN_CHANNEL_ID;
   let liffUrl = c.env.LIFF_URL;
 
-  // 1. entry_route → pool_id. getTrafficPoolById skips the is_active check
-  // that getTrafficPoolBySlug does for us, so we filter disabled pools here
-  // to honor an operator pause.
-  let resolvedPool: Awaited<ReturnType<typeof getTrafficPoolBySlug>> | null = null;
-  if (ref) {
-    const route = await getEntryRouteByRefCode(c.env.DB, ref);
-    if (route?.pool_id) {
-      const candidate = await getTrafficPoolById(c.env.DB, route.pool_id);
-      if (candidate?.is_active) resolvedPool = candidate;
-    }
-  }
-
-  if (!resolvedPool && accountParam) {
-    // 2. ?account= explicit override
+  // 1. ?account= explicit pin.
+  let accountResolved = false;
+  if (accountParam) {
     const account = await getLineAccountByChannelId(c.env.DB, accountParam);
     if (account?.login_channel_id) {
       channelId = account.login_channel_id;
@@ -358,6 +355,23 @@ liffRoutes.get('/auth/line', async (c) => {
     if (account?.liff_id) {
       liffUrl = `https://liff.line.me/${account.liff_id}`;
     }
+    accountResolved = Boolean(account?.login_channel_id || account?.liff_id);
+  }
+
+  // 2. entry_route → pool_id. getTrafficPoolById skips the is_active check
+  // that getTrafficPoolBySlug does for us, so we filter disabled pools here
+  // to honor an operator pause.
+  let resolvedPool: Awaited<ReturnType<typeof getTrafficPoolBySlug>> | null = null;
+  if (ref && !accountResolved) {
+    const route = await getEntryRouteByRefCode(c.env.DB, ref);
+    if (route?.pool_id) {
+      const candidate = await getTrafficPoolById(c.env.DB, route.pool_id);
+      if (candidate?.is_active) resolvedPool = candidate;
+    }
+  }
+
+  if (accountResolved) {
+    // account pin already applied above — skip pool resolution entirely
   } else {
     // 3 / 4: pool lookup (entry_route.pool_id wins over query)
     if (!resolvedPool) {
@@ -465,15 +479,24 @@ liffRoutes.get('/auth/line', async (c) => {
   // dropped onto liff.line.me directly. Direct liff.line.me redirects
   // surface LINE Login web for UL-未学習 devices, which kills conversion.
   // Exceptions:
-  //   - cross-account links (accountParam) → OAuth directly so the callback
-  //     can push from the correct account
+  //   - account links carrying callback-only state → OAuth. Three params can
+  //     only be honored by /auth/callback and are silently dropped on the
+  //     LIFF-direct path:
+  //       * uid   — cross-account UUID linking (the LIFF client never reads
+  //                 ?uid=; it only knows its own localStorage UUID)
+  //       * ref=xh: — X Harness one-time tokens ride the OAuth state and are
+  //                 deliberately stripped from external liff.line.me/QR URLs
+  //       * redirect — post-link redirect is not forwarded by qrUrl
+  //     Plain ?account= links go LIFF-direct instead: /api/liff/link resolves
+  //     the account from the verified id_token, so the OAuth web-login detour
+  //     added friction without adding correctness.
   //   - xh: refs (X Harness one-time tokens) → liff.line.me direct, since
   //     these tokens must NEVER appear in third-party URLs and the
   //     externalRef has already been zeroed for that case
   //   - empty ref → liff.line.me direct (no /r/:ref to route to)
   const isMobile = /iphone|ipad|android|mobile/.test(ua.toLowerCase());
   if (isMobile) {
-    if (accountParam) {
+    if (accountParam && (uidParam || redirect || ref.startsWith('xh:'))) {
       return c.redirect(loginUrl.toString());
     }
     if (externalRef) {

--- a/apps/worker/src/routes/r-account-links.test.ts
+++ b/apps/worker/src/routes/r-account-links.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// /r/:ref?account= resolution + /auth/line mobile routing for ?account= links.
+//
+// Admin-issued friend-add links moved from /auth/line?account= (which forced
+// the OAuth web-login detour on mobile) to /r/dashboard?account=. These tests
+// pin both halves:
+//   - /r resolves ?account= to that account's LIFF (priority: entry_route
+//     pool > account > pool fallback)
+//   - /auth/line?account= on mobile goes LIFF-direct; only uid-carrying
+//     links keep OAuth (uid linking exists solely in /auth/callback)
+
+const dbMocks = {
+  // eager module-load deps
+  getLineAccounts: vi.fn().mockResolvedValue([]),
+  getStaffByApiKey: vi.fn(),
+  recoverStalledBroadcasts: vi.fn(),
+  recoverStuckDeliveries: vi.fn(),
+  // route deps
+  getFriendByLineUserId: vi.fn(),
+  upsertFriend: vi.fn(),
+  createUser: vi.fn().mockResolvedValue({ id: 'U-uuid' }),
+  getUserByEmail: vi.fn().mockResolvedValue(null),
+  linkFriendToUser: vi.fn().mockResolvedValue(undefined),
+  getEntryRouteByRefCode: vi.fn().mockResolvedValue(null),
+  recordRefTracking: vi.fn().mockResolvedValue(undefined),
+  getTrackedLinkById: vi.fn().mockResolvedValue(null),
+  getMessageTemplateById: vi.fn().mockResolvedValue(null),
+  getAffiliateLinkByRefCode: vi.fn().mockResolvedValue(null),
+  getAffiliateOfferById: vi.fn().mockResolvedValue(null),
+  getAffiliateById: vi.fn().mockResolvedValue(null),
+  addTagToFriend: vi.fn().mockResolvedValue(undefined),
+  getLineAccountByChannelId: vi.fn().mockResolvedValue(null),
+  getLineAccountById: vi.fn().mockResolvedValue(null),
+  getScenarios: vi.fn().mockResolvedValue([]),
+  enrollFriendInScenario: vi.fn().mockResolvedValue(null),
+  getTrafficPoolBySlug: vi.fn().mockResolvedValue(null),
+  getTrafficPoolById: vi.fn().mockResolvedValue(null),
+  getRandomPoolAccount: vi.fn().mockResolvedValue(null),
+  getPoolAccounts: vi.fn().mockResolvedValue([]),
+  incrementAffiliateLinkClick: vi.fn().mockResolvedValue(undefined),
+  jstNow: () => '2026-08-20 00:00:00',
+};
+vi.mock('@line-crm/db', () => dbMocks);
+
+const pushImmediateFirstStep = vi.fn().mockResolvedValue(true);
+vi.mock('../services/immediate-first-step.js', () => ({ pushImmediateFirstStep }));
+
+const worker = (await import('../index.js')).default;
+
+const DB = {
+  prepare: () => ({
+    bind: () => ({
+      run: async () => ({ meta: { changes: 0 } }),
+      first: async () => null,
+      all: async () => ({ results: [] }),
+    }),
+  }),
+} as unknown as D1Database;
+
+const env = {
+  DB,
+  WORKER_URL: 'https://worker.example.com',
+  LINE_CHANNEL_ACCESS_TOKEN: 'env-token',
+  LIFF_URL: 'https://liff.line.me/1000000000-DefaultAA',
+  LINE_LOGIN_CHANNEL_ID: '2000000000',
+  LINE_LOGIN_CHANNEL_SECRET: 'login-secret',
+} as unknown as import('../index.js').Env['Bindings'];
+
+const MOBILE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15';
+const DESKTOP_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
+
+function get(path: string, ua = MOBILE_UA) {
+  return worker.fetch(
+    new Request(`https://worker.example.com${path}`, {
+      headers: { 'user-agent': ua },
+      redirect: 'manual',
+    }),
+    env,
+    { waitUntil() {}, passThroughOnException() {} } as unknown as ExecutionContext,
+  );
+}
+
+const TESTIN = {
+  id: 'acct-testin',
+  channel_id: '2011171710',
+  login_channel_id: '2011177336',
+  liff_id: '2011177336-RWMDBXOl',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dbMocks.getLineAccounts.mockResolvedValue([]);
+  dbMocks.getEntryRouteByRefCode.mockResolvedValue(null);
+  dbMocks.getAffiliateLinkByRefCode.mockResolvedValue(null);
+  dbMocks.getTrafficPoolBySlug.mockResolvedValue(null);
+  dbMocks.getLineAccountByChannelId.mockResolvedValue(null);
+});
+
+describe('/r/:ref — ?account= resolution', () => {
+  it('resolves the account LIFF and skips the pool fallback', async () => {
+    dbMocks.getLineAccountByChannelId.mockResolvedValue(TESTIN);
+
+    const res = await get('/r/dashboard?account=2011171710');
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(dbMocks.getLineAccountByChannelId).toHaveBeenCalledWith(DB, '2011171710');
+    // Landing page targets the account's LIFF, with ref + account riding along.
+    expect(html).toContain('liff.line.me/2011177336-RWMDBXOl');
+    expect(html).toContain('ref%3Ddashboard');
+    expect(html).toContain('account%3D2011171710');
+    // account resolution replaces the pool fallback entirely
+    expect(dbMocks.getTrafficPoolBySlug).not.toHaveBeenCalled();
+  });
+
+  it('unknown account (or one without liff_id) falls through to the pool fallback', async () => {
+    dbMocks.getLineAccountByChannelId.mockResolvedValue({ ...TESTIN, liff_id: null });
+
+    const res = await get('/r/dashboard?account=999');
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // env LIFF_URL default via the normal fallback chain
+    expect(html).toContain('liff.line.me/1000000000-DefaultAA');
+    expect(dbMocks.getTrafficPoolBySlug).toHaveBeenCalledWith(DB, 'main');
+  });
+
+  it('?account= wins over a colliding entry_route ref (selected-account guarantee)', async () => {
+    // A tenant may have an entry route or affiliate link whose ref_code happens
+    // to be the same word the dashboard uses ('dashboard'). The explicit
+    // account pin must not be re-routed by it.
+    dbMocks.getEntryRouteByRefCode.mockResolvedValue({ id: 'er-1', pool_id: 'pool-1' });
+    dbMocks.getTrafficPoolById.mockResolvedValue({ id: 'pool-1', is_active: 1 });
+    dbMocks.getRandomPoolAccount.mockResolvedValue({
+      id: 'acct-pool',
+      channel_id: '3000000001',
+      liff_id: '3000000001-PoolAAAA',
+    });
+    dbMocks.getLineAccountByChannelId.mockResolvedValue(TESTIN);
+
+    const res = await get('/r/dashboard?account=2011171710');
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    expect(html).toContain('liff.line.me/2011177336-RWMDBXOl');
+    expect(html).not.toContain('liff.line.me/3000000001-PoolAAAA');
+    // account pin short-circuits route/pool resolution entirely
+    expect(dbMocks.getEntryRouteByRefCode).not.toHaveBeenCalled();
+    expect(dbMocks.getRandomPoolAccount).not.toHaveBeenCalled();
+  });
+});
+
+describe('/auth/line — mobile ?account= routing', () => {
+  it('?account= without uid goes LIFF-direct (LINE app), not OAuth', async () => {
+    dbMocks.getLineAccountByChannelId.mockResolvedValue(TESTIN);
+
+    const res = await get('/auth/line?account=2011171710');
+    expect(res.status).toBe(302);
+    const location = res.headers.get('location') ?? '';
+
+    expect(location).toContain('liff.line.me/2011177336-RWMDBXOl');
+    expect(location).not.toContain('access.line.me');
+    expect(location).toContain('account=2011171710');
+  });
+
+  it.each([
+    ['uid', '/auth/line?account=2011171710&uid=user-uuid-1'],
+    ['redirect', '/auth/line?account=2011171710&redirect=https%3A%2F%2Fexample.com%2Fthanks'],
+    ['xh: ref', '/auth/line?account=2011171710&ref=xh%3Asecret-token'],
+  ])(
+    '?account= with callback-only state (%s) keeps the OAuth detour',
+    async (_label, path) => {
+      dbMocks.getLineAccountByChannelId.mockResolvedValue(TESTIN);
+
+      const res = await get(path);
+      expect(res.status).toBe(302);
+      const location = res.headers.get('location') ?? '';
+
+      expect(location).toContain('access.line.me/oauth2/v2.1/authorize');
+      expect(location).toContain('client_id=2011177336');
+    },
+  );
+
+  it('reserved ref codes are rejected at entry-route creation', async () => {
+    const res = await worker.fetch(
+      new Request('https://worker.example.com/api/entry-routes', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer env-key',
+        },
+        body: JSON.stringify({ refCode: 'Dashboard', name: 'collision' }),
+      }),
+      { ...env, API_KEY: 'env-key' } as typeof env,
+      { waitUntil() {}, passThroughOnException() {} } as unknown as ExecutionContext,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toContain('予約済み');
+  });
+
+  it('PC still gets the QR landing page for ?account= links', async () => {
+    dbMocks.getLineAccountByChannelId.mockResolvedValue(TESTIN);
+
+    const res = await get('/auth/line?account=2011171710', DESKTOP_UA);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('/api/qr');
+    expect(html).toContain(encodeURIComponent('liff.line.me/2011177336-RWMDBXOl'));
+  });
+});


### PR DESCRIPTION
private main c37865c([Shudesu/line-harness#141](https://github.com/Shudesu/line-harness/pull/141)、4コミット)の単発同期。

## 変更内容
- `/r/:ref` が `?account=` 明示ピンに対応(ref 由来の pool/affiliate 解決より優先)
- 管理ダッシュボードの友だち追加カードは `/r/dashboard?account=...` を配布(モバイルで Web版 LINE ログインを挟まずアプリ直行)
- `/auth/line` のモバイル分岐: 素の `?account=` リンクは LIFF 直行、callback 必須状態(uid / redirect / xh:)のみ OAuth 経由を維持
- `dashboard` を予約 ref 化: entry-route の作成/更新で拒否、キャンペーン attribution 副作用から除外(friends.ref_code への記録は維持)

## 検証
- OSS checkout で worker 全テスト 94 files / 977 tests パス
- コンフリクト1件(private 先行の loginUnconfiguredPage import)は OSS 未同期機能のため除外して解決

🤖 Generated with [Claude Code](https://claude.com/claude-code)