### PR TITLE
chore: release v0.22.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "line-oss-crm",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "private": true,
   "description": "Open-source LINE Official Account CRM/marketing automation",
   "homepage": "https://the-harness.com/line-harness/",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/mcp-server",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "description": "MCP server for L Harness — operate a LINE official account from AI agents over MCP",
   "type": "module",
   "bin": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/sdk",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "description": "AI-native SDK for L Harness — programmatic LINE official account automation",
   "type": "module",
   "exports": {


### PR DESCRIPTION
v0.22.0 バージョンbump(private main 14f4ad33 と同期)。

主な内容(前リリース v0.21.3 以降):
- 友だち追加リンクのアプリ直行化(/r ?account= / /r/dashboard / auth/line LIFF直行 / dashboard 予約 ref)
- 管理ダッシュボードの QR 表示削除
- 外部 SSO(ADMIN_SSO_SECRET、未設定なら完全不活性)
- login-unconfigured セットアップ案内
- ブランド表示名 L Harness 化
- update-engine 0.0.11 の Pages ハッシュ修正を含むリリース bundle

マージ後に v0.22.0 タグを push し、Release ワークフローで draft release(bundle + manifest)を生成します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)