### PR TITLE
fix(worker): use JST timestamps for media inquiries

### DIFF
--- a/apps/worker/src/routes/media-inquiries.test.ts
+++ b/apps/worker/src/routes/media-inquiries.test.ts
@@ -99,4 +99,41 @@ describe('POST /api/public/media-inquiries', () => {
     const body = await res.json() as { data: { notification: string } };
     expect(body.data.notification).toBe('activation_required');
   });
+
+  // タイムスタンプはプロジェクト共通の JST ISO-8601（+09:00 付き）で保存する。
+  // SQLite 側の now 系関数はオフセットなしの UTC 文字列を返すため、それを
+  // 使うと読み手がローカル時刻として解釈し、JST 00:00〜09:00 の問い合わせが
+  // 前日の日付として扱われる。
+  it('persists offset-bearing JST timestamps instead of offset-less UTC', async () => {
+    const calls: RunCall[] = [];
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ success: true }), { status: 200 })));
+
+    await mediaInquiries.request(
+      '/api/public/media-inquiries',
+      {
+        method: 'POST',
+        headers: { origin: 'https://the-harness.com', 'content-type': 'application/json' },
+        body: JSON.stringify(validBody),
+      },
+      createEnv(calls),
+    );
+
+    const JST_ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+09:00$/;
+
+    // INSERT: created_at / updated_at は末尾 2 バインド。
+    const [createdAt, initialUpdatedAt] = calls[0].values.slice(-2) as [string, string];
+    expect(createdAt).toMatch(JST_ISO);
+    expect(initialUpdatedAt).toMatch(JST_ISO);
+    // 同一イベントなので初期値は完全一致させる（無駄な数 ms 差を作らない）。
+    expect(initialUpdatedAt).toBe(createdAt);
+
+    // UPDATE: updated_at は id の 1 つ手前。
+    const notifiedUpdatedAt = calls[1].values.at(-2) as string;
+    expect(notifiedUpdatedAt).toMatch(JST_ISO);
+
+    // タイムスタンプを SQL 側で生成しない（オフセットなし UTC への逆戻り防止）。
+    expect(calls[0].sql).not.toContain('datetime(');
+    expect(calls[1].sql).not.toContain('datetime(');
+  });
 });

--- a/apps/worker/src/routes/media-inquiries.ts
+++ b/apps/worker/src/routes/media-inquiries.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { jstNow } from '@line-crm/db';
 import type { Env } from '../index.js';
 
 const mediaInquiries = new Hono<Env>();
@@ -91,6 +92,12 @@ mediaInquiries.post('/api/public/media-inquiries', async (c) => {
     utmCampaign: text(body.utmCampaign, 200),
   };
 
+  // 他テーブルと同じく JST ISO-8601（+09:00 付き）で保存する。SQLite 側の
+  // now 系関数はオフセットなしの UTC 文字列を返すため、読み手がローカル時刻
+  // として解釈してしまう。created_at と初期 updated_at は同一イベントなので
+  // 同じ値を使う。
+  const now = jstNow();
+
   await c.env.DB.prepare(
     `INSERT INTO media_inquiries (
       id, inquiry_type, company_name, contact_name, department, position,
@@ -99,7 +106,7 @@ mediaInquiries.post('/api/public/media-inquiries', async (c) => {
       preferred_contact, source_article, source_url, referrer,
       utm_source, utm_medium, utm_campaign, country, cf_ray,
       mail_status, created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', datetime('now'), datetime('now'))`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`,
   ).bind(
     id, inquiryType, companyName, contactName, values.department, values.position,
     values.decisionRole, email, values.phone, values.companySize, values.currentTools,
@@ -107,6 +114,7 @@ mediaInquiries.post('/api/public/media-inquiries', async (c) => {
     values.preferredContact, values.sourceArticle, values.sourceUrl, values.referrer,
     values.utmSource, values.utmMedium, values.utmCampaign,
     c.req.header('cf-ipcountry') || '', c.req.header('cf-ray') || '',
+    now, now,
   ).run();
 
   let mailStatus = 'pending';
@@ -167,8 +175,8 @@ mediaInquiries.post('/api/public/media-inquiries', async (c) => {
   }
 
   await c.env.DB.prepare(
-    `UPDATE media_inquiries SET mail_status = ?, mail_error = ?, updated_at = datetime('now') WHERE id = ?`,
-  ).bind(mailStatus, mailError || null, id).run();
+    `UPDATE media_inquiries SET mail_status = ?, mail_error = ?, updated_at = ? WHERE id = ?`,
+  ).bind(mailStatus, mailError || null, jstNow(), id).run();
 
   return c.json({
     success: true,


### PR DESCRIPTION
### Problem

`media_inquiries` is the only table written with SQLite's `datetime('now')` rather than the project's `jstNow()` helper:

```ts
) VALUES (..., 'pending', datetime('now'), datetime('now'))`
...
`UPDATE media_inquiries SET mail_status = ?, mail_error = ?, updated_at = datetime('now') WHERE id = ?`
```

`datetime('now')` returns `YYYY-MM-DD HH:MM:SS` — UTC, space-separated, **no offset marker**. The project convention (`packages/db/src/utils.ts`) is offset-bearing JST, `YYYY-MM-DDTHH:mm:ss.sss+09:00`, and that file notes the `+09:00` suffix exists specifically so `new Date()` parses the value correctly.

To be precise about what was and wasn't wrong: **the recorded instant was correct.** This was never JST stored as UTC, and it is not a date-only/timestamp confusion — I checked, and `julianday()` between the two representations of the same moment differs by exactly 0. The defect is that a string with no offset is ambiguous to whoever reads it:

```text
stored:  "2026-08-19 15:30:00"            → parsed as local time in Asia/Tokyo → 2026-08-19T06:30:00Z  (9h early)
correct: "2026-08-20T00:30:00.000+09:00"  → 2026-08-19T15:30:00Z                                       (true instant)
```

The consequence is a calendar-date shift for any inquiry submitted between **JST 00:00 and 09:00**, which crosses month and year boundaries:

| JST wall-clock | stored date | JST-convention date |
|---|---|---|
| 2026-08-20 00:30 | 2026-08-**19** | 2026-08-**20** |
| 2026-09-01 00:10 | 2026-08-**31** | 2026-09-**01** |
| 2027-01-01 00:05 | 2026-**12-31** | 2027-**01-01** |

Nothing reads the table yet, so there is no failure to observe today — I found no `SELECT` against `media_inquiries` anywhere in the repo. But the release notes describe these rows as being kept "for operational follow-up", so a reader is intended, and the ambiguity would surface as soon as one is written.

### Fix

- bind `jstNow()` for the initial inquiry `INSERT`
- bind `jstNow()` for the notification-status `UPDATE`
- use the same value for `created_at` and the initial `updated_at`, since they describe one event
- add regression assertions on the persisted timestamp format

Timestamps are no longer generated SQL-side at either site. The route is otherwise untouched — origin allowlist, honeypot, field validation, notification handling and response shape are all unchanged, and the diff contains no lines from those areas.

The regression test asserts both `INSERT` timestamps and the post-notification `UPDATE` timestamp match `/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+09:00$/`, that `created_at` equals the initial `updated_at`, and that neither statement generates a timestamp in SQL. It uses the existing D1 mock, which already captures bound values, so no new fixtures, no time-freezing, and no new dependencies. I confirmed it fails against the previous implementation before keeping it.

### Validation

Run as `worker-ci.yml` does, after `pnpm --filter @line-crm/shared --filter @line-crm/line-sdk --filter @line-crm/db --filter @line-harness/update-engine build`:

- `pnpm --filter worker typecheck` — **pass**
- `pnpm --filter worker test` — **98 files, 1045 tests, all pass** (baseline on `main` was 1044; this PR adds 1)
- `pnpm --filter worker build` — **pass**
- `pnpm --dir apps/worker test media-inquiries` — **4/4 pass**

No pre-existing failures in this package, so there is no baseline noise to separate out.

### Scope

```text
- no migration changes
- no schema changes
- no column default changes
- no production data modification
- no backfill
- no dependency changes
- no lockfile changes
- no deploy changes
```

The column default remains `datetime('now')`. Changing it would require a full SQLite table rebuild, and once both write sites bind explicitly the default never fires — so it did not seem worth the churn. Existing rows are left untouched and may still use the previous offset-less format; normalising them is a separate decision, and I have not inspected the live table.
