### PR TITLE
fix(setup): LIFF ID を line_accounts に保存せず LIFF 予約・イベント画面が 404 になる問題を修正

### DIFF
--- a/packages/create-line-harness/src/commands/setup.ts
+++ b/packages/create-line-harness/src/commands/setup.ts
@@ -17,6 +17,7 @@ import { setSecrets } from "../steps/secrets.js";
 import { configureAdminAuth } from "../steps/admin-auth.js";
 import { generateMcpConfig } from "../steps/mcp-config.js";
 import { generateApiKey } from "../lib/crypto.js";
+import { buildLineIdentitySql, quoteSqlString } from "../lib/line-account-sql.js";
 import {
   getAccountIds,
   setAccountId,
@@ -670,8 +671,8 @@ async function runSetupInner(
     // Two separate temp files so we can clean each one immediately and never
     // hold both plaintext credentials on disk simultaneously.
     const insertSqlFile = join(tmpdir(), `clh-line-account-${randomUUID()}.sql`);
-    const loginSqlFile = join(tmpdir(), `clh-line-login-${randomUUID()}.sql`);
-    const q = (val: string) => `'${val.replace(/'/g, "''")}'`;
+    const identitySqlFile = join(tmpdir(), `clh-line-identity-${randomUUID()}.sql`);
+    const q = quoteSqlString;
     let insertErr: unknown = null;
 
     try {
@@ -724,12 +725,21 @@ ON CONFLICT(channel_id) DO UPDATE SET
       process.exit(1);
     }
 
-    // Step B (best-effort): set login_channel_id. May fail on older
-    // schemas that don't have the column — that's fine, the dashboard
-    // can set it later.
+    // Step B (best-effort): set the non-secret identifiers — login_channel_id
+    // and liff_id. Both columns arrived in the same later migration
+    // (008_multi_account), so this may fail on an older schema — that's fine,
+    // the dashboard can set them later.
+    //
+    // liff_id has to be written here: the LIFF endpoints resolve the owning
+    // account with `WHERE liff_id = ?`, so leaving it NULL makes the booking
+    // and event screens answer `unknown_liff` (404) on a fresh install.
     try {
-      const loginSql = `UPDATE line_accounts SET login_channel_id = ${q(state.lineLoginChannelId!)} WHERE channel_id = ${q(state.lineChannelId!)};`;
-      writeFileSync(loginSqlFile, loginSql, { mode: 0o600 });
+      const identitySql = buildLineIdentitySql({
+        channelId: state.lineChannelId!,
+        loginChannelId: state.lineLoginChannelId!,
+        liffId: state.liffId!,
+      });
+      writeFileSync(identitySqlFile, identitySql, { mode: 0o600 });
       try {
         await wrangler([
           "d1",
@@ -737,13 +747,13 @@ ON CONFLICT(channel_id) DO UPDATE SET
           state.d1DatabaseName!,
           "--remote",
           "--file",
-          loginSqlFile,
+          identitySqlFile,
         ]);
       } finally {
-        try { rmSync(loginSqlFile, { force: true }); } catch { /* best-effort */ }
+        try { rmSync(identitySqlFile, { force: true }); } catch { /* best-effort */ }
       }
     } catch {
-      // Non-critical — login_channel_id can be set from the dashboard.
+      // Non-critical — both identifiers can be set from the dashboard.
     }
 
     s.stop("LINE アカウント登録完了");

--- a/packages/create-line-harness/src/lib/line-account-sql.ts
+++ b/packages/create-line-harness/src/lib/line-account-sql.ts
@@ -1,0 +1,46 @@
+/**
+ * SQL builders for the `line_accounts` row the setup CLI registers.
+ *
+ * Kept out of `commands/setup.ts` so the statements can be asserted in a unit
+ * test without driving the whole interactive flow.
+ */
+
+/**
+ * Quote a value for inline SQL. The setup CLI writes statements to a file and
+ * runs them through `wrangler d1 execute --file`, which has no parameter
+ * binding, so values are escaped here instead.
+ */
+export function quoteSqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export interface LineIdentitySqlOptions {
+  /** Messaging API channel ID — identifies the row to update. */
+  channelId: string;
+  /** LINE Login channel ID (a different channel from the Messaging API one). */
+  loginChannelId: string;
+  /** LIFF ID in `<login channel id>-<random>` form. */
+  liffId: string;
+}
+
+/**
+ * Non-secret LINE identifiers stored on the account row.
+ *
+ * `liff_id` is not bookkeeping: the LIFF endpoints resolve the owning account
+ * with `WHERE liff_id = ?` (booking, events), and `{{liff_id}}` in an auto-reply
+ * is expanded from the receiving account's row — deliberately without falling
+ * back to the global `LIFF_URL`, so one account never hands out another
+ * account's LIFF link. Leaving the column NULL therefore breaks those paths on
+ * a stock install even though the CLI already collected the value.
+ *
+ * `login_channel_id` and `liff_id` were both added by migration
+ * `008_multi_account`, so a single statement is either fully applied or fully
+ * skipped on an older schema.
+ */
+export function buildLineIdentitySql(options: LineIdentitySqlOptions): string {
+  return (
+    `UPDATE line_accounts SET login_channel_id = ${quoteSqlString(options.loginChannelId)}, ` +
+    `liff_id = ${quoteSqlString(options.liffId)} ` +
+    `WHERE channel_id = ${quoteSqlString(options.channelId)};`
+  );
+}

--- a/packages/create-line-harness/test/line-account-sql.test.ts
+++ b/packages/create-line-harness/test/line-account-sql.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { buildLineIdentitySql, quoteSqlString } from '../src/lib/line-account-sql.js';
+
+const CHANNEL_ID = '2011000001';
+const LOGIN_CHANNEL_ID = '2011000002';
+const LIFF_ID = '2011000002-ab12CD34';
+
+describe('quoteSqlString', () => {
+  it('wraps the value in single quotes', () => {
+    expect(quoteSqlString('2011000001')).toBe("'2011000001'");
+  });
+
+  it('doubles embedded single quotes', () => {
+    expect(quoteSqlString("O'Brien")).toBe("'O''Brien'");
+  });
+});
+
+describe('buildLineIdentitySql', () => {
+  it('sets both login_channel_id and liff_id', () => {
+    const sql = buildLineIdentitySql({
+      channelId: CHANNEL_ID,
+      loginChannelId: LOGIN_CHANNEL_ID,
+      liffId: LIFF_ID,
+    });
+
+    // liff_id is what the LIFF booking/event endpoints look the account up by
+    // (`WHERE liff_id = ?`), so a setup run that skips it leaves those screens
+    // answering `unknown_liff`.
+    expect(sql).toContain(`login_channel_id = '${LOGIN_CHANNEL_ID}'`);
+    expect(sql).toContain(`liff_id = '${LIFF_ID}'`);
+  });
+
+  it('scopes the update to the Messaging API channel that was just registered', () => {
+    const sql = buildLineIdentitySql({
+      channelId: CHANNEL_ID,
+      loginChannelId: LOGIN_CHANNEL_ID,
+      liffId: LIFF_ID,
+    });
+
+    expect(sql).toContain(`WHERE channel_id = '${CHANNEL_ID}'`);
+    expect(sql.endsWith(';')).toBe(true);
+  });
+
+  it('escapes values instead of interpolating them raw', () => {
+    const sql = buildLineIdentitySql({
+      channelId: CHANNEL_ID,
+      loginChannelId: LOGIN_CHANNEL_ID,
+      liffId: "2011000002-ab'12",
+    });
+
+    expect(sql).toContain("liff_id = '2011000002-ab''12'");
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** セットアップ CLI は LIFF ID を入力させ、`LIFF_URL` シークレットと Worker のデプロイには使っていますが、自分で作成する `line_accounts` 行の `liff_id` 列には一度も書き込んでいません。その結果、`npx create-line-harness` で構築した直後の環境は `line_accounts.liff_id` が NULL のままになります。
- **影響 1（LIFF 画面が全滅）:** 予約・イベントの LIFF エンドポイントは `resolveAccountIdFromLiff()` が `SELECT id FROM line_accounts WHERE liff_id = ? AND is_active = 1` でアカウントを解決し、見つからなければ即 `404 unknown_liff` を返します（`apps/worker/src/routes/booking.ts:101`、`apps/worker/src/routes/events.ts:57`）。`liff_id` が NULL なので `/api/liff/booking/*` と `/api/liff/events/*` が全て 404 になります。CLI が最後に案内するエンドポイント URL は `...workers.dev?liffId=<LIFF ID>` で、LIFF 側は実際にこのクエリを送っています（`apps/liff/src/lib/liff-auth.ts`）。
- **影響 2（`{{liff_id}}` 自動応答）:** `resolveAutoReplyLiffId()` は受信アカウントの `liff_id` を返し、無ければ `null` → `LIFF ID is not configured for the matched LINE account` で送信が落ちます（`apps/worker/src/services/auto-reply.ts:62`）。migration `067_mileage_keyword_auto_reply` の組み込みルールがこのテンプレートを使うため、既定インストールでも踏みます。
- **Solution:** Step 12（LINE アカウント登録）の best-effort UPDATE で `login_channel_id` と一緒に `liff_id` も書きます。`login_channel_id` と `liff_id` は同じ migration `008_multi_account` で追加された列なので、1 文にまとめても「古いスキーマでは丸ごとスキップ」という既存の性質は変わりません。
- **What changed:** `packages/create-line-harness/src/commands/setup.ts` の UPDATE 文と、単体テストのために切り出した `src/lib/line-account-sql.ts`（＋テスト）。SQL エスケープはこれまで setup.ts にインラインで置かれていた同じ実装を移しただけです。
- **What did NOT change:** Worker 側のフォールバック挙動は触っていません。受信アカウントに `liff_id` が無いとき env の `LIFF_URL` へフォールバックしないのは、他アカウントの LIFF リンクを配らないための意図的な設計で、`apps/worker/src/services/auto-reply.test.ts` の "does not send another account URL when the receiving account has no LIFF ID" が明示的に守っています。したがって修正すべきは書き込み側だと判断しました。スキーマ・マイグレーション・シークレット・デプロイ経路は変更なしです。

## Related Issue

N/A — 既存の open / closed issue を `liff_id` で検索して該当なしでした。再現手順と before/after は本文に記載しています。

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Security hardening
- [ ] Documentation
- [ ] Tests only
- [ ] Chore / infra
- [ ] Private sync

## Scope

- [ ] Admin web UI
- [ ] Worker API
- [ ] LINE webhook / postback / reply token
- [ ] Broadcast / multicast / step delivery / reminders
- [ ] Auth / API keys / cookies / CORS / staff permissions
- [ ] D1 schema / migrations / account scoping
- [x] SDK / MCP / create-line-harness CLI
- [ ] Cloudflare deploy / release / update workflow
- [ ] Docs only

`line_accounts` の既存列への UPDATE のみで、スキーマ変更やマイグレーション追加はありません。

## Verification

- **Commands:**
  - `pnpm --filter create-line-harness test` → 6 files / 54 tests passed（うち新規 5 件）
  - `pnpm --filter create-line-harness build` → success
  - `npx tsc --noEmit -p packages/create-line-harness/tsconfig.json` → exit 0
- **Manual checks:** v0.22.0 で構築した実環境（Cloudflare Workers + D1）で、`liff_id` の有無だけを変えて LIFF 予約エンドポイントを叩き分けました。URL・チャネル ID・LIFF ID は伏せています。

  ```
  # 修正前（CLI 構築直後の状態: line_accounts.liff_id IS NULL）
  GET https://<worker>.workers.dev/api/liff/booking/menus?liffId=<LIFF ID>
  → 404 {"error":"unknown_liff"}

  # 本 PR と同じ UPDATE を流したあと
  UPDATE line_accounts SET liff_id = '<LIFF ID>' WHERE channel_id = '<channel id>';
  GET https://<worker>.workers.dev/api/liff/booking/menus?liffId=<LIFF ID>
  → 200 {"menus":[]}

  # 対照: 存在しない LIFF ID
  GET https://<worker>.workers.dev/api/liff/booking/menus?liffId=<存在しない ID>
  → 404 {"error":"unknown_liff"}
  ```

  構築直後の DB は `channel_id` と `login_channel_id` は入っていて `liff_id` だけが NULL、という状態でした。
- **Not tested:** セットアップ CLI の対話フローを頭から通した実行はしていません（実 LINE チャネルと Cloudflare リソースを新規に消費するため）。検証は既存環境に同じ SQL を適用する形で行いました。`{{liff_id}}` 自動応答が実配信で復旧することは、コードパスの追跡までで実送信は確認していません。古いスキーマ（migration 008 未適用）での挙動も未確認です。

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — この UPDATE が扱うのは非秘匿の識別子（LINE Login チャネル ID と LIFF ID）だけです。チャネルシークレット／アクセストークンを含む INSERT 側の一時ファイルは従来どおり別ファイル・`mode: 0o600`・実行直後に削除、という扱いのまま変えていません。
- New/changed network calls? `No`
- Message sending behavior changed? `No` — 送信ロジックは未変更です。これまで `liff_id` 欠落で失敗していた `{{liff_id}}` 自動応答が、正しい自アカウントの LIFF ID で送れるようになります。
- Customer/friend data access changed? `No`
- D1 migration or data deletion changed? `No` — 既存列への UPDATE のみ。削除もマイグレーション追加もありません。

## Safety Checklist

- [x] This PR is focused on one problem and contains no unrelated commits.
- [x] I searched for existing issues/PRs to avoid duplicates.
- [x] No secrets, tokens, customer data, friend IDs, private URLs, or private configuration are included.
- [x] No generated build output, `.tsbuildinfo`, local env files, or formatting-only churn is included.
- [x] Docs or tests were updated when useful.
- [x] Deployment impact is understood.
- [x] For high-risk areas, I included a clear rollback or recovery note.
- [x] I personally verified the behavior described above.

## Rollback / Recovery

CLI 側の変更のみなので、リバートすれば以前の挙動（`liff_id` を書かない）に戻ります。書き込み済みの値を戻したい場合は `UPDATE line_accounts SET liff_id = NULL WHERE channel_id = '<channel id>';` です。

既に構築済みの環境は本 PR では復旧しません（`update` コマンドは LIFF ID を保持していないため）。運用者が管理画面のアカウント編集から LIFF ID を入れるか、同じ UPDATE を 1 回流す必要があります。既存環境の自動バックフィル手段が要るようなら、別 PR で `update --repair-*` 系に足す形が良さそうです。方針をいただければ対応します。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
