### PR TITLE
fix(chats): auto-wrap URLs in chat replies with tracking links

### DIFF
--- a/apps/worker/src/routes/chats.test.ts
+++ b/apps/worker/src/routes/chats.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('@line-crm/db', () => ({
+  getOperators: vi.fn(),
+  getOperatorById: vi.fn(),
+  createOperator: vi.fn(),
+  updateOperator: vi.fn(),
+  deleteOperator: vi.fn(),
+  getChats: vi.fn(),
+  createChat: vi.fn(),
+  getChatById: vi.fn(async () => ({ id: 'chat-1', friend_id: 'friend-1' })),
+  getFriendById: vi.fn(async () => ({
+    id: 'friend-1',
+    line_user_id: `U${'1'.repeat(32)}`,
+    line_account_id: 'account-1',
+  })),
+  getLineAccountById: vi.fn(async () => ({ channel_access_token: 'account-token' })),
+  updateChat: vi.fn(async () => ({})),
+  jstNow: vi.fn(() => '2026-08-24T12:00:00.000+09:00'),
+}));
+
+const pushTextMessage = vi.fn(async () => ({}));
+vi.mock('@line-crm/line-sdk', () => ({
+  LineClient: class {
+    pushTextMessage = pushTextMessage;
+  },
+}));
+
+const autoTrackContent = vi.fn(async (_db: unknown, messageType: string) => ({
+  messageType,
+  content: 'see https://worker.test/t/Ab3xY9k',
+}));
+const appendFriendToTrackedLinks = vi.fn(async (_db: unknown, content: string) => content);
+vi.mock('../services/auto-track.js', () => ({
+  autoTrackContent: (...args: unknown[]) => autoTrackContent(...(args as [unknown, string])),
+  appendFriendToTrackedLinks: (...args: unknown[]) =>
+    appendFriendToTrackedLinks(...(args as [unknown, string])),
+}));
+
+import { chats } from './chats.js';
+
+function fakeDb() {
+  const db = {
+    prepare(sql: string) {
+      const statement = {
+        bind(..._params: unknown[]) {
+          return statement;
+        },
+        async run() {
+          return { success: true };
+        },
+        async all() {
+          return { results: [] };
+        },
+        async first() {
+          return null;
+        },
+      };
+      void sql;
+      return statement;
+    },
+  };
+  return db as unknown as D1Database;
+}
+
+function app() {
+  const a = new Hono();
+  a.route('/', chats);
+  return a;
+}
+
+function send(body: Record<string, unknown>) {
+  return app().request(
+    new Request('http://worker.test/api/chats/chat-1/send', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+    {},
+    { DB: fakeDb(), LINE_CHANNEL_ACCESS_TOKEN: 'default-token', WORKER_URL: 'https://worker.test' } as never,
+  );
+}
+
+describe('POST /api/chats/:id/send link tracking', () => {
+  beforeEach(() => {
+    pushTextMessage.mockClear();
+    autoTrackContent.mockClear();
+    appendFriendToTrackedLinks.mockClear();
+  });
+
+  test('wraps URLs before pushing, same as the friends message route', async () => {
+    const response = await send({ content: 'see https://example.com/join' });
+
+    expect(response.status).toBe(200);
+    expect(autoTrackContent).toHaveBeenCalledWith(
+      expect.anything(),
+      'text',
+      'see https://example.com/join',
+      'https://worker.test',
+      { lineAccountId: 'account-1' },
+    );
+    // The tracked content (not the raw body) is what reaches LINE.
+    expect(pushTextMessage).toHaveBeenCalledWith(
+      `U${'1'.repeat(32)}`,
+      'see https://worker.test/t/Ab3xY9k',
+    );
+  });
+
+  test('trackLinks=false sends the content as-is', async () => {
+    const response = await send({ content: 'see https://example.com/join', trackLinks: false });
+
+    expect(response.status).toBe(200);
+    expect(autoTrackContent).not.toHaveBeenCalled();
+    // Friend attribution on pre-existing /t links still runs.
+    expect(appendFriendToTrackedLinks).toHaveBeenCalled();
+    expect(pushTextMessage).toHaveBeenCalledWith(`U${'1'.repeat(32)}`, 'see https://example.com/join');
+  });
+});

--- a/apps/worker/src/routes/chats.ts
+++ b/apps/worker/src/routes/chats.ts
@@ -551,7 +551,7 @@ chats.post('/api/chats/:id/send', async (c) => {
     const chat = await resolveOrCreateChat(c.env.DB, chatId);
     if (!chat) return c.json({ success: false, error: 'Chat not found' }, 404);
 
-    const body = await c.req.json<{ messageType?: string; content: string }>();
+    const body = await c.req.json<{ messageType?: string; content: string; trackLinks?: boolean }>();
     if (!body.content) return c.json({ success: false, error: 'content is required' }, 400);
 
     const { friend, accessToken } = await resolveFriendAndAccessToken(
@@ -566,13 +566,35 @@ chats.post('/api/chats/:id/send', async (c) => {
     const lineClient = new LineClient(accessToken);
     const messageType = body.messageType ?? 'text';
 
-    if (messageType === 'text') {
-      await lineClient.pushTextMessage(friend.line_user_id, body.content);
-    } else if (messageType === 'flex') {
-      const contents = JSON.parse(body.content);
+    // Auto-wrap URLs with tracking links — mirrors POST /api/friends/:id/messages.
+    // Chat replies were the only manual-send path without this, so URLs pasted
+    // into the chat box went out untracked. trackLinks=false opts out (send as-is).
+    const sendWorkerUrl = c.env.WORKER_URL || new URL(c.req.url).origin;
+    let tracked = { messageType, content: body.content };
+    if (body.trackLinks !== false) {
+      const { autoTrackContent } = await import('../services/auto-track.js');
+      tracked = await autoTrackContent(c.env.DB, messageType, body.content, sendWorkerUrl, {
+        lineAccountId: friend.line_account_id ?? null,
+      });
+    }
+    // 1:1 send — burn f=<friendId> into /t links so clicks attribute without the
+    // LIFF identification hop (also applies to pre-existing /t links, hence
+    // unconditional).
+    {
+      const { appendFriendToTrackedLinks } = await import('../services/auto-track.js');
+      tracked = {
+        ...tracked,
+        content: await appendFriendToTrackedLinks(c.env.DB, tracked.content, sendWorkerUrl, friend.id),
+      };
+    }
+
+    if (tracked.messageType === 'text') {
+      await lineClient.pushTextMessage(friend.line_user_id, tracked.content);
+    } else if (tracked.messageType === 'flex') {
+      const contents = JSON.parse(tracked.content);
       await lineClient.pushFlexMessage(friend.line_user_id, extractFlexAltText(contents), contents);
-    } else if (messageType === 'image') {
-      const parsed = JSON.parse(body.content) as {
+    } else if (tracked.messageType === 'image') {
+      const parsed = JSON.parse(tracked.content) as {
         originalContentUrl: string;
         previewImageUrl: string;
       };


### PR DESCRIPTION
## 問題

チャット画面(個別トーク)の返信でURLを送ると、トラッキングリンクへ変換されず素のURLのまま届きます。

## 原因

手動送信の経路が2つあり、片方だけ変換が入っていません。

- `POST /api/friends/:id/messages`(友だち詳細のダイレクトメッセージ): `autoTrackContent` と `appendFriendToTrackedLinks` を通す
- `POST /api/chats/:id/send`(チャット画面の返信): 本文をそのまま `pushTextMessage` へ渡していて、変換を通らない

通常配信・ステップ配信・友だち追加直後の自動送信・フォーム特典は変換を通るので、手動送信でトラッキングを迂回するのはチャット返信だけでした。

## 修正

`/api/chats/:id/send` にfriends側と同じ処理を足しました。

- `autoTrackContent`(textはインライン置換、flexはuri actionの書き換え、imageは素通し)
- `appendFriendToTrackedLinks` による1:1送信の `f=<friendId>` 焼き込み
- `trackLinks: false` のオプトアウトもfriends側と同じ挙動

ルートテストを2件足しています。変換後の本文がpushへ渡ること、`trackLinks: false` なら原文のまま送ることを見ます。

## 確認

- `apps/worker`: vitest 1032件通過
- `tsc --noEmit` で出る `admin-update.ts` の3件(`@line-harness/update-engine` 未ビルド)はmainでも発生する既存の事象です