### PR TITLE
fix(web): チャット画面の横スクロールと操作不能を修正 (#265 の追随)

### DIFF
--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -987,10 +987,10 @@ export default function ChatsPage() {
                   </div>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                  {/* メモはPC(lg+)では右サイドバーに常設。狭い画面のみトグルで表示する */}
+                  {/* メモはPC(xl+)では右サイドバーに常設。狭い画面のみトグルで表示する */}
                   <button
                     onClick={() => setShowMobileMemo((v) => !v)}
-                    className={`lg:hidden px-3 py-1 min-h-[44px] text-xs font-medium rounded-md transition-colors ${
+                    className={`xl:hidden px-3 py-1 min-h-[44px] text-xs font-medium rounded-md transition-colors ${
                       showMobileMemo ? 'text-green-700 bg-green-50' : 'text-gray-600 bg-gray-50 hover:bg-gray-100'
                     }`}
                     title="メモを表示"
@@ -1044,7 +1044,7 @@ export default function ChatsPage() {
               </div>
 
               {/* Messages — LINE-style chat bubbles */}
-              <div ref={messagesScrollRef} className="flex-1 overflow-y-auto p-4 space-y-2" style={{ backgroundColor: '#7494C0' }}>
+              <div ref={messagesScrollRef} className="flex-1 overflow-y-auto overflow-x-hidden p-4 space-y-2" style={{ backgroundColor: '#7494C0' }}>
                 {(!chatDetail.messages || chatDetail.messages.length === 0) ? (
                   <div className="text-center py-8">
                     <p className="text-white/60 text-sm">メッセージはまだありません。</p>
@@ -1099,10 +1099,10 @@ export default function ChatsPage() {
                             )
                           )}
 
-                          <div className={`flex flex-col ${isOutgoing ? 'items-end' : 'items-start'}`}>
+                          <div className={`flex flex-col min-w-0 ${isOutgoing ? 'items-end' : 'items-start'}`}>
                             {/* メッセージバブル */}
                             <div
-                              className={`max-w-[75%] lg:max-w-[60%] px-3 py-2 text-sm break-words whitespace-pre-wrap ${
+                              className={`max-w-[75%] lg:max-w-[60%] min-w-0 overflow-hidden px-3 py-2 text-sm break-words whitespace-pre-wrap ${
                                 isOutgoing
                                   ? 'rounded-tl-2xl rounded-tr-md rounded-bl-2xl rounded-br-2xl text-white'
                                   : 'rounded-tl-md rounded-tr-2xl rounded-bl-2xl rounded-br-2xl bg-white text-gray-900'
@@ -1123,9 +1123,9 @@ export default function ChatsPage() {
                 )}
               </div>
 
-              {/* Notes — PC(lg+)は右サイドバーに常設。狭い画面のみトグル表示 */}
+              {/* Notes — PC(xl+)は右サイドバーに常設。狭い画面のみトグル表示 */}
               {showMobileMemo && (
-                <div className="lg:hidden px-4 py-2 border-t border-gray-200 bg-gray-50">
+                <div className="xl:hidden px-4 py-2 border-t border-gray-200 bg-gray-50">
                   <div className="flex items-center gap-2">
                     <input
                       type="text"
@@ -1210,7 +1210,7 @@ export default function ChatsPage() {
                     />
                   </div>
                 )}
-                <div className="flex items-end gap-1.5">
+                <div className="flex items-end gap-1.5 min-w-0">
                   <button
                     onClick={() => setShowImagePicker((v) => !v)}
                     className={`flex-shrink-0 p-2 rounded-lg transition-colors ${
@@ -1265,7 +1265,7 @@ export default function ChatsPage() {
                     onBlur={() => setIsMessageInputFocused(false)}
                     onKeyDown={handleKeyDown}
                     placeholder="メッセージを入力..."
-                    className="flex-1 text-sm border border-gray-300 rounded-lg px-3 py-2 bg-white focus:outline-none focus:ring-2 focus:ring-green-500 resize-none overflow-y-auto"
+                    className="flex-1 min-w-0 text-sm border border-gray-300 rounded-lg px-3 py-2 bg-white focus:outline-none focus:ring-2 focus:ring-green-500 resize-none overflow-y-auto"
                   />
                   <button
                     onClick={handleSendMessage}
@@ -1289,7 +1289,9 @@ export default function ChatsPage() {
           直接渡せる (chat list SQL が `id: f.id` で friend_id を返す)。
         */}
         {(selectedChatId || selectedFriendId) && (
-          <div className="hidden lg:flex">
+          // xl 未満で 3 カラムにすると中央のチャット列が 160px 前後まで潰れ、
+          // コンポーザーが収まらなくなる。サイドバーは xl 以上でのみ出す。
+          <div className="hidden xl:flex">
             <FriendInfoSidebar
               friendId={selectedFriendId || selectedChatId}
               chatStatus={
@@ -1309,7 +1311,9 @@ export default function ChatsPage() {
           </div>
         )}
       </div>
-      <CcPromptButton prompts={ccPrompts} />
+      {/* コンポーザーが画面下端まで来るレイアウトなので、既定位置 (bottom-6 right-6) だと
+          送信ボタンに重なってクリックを奪う。入力欄の上にずらす。 */}
+      <CcPromptButton prompts={ccPrompts} positionClassName="bottom-24 right-6" />
     </div>
   )
 }

--- a/apps/web/src/components/cc-prompt-button.tsx
+++ b/apps/web/src/components/cc-prompt-button.tsx
@@ -5,16 +5,22 @@ import PromptModal, { type PromptTemplate } from '@/components/prompt-modal'
 
 interface CcPromptButtonProps {
   prompts: PromptTemplate[]
+  /**
+   * 固定位置を指定する Tailwind クラス。既定は右下。
+   * チャット画面のようにページ下端まで操作要素がある画面では、送信ボタンと
+   * 重なってクリックを奪ってしまうため、呼び出し側でずらす。
+   */
+  positionClassName?: string
 }
 
-export default function CcPromptButton({ prompts }: CcPromptButtonProps) {
+export default function CcPromptButton({ prompts, positionClassName = 'bottom-6 right-6' }: CcPromptButtonProps) {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
     <>
       <button
         onClick={() => setIsOpen(true)}
-        className="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-3 min-h-[48px] bg-gray-900 text-white text-sm font-medium rounded-full shadow-lg hover:bg-gray-800 transition-colors"
+        className={`fixed ${positionClassName} z-50 flex items-center gap-2 px-4 py-3 min-h-[48px] bg-gray-900 text-white text-sm font-medium rounded-full shadow-lg hover:bg-gray-800 transition-colors`}
         aria-label="CCに依頼"
       >
         <span className="text-base leading-none">📋</span>

--- a/apps/web/src/components/flex-preview.tsx
+++ b/apps/web/src/components/flex-preview.tsx
@@ -187,7 +187,11 @@ function FlexBubble({ bubble, maxWidth }: { bubble: FlexNode; maxWidth?: number 
 
   return (
     <div style={{
-      width: w,
+      // 固定 width にすると、親が w より狭いときにバブルが親を押し広げて
+      // 横スクロールを生む (チャット画面の吹き出しは max-w が % 指定なので、
+      // 中央カラムが狭い構成でこれが起きた)。上限として扱い、狭ければ縮ませる。
+      width: '100%',
+      maxWidth: w,
       backgroundColor: '#fff',
       borderRadius: '12px',
       overflow: 'hidden',


### PR DESCRIPTION
#265 を本番投入したところ、横スクロールが出てコンポーザーが操作できなくなったため修正します。@sum1-wt さん、報告が遅れてすみません。

## 原因（3つ）

### 1. 横スクロール

Flex メッセージのプレビュー（`FlexBubble`）が **`width` 固定（280px）** でした。改修前の吹き出しは `max-w-[320px]` だったので常に収まっていましたが、`max-w-[75%] lg:max-w-[60%]` に変えたことで中央カラムが狭いと 280px が親をはみ出します。

さらにメッセージ一覧は `overflow-y-auto` で、**CSS 仕様上 `overflow-x` が `visible` のままだと `auto` に計算される**ため、そこに横スクロールが生まれていました。

1024px での実測: メッセージ一覧の `clientWidth` 160 に対し `scrollWidth` 254。

### 2. 入力欄・📎・⚙・送信が押せない

`CcPromptButton`（「CCに依頼」）が `fixed bottom-6 right-6 z-50` で、フルスクリーン化によって画面下端まで来たコンポーザーに重なり、クリックを奪っていました。`elementFromPoint` で送信ボタンの中心が `CcPromptButton` に取られていることを確認しています。

これは #265 のコード自体の誤りというより、**既存のフローティングボタンとフルスクリーン化の相互作用**でした。レビュー時にこちらが見落としました。

### 3. 中央カラムが潰れる

サイドバーの表示条件を `xl` → `lg` に緩和した結果、`lg`（1024-1279px）で3カラムになり中央が 160px まで縮んでいました。`xl` 以上に戻し、メモのトグルもそれに合わせています。

## 修正

- `FlexBubble`: `width: w` → `width: '100%'; maxWidth: w`。狭ければ縮む
- メッセージ一覧に `overflow-x-hidden`、吹き出しとその親に `min-w-0` / `overflow-hidden`
- サイドバーを `xl` 以上に戻す（メモのトグルと行も `lg:hidden` → `xl:hidden`）
- コンポーザーの行と textarea に `min-w-0`
- `CcPromptButton` に `positionClassName` を追加し、チャット画面では `bottom-24 right-6`

## 検証

前回のレビューではモックに Flex メッセージを入れておらず、これを見逃しました。今回は Flex メッセージを含む会話で、修正前に 1024px で再現することを確認した上で、1024 / 1280 / 1536 の各幅で実測しています。

| 検証項目 | 結果 |
|---|---|
| メッセージ一覧の `clientWidth === scrollWidth` | 横スクロールなし |
| `clientWidth` 100px 超で横にはみ出す要素 | 0 件 |
| 入力 / 📎 / ⚙ / 送信 / CCに依頼 の 5 要素 | すべてクリック可能 |
| メッセージ一覧の高さ | 652〜752px |