### PR TITLE
fix(web): チャットの吹き出しが縦一列に潰れる問題とコンポーザーの当たり判定を修正

### DIFF
--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -1099,10 +1099,13 @@ export default function ChatsPage() {
                             )
                           )}
 
-                          <div className={`flex flex-col min-w-0 ${isOutgoing ? 'items-end' : 'items-start'}`}>
+                          {/* w-full が要る: 吹き出しの max-w が % 指定なので、
+                              親の幅が確定していないとパーセントを解決できず
+                              min-content（1 文字幅）まで潰れて縦一列に改行される */}
+                          <div className={`flex flex-col w-full min-w-0 ${isOutgoing ? 'items-end' : 'items-start'}`}>
                             {/* メッセージバブル */}
                             <div
-                              className={`max-w-[75%] lg:max-w-[60%] min-w-0 overflow-hidden px-3 py-2 text-sm break-words whitespace-pre-wrap ${
+                              className={`max-w-[75%] lg:max-w-[60%] px-3 py-2 text-sm break-words whitespace-pre-wrap ${
                                 isOutgoing
                                   ? 'rounded-tl-2xl rounded-tr-md rounded-bl-2xl rounded-br-2xl text-white'
                                   : 'rounded-tl-md rounded-tr-2xl rounded-bl-2xl rounded-br-2xl bg-white text-gray-900'
@@ -1148,7 +1151,7 @@ export default function ChatsPage() {
               {/* Send Message Form — OAM風コンパクト構成。
                   画像添付は 📎、ローディング/送信キー設定は ⚙ に格納し、
                   通常時は入力欄1行だけにしてメッセージ表示領域を最大化する */}
-              <div className="relative px-4 py-3 border-t border-gray-200">
+              <div className="relative px-4 pt-3 pb-5 border-t border-gray-200">
                 {showComposerSettings && (
                   <div
                     ref={composerSettingsRef}
@@ -1213,7 +1216,7 @@ export default function ChatsPage() {
                 <div className="flex items-end gap-1.5 min-w-0">
                   <button
                     onClick={() => setShowImagePicker((v) => !v)}
-                    className={`flex-shrink-0 p-2 rounded-lg transition-colors ${
+                    className={`flex-shrink-0 flex items-center justify-center h-11 w-11 rounded-lg transition-colors ${
                       showImagePicker || pendingImage
                         ? 'text-green-600 bg-green-50'
                         : 'text-gray-400 hover:text-gray-600 hover:bg-gray-100'
@@ -1229,7 +1232,7 @@ export default function ChatsPage() {
                     ref={composerSettingsButtonRef}
                     onClick={() => setShowComposerSettings((v) => !v)}
                     aria-expanded={showComposerSettings}
-                    className={`flex-shrink-0 p-2 rounded-lg transition-colors ${
+                    className={`flex-shrink-0 flex items-center justify-center h-11 w-11 rounded-lg transition-colors ${
                       showComposerSettings
                         ? 'text-green-600 bg-green-50'
                         : 'text-gray-400 hover:text-gray-600 hover:bg-gray-100'
@@ -1265,12 +1268,12 @@ export default function ChatsPage() {
                     onBlur={() => setIsMessageInputFocused(false)}
                     onKeyDown={handleKeyDown}
                     placeholder="メッセージを入力..."
-                    className="flex-1 min-w-0 text-sm border border-gray-300 rounded-lg px-3 py-2 bg-white focus:outline-none focus:ring-2 focus:ring-green-500 resize-none overflow-y-auto"
+                    className="flex-1 min-w-0 text-sm border border-gray-300 rounded-lg px-3 py-3 min-h-[52px] bg-white focus:outline-none focus:ring-2 focus:ring-green-500 resize-none overflow-y-auto"
                   />
                   <button
                     onClick={handleSendMessage}
                     disabled={sending || (!messageContent.trim() && !pendingImage)}
-                    className="px-4 py-2 text-sm font-medium text-white rounded-lg transition-opacity hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="flex-shrink-0 px-4 h-11 text-sm font-medium text-white rounded-lg transition-opacity hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
                     style={{ backgroundColor: '#06C755' }}
                   >
                     {sending ? '送信中...' : '送信'}


### PR DESCRIPTION
#299 で入れた横スクロール対策が持ち込んだ回帰と、#265 から残っていた当たり判定の狭さをまとめて直します。

## 1. 短いメッセージが 1 文字ずつ縦に改行される

「おおお」が縦に「お/お/お」と 3 行になっていました。

原因は吹き出しの `max-w-[75%] lg:max-w-[60%]` が **% 指定**なのに、親（`flex flex-col items-end/items-start`）の幅が確定していなかったことです。パーセントを解決できないと max-width は min-content — 1 文字幅 — に落ちます。#265 以前は `max-w-[320px]` という固定値だったのでこの問題が出ませんでした。

親に `w-full` を付けて幅を確定させ、#299 で足した吹き出しの `min-w-0` / `overflow-hidden` を外しました。あれは横スクロール対策でしたが、実際の原因は `FlexBubble` の固定 `width` の方で既に解決済みなので、ここでは潰れを悪化させるだけでした。

| メッセージ | 修正前 | 修正後 |
|---|---|---|
| 「おおお」 | w=40 / 3 行 | **w=66 / 1 行** |
| 「了解です」 | w=48 / 4 行 | **w=80 / 1 行** |
| 長文 | w=257 / 2 行 | w=288 / 2 行（変化なし） |

横にはみ出す要素は 0 件のままで、#299 の修正は壊していません。

## 2. 入力欄・📎・⚙ の当たり判定が狭い

`p-2` + w-5 アイコンで実測 36x36 しかなく、タップ領域の下限 44px に届いていませんでした。

- 📎 / ⚙ を `h-11 w-11`（44x44）に
- 送信ボタンを `h-11` に
- textarea を `min-h-[52px]` + `py-3` に（実測 66px）
- コンポーザーを `py-3` → `pt-3 pb-5` にして、入力欄の下に 20px の余白を追加

## 検証（1280 / 1536 の両方）

- 短文の吹き出しがすべて 1 行に収まる
- 📎 / ⚙ / 入力欄 / 送信 の 4 要素が **すべて 44px 以上**、かつ `elementFromPoint` で自分自身を返す
- 横にはみ出す要素 0 件