### PR TITLE
test(worker): tenant-scheduler の alarm() テストを時刻依存から切り離す

### DIFF
--- a/apps/worker/src/durable-objects/tenant-scheduler.test.ts
+++ b/apps/worker/src/durable-objects/tenant-scheduler.test.ts
@@ -227,21 +227,58 @@ describe('TenantScheduler クラス — DO ランタイムへの配線', () => {
     expect(storage.alarm()).not.toBeNull();
   });
 
+  // alarm() は now を引数に取らず runSchedulerTick の既定値 (new Date()) を使うため、
+  // 実時刻のまま走らせると UTC 0/6/12/18 時ちょうどに CI が回ったときだけ
+  // isSixHourBoundary() が真になり scheduled() が 2 回呼ばれて落ちる。
+  // Date だけを固定して分岐を決め打ちする (タイマーは実物のまま = await を壊さない)。
+  function withFixedNow<T>(iso: string, run: () => Promise<T>): Promise<T> {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(iso));
+    return run().finally(() => {
+      vi.useRealTimers();
+    });
+  }
+
   test('alarm() は次アラームを先にセットしてから既存の scheduled() を呼ぶ', async () => {
-    const storage = fakeStorage(1_700_000_000_000); // コンストラクタの自己修復をスキップさせる
-    const ctx = fakeCtx(storage);
-    const env = { DB: {} } as never;
-    const scheduler = new TenantScheduler(ctx as never, env);
-    await ctx.ready;
+    // 6時間境界ではない時刻に固定する (境界の挙動は次のテストで確認する)。
+    await withFixedNow('2026-08-23T10:30:00Z', async () => {
+      const storage = fakeStorage(1_700_000_000_000); // コンストラクタの自己修復をスキップさせる
+      const ctx = fakeCtx(storage);
+      const env = { DB: {} } as never;
+      const scheduler = new TenantScheduler(ctx as never, env);
+      await ctx.ready;
 
-    const beforeAlarm = storage.alarm();
-    await scheduler.alarm();
+      const beforeAlarm = storage.alarm();
+      await scheduler.alarm();
 
-    expect(storage.alarm()).not.toBe(beforeAlarm); // 再アームされている
-    expect(scheduledMock).toHaveBeenCalledTimes(1);
-    const [eventArg, envArg] = scheduledMock.mock.calls[0] as unknown as [{ cron: string }, unknown];
-    expect(eventArg.cron).toBe('* * * * *');
-    expect(envArg).toBe(env);
+      expect(storage.alarm()).not.toBe(beforeAlarm); // 再アームされている
+      expect(scheduledMock).toHaveBeenCalledTimes(1);
+      const [eventArg, envArg] = scheduledMock.mock.calls[0] as unknown as [
+        { cron: string },
+        unknown,
+      ];
+      expect(eventArg.cron).toBe('* * * * *');
+      expect(envArg).toBe(env);
+    });
+  });
+
+  test('alarm() は6時間境界では分足と6h足の2イベントで scheduled() を呼ぶ', async () => {
+    // Cloudflare Cron Triggers が両パターンにマッチする分の挙動 (トリガーごとに1回) の再現。
+    await withFixedNow('2026-08-23T12:00:00Z', async () => {
+      const storage = fakeStorage(1_700_000_000_000);
+      const ctx = fakeCtx(storage);
+      const env = { DB: {} } as never;
+      const scheduler = new TenantScheduler(ctx as never, env);
+      await ctx.ready;
+
+      await scheduler.alarm();
+
+      expect(scheduledMock).toHaveBeenCalledTimes(2);
+      const crons = scheduledMock.mock.calls.map(
+        (call) => (call as unknown as [{ cron: string }])[0].cron,
+      );
+      expect(crons).toEqual(['* * * * *', '0 */6 * * *']);
+    });
   });
 
   test('ensureArmed() は公開 RPC メソッドとして自己修復ロジックに委譲する', async () => {


### PR DESCRIPTION
## 何が起きているか

`apps/worker/src/durable-objects/tenant-scheduler.test.ts` の
`alarm() は次アラームを先にセットしてから既存の scheduled() を呼ぶ` が、
**CI が UTC 0/6/12/18 時ちょうどに走ったときだけ**
`expected "spy" to be called 1 times, but got 2 times` で落ちます。

`TenantScheduler.alarm()` は `now` を受け取らず `runSchedulerTick` の既定値 `new Date()` を使うため、
テストの結果が実行時刻に依存していました。

## これは実装のバグではありません

`runSchedulerTick` が 6 時間境界で `scheduled()` を 2 回呼ぶのは
「Cron Triggers は両パターンにマッチする分ではトリガーごとに 1 回呼ぶ」を DO 側で再現する意図的な設計で、
コード内のコメントにもそう書かれています。落ちているのはテスト側の時刻依存です。

## 裏取り

`main` の直近 20 回の Worker CI を確認したところ、失敗は 1 回だけでした。

| createdAt | 結果 | 6時間境界 |
|---|---|---|
| 2026-08-25T00:00:17Z | failure | **該当** |
| 2026-08-24T09:34:39Z | success | 非該当 |
| （以下 18 回） | success | すべて非該当 |

失敗した 1 回だけが境界時刻に一致します。

## 変更内容

- `Date` だけを固定する小さなヘルパーを追加しました。タイマーは実物のまま
  (`vi.useFakeTimers({ toFake: ['Date'] })`) なので、`await ctx.ready` などの待ちを壊しません
- 既存テストを非境界の `2026-08-23T10:30:00Z` に固定しました
- 境界の挙動そのものを検証するテストを追加しました
  (`2026-08-23T12:00:00Z` で `* * * * *` と `0 */6 * * *` の 2 イベントがこの順に渡ること)

flake が消えるだけでなく、意図的な 2 回呼び出しが回帰テストで守られるようになります。

## 確認

`apps/worker` で当該ファイルを実行し、16 件すべて成功しました (追加分を含めて 15 → 16)。