### PR TITLE
feat(booking): 確定した予約にオンライン会議URLを自動発行する

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -134,6 +134,21 @@ export type Env = {
     // the Worker keeps a refresh token and never needs a service-account key.
     GOOGLE_OAUTH_CLIENT_ID?: string;
     GOOGLE_OAUTH_CLIENT_SECRET?: string;
+    // Online meeting links for confirmed bookings (services/booking-conference.ts).
+    // Provider is 'google_meet' (default) or 'zoom'. Per-account overrides live in
+    // account_settings; these env values are the fallback.
+    BOOKING_CONFERENCE_PROVIDER?: string;
+    ZOOM_ACCOUNT_ID?: string;
+    ZOOM_CLIENT_ID?: string;
+    ZOOM_CLIENT_SECRET?: string;
+    /**
+     * 'true' makes LIFF bookings confirm immediately instead of waiting for approval.
+     * Default (unset) keeps the approval flow. Per-account override: account_settings
+     * key 'booking_auto_confirm'.
+     */
+    BOOKING_AUTO_CONFIRM?: string;
+    /** LINE user id that receives owner notifications for new/cancelled bookings. */
+    OWNER_LINE_USER_ID?: string;
     /** Days to keep messages_log rows. Unset/invalid = keep forever. */
     LOG_RETENTION_DAYS?: string;
     /** Max friends (is_following=1). Unset/invalid = unlimited. */

--- a/apps/worker/src/routes/booking.ts
+++ b/apps/worker/src/routes/booking.ts
@@ -25,7 +25,14 @@ import {
   findIdempotencyResponse,
   saveIdempotencyResponse,
 } from '../services/booking-idempotency.js';
-import { sendBookingNotification } from '../services/booking-notifier.js';
+import {
+  sendBookingNotification,
+  sendOwnerBookingNotification,
+} from '../services/booking-notifier.js';
+import {
+  provisionBookingConference,
+  releaseBookingConference,
+} from '../services/booking-conference.js';
 import { insertConfirmationReminders } from '../services/booking-confirm.js';
 import { attachTagAndFireSideEffects } from '../services/friend-tag-attach.js';
 import {
@@ -249,18 +256,28 @@ async function resolveFriendId(
   return f?.id ?? null;
 }
 
-async function notifyForBooking(
+interface BookingNotifyRow {
+  starts_at: string;
+  menu_name: string;
+  staff_name: string;
+  channel_access_token: string;
+  line_user_id: string;
+  conference_url: string | null;
+  customer_name: string | null;
+}
+
+async function loadBookingNotifyRow(
   db: D1Database,
   bookingId: string,
-  kind: 'requested' | 'approved' | 'rejected',
-): Promise<void> {
-  const row = await db
+): Promise<BookingNotifyRow | null> {
+  return await db
     .prepare(
-      `SELECT b.starts_at,
+      `SELECT b.starts_at, b.conference_url,
               m.name AS menu_name,
               s.display_name AS staff_name,
               la.channel_access_token,
-              f.line_user_id
+              f.line_user_id,
+              f.display_name AS customer_name
          FROM bookings b
          INNER JOIN menus m ON m.id = b.menu_id
          INNER JOIN staff s ON s.id = b.staff_id
@@ -269,13 +286,15 @@ async function notifyForBooking(
         WHERE b.id = ?`,
     )
     .bind(bookingId)
-    .first<{
-      starts_at: string;
-      menu_name: string;
-      staff_name: string;
-      channel_access_token: string;
-      line_user_id: string;
-    }>();
+    .first<BookingNotifyRow>();
+}
+
+async function notifyForBooking(
+  db: D1Database,
+  bookingId: string,
+  kind: 'requested' | 'approved' | 'rejected',
+): Promise<void> {
+  const row = await loadBookingNotifyRow(db, bookingId);
   if (!row) return;
   await sendBookingNotification({
     channelAccessToken: row.channel_access_token,
@@ -286,8 +305,111 @@ async function notifyForBooking(
       staffName: row.staff_name,
       startsAtJst: startsAtJst(row.starts_at),
       hoursBefore: 0,
+      conferenceUrl: row.conference_url,
     },
   });
+}
+
+/**
+ * 運営者（アカウント所有者）へ予約の発生・取消を知らせる。
+ *
+ * 宛先は環境変数 OWNER_LINE_USER_ID。未設定なら何もしない（既存環境の挙動を変えないため）。
+ * 送信元は予約が入ったアカウント自身のチャネルトークンを使う。運営者がそのアカウントを
+ * 友だち追加していない場合は LINE 側で弾かれるので、セットアップ時に自分で友だち追加しておく。
+ */
+async function notifyOwnerForBooking(
+  db: D1Database,
+  env: { OWNER_LINE_USER_ID?: string },
+  bookingId: string,
+  kind: 'owner_new_booking' | 'owner_cancelled',
+): Promise<void> {
+  const ownerUserId = env.OWNER_LINE_USER_ID;
+  if (!ownerUserId) return;
+  const row = await loadBookingNotifyRow(db, bookingId);
+  if (!row) return;
+  await sendOwnerBookingNotification({
+    channelAccessToken: row.channel_access_token,
+    toLineUserId: ownerUserId,
+    kind,
+    ctx: {
+      customerName: row.customer_name ?? '（名前未取得）',
+      menuName: row.menu_name,
+      staffName: row.staff_name,
+      startsAtJst: startsAtJst(row.starts_at),
+      hoursBefore: 0,
+      conferenceUrl: row.conference_url,
+    },
+  });
+}
+
+/**
+ * LIFF からの予約を即時確定にするかどうか。
+ *
+ * 既定は false（承認制）で、これは既存環境の挙動を変えないため。
+ * オンライン個別面談のように「申し込み＝確定」で運用する場合は、
+ * account_settings（key = 'booking_auto_confirm'）に 'true' を入れるか、
+ * 環境変数 BOOKING_AUTO_CONFIRM=true を設定する。
+ *
+ * 承認制のまま運用する場合、24 時間承認しないと予約は自動的に期限切れになり、
+ * 申込者へ期限切れの通知が飛ぶ（booking-expirer.ts）。承認を見落とさない運用が前提になる。
+ */
+async function resolveAutoConfirm(
+  db: D1Database,
+  lineAccountId: string,
+  env: { BOOKING_AUTO_CONFIRM?: string },
+): Promise<boolean> {
+  const row = await db
+    .prepare(`SELECT value FROM account_settings WHERE line_account_id = ? AND key = ?`)
+    .bind(lineAccountId, 'booking_auto_confirm')
+    .first<{ value: string }>();
+  const raw = row?.value ?? env.BOOKING_AUTO_CONFIRM;
+  return raw === 'true' || raw === '1';
+}
+
+/**
+ * 予約が confirmed になった直後の副作用をまとめて実行する。
+ *
+ * 実行順は「リマインダー登録 → 会議URL発行とカレンダー登録 → 予約者へ通知 → 運営者へ通知」。
+ * 会議URLを先に確定させてから通知を送るため、確定通知に参加URLが載る。
+ * 通知は fire-and-forget（失敗しても予約は成立させる）。
+ */
+async function runConfirmedSideEffects(
+  env: Env['Bindings'],
+  waitUntil: (p: Promise<unknown>) => void,
+  bookingId: string,
+  startsAt: Date,
+): Promise<'not_configured' | 'synced' | 'failed'> {
+  await insertConfirmationReminders(env.DB, {
+    bookingId,
+    startsAt,
+    now: new Date(),
+  });
+
+  const provisioned = await provisionBookingConference(
+    env.DB,
+    googleCredentials(env),
+    env,
+    bookingId,
+  ).catch((error) => {
+    console.error('booking conference provisioning failed:', error);
+    return null;
+  });
+
+  waitUntil(
+    notifyForBooking(env.DB, bookingId, 'approved').catch((err) =>
+      console.error('booking notify (approved) failed:', err),
+    ),
+  );
+  waitUntil(
+    notifyOwnerForBooking(env.DB, env, bookingId, 'owner_new_booking').catch((err) =>
+      console.error('owner notify (new booking) failed:', err),
+    ),
+  );
+
+  if (!provisioned) return 'failed';
+  // 'failed'（Google APIがエラーを返した）と 'not_configured'（そもそも未連携）を潰さない。
+  // 潰すと、カレンダーに予定が入っていない予約を障害として検知できなくなる。
+  return provisioned.calendarStatus;
 }
 
 // ================================================================
@@ -453,6 +575,9 @@ booking.post('/api/liff/booking/requests', async (c) => {
 
   const bookingId = crypto.randomUUID();
   const nowIso = new Date().toISOString();
+  // 即時確定モードでは requested を経由せず confirmed で作る。承認制のままなら requested。
+  const autoConfirm = await resolveAutoConfirm(c.env.DB, accountId, c.env);
+  const initialStatus: BookingStatus = autoConfirm ? 'confirmed' : 'requested';
   // 競合チェックと INSERT を 1 ステートメントで原子化する。
   // INSERT ... SELECT WHERE NOT EXISTS パターンで、同一スタッフの overlap 行がある場合は
   // 0 行 INSERT に落とす。changes=0 を 409 として扱う。
@@ -461,8 +586,8 @@ booking.post('/api/liff/booking/requests', async (c) => {
       `INSERT INTO bookings
         (id, line_account_id, friend_id, staff_id, menu_id,
          starts_at, ends_at, block_ends_at, status,
-         customer_note, price_at_booking, requested_at)
-       SELECT ?,?,?,?,?,?,?,?,?,?,?,?
+         customer_note, price_at_booking, requested_at, decided_at)
+       SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?
         WHERE NOT EXISTS (
           SELECT 1 FROM bookings
            WHERE staff_id = ?
@@ -480,10 +605,11 @@ booking.post('/api/liff/booking/requests', async (c) => {
       startsAt.toISOString(),
       endsAt.toISOString(),
       blockEndsAt.toISOString(),
-      'requested' satisfies BookingStatus,
+      initialStatus,
       body.customer_note ?? null,
       menuRow.price,
       nowIso,
+      autoConfirm ? nowIso : null,
       // NOT EXISTS subquery params
       body.staff_id,
       blockEndsAt.toISOString(),
@@ -515,12 +641,28 @@ booking.post('/api/liff/booking/requests', async (c) => {
     }),
   );
 
-  // Fire-and-forget notification — failures must not roll back the booking.
-  c.executionCtx.waitUntil(
-    notifyForBooking(c.env.DB, bookingId, 'requested').catch((err) =>
-      console.error('booking notify (requested) failed:', err),
-    ),
-  );
+  if (autoConfirm) {
+    // 即時確定：リマインダー登録・会議URL発行・カレンダー登録・確定通知・運営者通知まで走らせる。
+    await runConfirmedSideEffects(
+      c.env,
+      (p) => c.executionCtx.waitUntil(p),
+      bookingId,
+      startsAt,
+    );
+  } else {
+    // Fire-and-forget notification — failures must not roll back the booking.
+    c.executionCtx.waitUntil(
+      notifyForBooking(c.env.DB, bookingId, 'requested').catch((err) =>
+        console.error('booking notify (requested) failed:', err),
+      ),
+    );
+    // 承認待ちであることを運営者に知らせる。放置すると 24 時間で自動失効するため。
+    c.executionCtx.waitUntil(
+      notifyOwnerForBooking(c.env.DB, c.env, bookingId, 'owner_new_booking').catch((err) =>
+        console.error('owner notify (requested) failed:', err),
+      ),
+    );
+  }
 
   // notifyForBooking と同じく fire-and-forget。タグ付与失敗は予約成功扱い。
   // attachTagAndFireSideEffects は POST /api/friends/:id/tags と同じ side effects
@@ -538,7 +680,7 @@ booking.post('/api/liff/booking/requests', async (c) => {
     );
   }
 
-  const responseBody = { booking_id: bookingId, status: 'requested' };
+  const responseBody = { booking_id: bookingId, status: initialStatus };
   await saveIdempotencyResponse(c.env.DB, {
     key: idemKey,
     lineAccountId: accountId,
@@ -933,27 +1075,11 @@ booking.post('/api/booking/admin/bookings', async (c) => {
     return c.json({ error: 'slot_conflict' }, 409);
   }
 
-  await insertConfirmationReminders(c.env.DB, {
+  const calendarSync = await runConfirmedSideEffects(
+    c.env,
+    (p) => c.executionCtx.waitUntil(p),
     bookingId,
     startsAt,
-    now: new Date(),
-  });
-  let calendarSync: 'not_configured' | 'synced' | 'failed' = 'not_configured';
-  try {
-    const synced = await syncConfirmedBookingToGoogle(
-      c.env.DB,
-      googleCredentials(c.env),
-      bookingId,
-    );
-    calendarSync = synced.synced ? 'synced' : 'not_configured';
-  } catch (error) {
-    calendarSync = 'failed';
-    console.error('Google Calendar sync (proxy-create) failed:', error);
-  }
-  c.executionCtx.waitUntil(
-    notifyForBooking(c.env.DB, bookingId, 'approved').catch((err) =>
-      console.error('booking notify (proxy-create) failed:', err),
-    ),
   );
   return c.json({ booking_id: bookingId, status: 'confirmed', calendar_sync: calendarSync }, 201);
 });
@@ -1618,20 +1744,11 @@ booking.patch('/api/booking/admin/requests/:id', async (c) => {
   }
 
   if (next === 'confirmed') {
-    await insertConfirmationReminders(c.env.DB, {
-      bookingId: id,
-      startsAt: new Date(row.starts_at),
-      now: new Date(),
-    });
-    try {
-      await syncConfirmedBookingToGoogle(c.env.DB, googleCredentials(c.env), id);
-    } catch (error) {
-      console.error('Google Calendar sync (approve) failed:', error);
-    }
-    c.executionCtx.waitUntil(
-      notifyForBooking(c.env.DB, id, 'approved').catch((err) =>
-        console.error('booking notify (approved) failed:', err),
-      ),
+    await runConfirmedSideEffects(
+      c.env,
+      (p) => c.executionCtx.waitUntil(p),
+      id,
+      new Date(row.starts_at),
     );
   } else if (next === 'rejected') {
     c.executionCtx.waitUntil(
@@ -1646,9 +1763,20 @@ booking.patch('/api/booking/admin/requests/:id', async (c) => {
       )
       .bind(id)
       .run();
+    // 運営者通知は Google/Zoom を消す前に打つ（conference_url を文面に載せるため）。
+    c.executionCtx.waitUntil(
+      notifyOwnerForBooking(c.env.DB, c.env, id, 'owner_cancelled').catch((err) =>
+        console.error('owner notify (cancelled) failed:', err),
+      ),
+    );
     c.executionCtx.waitUntil(
       removeBookingFromGoogle(c.env.DB, googleCredentials(c.env), id).catch((error) =>
         console.error('Google Calendar delete failed:', error),
+      ),
+    );
+    c.executionCtx.waitUntil(
+      releaseBookingConference(c.env.DB, c.env, id).catch((error) =>
+        console.error('conference release failed:', error),
       ),
     );
   }

--- a/apps/worker/src/services/booking-calendar-sync.ts
+++ b/apps/worker/src/services/booking-calendar-sync.ts
@@ -1,4 +1,6 @@
 import { GoogleCalendarClient, type BusyInterval } from './google-calendar.js';
+
+export type { GoogleCalendarCredentials };
 import { getGoogleServiceAccountToken } from './google-service-account.js';
 import {
   refreshGoogleOAuthAccessToken,
@@ -84,6 +86,7 @@ export async function syncConfirmedBookingToGoogle(
   const row = await db
     .prepare(
       `SELECT b.id, b.starts_at, b.ends_at, b.customer_note, b.external_event_id,
+              b.conference_url,
               f.display_name AS friend_name, m.name AS menu_name,
               s.display_name AS staff_name,
               gc.id AS connection_id, gc.calendar_id, gc.auth_type,
@@ -105,6 +108,7 @@ export async function syncConfirmedBookingToGoogle(
       ends_at: string;
       customer_note: string | null;
       external_event_id: string | null;
+      conference_url: string | null;
       friend_name: string | null;
       menu_name: string;
       staff_name: string;
@@ -133,6 +137,8 @@ export async function syncConfirmedBookingToGoogle(
     start: row.starts_at,
     end: row.ends_at,
     description: [
+      // 会議URLは予約者にも共有されるため、カレンダー本文の先頭に置く。
+      row.conference_url ? `オンライン会議: ${row.conference_url}\n` : '',
       `L Harness予約（担当: ${row.staff_name}）`,
       `予約ID: ${row.id}`,
       row.customer_note ? `メモ: ${row.customer_note}` : '',

--- a/apps/worker/src/services/booking-conference.test.ts
+++ b/apps/worker/src/services/booking-conference.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+// booking-calendar-sync をモックしてから対象を読み込む（実 Google API を叩かないため）。
+const syncMock = vi.hoisted(() => vi.fn());
+vi.mock('./booking-calendar-sync.js', () => ({
+  syncConfirmedBookingToGoogle: syncMock,
+}));
+
+const zoomCreate = vi.hoisted(() => vi.fn());
+const zoomDelete = vi.hoisted(() => vi.fn());
+vi.mock('./zoom.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./zoom.js')>();
+  return {
+    ...actual,
+    createZoomMeeting: zoomCreate,
+    deleteZoomMeeting: zoomDelete,
+  };
+});
+
+const { provisionBookingConference, releaseBookingConference, resolveConferenceProvider } =
+  await import('./booking-conference.js');
+
+/** 最小限の D1 スタブ。SQL の頭で分岐して固定行を返す。 */
+function makeDb(opts: {
+  settingValue?: string | null;
+  booking?: Record<string, unknown> | null;
+  releaseRow?: Record<string, unknown> | null;
+}) {
+  const updates: Array<{ sql: string; args: unknown[] }> = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            async first() {
+              if (sql.includes('FROM account_settings')) {
+                return opts.settingValue == null ? null : { value: opts.settingValue };
+              }
+              if (sql.includes('conference_provider, conference_external_id')) {
+                return opts.releaseRow ?? null;
+              }
+              if (sql.includes('FROM bookings b')) {
+                return opts.booking ?? null;
+              }
+              return null;
+            },
+            async run() {
+              updates.push({ sql, args });
+              return { meta: { changes: 1 } };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+  return { db, updates };
+}
+
+const booking = {
+  line_account_id: 'acct-1',
+  starts_at: '2026-05-10T05:00:00.000Z',
+  ends_at: '2026-05-10T06:00:00.000Z',
+  menu_name: '個別面談',
+  friend_name: '佐藤',
+  conference_url: null,
+};
+
+const googleCreds = {} as never;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveConferenceProvider', () => {
+  test('アカウント設定が最優先', async () => {
+    const { db } = makeDb({ settingValue: 'zoom' });
+    await expect(
+      resolveConferenceProvider(db, 'acct-1', { BOOKING_CONFERENCE_PROVIDER: 'google_meet' }),
+    ).resolves.toBe('zoom');
+  });
+  test('設定が無ければ環境変数', async () => {
+    const { db } = makeDb({ settingValue: null });
+    await expect(
+      resolveConferenceProvider(db, 'acct-1', { BOOKING_CONFERENCE_PROVIDER: 'zoom' }),
+    ).resolves.toBe('zoom');
+  });
+  test('どちらも無ければ google_meet', async () => {
+    const { db } = makeDb({ settingValue: null });
+    await expect(resolveConferenceProvider(db, 'acct-1', {})).resolves.toBe('google_meet');
+  });
+  test('不正な値は無視して既定に落ちる', async () => {
+    const { db } = makeDb({ settingValue: 'teams' });
+    await expect(resolveConferenceProvider(db, 'acct-1', {})).resolves.toBe('google_meet');
+  });
+});
+
+describe('provisionBookingConference — google_meet', () => {
+  test('カレンダー登録時に Meet を発行し、URLを保存する', async () => {
+    const { db, updates } = makeDb({ settingValue: null, booking });
+    syncMock.mockResolvedValue({
+      synced: true,
+      eventId: 'evt',
+      meetUrl: 'https://meet.google.com/abc-defg-hij',
+    });
+
+    const result = await provisionBookingConference(db, googleCreds, {}, 'bk-1');
+
+    expect(syncMock).toHaveBeenCalledWith(db, googleCreds, 'bk-1', { addGoogleMeet: true });
+    expect(result.conferenceUrl).toBe('https://meet.google.com/abc-defg-hij');
+    expect(result.calendarSynced).toBe(true);
+    const saved = updates.find((u) => u.sql.includes('SET conference_provider = ?'));
+    expect(saved?.args.slice(0, 3)).toEqual([
+      'google_meet',
+      'https://meet.google.com/abc-defg-hij',
+      null,
+    ]);
+  });
+
+  test('Googleが未接続ならURLなしで静かに終わる（予約は成立させる）', async () => {
+    const { db } = makeDb({ settingValue: null, booking });
+    syncMock.mockResolvedValue({ synced: false });
+    const result = await provisionBookingConference(db, googleCreds, {}, 'bk-1');
+    expect(result.conferenceUrl).toBeNull();
+    expect(result.calendarSynced).toBe(false);
+  });
+});
+
+describe('provisionBookingConference — zoom', () => {
+  const zoomEnv = {
+    BOOKING_CONFERENCE_PROVIDER: 'zoom',
+    ZOOM_ACCOUNT_ID: 'a',
+    ZOOM_CLIENT_ID: 'b',
+    ZOOM_CLIENT_SECRET: 'c',
+  };
+
+  test('Zoomを発行してから、そのURL入りでカレンダーへ登録する', async () => {
+    const { db, updates } = makeDb({ settingValue: null, booking });
+    zoomCreate.mockResolvedValue({ joinUrl: 'https://zoom.us/j/1', meetingId: '1' });
+    syncMock.mockResolvedValue({ synced: true, eventId: 'evt' });
+
+    const result = await provisionBookingConference(db, googleCreds, zoomEnv, 'bk-1');
+
+    expect(zoomCreate).toHaveBeenCalledWith(
+      { accountId: 'a', clientId: 'b', clientSecret: 'c' },
+      { topic: '佐藤｜個別面談', startAt: booking.starts_at, durationMin: 60 },
+    );
+    // Meet は付けない（Zoomを使うため）
+    expect(syncMock).toHaveBeenCalledWith(db, googleCreds, 'bk-1', { addGoogleMeet: false });
+    expect(result.conferenceUrl).toBe('https://zoom.us/j/1');
+    const saved = updates.find((u) => u.sql.includes('SET conference_provider = ?'));
+    expect(saved?.args.slice(0, 3)).toEqual(['zoom', 'https://zoom.us/j/1', '1']);
+  });
+
+  test('カレンダー登録が失敗したら、発行済みZoomを削除して巻き戻す', async () => {
+    const { db, updates } = makeDb({ settingValue: null, booking });
+    zoomCreate.mockResolvedValue({ joinUrl: 'https://zoom.us/j/1', meetingId: '1' });
+    syncMock.mockRejectedValue(new Error('calendar down'));
+    zoomDelete.mockResolvedValue(undefined);
+
+    const result = await provisionBookingConference(db, googleCreds, zoomEnv, 'bk-1');
+
+    expect(zoomDelete).toHaveBeenCalledWith(
+      { accountId: 'a', clientId: 'b', clientSecret: 'c' },
+      '1',
+    );
+    expect(result.conferenceUrl).toBeNull();
+    expect(updates.some((u) => u.sql.includes('conference_provider = NULL'))).toBe(true);
+  });
+
+  test('Zoom発行が失敗しても予約は残し、カレンダーだけは登録する', async () => {
+    const { db } = makeDb({ settingValue: null, booking });
+    zoomCreate.mockRejectedValue(new Error('zoom down'));
+    syncMock.mockResolvedValue({ synced: true, eventId: 'evt' });
+
+    const result = await provisionBookingConference(db, googleCreds, zoomEnv, 'bk-1');
+
+    expect(result.conferenceUrl).toBeNull();
+    expect(result.calendarSynced).toBe(true);
+  });
+
+  test('資格情報が無いのに zoom 指定なら、発行を飛ばして続行する', async () => {
+    const { db } = makeDb({ settingValue: 'zoom', booking });
+    syncMock.mockResolvedValue({ synced: true, eventId: 'evt' });
+
+    const result = await provisionBookingConference(db, googleCreds, {}, 'bk-1');
+
+    expect(zoomCreate).not.toHaveBeenCalled();
+    expect(result.conferenceUrl).toBeNull();
+  });
+});
+
+describe('カレンダーの状態を潰さない', () => {
+  test('Google APIがエラーなら failed（未連携と区別する）', async () => {
+    const { db } = makeDb({ settingValue: null, booking });
+    syncMock.mockRejectedValue(new Error('calendar down'));
+    const result = await provisionBookingConference(db, googleCreds, {}, 'bk-1');
+    expect(result.calendarStatus).toBe('failed');
+  });
+
+  test('未連携なら not_configured', async () => {
+    const { db } = makeDb({ settingValue: null, booking });
+    syncMock.mockResolvedValue({ synced: false });
+    const result = await provisionBookingConference(db, googleCreds, {}, 'bk-1');
+    expect(result.calendarStatus).toBe('not_configured');
+  });
+
+  test('登録できたら synced', async () => {
+    const { db } = makeDb({ settingValue: null, booking });
+    syncMock.mockResolvedValue({ synced: true, eventId: 'evt', meetUrl: 'https://meet.example/x' });
+    const result = await provisionBookingConference(db, googleCreds, {}, 'bk-1');
+    expect(result.calendarStatus).toBe('synced');
+  });
+
+  test('Zoomをロールバックしたときも failed が残る', async () => {
+    const { db } = makeDb({ settingValue: null, booking });
+    zoomCreate.mockResolvedValue({ joinUrl: 'https://zoom.us/j/1', meetingId: '1' });
+    syncMock.mockRejectedValue(new Error('calendar down'));
+    zoomDelete.mockResolvedValue(undefined);
+    const result = await provisionBookingConference(db, googleCreds, {
+      BOOKING_CONFERENCE_PROVIDER: 'zoom',
+      ZOOM_ACCOUNT_ID: 'a',
+      ZOOM_CLIENT_ID: 'b',
+      ZOOM_CLIENT_SECRET: 'c',
+    }, 'bk-1');
+    expect(result.calendarStatus).toBe('failed');
+  });
+});
+
+describe('provisionBookingConference — 冪等性', () => {
+  test('すでにURLが入っている予約では作り直さない', async () => {
+    const { db } = makeDb({
+      settingValue: null,
+      booking: { ...booking, conference_url: 'https://zoom.us/j/existing' },
+    });
+    syncMock.mockResolvedValue({ synced: true, eventId: 'evt' });
+
+    const result = await provisionBookingConference(db, googleCreds, {}, 'bk-1');
+
+    expect(zoomCreate).not.toHaveBeenCalled();
+    expect(result.conferenceUrl).toBe('https://zoom.us/j/existing');
+  });
+
+  test('確定していない予約には何もしない', async () => {
+    const { db } = makeDb({ settingValue: null, booking: null });
+    const result = await provisionBookingConference(db, googleCreds, {}, 'bk-1');
+    expect(result.conferenceUrl).toBeNull();
+    expect(syncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('releaseBookingConference', () => {
+  test('Zoom予約はミーティングを削除する', async () => {
+    const { db } = makeDb({
+      releaseRow: { conference_provider: 'zoom', conference_external_id: '1' },
+    });
+    zoomDelete.mockResolvedValue(undefined);
+    await releaseBookingConference(db, {
+      ZOOM_ACCOUNT_ID: 'a',
+      ZOOM_CLIENT_ID: 'b',
+      ZOOM_CLIENT_SECRET: 'c',
+    }, 'bk-1');
+    expect(zoomDelete).toHaveBeenCalled();
+  });
+
+  test('Google Meet はカレンダー削除で消えるので何もしない', async () => {
+    const { db } = makeDb({
+      releaseRow: { conference_provider: 'google_meet', conference_external_id: null },
+    });
+    await releaseBookingConference(db, {}, 'bk-1');
+    expect(zoomDelete).not.toHaveBeenCalled();
+  });
+
+  test('Zoom削除が失敗しても例外を投げない（キャンセル処理は止めない）', async () => {
+    const { db } = makeDb({
+      releaseRow: { conference_provider: 'zoom', conference_external_id: '1' },
+    });
+    zoomDelete.mockRejectedValue(new Error('zoom down'));
+    await expect(
+      releaseBookingConference(db, {
+        ZOOM_ACCOUNT_ID: 'a',
+        ZOOM_CLIENT_ID: 'b',
+        ZOOM_CLIENT_SECRET: 'c',
+      }, 'bk-1'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/worker/src/services/booking-conference.ts
+++ b/apps/worker/src/services/booking-conference.ts
@@ -1,0 +1,282 @@
+/**
+ * 予約が確定したときに、オンライン会議URLを発行して予約に紐づける。
+ *
+ * 対応プロバイダは 2 つ。
+ *   - 'google_meet'（既定）… Googleカレンダーのイベントに Meet を同時発行する。
+ *                            追加の外部サービス契約が不要。
+ *   - 'zoom'                … Zoom Server-to-Server OAuth で専用ミーティングを作る。
+ *                            Zoom 側でアプリ作成と有効化が要る（無料プランは 40 分制限）。
+ *
+ * プロバイダの決め方は account_settings（key = 'booking_conference_provider'）が正で、
+ * 行が無ければ環境変数 BOOKING_CONFERENCE_PROVIDER、それも無ければ 'google_meet'。
+ *
+ * Zoom を選んだ場合の順序は「Zoom 発行 → D1 保存 → Googleカレンダー登録」。
+ * カレンダー登録が失敗したら発行済み Zoom を削除して元に戻す（孤児ミーティングを残さない）。
+ * Google Meet を選んだ場合はカレンダー登録が発行そのものなので、登録後に URL を保存する。
+ *
+ * 会議URLの発行に失敗しても予約自体は成立させる（ベストエフォート）。面談日時が押さえられて
+ * いることのほうが重要で、URL は後から repair で入れ直せるため。
+ */
+
+import {
+  syncConfirmedBookingToGoogle,
+  type GoogleCalendarCredentials,
+} from './booking-calendar-sync.js';
+import { createZoomMeeting, deleteZoomMeeting, zoomConfigured } from './zoom.js';
+
+export type ConferenceProvider = 'google_meet' | 'zoom';
+
+export interface ConferenceEnv {
+  BOOKING_CONFERENCE_PROVIDER?: string;
+  ZOOM_ACCOUNT_ID?: string;
+  ZOOM_CLIENT_ID?: string;
+  ZOOM_CLIENT_SECRET?: string;
+}
+
+const SETTINGS_KEY = 'booking_conference_provider';
+
+function normalizeProvider(value: string | null | undefined): ConferenceProvider | null {
+  if (value === 'zoom' || value === 'google_meet') return value;
+  return null;
+}
+
+/** アカウント設定 → 環境変数 → 既定値 の順でプロバイダを決める。 */
+export async function resolveConferenceProvider(
+  db: D1Database,
+  lineAccountId: string,
+  env: ConferenceEnv,
+): Promise<ConferenceProvider> {
+  const row = await db
+    .prepare(`SELECT value FROM account_settings WHERE line_account_id = ? AND key = ?`)
+    .bind(lineAccountId, SETTINGS_KEY)
+    .first<{ value: string }>();
+  return (
+    normalizeProvider(row?.value) ??
+    normalizeProvider(env.BOOKING_CONFERENCE_PROVIDER) ??
+    'google_meet'
+  );
+}
+
+interface BookingConferenceRow {
+  line_account_id: string;
+  starts_at: string;
+  ends_at: string;
+  menu_name: string;
+  friend_name: string | null;
+  conference_url: string | null;
+}
+
+async function loadBookingForConference(
+  db: D1Database,
+  bookingId: string,
+): Promise<BookingConferenceRow | null> {
+  return await db
+    .prepare(
+      `SELECT b.line_account_id, b.starts_at, b.ends_at, b.conference_url,
+              m.name AS menu_name, f.display_name AS friend_name
+         FROM bookings b
+         INNER JOIN menus m ON m.id = b.menu_id
+         INNER JOIN friends f ON f.id = b.friend_id
+        WHERE b.id = ? AND b.status = 'confirmed'`,
+    )
+    .bind(bookingId)
+    .first<BookingConferenceRow>();
+}
+
+async function saveConference(
+  db: D1Database,
+  bookingId: string,
+  provider: ConferenceProvider,
+  url: string,
+  externalId: string | null,
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE bookings
+          SET conference_provider = ?, conference_url = ?, conference_external_id = ?,
+              updated_at = strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')
+        WHERE id = ?`,
+    )
+    .bind(provider, url, externalId, bookingId)
+    .run();
+}
+
+export type CalendarStatus = 'synced' | 'not_configured' | 'failed';
+
+export interface ProvisionResult {
+  provider: ConferenceProvider;
+  conferenceUrl: string | null;
+  calendarSynced: boolean;
+  /**
+   * 'failed' は Google API がエラーを返した状態で、'not_configured'（未連携）とは区別する。
+   * ここを潰すと、カレンダーに予定が入っていない予約を障害として検知できなくなる。
+   */
+  calendarStatus: CalendarStatus;
+}
+
+function toCalendarStatus(r: { ok: boolean; synced: boolean }): CalendarStatus {
+  if (!r.ok) return 'failed';
+  return r.synced ? 'synced' : 'not_configured';
+}
+
+/**
+ * 確定した予約に会議URLを用意し、Googleカレンダーへも登録する。
+ *
+ * 呼び出し側は「予約が confirmed になった直後」に1回だけ呼ぶ。
+ * 例外は投げない（失敗しても予約は成立させる）。結果は戻り値と console で報告する。
+ */
+export async function provisionBookingConference(
+  db: D1Database,
+  googleCredentials: GoogleCalendarCredentials,
+  env: ConferenceEnv,
+  bookingId: string,
+): Promise<ProvisionResult> {
+  const row = await loadBookingForConference(db, bookingId);
+  if (!row) {
+    return {
+      provider: 'google_meet',
+      conferenceUrl: null,
+      calendarSynced: false,
+      calendarStatus: 'not_configured',
+    };
+  }
+
+  const provider = await resolveConferenceProvider(db, row.line_account_id, env);
+
+  // すでに発行済みなら作り直さない（再実行・冪等性のため）。
+  if (row.conference_url) {
+    const synced = await syncCalendarQuietly(db, googleCredentials, bookingId, false);
+    return {
+      provider,
+      conferenceUrl: row.conference_url,
+      calendarSynced: synced.synced,
+      calendarStatus: toCalendarStatus(synced),
+    };
+  }
+
+  if (provider === 'zoom') {
+    const creds = zoomConfigured(env);
+    if (!creds) {
+      console.warn('booking conference: zoom selected but credentials are missing — skipping');
+      const synced = await syncCalendarQuietly(db, googleCredentials, bookingId, false);
+      return {
+        provider,
+        conferenceUrl: null,
+        calendarSynced: synced.synced,
+        calendarStatus: toCalendarStatus(synced),
+      };
+    }
+
+    const durationMin = Math.max(
+      1,
+      Math.round((new Date(row.ends_at).getTime() - new Date(row.starts_at).getTime()) / 60_000),
+    );
+    let created: { joinUrl: string; meetingId: string } | null = null;
+    try {
+      created = await createZoomMeeting(creds, {
+        topic: `${row.friend_name ?? 'お客様'}｜${row.menu_name}`,
+        startAt: row.starts_at,
+        durationMin,
+      });
+      await saveConference(db, bookingId, 'zoom', created.joinUrl, created.meetingId);
+    } catch (error) {
+      console.error('booking conference: zoom create failed:', error);
+      const synced = await syncCalendarQuietly(db, googleCredentials, bookingId, false);
+      return {
+        provider,
+        conferenceUrl: null,
+        calendarSynced: synced.synced,
+        calendarStatus: toCalendarStatus(synced),
+      };
+    }
+
+    // カレンダー登録が失敗したら Zoom を巻き戻す（孤児ミーティングを残さない）。
+    const synced = await syncCalendarQuietly(db, googleCredentials, bookingId, false);
+    if (!synced.ok) {
+      try {
+        await deleteZoomMeeting(creds, created.meetingId);
+        await db
+          .prepare(
+            `UPDATE bookings
+                SET conference_provider = NULL, conference_url = NULL, conference_external_id = NULL
+              WHERE id = ?`,
+          )
+          .bind(bookingId)
+          .run();
+        console.warn('booking conference: rolled back zoom meeting after calendar failure');
+        return {
+          provider,
+          conferenceUrl: null,
+          calendarSynced: false,
+          calendarStatus: 'failed',
+        };
+      } catch (error) {
+        // 巻き戻しにも失敗した場合は手動掃除が要る。URLは残しておく（予約者には案内済みのため）。
+        console.error('booking conference: zoom rollback failed — manual cleanup required:', error);
+      }
+    }
+    return {
+      provider,
+      conferenceUrl: created.joinUrl,
+      calendarSynced: synced.synced,
+      calendarStatus: toCalendarStatus(synced),
+    };
+  }
+
+  // google_meet: カレンダーイベントの作成そのものが Meet の発行になる。
+  const synced = await syncCalendarQuietly(db, googleCredentials, bookingId, true);
+  if (synced.meetUrl) {
+    await saveConference(db, bookingId, 'google_meet', synced.meetUrl, null);
+  }
+  return {
+    provider,
+    conferenceUrl: synced.meetUrl ?? null,
+    calendarSynced: synced.synced,
+    calendarStatus: toCalendarStatus(synced),
+  };
+}
+
+/** 例外を投げないカレンダー同期。ok=false は「呼び出しが失敗した」ことを示す。 */
+async function syncCalendarQuietly(
+  db: D1Database,
+  credentials: GoogleCalendarCredentials,
+  bookingId: string,
+  addGoogleMeet: boolean,
+): Promise<{ ok: boolean; synced: boolean; meetUrl?: string }> {
+  try {
+    const result = await syncConfirmedBookingToGoogle(db, credentials, bookingId, {
+      addGoogleMeet,
+    });
+    return { ok: true, synced: result.synced, meetUrl: result.meetUrl };
+  } catch (error) {
+    console.error('Google Calendar sync failed:', error);
+    return { ok: false, synced: false };
+  }
+}
+
+/**
+ * 予約が取り消されたときに、発行済みの会議を片付ける。
+ * Google Meet はカレンダーイベントに紐づくので、イベント削除で一緒に消える（ここでは何もしない）。
+ */
+export async function releaseBookingConference(
+  db: D1Database,
+  env: ConferenceEnv,
+  bookingId: string,
+): Promise<void> {
+  const row = await db
+    .prepare(
+      `SELECT conference_provider, conference_external_id
+         FROM bookings WHERE id = ?`,
+    )
+    .bind(bookingId)
+    .first<{ conference_provider: string | null; conference_external_id: string | null }>();
+  if (row?.conference_provider !== 'zoom' || !row.conference_external_id) return;
+
+  const creds = zoomConfigured(env);
+  if (!creds) return;
+  try {
+    await deleteZoomMeeting(creds, row.conference_external_id);
+  } catch (error) {
+    console.error('booking conference: zoom delete failed:', error);
+  }
+}

--- a/apps/worker/src/services/booking-notifier.test.ts
+++ b/apps/worker/src/services/booking-notifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { renderNotificationText } from './booking-notifier.js';
+import { renderNotificationText, renderOwnerNotificationText } from './booking-notifier.js';
 
 const ctx = {
   menuName: 'カット',
@@ -15,12 +15,12 @@ describe('renderNotificationText', () => {
     expect(text).toContain('カット');
     expect(text).toContain('山田');
     expect(text).toContain('2026-05-10 14:00');
-    expect(text).toContain('お店からの返信をお待ちください');
+    expect(text).toContain('担当者からの返信をお待ちください');
   });
   test('承認', () => {
     const text = renderNotificationText('approved', ctx);
     expect(text).toContain('予約が確定しました');
-    expect(text).toContain('変更・キャンセルはお店に直接ご連絡ください');
+    expect(text).toContain('変更・キャンセルはこのトークからご連絡ください');
   });
   test('拒否', () => {
     expect(renderNotificationText('rejected', ctx)).toContain('お取りできませんでした');
@@ -34,5 +34,54 @@ describe('renderNotificationText', () => {
   test('当日 N 時間前', () => {
     const t = renderNotificationText('hours_before', ctx);
     expect(t).toContain('本日のご予約まであと 2 時間');
+  });
+});
+
+describe('オンライン会議URL', () => {
+  const online = { ...ctx, conferenceUrl: 'https://example.zoom.us/j/123456789' };
+
+  test('確定通知に参加URLが載る', () => {
+    const text = renderNotificationText('approved', online);
+    expect(text).toContain('参加URL:');
+    expect(text).toContain('https://example.zoom.us/j/123456789');
+  });
+  test('前日・当日リマインダにも載る', () => {
+    expect(renderNotificationText('day_before', online)).toContain(
+      'https://example.zoom.us/j/123456789',
+    );
+    expect(renderNotificationText('hours_before', online)).toContain(
+      'https://example.zoom.us/j/123456789',
+    );
+  });
+  test('対面予約（URLなし）では参加URL行を出さない', () => {
+    expect(renderNotificationText('approved', ctx)).not.toContain('参加URL');
+    expect(renderNotificationText('day_before', ctx)).not.toContain('参加URL');
+  });
+  test('リクエスト受付の時点ではURLを出さない（未発行のため）', () => {
+    expect(renderNotificationText('requested', online)).not.toContain('参加URL');
+  });
+});
+
+describe('renderOwnerNotificationText', () => {
+  const ownerCtx = { ...ctx, customerName: '佐藤' };
+
+  test('新規予約は相手の名前と日時が入る', () => {
+    const text = renderOwnerNotificationText('owner_new_booking', ownerCtx);
+    expect(text).toContain('【新規予約】');
+    expect(text).toContain('佐藤');
+    expect(text).toContain('カット');
+    expect(text).toContain('2026-05-10 14:00');
+  });
+  test('新規予約に会議URLがあれば載る', () => {
+    const text = renderOwnerNotificationText('owner_new_booking', {
+      ...ownerCtx,
+      conferenceUrl: 'https://meet.google.com/abc-defg-hij',
+    });
+    expect(text).toContain('https://meet.google.com/abc-defg-hij');
+  });
+  test('キャンセルは取消と分かる文面になる', () => {
+    const text = renderOwnerNotificationText('owner_cancelled', ownerCtx);
+    expect(text).toContain('【予約キャンセル】');
+    expect(text).toContain('佐藤');
   });
 });

--- a/apps/worker/src/services/booking-notifier.ts
+++ b/apps/worker/src/services/booking-notifier.ts
@@ -8,11 +8,16 @@ export type NotificationKind =
   | 'day_before'
   | 'hours_before';
 
+/** 運営者（アカウント所有者）向けの通知種別。予約者向けとは文面も宛先も別。 */
+export type OwnerNotificationKind = 'owner_new_booking' | 'owner_cancelled';
+
 export interface NotificationContext {
   menuName: string;
   staffName: string;
   startsAtJst: string; // 例: "2026-05-10 14:00"
   hoursBefore: number;
+  /** オンライン会議URL（Zoom / Google Meet）。対面予約では undefined。 */
+  conferenceUrl?: string | null;
 }
 
 export function renderNotificationText(
@@ -20,19 +25,39 @@ export function renderNotificationText(
   ctx: NotificationContext,
 ): string {
   const detail = `\nメニュー: ${ctx.menuName}\n担当: ${ctx.staffName}\n日時: ${ctx.startsAtJst}`;
+  const conference = ctx.conferenceUrl ? `\n\n参加URL:\n${ctx.conferenceUrl}` : '';
   switch (kind) {
     case 'requested':
-      return `予約リクエストを受け付けました。${detail}\n\nお店からの返信をお待ちください。`;
+      return `予約リクエストを受け付けました。${detail}\n\n担当者からの返信をお待ちください。`;
     case 'approved':
-      return `予約が確定しました。${detail}\n\n変更・キャンセルはお店に直接ご連絡ください。`;
+      return `予約が確定しました。${detail}${conference}\n\n変更・キャンセルはこのトークからご連絡ください。`;
     case 'rejected':
       return `申し訳ありません、ご希望の枠でお取りできませんでした。\n別の日時で再度お試しください。`;
     case 'expired':
       return `予約リクエストが 24 時間返信が無かったため、期限切れになりました。${detail}`;
     case 'day_before':
-      return `明日のご予約のお知らせです。${detail}`;
+      return `明日のご予約のお知らせです。${detail}${conference}`;
     case 'hours_before':
-      return `本日のご予約まであと ${ctx.hoursBefore} 時間です。${detail}`;
+      return `本日のご予約まであと ${ctx.hoursBefore} 時間です。${detail}${conference}`;
+  }
+}
+
+export interface OwnerNotificationContext extends NotificationContext {
+  /** 予約者の表示名。 */
+  customerName: string;
+}
+
+export function renderOwnerNotificationText(
+  kind: OwnerNotificationKind,
+  ctx: OwnerNotificationContext,
+): string {
+  const detail =
+    `\nお相手: ${ctx.customerName}\nメニュー: ${ctx.menuName}\n担当: ${ctx.staffName}\n日時: ${ctx.startsAtJst}`;
+  switch (kind) {
+    case 'owner_new_booking':
+      return `【新規予約】${detail}${ctx.conferenceUrl ? `\n参加URL: ${ctx.conferenceUrl}` : ''}`;
+    case 'owner_cancelled':
+      return `【予約キャンセル】${detail}`;
   }
 }
 
@@ -45,6 +70,21 @@ export interface SendNotificationParams {
 
 export async function sendBookingNotification(params: SendNotificationParams): Promise<void> {
   const text = renderNotificationText(params.kind, params.ctx);
+  const client = new LineClient(params.channelAccessToken);
+  await client.pushMessage(params.toLineUserId, [{ type: 'text', text }]);
+}
+
+export interface SendOwnerNotificationParams {
+  channelAccessToken: string;
+  toLineUserId: string;
+  kind: OwnerNotificationKind;
+  ctx: OwnerNotificationContext;
+}
+
+export async function sendOwnerBookingNotification(
+  params: SendOwnerNotificationParams,
+): Promise<void> {
+  const text = renderOwnerNotificationText(params.kind, params.ctx);
   const client = new LineClient(params.channelAccessToken);
   await client.pushMessage(params.toLineUserId, [{ type: 'text', text }]);
 }

--- a/apps/worker/src/services/booking-reminders.ts
+++ b/apps/worker/src/services/booking-reminders.ts
@@ -11,6 +11,7 @@ interface DueRow {
   kind: 'day_before' | 'hours_before';
   retry_count: number;
   starts_at: string;
+  conference_url: string | null;
   menu_name: string;
   staff_name: string;
   channel_access_token: string;
@@ -39,7 +40,7 @@ export async function processDueReminders(
   const due = await db
     .prepare(
       `SELECT r.id, r.booking_id, r.kind, r.retry_count,
-              b.starts_at,
+              b.starts_at, b.conference_url,
               m.name AS menu_name,
               s.display_name AS staff_name,
               la.channel_access_token,
@@ -73,6 +74,7 @@ export async function processDueReminders(
           staffName: row.staff_name,
           startsAtJst: startsAtJst(row.starts_at),
           hoursBefore: params.reminderHoursBefore,
+          conferenceUrl: row.conference_url,
         },
       });
       await db

--- a/apps/worker/src/services/zoom.test.ts
+++ b/apps/worker/src/services/zoom.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createZoomMeeting, deleteZoomMeeting, zoomConfigured } from './zoom.js';
+
+const creds = {
+  accountId: 'acct_1',
+  clientId: 'client_1',
+  clientSecret: 'secret_1',
+};
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  const spy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) =>
+    handler(String(input), init),
+  );
+  vi.stubGlobal('fetch', spy);
+  return spy;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('zoomConfigured', () => {
+  test('3点そろって初めて有効になる', () => {
+    expect(zoomConfigured({})).toBeNull();
+    expect(zoomConfigured({ ZOOM_ACCOUNT_ID: 'a' })).toBeNull();
+    expect(zoomConfigured({ ZOOM_ACCOUNT_ID: 'a', ZOOM_CLIENT_ID: 'b' })).toBeNull();
+    expect(
+      zoomConfigured({ ZOOM_ACCOUNT_ID: 'a', ZOOM_CLIENT_ID: 'b', ZOOM_CLIENT_SECRET: 'c' }),
+    ).toEqual({ accountId: 'a', clientId: 'b', clientSecret: 'c' });
+  });
+});
+
+describe('createZoomMeeting', () => {
+  test('トークン取得→ミーティング作成の順で叩き、join_url を返す', async () => {
+    const calls: string[] = [];
+    const spy = mockFetch((url) => {
+      calls.push(url);
+      if (url.startsWith('https://zoom.us/oauth/token')) {
+        return new Response(JSON.stringify({ access_token: 'tok_1' }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ join_url: 'https://zoom.us/j/999', id: 999 }),
+        { status: 201 },
+      );
+    });
+
+    const result = await createZoomMeeting(creds, {
+      topic: '佐藤様｜個別面談',
+      startAt: '2026-05-10T05:00:00.000Z',
+      durationMin: 60,
+    });
+
+    expect(result).toEqual({ joinUrl: 'https://zoom.us/j/999', meetingId: '999' });
+    expect(calls[0]).toContain('grant_type=account_credentials');
+    expect(calls[0]).toContain('account_id=acct_1');
+    expect(calls[1]).toBe('https://api.zoom.us/v2/users/me/meetings');
+
+    const body = JSON.parse(String(spy.mock.calls[1][1]?.body));
+    expect(body.type).toBe(2);
+    expect(body.duration).toBe(60);
+    expect(body.timezone).toBe('Asia/Tokyo');
+    // Zoom は UTC の ISO を受け取る。ミリ秒は落とす。
+    expect(body.start_time).toBe('2026-05-10T05:00:00Z');
+  });
+
+  test('ホスト入室前の入室を許さない（URLが第三者に渡っても先回り入室されないため）', async () => {
+    const spy = mockFetch((url) =>
+      url.startsWith('https://zoom.us/oauth/token')
+        ? new Response(JSON.stringify({ access_token: 'tok_1' }), { status: 200 })
+        : new Response(JSON.stringify({ join_url: 'https://zoom.us/j/1', id: 1 }), { status: 201 }),
+    );
+    await createZoomMeeting(creds, {
+      topic: 't',
+      startAt: '2026-05-10T05:00:00Z',
+      durationMin: 60,
+    });
+    const body = JSON.parse(String(spy.mock.calls[1][1]?.body));
+    expect(body.settings.join_before_host).toBe(false);
+  });
+
+  test('OAuth が失敗したら例外にする（本文も残す）', async () => {
+    mockFetch(() => new Response('bad credentials', { status: 401 }));
+    await expect(
+      createZoomMeeting(creds, { topic: 't', startAt: '2026-05-10T05:00:00Z', durationMin: 30 }),
+    ).rejects.toThrow(/Zoom OAuth error: 401/);
+  });
+
+  test('ミーティング作成が失敗したら例外にする', async () => {
+    mockFetch((url) =>
+      url.startsWith('https://zoom.us/oauth/token')
+        ? new Response(JSON.stringify({ access_token: 'tok_1' }), { status: 200 })
+        : new Response('scope missing', { status: 400 }),
+    );
+    await expect(
+      createZoomMeeting(creds, { topic: 't', startAt: '2026-05-10T05:00:00Z', durationMin: 30 }),
+    ).rejects.toThrow(/Zoom createMeeting error: 400/);
+  });
+});
+
+describe('deleteZoomMeeting', () => {
+  test('204 は成功', async () => {
+    mockFetch((url) =>
+      url.startsWith('https://zoom.us/oauth/token')
+        ? new Response(JSON.stringify({ access_token: 'tok_1' }), { status: 200 })
+        : new Response(null, { status: 204 }),
+    );
+    await expect(deleteZoomMeeting(creds, '999')).resolves.toBeUndefined();
+  });
+
+  test('404（すでに消えている）も成功として扱う', async () => {
+    mockFetch((url) =>
+      url.startsWith('https://zoom.us/oauth/token')
+        ? new Response(JSON.stringify({ access_token: 'tok_1' }), { status: 200 })
+        : new Response('not found', { status: 404 }),
+    );
+    await expect(deleteZoomMeeting(creds, '999')).resolves.toBeUndefined();
+  });
+
+  test('それ以外のエラーは例外にする', async () => {
+    mockFetch((url) =>
+      url.startsWith('https://zoom.us/oauth/token')
+        ? new Response(JSON.stringify({ access_token: 'tok_1' }), { status: 200 })
+        : new Response('boom', { status: 500 }),
+    );
+    await expect(deleteZoomMeeting(creds, '999')).rejects.toThrow(/Zoom deleteMeeting error: 500/);
+  });
+});

--- a/apps/worker/src/services/zoom.ts
+++ b/apps/worker/src/services/zoom.ts
@@ -1,0 +1,113 @@
+/**
+ * Zoom Server-to-Server OAuth クライアント。
+ *
+ * 予約確定時に「その面談専用の Zoom ミーティング」を発行し、キャンセル時に削除する。
+ * Server-to-Server OAuth を使うため、ユーザーごとの OAuth 同意フローは不要で、
+ * アカウント単位の資格情報（Account ID / Client ID / Client Secret）だけで動く。
+ *
+ * Zoom 側の準備:
+ *   Zoom Marketplace → Develop → Build App → Server-to-Server OAuth
+ *   スコープ: meeting:write:admin（作成・削除）
+ *   アプリを Activate しないとトークンが発行されない（401 になる）。
+ *
+ * 注意: 無料プランは 3 人以上の会議が 40 分で切れる。60 分面談を運用するなら
+ * 有料プランが前提になる。
+ */
+
+export interface ZoomCredentials {
+  accountId: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+export interface CreatedZoomMeeting {
+  joinUrl: string;
+  meetingId: string;
+}
+
+/** 資格情報が3点そろっているときだけ ZoomCredentials を返す。 */
+export function zoomConfigured(env: {
+  ZOOM_ACCOUNT_ID?: string;
+  ZOOM_CLIENT_ID?: string;
+  ZOOM_CLIENT_SECRET?: string;
+}): ZoomCredentials | null {
+  if (!env.ZOOM_ACCOUNT_ID || !env.ZOOM_CLIENT_ID || !env.ZOOM_CLIENT_SECRET) return null;
+  return {
+    accountId: env.ZOOM_ACCOUNT_ID,
+    clientId: env.ZOOM_CLIENT_ID,
+    clientSecret: env.ZOOM_CLIENT_SECRET,
+  };
+}
+
+async function getZoomAccessToken(creds: ZoomCredentials): Promise<string> {
+  const encoded = btoa(`${creds.clientId}:${creds.clientSecret}`);
+  const res = await fetch(
+    `https://zoom.us/oauth/token?grant_type=account_credentials&account_id=${encodeURIComponent(creds.accountId)}`,
+    { method: 'POST', headers: { Authorization: `Basic ${encoded}` } },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Zoom OAuth error: ${res.status} ${text.slice(0, 200)}`);
+  }
+  const data = (await res.json()) as { access_token: string };
+  return data.access_token;
+}
+
+export async function createZoomMeeting(
+  creds: ZoomCredentials,
+  opts: {
+    topic: string;
+    /** 開始時刻。UTC ISO でも JST ISO でもよい（内部で UTC に正規化する）。 */
+    startAt: string;
+    durationMin: number;
+  },
+): Promise<CreatedZoomMeeting> {
+  const token = await getZoomAccessToken(creds);
+  const startUtc = new Date(opts.startAt).toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+  const res = await fetch('https://api.zoom.us/v2/users/me/meetings', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      topic: opts.topic,
+      type: 2, // scheduled
+      start_time: startUtc,
+      duration: opts.durationMin,
+      timezone: 'Asia/Tokyo',
+      settings: {
+        host_video: true,
+        participant_video: true,
+        // ホスト入室前の入室を許さない。参加URLは確定通知・リマインド・カレンダー本文に載るため、
+        // 転送やカレンダー共有で第三者へ渡り得る。join_before_host を許すと、その第三者が
+        // 面談開始前から入室して待ち構えられてしまう（個別相談は機微な内容を扱う）。
+        join_before_host: false,
+        // 待機室は既定で使わない（毎回の入室許可が運用の負担になるため）。
+        // 参加者を毎回確認したい場合は、Zoom のアカウント設定で待機室を全体に強制できる。
+        waiting_room: false,
+      },
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Zoom createMeeting error: ${res.status} ${text.slice(0, 200)}`);
+  }
+  const meeting = (await res.json()) as { join_url: string; id: number | string };
+  return { joinUrl: meeting.join_url, meetingId: String(meeting.id) };
+}
+
+export async function deleteZoomMeeting(
+  creds: ZoomCredentials,
+  meetingId: string,
+): Promise<void> {
+  const token = await getZoomAccessToken(creds);
+  const res = await fetch(`https://api.zoom.us/v2/meetings/${encodeURIComponent(meetingId)}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  // 204 = 削除成功 / 404 = すでに存在しない（どちらも成功扱い）
+  if (!res.ok && res.status !== 404) {
+    // 400 の内訳（scope 不足 code 4700 / meeting 不正 code 3000 等）を切り分けられるよう本文を残す
+    const text = await res.text().catch(() => '');
+    throw new Error(`Zoom deleteMeeting error: ${res.status} ${text.slice(0, 200)}`);
+  }
+}

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -52,6 +52,14 @@ crons = ["*/5 * * * *"]
 | `GOOGLE_OAUTH_CLIENT_SECRET` | 推奨 | string | OAuthクライアントの秘密鍵（Worker secretとして保存） | `GOCSPX-...` |
 | `GOOGLE_SERVICE_ACCOUNT_EMAIL` | 互換用 | string | 旧サービスアカウント方式で使うメールアドレス | `calendar-sync@project.iam.gserviceaccount.com` |
 | `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` | 互換用 | string | 旧サービスアカウント方式で使うPKCS#8秘密鍵 | `-----BEGIN PRIVATE KEY-----...` |
+| `ZOOM_ACCOUNT_ID` | 任意 | string | Zoom Server-to-Server OAuth のアカウントID（会議URL自動発行） | `abcDEF...` |
+| `ZOOM_CLIENT_ID` | 任意 | string | 同 クライアントID | `abcDEF...` |
+| `ZOOM_CLIENT_SECRET` | 任意 | string | 同 クライアントシークレット | `abcDEF...` |
+| `OWNER_LINE_USER_ID` | 任意 | string | 新規予約・キャンセルの通知を受け取る運営者のLINE利用者ID | `U0123...` |
+
+> **`wrangler.toml` の `[vars]` には書かないこと。** `wrangler.toml` は Git 追跡対象のため、
+> シークレットや LINE 利用者IDを書くと公開リポジトリに入る。上表の値は必ず `wrangler secret put` で設定する。
+> 非機密の `BOOKING_CONFERENCE_PROVIDER`（`zoom` / `google_meet`）と `BOOKING_AUTO_CONFIRM`（`true` で即時確定）は `[vars]` でよい。
 
 ### シークレット設定コマンド
 

--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -182,6 +182,9 @@ CREATE TABLE IF NOT EXISTS bookings (
   decided_by_staff_id     TEXT,
   external_event_id       TEXT,                 -- Phase 3 余地 (Google Calendar)
   external_calendar_id    TEXT,                 -- Phase 3 余地
+  conference_provider     TEXT,                 -- 'zoom' | 'google_meet'
+  conference_url          TEXT,                 -- 参加URL
+  conference_external_id  TEXT,                 -- Zoom meeting id 等（削除・再発行用）
   created_at              TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   updated_at              TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   FOREIGN KEY (line_account_id) REFERENCES line_accounts(id),

--- a/packages/db/migrations/071_booking_conference.sql
+++ b/packages/db/migrations/071_booking_conference.sql
@@ -1,0 +1,13 @@
+-- 071: オンライン会議URLを予約に紐づける。
+--
+-- 個別面談（オンライン相談）用途では、予約確定時に Zoom / Google Meet の
+-- 会議URLを発行して予約者へ案内する必要がある。従来は Google Meet の URL を
+-- meet_consultations（ウェビナーCTA経路）にしか保存しておらず、通常の
+-- LIFF 予約経路では会議URLがどこにも残らなかった。
+--
+-- provider は 'zoom' | 'google_meet'。external_id は再発行・削除に使う
+-- プロバイダ側のID（Zoom の meeting id など）。Google Meet は
+-- カレンダーイベントに紐づくため external_id は NULL になる。
+ALTER TABLE bookings ADD COLUMN conference_provider TEXT;
+ALTER TABLE bookings ADD COLUMN conference_url TEXT;
+ALTER TABLE bookings ADD COLUMN conference_external_id TEXT;

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -1044,6 +1044,9 @@ CREATE TABLE IF NOT EXISTS bookings (
   decided_by_staff_id     TEXT,
   external_event_id       TEXT,                 -- Phase 3 余地 (Google Calendar)
   external_calendar_id    TEXT,                 -- Phase 3 余地
+  conference_provider     TEXT,                 -- 'zoom' | 'google_meet'
+  conference_url          TEXT,                 -- 参加URL
+  conference_external_id  TEXT,                 -- Zoom meeting id 等（削除・再発行用）
   created_at              TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   updated_at              TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   FOREIGN KEY (line_account_id) REFERENCES line_accounts(id),


### PR DESCRIPTION
## 背景

オンライン個別相談を LINE 経由で受ける運用では、予約が確定した時点で会議URLが決まっている必要があります。

しかし現状、通常の LIFF 予約経路には会議URLの発行が付いていません。`addGoogleMeet: true` を渡しているのは `services/webinar-consultation-booking.ts` のウェビナーCTA経路だけで、`routes/booking.ts` の2つの確定経路（L943 の代理作成、L1627 の承認）はフラグを渡していません。そのため確定通知にもリマインドにもURLが載らず、運営者が毎回手作業で会議を作って個別に案内する必要がありました。

このPRは、確定した予約に会議URLを自動で用意します。

## 変更点

- **`services/zoom.ts` を追加** — Zoom Server-to-Server OAuth で予約ごとのミーティングを発行・削除します。資格情報は Worker secret から受け取り、コードには持ちません。
- **`services/booking-conference.ts` を追加** — `zoom` / `google_meet` を切り替え、発行・保存・ロールバックを一箇所にまとめます。プロバイダは `account_settings`（key: `booking_conference_provider`）→ 環境変数 `BOOKING_CONFERENCE_PROVIDER` → 既定 `google_meet` の順で解決します。
- **migration 071** — `bookings` に `conference_provider` / `conference_url` / `conference_external_id` を追加します（`ADD COLUMN` のみ、additive-only ポリシー準拠）。
- **通知に会議URLを載せる** — 確定通知・前日/当日リマインド・Googleカレンダー本文。
- **運営者向け通知を追加** — 新規予約とキャンセルを `OWNER_LINE_USER_ID` へ push します。未設定なら何もしないので、既存環境の挙動は変わりません。
- **即時確定モードを追加** — `BOOKING_AUTO_CONFIRM=true` で LIFF 予約を `requested` を経ずに `confirmed` で作ります。**既定は false（従来どおりの承認制）です。**
- **確定時の副作用を集約** — リマインダー登録・会議URL発行・カレンダー登録・通知を `runConfirmedSideEffects` にまとめ、LIFF即時確定・管理者代理作成・承認の3経路で同じ処理が走るようにしました。

## 即時確定モードを入れた理由

承認制のままだと、`REQUEST_TTL_HOURS = 24` を過ぎた予約が `runExpirer` で `expired` になり、申込者へ「予約リクエストが 24 時間返信が無かったため、期限切れになりました」が自動送信されます（`services/booking-notifier.ts` / `services/booking-expirer.ts`）。

サロン予約なら妥当ですが、見込み客からのオンライン相談では、承認を1日忘れただけで自動的にお断りが飛ぶことになります。しかも運営者向け通知が無かったため、それに気づく手段もありませんでした。運営者通知と即時確定を同時に入れているのはこのためです。

## 設計上の判断

- **Zoom は「発行 → D1保存 → カレンダー登録」の順**にし、カレンダー登録が失敗したら発行済みミーティングを削除して巻き戻します。使われない会議を残さないためです。
- **逆に Zoom の発行だけが失敗した場合は予約を成立させます。** 日時が押さえられていることのほうが重要で、URLは後から入れ直せるためです。
- **`join_before_host: false`** にしています。参加URLは LINE とカレンダー本文に載るため、転送やカレンダー共有で第三者に渡り得ます。ホスト入室前の入室を許すと、その第三者が面談開始前から入室して待ち構えられてしまいます。待機室は既定で使いません（毎回の入室許可が運用の負担になるため。必要なら Zoom のアカウント設定で全体に強制できます）。
- **カレンダー登録の結果は `synced` / `not_configured` / `failed` を区別**して返します。失敗を未設定に丸めると、予定が入っていない予約を障害として検知できなくなります。

## 後方互換性

既存環境への影響はありません。

- `OWNER_LINE_USER_ID` 未設定 → 運営者通知は送られません
- `BOOKING_AUTO_CONFIRM` 未設定 → 従来どおりの承認制です
- `BOOKING_CONFERENCE_PROVIDER` 未設定 → `google_meet` ですが、`syncConfirmedBookingToGoogle` の早期リターンにより、Googleカレンダー未連携の環境では Google API を一切叩きません
- migration 071 は `ADD COLUMN` のみで、NOT NULL 制約もデータ移行もありません

なお通知の既定文面を店舗前提から中立な表現に変えています（「お店からの返信」→「担当者からの返信」、「変更・キャンセルはお店に直接」→「このトークから」）。店舗運用の既存利用者に影響するため、必要でしたら戻します。

## テスト

- `services/zoom.test.ts`（8件）— OAuth→作成の順序、UTC正規化、入室制御、404を成功扱いにする削除、各種エラー
- `services/booking-conference.test.ts`（19件）— プロバイダ解決の優先順位、Zoom/Meet それぞれの発行、カレンダー失敗時のロールバック、冪等性、カレンダー状態の区別
- 既存テストを含め **1287 件パス**。`tsc --noEmit`・`pnpm -r build`・`scripts/check-migrations.ts` も通過
- まっさらな clone に本ブランチの変更を適用した状態で、`bootstrap.sql` がエラーなく 90 テーブルを作り、会議URL列が生成されることを実測

## 未実施

実際の Zoom / Google アカウントを繋いだ end-to-end の疎通は行っていません。外部サービスの資格情報が必要なためです。API 呼び出しはモックでの検証にとどまります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZxWRDg6EDVtMRbdD2kxdp