### PR TITLE
fix(scenarios): never enroll or push a scenario across LINE accounts

### DIFF
--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -10,6 +10,7 @@ import {
   recordRefTracking,
   addTagToFriend,
   getLineAccountByChannelId,
+  getScenarioById,
   getLineAccountById,
   getLineAccounts,
   getTrafficPoolBySlug,
@@ -923,8 +924,28 @@ liffRoutes.get('/auth/callback', async (c) => {
     // Auto-enroll in friend_add scenarios + immediate delivery.
     // Skip entirely when the referral link explicitly overrides account-level
     // friend_add scenarios (entry_routes.run_account_friend_add_scenarios = 0).
-    const referralRouteForOverride =
+    let referralRouteForOverride =
       ref && !ref.startsWith('xh:') ? await getEntryRouteByRefCode(db, ref) : null;
+
+    // Same cross-account rule as the follow webhook: a route belonging to a
+    // different account must not suppress THIS account's own friend_add welcome
+    // (its scenario is already blocked by scenarioAllowedForFriendAccount).
+    if (referralRouteForOverride?.scenario_id && accountParam) {
+      const overrideAccount = await getLineAccountByChannelId(db, accountParam);
+      const routeScenario = await getScenarioById(db, referralRouteForOverride.scenario_id);
+      if (
+        overrideAccount &&
+        routeScenario?.line_account_id &&
+        routeScenario.line_account_id !== overrideAccount.id
+      ) {
+        console.error(
+          `[liff] referral route override ignored: ref=${ref} belongs to account ` +
+            `${routeScenario.line_account_id}, not ${overrideAccount.id}`,
+        );
+        referralRouteForOverride = null;
+      }
+    }
+
     const runAccountScenariosLiff =
       !referralRouteForOverride || referralRouteForOverride.run_account_friend_add_scenarios !== 0;
 

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -13,6 +13,7 @@ import {
   jstNow,
   getEntryRouteByRefCode,
   getMessageTemplateById,
+  getScenarioById,
 } from '@line-crm/db';
 import type { EntryRoute, Friend } from '@line-crm/db';
 import { fireEvent } from '../services/event-bus.js';
@@ -271,9 +272,29 @@ async function handleEvent(
         }
       }
     }
-    const referralRoute: EntryRoute | null = friendRefCode
+    let referralRoute: EntryRoute | null = friendRefCode
       ? await getEntryRouteByRefCode(db, friendRefCode)
       : null;
+
+    // A ref_code can outlive the account it was issued for: LINE user ids are
+    // shared across channels of the same provider, so following a DIFFERENT
+    // account reuses the existing friend row (only line_account_id is
+    // rewritten) and the stale ref still resolves its original entry_route.
+    // Treat such a route as "not ours" and drop it whole — its scenario would
+    // deliver another account's messages out of this bot, its intro template is
+    // written for the other brand, and its run_account_friend_add_scenarios
+    // override would suppress THIS account's own welcome.
+    if (referralRoute?.scenario_id && lineAccountId) {
+      const routeScenario = await getScenarioById(db, referralRoute.scenario_id);
+      if (routeScenario?.line_account_id && routeScenario.line_account_id !== lineAccountId) {
+        console.error(
+          `[follow] referral route ignored: ref=${friendRefCode} belongs to account ` +
+            `${routeScenario.line_account_id}, not ${lineAccountId} (stale ref_code on friend ${friend.id})`,
+        );
+        referralRoute = null;
+      }
+    }
+
     const runAccountScenarios =
       !referralRoute || referralRoute.run_account_friend_add_scenarios !== 0;
 

--- a/apps/worker/src/services/immediate-first-step.test.ts
+++ b/apps/worker/src/services/immediate-first-step.test.ts
@@ -25,6 +25,7 @@ const dbMocks = vi.hoisted(() => ({
   completeFriendScenario: vi.fn(),
   claimFriendScenarioForDelivery: vi.fn(),
   enrollFriendInScenario: vi.fn(),
+  scenarioAllowedForFriendAccount: vi.fn(),
   getLineAccountByChannelId: vi.fn(),
   getLineAccountById: vi.fn(),
   // 既定は env をそのまま返す（＝従来挙動）。テナントに有効なアカウントが1本
@@ -124,8 +125,10 @@ beforeEach(() => {
     id: 'scn-1',
     is_active: 1,
     delivery_mode: 'relative',
+    line_account_id: null,
     steps: [STEP1, STEP2],
   });
+  dbMocks.scenarioAllowedForFriendAccount.mockResolvedValue(true);
   dbMocks.getFriendById.mockResolvedValue({
     id: 'friend-1',
     line_user_id: 'U-1',
@@ -630,5 +633,35 @@ describe('step conditions — cron parity on the instant path', () => {
     expect(sent).toBe(false);
     expect(lineClientMock.pushMessage).not.toHaveBeenCalled();
     expect(dbMocks.claimFriendScenarioForDelivery).not.toHaveBeenCalled();
+  });
+});
+
+describe('cross-account guard', () => {
+  // The delivery client is resolved from the FRIEND's account, so pushing a
+  // scenario owned by another account sends that brand's message out of this
+  // bot. 'every-click' pushes even when the enrollment already exists, so the
+  // check cannot live in enrollFriendInScenario alone.
+  it('does not push a scenario belonging to another account', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    dbMocks.getScenarioById.mockResolvedValue({
+      id: 'scn-1',
+      is_active: 1,
+      delivery_mode: 'relative',
+      line_account_id: 'acct-a',
+      steps: [STEP1, STEP2],
+    });
+    dbMocks.scenarioAllowedForFriendAccount.mockResolvedValue(false);
+
+    const { db } = makeDb();
+    const sent = await pushImmediateFirstStep(db, 'friend-1', 'scn-1', ctx, {
+      mode: 'every-click',
+      targetLineUserId: 'U-1',
+    });
+
+    expect(sent).toBe(false);
+    expect(lineClientMock.pushMessage).not.toHaveBeenCalled();
+    expect(dbMocks.enrollFriendInScenario).not.toHaveBeenCalled();
+    expect(dbMocks.claimFriendScenarioForDelivery).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/apps/worker/src/services/immediate-first-step.ts
+++ b/apps/worker/src/services/immediate-first-step.ts
@@ -7,6 +7,7 @@ import {
   completeFriendScenario,
   claimFriendScenarioForDelivery,
   enrollFriendInScenario,
+  scenarioAllowedForFriendAccount,
   getLineAccountByChannelId,
   getLineAccountById,
   resolveDefaultLineAccount,
@@ -133,6 +134,17 @@ export async function pushImmediateFirstStep(
     // this an entry route pointing at a deactivated campaign would still
     // instant-push its first step.
     if (!scenarioRow.is_active) return false;
+    // Cross-account guard: never instant-push a scenario owned by another
+    // account out of THIS friend's bot. enrollFriendInScenario applies the same
+    // rule, but 'every-click' pushes even when the enrollment already exists
+    // (or was just blocked), so the check has to be here too.
+    if (!(await scenarioAllowedForFriendAccount(db, friendId, scenarioRow.line_account_id))) {
+      console.error(
+        `[immediate-first-step] cross-account push blocked: scenario=${scenarioId} ` +
+          `(account=${scenarioRow.line_account_id}) does not belong to friend=${friendId}'s account`,
+      );
+      return false;
+    }
     const steps = scenarioRow.steps;
     if (!steps[0]) return false;
 

--- a/packages/db/src/scenarios.ts
+++ b/packages/db/src/scenarios.ts
@@ -361,6 +361,43 @@ export async function getScenarioSteps(
 // Friend Scenario Enrollments
 // ============================================================
 
+/**
+ * Cross-account guard: may this scenario be enrolled for this friend?
+ *
+ * Delivery resolves the push client from the FRIEND's current account (both
+ * step-delivery and immediate-first-step do), so a scenario owned by account A
+ * that gets enrolled for a friend sitting on account B is delivered out of
+ * account B's bot — one brand's step message sent from another brand's
+ * official account.
+ *
+ * This is reachable whenever a friend's ref_code outlives the account it was
+ * issued for. LINE user ids are shared across channels of the same provider,
+ * so following a SECOND account reuses the existing friend row and only
+ * rewrites line_account_id; the ref_code issued by the first account survives
+ * and still resolves its original entry_route. The friend_add and tag_added
+ * trigger loops already compare accounts before enrolling — the referral-route
+ * and tracked-link paths reach enrollment without that check, which is what
+ * this guard closes.
+ *
+ * Only a hard mismatch (both sides non-NULL and different) is rejected. A NULL
+ * on either side means "unassigned / single-account install" and stays allowed,
+ * matching the trigger loops' own `scenarioAccountMatch` rule.
+ */
+export async function scenarioAllowedForFriendAccount(
+  db: D1Database,
+  friendId: string,
+  scenarioAccountId: string | null,
+): Promise<boolean> {
+  if (!scenarioAccountId) return true;
+  const friendRow = await db
+    .prepare(`SELECT line_account_id FROM friends WHERE id = ?`)
+    .bind(friendId)
+    .first<{ line_account_id: string | null }>();
+  const friendAccountId = friendRow?.line_account_id ?? null;
+  if (!friendAccountId) return true;
+  return friendAccountId === scenarioAccountId;
+}
+
 export async function enrollFriendInScenario(
   db: D1Database,
   friendId: string,
@@ -371,10 +408,19 @@ export async function enrollFriendInScenario(
 
   // delivery_mode を取得（migration 037 適用前の DB では 'relative' が DEFAULT で既に入っている）
   const scenarioRow = await db
-    .prepare(`SELECT delivery_mode FROM scenarios WHERE id = ?`)
+    .prepare(`SELECT delivery_mode, line_account_id FROM scenarios WHERE id = ?`)
     .bind(scenarioId)
-    .first<{ delivery_mode: DeliveryMode }>();
+    .first<{ delivery_mode: DeliveryMode; line_account_id: string | null }>();
   if (!scenarioRow) return null;
+
+  // 別アカウントのシナリオには登録しない（登録経路を問わない最後の砦）。
+  if (!(await scenarioAllowedForFriendAccount(db, friendId, scenarioRow.line_account_id))) {
+    console.error(
+      `[scenario] cross-account enrollment blocked: scenario=${scenarioId} ` +
+        `(account=${scenarioRow.line_account_id}) does not belong to friend=${friendId}'s account`,
+    );
+    return null;
+  }
 
   const firstStep = await db
     .prepare(

--- a/packages/db/test/scenario-account-guard.test.ts
+++ b/packages/db/test/scenario-account-guard.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  enrollFriendInScenario,
+  scenarioAllowedForFriendAccount,
+} from '../src/scenarios.js';
+
+/**
+ * Cross-account enrollment guard.
+ *
+ * Regression: a friend row is shared across every channel of the same LINE
+ * provider (same userId), so following a SECOND account reuses the row and
+ * only rewrites line_account_id — the ref_code issued by the FIRST account
+ * survives. The follow handler then resolved that stale ref to an entry_route
+ * owned by the first account and enrolled the friend in its scenario; the
+ * delivery worker picks its push client from the friend's CURRENT account, so
+ * account A's step message went out of account B's official account.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = join(__dirname, '..');
+const MIGRATIONS_DIR = join(PKG_ROOT, 'migrations');
+
+const BENIGN = /duplicate column name|already exists/i;
+
+function execSafe(db: Database.Database, sql: string): void {
+  for (const stmt of sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    try {
+      db.exec(stmt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!BENIGN.test(msg)) throw err;
+    }
+  }
+}
+
+function setupDb(): Database.Database {
+  const db = new Database(':memory:');
+  execSafe(db, readFileSync(join(PKG_ROOT, 'schema.sql'), 'utf8'));
+  const migrationFiles = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  for (const file of migrationFiles) {
+    execSafe(db, readFileSync(join(MIGRATIONS_DIR, file), 'utf8'));
+  }
+  return db;
+}
+
+// enrollFriendInScenario gates on result.meta.changes, so the wrapper has to
+// surface better-sqlite3's change count (an empty meta reads as "no insert").
+function asD1(sqlite: Database.Database): D1Database {
+  const wrap = (query: string, params: unknown[]) => {
+    const stmt = sqlite.prepare(query);
+    return {
+      async run() {
+        const info = stmt.run(...params);
+        return {
+          results: [],
+          success: true,
+          meta: { changes: info.changes, last_row_id: Number(info.lastInsertRowid) },
+        };
+      },
+      async first<T>() {
+        return (stmt.get(...params) as T) ?? null;
+      },
+      async all<T>() {
+        return { results: stmt.all(...params) as T[], success: true, meta: {} };
+      },
+    };
+  };
+  return {
+    prepare(query: string) {
+      return {
+        bind: (...params: unknown[]) => wrap(query, params),
+        ...wrap(query, []),
+      };
+    },
+  } as unknown as D1Database;
+}
+
+const ACCOUNT_A = 'acct-beauty-trend-lab';
+const ACCOUNT_B = 'acct-ai-blossom';
+
+function seed(
+  sqlite: Database.Database,
+  opts: { friendAccount: string | null; scenarioAccount: string | null },
+): { friendId: string; scenarioId: string } {
+  const friendId = 'friend-1';
+  const scenarioId = 'scenario-1';
+
+  for (const [id, name] of [
+    [ACCOUNT_A, 'Beauty Trend Lab'],
+    [ACCOUNT_B, 'AI BLOSSOM'],
+  ]) {
+    sqlite
+      .prepare(
+        `INSERT INTO line_accounts (id, channel_id, name, channel_access_token, channel_secret)
+         VALUES (?, ?, ?, 'token', 'secret')`,
+      )
+      .run(id, `channel-${id}`, name);
+  }
+
+  sqlite
+    .prepare(
+      `INSERT INTO friends (id, line_user_id, display_name, line_account_id, ref_code)
+       VALUES (?, 'U-shared-across-channels', 'はるな', ?, 'slimming')`,
+    )
+    .run(friendId, opts.friendAccount);
+
+  sqlite
+    .prepare(
+      `INSERT INTO scenarios (id, name, trigger_type, is_active, delivery_mode, line_account_id)
+       VALUES (?, '痩身ステップ配信', 'manual', 1, 'absolute_time', ?)`,
+    )
+    .run(scenarioId, opts.scenarioAccount);
+
+  sqlite
+    .prepare(
+      `INSERT INTO scenario_steps (id, scenario_id, step_order, delay_minutes, message_type, message_content, offset_days, delivery_time)
+       VALUES ('step-1', ?, 1, 0, 'text', '「がんばってるのに痩せない」その理由', 1, '20:00')`,
+    )
+    .run(scenarioId);
+
+  return { friendId, scenarioId };
+}
+
+function enrollmentCount(sqlite: Database.Database): number {
+  const row = sqlite.prepare('SELECT COUNT(*) AS n FROM friend_scenarios').get() as { n: number };
+  return row.n;
+}
+
+describe('cross-account scenario enrollment guard', () => {
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    sqlite = setupDb();
+  });
+
+  test('does not enroll a friend in another account\'s scenario', async () => {
+    const { friendId, scenarioId } = seed(sqlite, {
+      friendAccount: ACCOUNT_B,
+      scenarioAccount: ACCOUNT_A,
+    });
+
+    const result = await enrollFriendInScenario(asD1(sqlite), friendId, scenarioId);
+
+    expect(result).toBeNull();
+    expect(enrollmentCount(sqlite)).toBe(0);
+  });
+
+  test('enrolls when the scenario belongs to the friend\'s own account', async () => {
+    const { friendId, scenarioId } = seed(sqlite, {
+      friendAccount: ACCOUNT_A,
+      scenarioAccount: ACCOUNT_A,
+    });
+
+    const result = await enrollFriendInScenario(asD1(sqlite), friendId, scenarioId);
+
+    expect(result).not.toBeNull();
+    expect(enrollmentCount(sqlite)).toBe(1);
+  });
+
+  test('enrolls when the scenario is unassigned (single-account install)', async () => {
+    const { friendId, scenarioId } = seed(sqlite, {
+      friendAccount: ACCOUNT_B,
+      scenarioAccount: null,
+    });
+
+    const result = await enrollFriendInScenario(asD1(sqlite), friendId, scenarioId);
+
+    expect(result).not.toBeNull();
+    expect(enrollmentCount(sqlite)).toBe(1);
+  });
+
+  test('enrolls when the friend has no account yet', async () => {
+    const { friendId, scenarioId } = seed(sqlite, {
+      friendAccount: null,
+      scenarioAccount: ACCOUNT_A,
+    });
+
+    const result = await enrollFriendInScenario(asD1(sqlite), friendId, scenarioId);
+
+    expect(result).not.toBeNull();
+    expect(enrollmentCount(sqlite)).toBe(1);
+  });
+
+  describe('scenarioAllowedForFriendAccount', () => {
+    test('rejects only a hard mismatch', async () => {
+      const { friendId } = seed(sqlite, {
+        friendAccount: ACCOUNT_B,
+        scenarioAccount: ACCOUNT_A,
+      });
+      const db = asD1(sqlite);
+
+      expect(await scenarioAllowedForFriendAccount(db, friendId, ACCOUNT_A)).toBe(false);
+      expect(await scenarioAllowedForFriendAccount(db, friendId, ACCOUNT_B)).toBe(true);
+      expect(await scenarioAllowedForFriendAccount(db, friendId, null)).toBe(true);
+    });
+
+    test('allows an unknown friend id rather than blocking delivery', async () => {
+      expect(await scenarioAllowedForFriendAccount(asD1(sqlite), 'missing', ACCOUNT_A)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What happens today

A friend row is shared across every channel of the same LINE provider (same
`userId`), so following a **second** account reuses the existing row and only
rewrites `line_account_id` — the `ref_code` issued by the **first** account
survives.

The follow handler then resolves that stale ref to an `entry_route` owned by
the first account and enrolls the friend in its scenario. Delivery resolves its
push client from the friend's **current** account
(`step-delivery` / `immediate-first-step` both do), so account A's step message
goes out of account B's official account.

Seen in production on a six-account install: a beauty-media step message was
delivered from an unrelated web-services account the day after that account was
added. Nothing in the UI hints at it — the enrollment looks ordinary, and with
an `absolute_time` scenario the wrong message only appears the next evening.

## Why the existing checks miss it

The `friend_add` and `tag_added` trigger loops already compare accounts before
enrolling (`scenarioAccountMatch`). The referral-route and tracked-link paths
reach `enrollFriendInScenario` without that check.

## The fix

Closed in three places so no single call site has to remember the rule:

- **`enrollFriendInScenario`** rejects a hard account mismatch, via a new
  exported `scenarioAllowedForFriendAccount` helper. This is the backstop for
  every enrollment path, including `absolute_time` scenarios that only surface
  a day later.
- **`pushImmediateFirstStep`** applies the same check. `'every-click'` pushes
  even when the enrollment already exists (or was just blocked), so refusing
  the insert alone is not enough.
- **The follow webhook and the LIFF callback** drop a referral route whose
  scenario belongs to another account *entirely* — not just its enrollment.
  Otherwise its `intro_template_id` still pushes the other brand's copy, and
  its `run_account_friend_add_scenarios = 0` override still suppresses **this**
  account's own welcome.

Only a **hard mismatch** is rejected: both sides non-NULL and different. A NULL
on either side means "unassigned / single-account install" and is still
allowed, so single-account installs and unassigned scenarios behave exactly as
before.

## Tests

- `packages/db/test/scenario-account-guard.test.ts` (new) — reproduces the
  incident against the real schema: a friend moved to account B is not enrolled
  in account A's scenario, while same-account / unassigned-scenario /
  unassigned-friend cases still enroll.
- `immediate-first-step.test.ts` — a cross-account `'every-click'` call pushes
  nothing, enrolls nothing, claims nothing.

`packages/db` 164 passed, `apps/worker` 1263 passed, `tsc --noEmit` clean on
both.

## Not included

No migration, and no schema change — the guard reads columns that already
exist.
