### PR TITLE
fix(create-line-harness): install dependencies during --from-source setup

### DIFF
--- a/packages/create-line-harness/src/commands/setup.ts
+++ b/packages/create-line-harness/src/commands/setup.ts
@@ -12,7 +12,7 @@ import { deployWorker, syncInstalledWorkerConfig } from "../steps/deploy-worker.
 import { ensureWorkersDevSubdomain } from "../steps/ensure-subdomain.js";
 import { deployAdmin } from "../steps/deploy-admin.js";
 import { fetchLatestRelease, type FetchedRelease } from "../steps/release-bundle.js";
-import { pinRepoToTag } from "../steps/clone-repo.js";
+import { installRepoDeps, pinRepoToTag } from "../steps/clone-repo.js";
 import { setSecrets } from "../steps/secrets.js";
 import { configureAdminAuth } from "../steps/admin-auth.js";
 import { generateMcpConfig } from "../steps/mcp-config.js";
@@ -415,6 +415,9 @@ async function runSetupInner(
         "(`npx create-line-harness update`) の対象外になります。開発用途向けです。",
       ].join("\n"),
     );
+    // Nothing else installs on this path: pinRepoToTag() is skipped, and
+    // ensureRepo() returns early for a checkout that already exists.
+    await installRepoDeps(repoDir);
   }
 
   // Step 2: Authenticate with Cloudflare

--- a/packages/create-line-harness/src/steps/clone-repo.ts
+++ b/packages/create-line-harness/src/steps/clone-repo.ts
@@ -70,12 +70,28 @@ export async function pinRepoToTag(
 
   // The tag may pin different dependency versions than the previously
   // installed main HEAD — reinstall to match its lockfile.
+  await installRepoDeps(repoDir);
+}
+
+/**
+ * Install workspace dependencies into an existing checkout.
+ *
+ * `ensureRepo()` installs only on the fresh-clone path, so a checkout that
+ * already exists locally — cwd, `--repo-dir`, or a previous
+ * `~/.line-harness` clone — arrives at the build steps with no
+ * `node_modules`. `pinRepoToTag()` covers that for release installs;
+ * `--from-source` skips pinning entirely and must install here instead,
+ * or the first build fails with `tsc: command not found`.
+ */
+export async function installRepoDeps(repoDir: string): Promise<void> {
+  const s = p.spinner();
   s.start("依存関係インストール中...");
   try {
     await repoPnpm(repoDir, ["install", "--frozen-lockfile"], {
       cwd: repoDir,
     });
   } catch {
+    // A drifted lockfile must not block setup — retry unfrozen.
     await repoPnpm(repoDir, ["install"], { cwd: repoDir });
   }
   s.stop("依存関係インストール完了");
@@ -167,17 +183,7 @@ export async function ensureRepo(repoDir: string | null): Promise<string> {
   }
   s.stop("ダウンロード完了");
 
-  // Install dependencies
-  s.start("依存関係インストール中...");
-  try {
-    await repoPnpm(homeDir, ["install", "--frozen-lockfile"], {
-      cwd: homeDir,
-    });
-  } catch {
-    // Try without frozen lockfile
-    await repoPnpm(homeDir, ["install"], { cwd: homeDir });
-  }
-  s.stop("依存関係インストール完了");
+  await installRepoDeps(homeDir);
 
   return homeDir;
 }

--- a/packages/create-line-harness/test/install-repo-deps.test.ts
+++ b/packages/create-line-harness/test/install-repo-deps.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const repoPnpm = vi.fn();
+
+vi.mock('../src/lib/pnpm.js', () => ({ repoPnpm }));
+vi.mock('@clack/prompts', () => ({
+  spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+  log: { warn: vi.fn(), info: vi.fn() },
+}));
+
+const { installRepoDeps } = await import('../src/steps/clone-repo.js');
+
+const REPO = '/tmp/repo';
+
+describe('installRepoDeps', () => {
+  beforeEach(() => {
+    repoPnpm.mockReset();
+  });
+
+  it('installs with the lockfile frozen', async () => {
+    repoPnpm.mockResolvedValue(undefined);
+    await installRepoDeps(REPO);
+    expect(repoPnpm).toHaveBeenCalledTimes(1);
+    expect(repoPnpm).toHaveBeenCalledWith(
+      REPO,
+      ['install', '--frozen-lockfile'],
+      { cwd: REPO },
+    );
+  });
+
+  it('retries unfrozen when the lockfile is out of date', async () => {
+    repoPnpm
+      .mockRejectedValueOnce(new Error('ERR_PNPM_OUTDATED_LOCKFILE'))
+      .mockResolvedValueOnce(undefined);
+    await installRepoDeps(REPO);
+    expect(repoPnpm).toHaveBeenCalledTimes(2);
+    expect(repoPnpm).toHaveBeenLastCalledWith(REPO, ['install'], { cwd: REPO });
+  });
+
+  it('propagates the failure when the unfrozen retry also fails', async () => {
+    repoPnpm.mockRejectedValue(new Error('network unreachable'));
+    await expect(installRepoDeps(REPO)).rejects.toThrow('network unreachable');
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** `npx create-line-harness --from-source` は依存関係を一度もインストールしないため、`node_modules` の無いチェックアウトでは最初のビルドで必ず `sh: tsc: command not found` になり、セットアップが完走しません。
- **Solution:** インストール処理を `installRepoDeps()` として切り出し、`--from-source` の分岐からも呼ぶようにしました。
- **What changed:** `pinRepoToTag()` と `ensureRepo()` に重複していたインストール処理を共通ヘルパーに統一。ユニットテストを追加。
- **What did NOT change:** リリース経路（`--from-source` なし）の挙動、タグ固定のロジック、デプロイ手順、生成される設定は一切変わりません。

### 原因

インストール処理が `pinRepoToTag()` の内部にあり、この関数はリリース経路でしか呼ばれません。

```ts
if (!options.fromSource) {
  release = await fetchLatestRelease(...);
  await pinRepoToTag(repoDir, release.release.version);  // ← install はこの中
} else {
  p.log.warn([...]);   // install が走らない
}
```

もう一方の `ensureRepo()` は fresh clone の経路でしか install せず、既にチェックアウトが存在する場合（cwd がリポジトリ / `--repo-dir` 指定 / 既存の `~/.line-harness`）は早期 return します。

この2つの穴が `--from-source` で重なるため、インストールがどこでも走りません。

### 再現手順

```bash
git clone https://github.com/Shudesu/line-harness-oss.git
cd line-harness-oss
npx create-line-harness --from-source
```

```
◇  Worker デプロイ失敗
Error: Command failed with exit code 1: npx -y 'pnpm@9.15.4' -r --filter ./packages/shared ... build
packages/shared build: sh: tsc: command not found
packages/line-sdk build: sh: tsc: command not found
packages/update-engine build: sh: tsup: command not found
 WARN  Local package.json exists, but node_modules missing, did you mean to install?
```

`pnpm install` を手動で実行してから再開すると、そのまま完走します。

## Related Issue

N/A（同種の issue / PR は見つかりませんでした）

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Security hardening
- [ ] Documentation
- [ ] Tests only
- [ ] Chore / infra
- [ ] Private sync

## Scope

- [ ] Admin web UI
- [ ] Worker API
- [ ] LINE webhook / postback / reply token
- [ ] Broadcast / multicast / step delivery / reminders
- [ ] Auth / API keys / cookies / CORS / staff permissions
- [ ] D1 schema / migrations / account scoping
- [x] SDK / MCP / create-line-harness CLI
- [ ] Cloudflare deploy / release / update workflow
- [ ] Docs only

> `--from-source` のセットアップ経路に触れるため Cloudflare deploy 系に近い変更ですが、追加しているのはビルド前の `pnpm install` のみで、wrangler 設定・シークレット・リリース処理には手を入れていません。

## Verification

- **Commands:**
  - `pnpm install --frozen-lockfile`
  - `pnpm --filter @line-harness/update-engine build`
  - `pnpm --filter create-line-harness test` → 6 files / 52 tests passed（うち新規3件）
  - `pnpm --filter create-line-harness build` → success
- **Manual checks:** 上記の再現手順で失敗を確認したのち、手動 `pnpm install` → 再実行で D1 作成・R2 バケット作成・Worker デプロイまで完走することを実機（Cloudflare 無料枠 + 実 LINE 公式アカウント）で確認しました。
- **Screenshots/logs:** 上記の再現ログのとおりです。
- **Not tested:** 修正後の CLI をクリーンな環境で end-to-end 実行してはいません（検証時は先に手動インストール済みだったため）。`installRepoDeps()` の呼び出し自体はユニットテストとビルド成果物の確認で担保しています。また Windows 環境では未検証です。

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`（既存のリリース経路と同じ `pnpm install` を、別の分岐でも実行するだけです）
- Message sending behavior changed? `No`
- Customer/friend data access changed? `No`
- D1 migration or data deletion changed? `No`

## Safety Checklist

- [x] This PR is focused on one problem and contains no unrelated commits.
- [x] I searched for existing issues/PRs to avoid duplicates.
- [x] No secrets, tokens, customer data, friend IDs, private URLs, or private configuration are included.
- [x] No generated build output, `.tsbuildinfo`, local env files, or formatting-only churn is included.
- [x] Docs or tests were updated when useful.
- [x] Deployment impact is understood.
- [x] For high-risk areas, I included a clear rollback or recovery note.
- [x] I personally verified the behavior described above.

## Rollback / Recovery

この commit を revert すれば元の挙動に戻ります。`--from-source` は revert 後も現状どおり失敗しますが、利用者は `pnpm install` を手動実行してから再実行することで回避できます（セットアップは state ファイルから再開されます）。リリース経路には影響しないため、既存利用者へのデプロイ影響はありません。
