### PR TITLE
fix(db): account_health_logsの最新参照を複合インデックス化

### DIFF
--- a/packages/db/bootstrap-meta.json
+++ b/packages/db/bootstrap-meta.json
@@ -74,7 +74,8 @@
     "067_mileage_keyword_auto_reply.sql",
     "068_media_inquiries.sql",
     "069_rich_menu_selected.sql",
-    "070_admin_sso_jti.sql"
+    "070_admin_sso_jti.sql",
+    "072_health_logs_composite_index.sql"
   ],
-  "migrationCount": 75
+  "migrationCount": 76
 }

--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -1272,7 +1272,8 @@ CREATE INDEX IF NOT EXISTS idx_friends_user_id ON friends (user_id);
 CREATE INDEX IF NOT EXISTS idx_google_calendar_connections_staff
   ON google_calendar_connections (line_account_id, staff_id, is_active);
 
-CREATE INDEX IF NOT EXISTS idx_health_logs_account ON account_health_logs (line_account_id);
+CREATE INDEX IF NOT EXISTS idx_health_logs_account_created_at
+  ON account_health_logs (line_account_id, created_at DESC);
 
 CREATE INDEX IF NOT EXISTS idx_idempotency_expires ON booking_idempotency_keys (expires_at);
 

--- a/packages/db/migrations/072_health_logs_composite_index.sql
+++ b/packages/db/migrations/072_health_logs_composite_index.sql
@@ -1,0 +1,9 @@
+-- The v0.23.1 health check reads the latest state for each LINE account every
+-- five minutes. The previous line_account_id-only index still had to scan and
+-- sort the account's full history before returning LIMIT 1.
+CREATE INDEX IF NOT EXISTS idx_health_logs_account_created_at
+  ON account_health_logs (line_account_id, created_at DESC);
+
+-- The composite index covers lookups by line_account_id as its leftmost
+-- prefix, so retaining the old index would only add write and storage cost.
+DROP INDEX IF EXISTS idx_health_logs_account;

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -810,7 +810,8 @@ CREATE TABLE IF NOT EXISTS account_health_logs (
   created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
 );
 
-CREATE INDEX IF NOT EXISTS idx_health_logs_account ON account_health_logs (line_account_id);
+CREATE INDEX IF NOT EXISTS idx_health_logs_account_created_at
+  ON account_health_logs (line_account_id, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS account_migrations (
   id               TEXT PRIMARY KEY,

--- a/packages/db/test/072_health_logs_composite_index.test.ts
+++ b/packages/db/test/072_health_logs_composite_index.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const MIGRATION_PATH = join(PKG_ROOT, 'migrations', '072_health_logs_composite_index.sql');
+const LATEST_HEALTH_QUERY = `
+  SELECT *
+    FROM account_health_logs
+   WHERE line_account_id = ?
+   ORDER BY created_at DESC
+   LIMIT ?
+`;
+
+function legacyDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE account_health_logs (
+      id              TEXT PRIMARY KEY,
+      line_account_id TEXT NOT NULL,
+      error_code      INTEGER,
+      error_count     INTEGER NOT NULL DEFAULT 0,
+      check_period    TEXT NOT NULL,
+      risk_level      TEXT NOT NULL DEFAULT 'normal',
+      created_at      TEXT NOT NULL
+    );
+    CREATE INDEX idx_health_logs_account
+      ON account_health_logs (line_account_id);
+  `);
+
+  const insert = db.prepare(`
+    INSERT INTO account_health_logs
+      (id, line_account_id, error_count, check_period, risk_level, created_at)
+    VALUES (?, ?, 0, ?, 'normal', ?)
+  `);
+  const insertMany = db.transaction(() => {
+    for (let index = 0; index < 1_000; index += 1) {
+      const timestamp = `2026-08-${String((index % 28) + 1).padStart(2, '0')}T${String(index % 24).padStart(2, '0')}:00:00.000+09:00`;
+      insert.run(`log-${index}`, 'account-1', timestamp, timestamp);
+    }
+  });
+  insertMany();
+  return db;
+}
+
+describe('migration 072_health_logs_composite_index', () => {
+  it('uses the composite index for the v0.23.1 latest-state query', () => {
+    const db = legacyDb();
+    db.exec(readFileSync(MIGRATION_PATH, 'utf8'));
+
+    const plan = db
+      .prepare(`EXPLAIN QUERY PLAN ${LATEST_HEALTH_QUERY}`)
+      .all('account-1', 1) as Array<{ detail: string }>;
+
+    expect(plan.map(({ detail }) => detail).join('\n')).toContain(
+      'USING INDEX idx_health_logs_account_created_at (line_account_id=?)',
+    );
+    expect(plan.map(({ detail }) => detail).join('\n')).not.toContain('USE TEMP B-TREE');
+    db.close();
+  });
+
+  it('removes the redundant line_account_id-only index', () => {
+    const db = legacyDb();
+    db.exec(readFileSync(MIGRATION_PATH, 'utf8'));
+
+    const indexes = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type = 'index' ORDER BY name`)
+      .all() as Array<{ name: string }>;
+
+    expect(indexes.map(({ name }) => name)).toContain('idx_health_logs_account_created_at');
+    expect(indexes.map(({ name }) => name)).not.toContain('idx_health_logs_account');
+    db.close();
+  });
+
+  it('is idempotent and safe to re-apply', () => {
+    const db = legacyDb();
+    const migration = readFileSync(MIGRATION_PATH, 'utf8');
+
+    expect(() => db.exec(migration)).not.toThrow();
+    expect(() => db.exec(migration)).not.toThrow();
+    db.close();
+  });
+});


### PR DESCRIPTION
## 背景

v0.23.1でヘルス状態の重複保存を止めるため、5分ごとにアカウント別の最新履歴1件を参照するようになりました。しかし既存インデックスは line_account_id 単独で、履歴が多い環境では created_at DESC LIMIT 1 のために過去行を広く読み取り、D1 rows_readを大量消費していました。

Private PR: Shudesu/line-harness#184

## 変更

- (line_account_id, created_at DESC) の複合インデックスを追加
- 左端列が重複する旧単独インデックスを削除
- 既存環境向けマイグレーション 072 を追加
- 新規環境向け schema / bootstrap を更新
- EXPLAIN QUERY PLANで複合インデックス利用と一時ソート非発生を固定する回帰テストを追加

## 検証

- OSS同期dry-runとシークレット検査を通過
- OSS packages/db: 20 files / 161 tests passed
- Private worker: 117 files / 1265 tests passed
- DB/Worker typecheck passed
- Worker/Web production build passed
- bootstrap --check / git diff --check passed

## ロールアウト / ロールバック

既存ログの削除は不要です。マイグレーションは新しい複合インデックスを作成してから旧単独インデックスを削除します。ロールバックが必要な場合は旧単独インデックスを再作成し、複合インデックスを削除できます。

Migration変更のため、merge前にsandbox D1でsmokeを実施します。