### PR TITLE
test(web): Kumo Select移行後の流入タグ配線テストを更新

### DIFF
--- a/scripts/inflow-link-tag-ui.test.ts
+++ b/scripts/inflow-link-tag-ui.test.ts
@@ -31,8 +31,12 @@ describe('inflow link tag auto-assignment UI wiring', () => {
     expect(modal).toContain('tagId: route?.tagId ?? null');
     expect(modal).toContain('自動付与タグ（任意）');
     expect(modal).toContain('value={form.tagId ?? \'\'}');
-    expect(modal).toContain('tagId: e.target.value || null');
+    expect(modal).toContain(
+      'onValueChange={(value) => setForm({ ...form, tagId: value || null })}',
+    );
     expect(modal).toContain('友だち追加時にこのタグを自動付与します');
-    expect(modal).toContain('tags.map((tag) => (');
+    expect(modal).toContain(
+      'items={Object.fromEntries(tags.map((tag) => [tag.id, tag.name]))}',
+    );
   });
 });


### PR DESCRIPTION
v0.23.2 Release workflowで、Kumo Select移行前のDOM文字列を期待するOSS専用source-level testが失敗したため、現行のonValueChange / items配線を検証するよう更新します。

- 製品コード変更なし
- pnpm test:scripts: 44 tests passed
- git diff --check passed