### PR TITLE
sync: LINEプランクォータ監視 + プロキシ429 source/reason (private 2026-09-02)

### DIFF
--- a/apps/web/src/app/broadcasts/page.tsx
+++ b/apps/web/src/app/broadcasts/page.tsx
@@ -200,7 +200,12 @@ function BroadcastList() {
                         </div>
                         <p className="mt-0.5 text-xs text-kumo-subtle">{broadcast.messageType === 'text' ? 'テキスト' : broadcast.messageType === 'image' ? '画像' : 'Flex'}</p>
                       </Table.Cell>
-                      <Table.Cell><Badge variant={status.variant} appearance="dot">{status.label}</Badge></Table.Cell>
+                      <Table.Cell>
+                        <Badge variant={status.variant} appearance="dot">{status.label}</Badge>
+                        {broadcast.lastError ? (
+                          <p className="mt-1 max-w-56 text-xs text-kumo-danger" title={broadcast.lastError}>{broadcast.lastError}</p>
+                        ) : null}
+                      </Table.Cell>
                       <Table.Cell>{isDedup ? `重複除外${tagName ? `：${tagName}` : ''}` : broadcast.targetType === 'all' ? '全員' : tagName ? `タグ：${tagName}` : 'タグ指定'}</Table.Cell>
                       <Table.Cell className="text-kumo-subtle">{formatDatetime(broadcast.scheduledAt)}</Table.Cell>
                       <Table.Cell className="text-kumo-subtle">{formatDatetime(broadcast.sentAt)}</Table.Cell>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,11 +3,13 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { api } from '@/lib/api'
+import type { AccountDeliveryHealth } from '@/lib/api'
 import { getApiBase } from '@/lib/api-base'
 import CcPromptButton from '@/components/cc-prompt-button'
 import { useAccount } from '@/contexts/account-context'
 import Header from '@/components/layout/header'
-import { HarnessStatCard } from '@/components/ui/harness-ui'
+import { formatCount, HarnessStatCard, HarnessStatCell } from '@/components/ui/harness-ui'
+import type { HarnessStatCellTone } from '@/components/ui/harness-ui'
 import { Badge } from '@cloudflare/kumo/components/badge'
 import { Banner } from '@cloudflare/kumo/components/banner'
 import { Button } from '@cloudflare/kumo/components/button'
@@ -100,6 +102,159 @@ function FriendAddLinkCard() {
   )
 }
 
+/** "+5" / "−3" / "±0"; null (insight not ready) renders as em dash. */
+function formatDelta(value: number | null): string {
+  if (value === null) return '—'
+  if (value > 0) return `+${value.toLocaleString('ja-JP')}`
+  if (value < 0) return `−${Math.abs(value).toLocaleString('ja-JP')}`
+  return '±0'
+}
+
+/** "20260901" → "9/1" for the compact as-of label. */
+function formatInsightDate(yyyyMmDd: string | null): string | null {
+  if (!yyyyMmDd || !/^\d{8}$/.test(yyyyMmDd)) return null
+  return `${Number(yyyyMmDd.slice(4, 6))}/${Number(yyyyMmDd.slice(6, 8))}`
+}
+
+/** Success/danger tone for a day-over-day delta; ±0 and unknown stay muted. */
+function deltaTone(delta: number | null, upIsGood: boolean): HarnessStatCellTone | undefined {
+  if (delta === null || delta === 0) return undefined
+  return (upIsGood ? delta > 0 : delta < 0) ? 'positive' : 'negative'
+}
+
+/**
+ * Quota cell contents. Precedence, most-specific first: unlimited plan →
+ * remaining computable → fetch failed. A limited plan whose consumption call
+ * failed lands in the last branch (value —, alert) so a broken quota fetch is
+ * as loud as a real shortage — the 2026-09-01 incident was invisible data.
+ */
+function quotaCell(account: AccountDeliveryHealth): { value: string; sub?: string; alert: boolean } {
+  const { quota, quotaAlert, errors } = account
+  if (quota.type === 'none') {
+    return { value: '∞', sub: '上限なしプラン', alert: false }
+  }
+  if (quota.remaining !== null) {
+    return {
+      value: formatCount(quota.remaining),
+      sub: `上限 ${formatCount(quota.limit)} ・消費 ${formatCount(quota.consumption)}`,
+      alert: quotaAlert,
+    }
+  }
+  const fetchFailed = errors.includes('quota') || errors.includes('consumption')
+  return { value: '—', sub: fetchFailed ? '取得失敗（要確認）' : undefined, alert: fetchFailed }
+}
+
+/** Sub line for the insight cells: delta when ready, otherwise why not. */
+function insightSub(account: AccountDeliveryHealth, delta: number | null): string {
+  if (account.insight.status === 'ready') return `前日比 ${formatDelta(delta)}`
+  return account.insight.status === 'unready' ? 'LINE集計待ち' : '取得失敗'
+}
+
+// 2026-09-01 の一斉配信事故（2アカウントがクォータ不足で全滅、UI 上どこにも
+// 出ていなかった）を受けたセクション。クォータはリアルタイム、友だち/ブロックの
+// インサイトは LINE 側の集計が前日分までなので as-of がずれる点をラベルで明示する。
+function DeliveryHealthSection() {
+  const [health, setHealth] = useState<AccountDeliveryHealth[] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const res = await api.lineAccounts.deliveryHealth()
+        if (cancelled) return
+        if (res.success) {
+          setHealth(res.data.accounts)
+        } else {
+          setError('配信健全性の取得に失敗しました')
+        }
+      } catch {
+        if (!cancelled) setError('配信健全性の取得に失敗しました')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (!loading && !error && (health?.length ?? 0) === 0) return null
+
+  return (
+    <section className="mb-6" aria-label="配信健全性">
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-semibold text-kumo-strong">アカウント別 配信健全性</h2>
+        <p className="text-[11px] text-kumo-subtle">クォータ=リアルタイム / 友だち・ブロック=前日時点</p>
+      </div>
+
+      {error ? (
+        <Banner variant="alert" title="配信健全性を読み込めませんでした" description={error} />
+      ) : null}
+
+      {loading ? (
+        <LayerCard className="p-4">
+          <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} className="h-20 animate-pulse rounded-lg bg-gray-100" />
+            ))}
+          </div>
+        </LayerCard>
+      ) : (
+        <div className="space-y-3">
+          {health?.map((account) => {
+            const asOf = formatInsightDate(account.insight.date)
+            const quota = quotaCell(account)
+            return (
+              <LayerCard key={account.lineAccountId} className="p-4">
+                <div className="mb-3 flex items-center gap-2">
+                  <p className="text-sm font-semibold text-kumo-strong">{account.name}</p>
+                  {account.quotaAlert ? (
+                    <Badge variant="error">クォータ不足: 全員配信不可</Badge>
+                  ) : account.errors.length > 0 ? (
+                    <Badge variant="neutral">一部データ取得失敗</Badge>
+                  ) : account.insight.status === 'unready' ? (
+                    <Badge variant="neutral">インサイト集計待ち</Badge>
+                  ) : (
+                    <Badge variant="success">正常</Badge>
+                  )}
+                </div>
+                <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
+                  <HarnessStatCell
+                    title="配信クォータ 残り"
+                    value={quota.value}
+                    sub={quota.sub}
+                    alert={quota.alert}
+                  />
+                  <HarnessStatCell
+                    title={asOf ? `友だち数 (${asOf})` : '友だち数'}
+                    value={formatCount(account.insight.followers)}
+                    sub={insightSub(account, account.insight.followersDelta)}
+                    subTone={deltaTone(account.insight.followersDelta, true)}
+                  />
+                  <HarnessStatCell
+                    title={asOf ? `ブロック数 (${asOf})` : 'ブロック数'}
+                    value={formatCount(account.insight.blocks)}
+                    sub={insightSub(account, account.insight.blocksDelta)}
+                    subTone={deltaTone(account.insight.blocksDelta, false)}
+                  />
+                  <HarnessStatCell
+                    title="今月の配信済み通数"
+                    value={formatCount(account.messagesThisMonth)}
+                    sub="push配信のみ・月初から"
+                  />
+                </div>
+              </LayerCard>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}
+
 export default function DashboardPage() {
   const { selectedAccountId, selectedAccount } = useAccount()
   const [stats, setStats] = useState<DashboardStats>({
@@ -174,6 +329,8 @@ export default function DashboardPage() {
       />
 
       {error && <Banner className="mb-6" variant="error" title="データを読み込めませんでした" description={error} />}
+
+      <DeliveryHealthSection />
 
       <FriendAddLinkCard />
 

--- a/apps/web/src/components/ui/harness-ui.tsx
+++ b/apps/web/src/components/ui/harness-ui.tsx
@@ -48,6 +48,50 @@ export function HarnessPageHeader({
   )
 }
 
+/** Shared count formatting for stat cards/cells: null renders as an em dash. */
+export function formatCount(value: number | null): string {
+  return value !== null ? value.toLocaleString('ja-JP') : '—'
+}
+
+export type HarnessStatCellTone = 'positive' | 'negative'
+
+export interface HarnessStatCellProps {
+  title: string
+  value: string
+  sub?: string
+  /** Alert state paints the whole cell in danger tokens and wins over subTone. */
+  alert?: boolean
+  subTone?: HarnessStatCellTone
+}
+
+/**
+ * Compact stat tile for dense per-entity grids (e.g. the dashboard's
+ * delivery-health cards) — the small sibling of HarnessStatCard, which is a
+ * full-size linked card.
+ */
+export function HarnessStatCell({ title, value, sub, alert = false, subTone }: HarnessStatCellProps) {
+  const subClass = alert
+    ? 'text-kumo-danger'
+    : subTone === 'positive'
+      ? 'text-kumo-success'
+      : subTone === 'negative'
+        ? 'text-kumo-danger'
+        : 'text-kumo-subtle'
+  return (
+    <div
+      className={`rounded-lg border p-3 ${
+        alert ? 'border-kumo-danger bg-kumo-danger-tint' : 'border-kumo-line bg-kumo-tint'
+      }`}
+    >
+      <p className={`text-xs font-medium ${alert ? 'text-kumo-danger' : 'text-kumo-subtle'}`}>{title}</p>
+      <p className={`mt-1 text-xl font-bold tabular-nums ${alert ? 'text-kumo-danger' : 'text-kumo-strong'}`}>
+        {value}
+      </p>
+      {sub ? <p className={`mt-0.5 text-[11px] ${subClass}`}>{sub}</p> : null}
+    </div>
+  )
+}
+
 export interface HarnessStatCardProps {
   title: string
   value: number | null
@@ -83,7 +127,7 @@ export function HarnessStatCard({
               <div className="h-8 w-20 animate-pulse rounded bg-gray-100" />
             ) : (
               <p className="text-3xl font-bold tabular-nums text-gray-900">
-                {value !== null ? value.toLocaleString('ja-JP') : '—'}
+                {formatCount(value)}
               </p>
             )}
             {subtitle && !loading ? <p className="mt-1 text-xs text-gray-400">{subtitle}</p> : null}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -35,6 +35,31 @@ import type {
 } from '@line-crm/shared'
 import { getApiBase } from './api-base'
 
+/** Per-account delivery-health snapshot for the dashboard cards. */
+export type AccountDeliveryHealth = {
+  lineAccountId: string
+  name: string
+  quota: {
+    type: string | null
+    limit: number | null
+    consumption: number | null
+    remaining: number | null
+  }
+  quotaAlert: boolean
+  insight: {
+    /** 'unready' = LINE がまだ前日分を集計していない状態（失敗とは別物） */
+    status: 'ready' | 'unready' | 'error'
+    date: string | null
+    followers: number | null
+    targetedReaches: number | null
+    blocks: number | null
+    followersDelta: number | null
+    blocksDelta: number | null
+  }
+  messagesThisMonth: number | null
+  errors: string[]
+}
+
 /** Affiliate offer (案件) as returned by the worker. */
 export type AffiliateOffer = {
   id: string
@@ -619,6 +644,10 @@ export const api = {
   lineAccounts: {
     list: () =>
       fetchApi<ApiResponse<LineAccount[]>>('/api/line-accounts'),
+    deliveryHealth: () =>
+      fetchApi<ApiResponse<{ insightDate: string; accounts: AccountDeliveryHealth[] }>>(
+        '/api/line-accounts/delivery-health',
+      ),
     get: (id: string) =>
       fetchApi<ApiResponse<LineAccount>>(`/api/line-accounts/${id}`),
     create: (data: {

--- a/apps/worker/src/durable-objects/tenant-scheduler.ts
+++ b/apps/worker/src/durable-objects/tenant-scheduler.ts
@@ -37,6 +37,16 @@ import type { Env } from '../index.js';
 /** 分足 cron ("* * * * *") と同じ粒度で自分自身を再アームする間隔。 */
 export const SCHEDULER_TICK_INTERVAL_MS = 60_000;
 
+/**
+ * 次の分境界 (UTC 分の頭) にアラインしたアラーム時刻。`now + 60s` で再アーム
+ * すると alarm 発火レイテンシぶんずつ tick が毎回前方へドリフトし、繰り上がりが
+ * 分0をまたいだ時間帯は isHourlyTick (毎時クォータチェック) 等の「特定の分」判定が
+ * silent にスキップされる。分境界に張り直せばドリフトは毎 tick リセットされる。
+ */
+export function nextMinuteBoundary(nowMs: number): number {
+  return (Math.floor(nowMs / SCHEDULER_TICK_INTERVAL_MS) + 1) * SCHEDULER_TICK_INTERVAL_MS;
+}
+
 /** DO インスタンスは1テナントにつき1つで足りるので固定名で解決する。 */
 export const SCHEDULER_INSTANCE_NAME = 'scheduler';
 
@@ -87,8 +97,9 @@ export async function runSchedulerTick(
   runJobs: RunSchedulerJobs,
   now: Date = new Date(),
 ): Promise<void> {
-  // 1. 再アーム最優先。work の成否を待たない。
-  await storage.setAlarm(now.getTime() + SCHEDULER_TICK_INTERVAL_MS);
+  // 1. 再アーム最優先。work の成否を待たない。分境界アライン (nextMinuteBoundary
+  //    のコメント参照) — ドリフトで毎時 tick が飛ばないように。
+  await storage.setAlarm(nextMinuteBoundary(now.getTime()));
 
   // 2. 実ジョブ。cron trigger が発火したときと同じ event 形を渡し、
   //    scheduled() 内の event.cron 分岐 (mileage キュー / 6h ジョブ) を
@@ -118,7 +129,7 @@ export async function ensureAlarmArmed(
 ): Promise<boolean> {
   const existing = await storage.getAlarm();
   if (existing !== null) return false;
-  await storage.setAlarm(now.getTime() + SCHEDULER_TICK_INTERVAL_MS);
+  await storage.setAlarm(nextMinuteBoundary(now.getTime()));
   return true;
 }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -41,9 +41,11 @@ import { scoring } from './routes/scoring.js';
 import { templates } from './routes/templates.js';
 import { chats } from './routes/chats.js';
 import { conversations } from './routes/conversations.js';
-// notifications ルート (notification_rules CRUD + notifications 一覧) は
-// インボックス機能 (/api/inbox/unanswered) に置き換えたため削除。
-// DB テーブル notification_rules / notifications は archive 目的で残してある。
+// notifications ルート: 一度インボックス機能 (/api/inbox/unanswered) に置き換えて
+// 削除したが、クォータ不足通知 (services/quota-alert.ts, 2026-09-01 事故対応) が
+// notifications / notification_rules に書き込むようになったため再マウント。
+// 書き込み側だけ復活して読み手が居ないと「通知したつもり」になるのが最悪のため。
+import { notifications } from './routes/notifications.js';
 import { stripe } from './routes/stripe.js';
 import { health } from './routes/health.js';
 import { automations } from './routes/automations.js';
@@ -223,6 +225,7 @@ app.route('/', reminders);
 app.route('/', scoring);
 app.route('/', templates);
 app.route('/', chats);
+app.route('/', notifications);
 app.route('/', conversations);
 app.route('/', stripe);
 app.route('/', health);

--- a/apps/worker/src/routes/broadcasts.ts
+++ b/apps/worker/src/routes/broadcasts.ts
@@ -9,6 +9,7 @@ import {
 import type { Broadcast as DbBroadcast, BroadcastMessageType, BroadcastTargetType } from '@line-crm/db';
 import { LineClient } from '@line-crm/line-sdk';
 import { processBroadcastSend, buildMessage, processQueuedBroadcasts } from '../services/broadcast.js';
+import { LinePlanQuotaError } from '../services/quota-alert.js';
 import {
   getQuotaUsage,
   wouldExceedMonthlyQuota,
@@ -133,6 +134,8 @@ function serializeBroadcast(row: DbBroadcast) {
     failedAccountIds: parseJsonArray(r.failed_account_ids),
     // 046 以前の行/未マイグレーション環境では undefined → 従来挙動 (ON) 扱い
     trackLinks: row.track_links === undefined ? true : row.track_links !== 0,
+    // 直近の送信失敗理由 (クォータ不足ガード等)。送信成功で null に戻る。
+    lastError: (r.last_error as string | undefined) ?? null,
     createdAt: row.created_at,
   };
 }
@@ -843,6 +846,12 @@ broadcasts.post('/api/broadcasts/:id/send', async (c) => {
     const result = await getBroadcastById(c.env.DB, id);
     return c.json({ success: true, data: result ? serializeBroadcast(result) : null });
   } catch (err) {
+    // LINE プランのクォータ不足ガード (services/broadcast.ts) の typed error。
+    // オペレーターには 500 ではなく理由を返す (詳細は broadcasts.last_error にも
+    // 記録済み)。
+    if (err instanceof LinePlanQuotaError) {
+      return c.json({ success: false, error: 'line_plan_quota_insufficient' }, 403);
+    }
     console.error('POST /api/broadcasts/:id/send error:', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }

--- a/apps/worker/src/routes/line-accounts.test.ts
+++ b/apps/worker/src/routes/line-accounts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { describe, expect, test, beforeEach, afterEach, vi } from 'vitest';
 import { Hono } from 'hono';
 
 // Mock @line-crm/db so we can assert on the values the route forwards to the
@@ -22,6 +22,8 @@ vi.mock('@line-crm/db', () => dbMocks);
 const lineClientMocks = {
   getFollowersInsight: vi.fn(),
   getFollowerIds: vi.fn(),
+  getMessageQuota: vi.fn(),
+  getMessageQuotaConsumption: vi.fn(),
 };
 vi.mock('@line-crm/line-sdk', () => ({
   LineClient: vi.fn().mockImplementation(() => lineClientMocks),
@@ -84,6 +86,8 @@ beforeEach(() => {
   for (const fn of Object.values(dbMocks)) fn.mockReset();
   lineClientMocks.getFollowersInsight.mockReset();
   lineClientMocks.getFollowerIds.mockReset();
+  lineClientMocks.getMessageQuota.mockReset();
+  lineClientMocks.getMessageQuotaConsumption.mockReset();
   dbMocks.getAccountSetting.mockResolvedValue(null);
   dbMocks.setAccountSetting.mockResolvedValue(undefined);
   dbMocks.jstNow.mockReturnValue('2026-08-10T12:00:00.000+09:00');
@@ -210,6 +214,222 @@ describe('GET /api/line-accounts/:id/follower-insight', () => {
 
     expect(res.status).toBe(400);
     expect(lineClientMocks.getFollowersInsight).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/line-accounts/delivery-health', () => {
+  // Freeze time so insight dates are deterministic and the followers-insight
+  // mock can be keyed on the requested date (order-independent):
+  // 2026-09-02T03:00Z = 2026-09-02 12:00 JST → yesterday 20260901, before 20260831.
+  const YESTERDAY = '20260901';
+  const DAY_BEFORE = '20260831';
+  beforeEach(() => {
+    vi.useFakeTimers({ now: new Date('2026-09-02T03:00:00Z'), toFake: ['Date'] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** SQL-sniffing D1 stub: monthly log rows / all-target broadcasts / friend count. */
+  function makeCountsDb(counts: { log?: number; broadcast?: number; friends?: number }): D1Database {
+    return {
+      prepare: (sql: string) => ({
+        bind: () => ({
+          first: async () => {
+            if (sql.includes('FROM messages_log')) return { count: counts.log ?? 0 };
+            if (sql.includes('FROM broadcasts')) return { count: counts.broadcast ?? 0 };
+            if (sql.includes('FROM friends')) return { count: counts.friends ?? 0 };
+            return null;
+          },
+        }),
+      }),
+    } as unknown as D1Database;
+  }
+
+  function mockInsightByDate(
+    byDate: Record<string, { status: string; followers?: number; targetedReaches?: number; blocks?: number }>,
+  ) {
+    lineClientMocks.getFollowersInsight.mockImplementation((date: string) =>
+      byDate[date] ? Promise.resolve(byDate[date]) : Promise.reject(new Error(`no insight for ${date}`)),
+    );
+  }
+
+  test('returns quota, insight deltas, monthly count and flags quota shortage', async () => {
+    dbMocks.getLineAccounts.mockResolvedValue([fakeAccount]);
+    lineClientMocks.getMessageQuota.mockResolvedValue({ type: 'limited', value: 300 });
+    lineClientMocks.getMessageQuotaConsumption.mockResolvedValue({ totalUsage: 260 });
+    mockInsightByDate({
+      [YESTERDAY]: { status: 'ready', followers: 120, targetedReaches: 100, blocks: 8 },
+      [DAY_BEFORE]: { status: 'ready', followers: 115, targetedReaches: 96, blocks: 5 },
+    });
+
+    const app = setupApp('owner', makeCountsDb({ log: 40, broadcast: 2, friends: 110 }));
+    const res = await app.request('/api/line-accounts/delivery-health');
+
+    expect(res.status).toBe(200);
+    const raw = await res.text();
+    expect(raw).not.toContain(fakeAccount.channel_access_token);
+    expect(raw).not.toContain(fakeAccount.channel_secret);
+
+    const body = JSON.parse(raw) as {
+      success: boolean;
+      data: { insightDate: string; accounts: Array<Record<string, unknown>> };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.insightDate).toBe(YESTERDAY);
+    expect(body.data.accounts).toHaveLength(1);
+    expect(body.data.accounts[0]).toMatchObject({
+      lineAccountId: 'acc-1',
+      name: 'メイン',
+      quota: { type: 'limited', limit: 300, consumption: 260, remaining: 40 },
+      // remaining 40 < targetedReaches 100 → an all-target send cannot complete
+      quotaAlert: true,
+      insight: {
+        status: 'ready',
+        date: YESTERDAY,
+        followers: 120,
+        targetedReaches: 100,
+        blocks: 8,
+        followersDelta: 5,
+        blocksDelta: 3,
+      },
+      // 40 log rows + 2 all-target broadcast recipients
+      messagesThisMonth: 42,
+      errors: [],
+    });
+  });
+
+  test('unlimited plan (type=none) yields null limit and no alert', async () => {
+    dbMocks.getLineAccounts.mockResolvedValue([fakeAccount]);
+    lineClientMocks.getMessageQuota.mockResolvedValue({ type: 'none' });
+    lineClientMocks.getMessageQuotaConsumption.mockResolvedValue({ totalUsage: 5000 });
+    mockInsightByDate({
+      [YESTERDAY]: { status: 'ready', followers: 10, targetedReaches: 9, blocks: 1 },
+      [DAY_BEFORE]: { status: 'ready', followers: 10, targetedReaches: 9, blocks: 1 },
+    });
+
+    const app = setupApp('owner', makeCountsDb({}));
+    const res = await app.request('/api/line-accounts/delivery-health');
+
+    const body = (await res.json()) as { data: { accounts: Array<Record<string, unknown>> } };
+    expect(body.data.accounts[0]).toMatchObject({
+      quota: { type: 'none', limit: null, consumption: 5000, remaining: null },
+      quotaAlert: false,
+    });
+  });
+
+  test('failing quota calls degrade to null with errors recorded; unready insight is a distinct status', async () => {
+    dbMocks.getLineAccounts.mockResolvedValue([fakeAccount]);
+    lineClientMocks.getMessageQuota.mockRejectedValue(new Error('LINE API error: 401'));
+    lineClientMocks.getMessageQuotaConsumption.mockRejectedValue(new Error('LINE API error: 401'));
+    mockInsightByDate({
+      [YESTERDAY]: { status: 'unready' },
+      [DAY_BEFORE]: { status: 'unready' },
+    });
+
+    const app = setupApp('owner', makeCountsDb({ log: 3 }));
+    const res = await app.request('/api/line-accounts/delivery-health');
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { accounts: Array<Record<string, unknown>> } };
+    expect(body.data.accounts[0]).toMatchObject({
+      quota: { type: null, limit: null, consumption: null, remaining: null },
+      quotaAlert: false,
+      insight: {
+        status: 'unready',
+        date: null,
+        followers: null,
+        targetedReaches: null,
+        blocks: null,
+        followersDelta: null,
+        blocksDelta: null,
+      },
+      messagesThisMonth: 3,
+    });
+    // Fulfilled-but-unready is NOT an error — only the real failures are.
+    expect(body.data.accounts[0].errors).toEqual(['quota', 'consumption']);
+  });
+
+  test('quota exhaustion still alerts when the insight is unready (DB friend-count fallback)', async () => {
+    dbMocks.getLineAccounts.mockResolvedValue([fakeAccount]);
+    lineClientMocks.getMessageQuota.mockResolvedValue({ type: 'limited', value: 300 });
+    lineClientMocks.getMessageQuotaConsumption.mockResolvedValue({ totalUsage: 280 });
+    mockInsightByDate({
+      [YESTERDAY]: { status: 'unready' },
+      [DAY_BEFORE]: { status: 'unready' },
+    });
+
+    // remaining 20 < 50 following friends in DB → alert even without insight
+    const app = setupApp('owner', makeCountsDb({ friends: 50 }));
+    const res = await app.request('/api/line-accounts/delivery-health');
+
+    const body = (await res.json()) as { data: { accounts: Array<Record<string, unknown>> } };
+    expect(body.data.accounts[0]).toMatchObject({
+      quota: { remaining: 20 },
+      quotaAlert: true,
+    });
+  });
+
+  test('remaining 0 alerts even when no audience estimate is available', async () => {
+    dbMocks.getLineAccounts.mockResolvedValue([fakeAccount]);
+    lineClientMocks.getMessageQuota.mockResolvedValue({ type: 'limited', value: 300 });
+    lineClientMocks.getMessageQuotaConsumption.mockResolvedValue({ totalUsage: 300 });
+    mockInsightByDate({
+      [YESTERDAY]: { status: 'unready' },
+      [DAY_BEFORE]: { status: 'unready' },
+    });
+
+    const app = setupApp('owner', makeCountsDb({ friends: 0 }));
+    const res = await app.request('/api/line-accounts/delivery-health');
+
+    const body = (await res.json()) as { data: { accounts: Array<Record<string, unknown>> } };
+    expect(body.data.accounts[0]).toMatchObject({
+      quota: { remaining: 0 },
+      quotaAlert: true,
+    });
+  });
+
+  test('a failing day-before insight call is recorded in errors, deltas stay null', async () => {
+    dbMocks.getLineAccounts.mockResolvedValue([fakeAccount]);
+    lineClientMocks.getMessageQuota.mockResolvedValue({ type: 'limited', value: 300 });
+    lineClientMocks.getMessageQuotaConsumption.mockResolvedValue({ totalUsage: 10 });
+    mockInsightByDate({
+      [YESTERDAY]: { status: 'ready', followers: 120, targetedReaches: 100, blocks: 8 },
+      // DAY_BEFORE missing → the mock rejects that call
+    });
+
+    const app = setupApp('owner', makeCountsDb({ friends: 100 }));
+    const res = await app.request('/api/line-accounts/delivery-health');
+
+    const body = (await res.json()) as { data: { accounts: Array<Record<string, unknown>> } };
+    expect(body.data.accounts[0]).toMatchObject({
+      insight: {
+        status: 'ready',
+        followers: 120,
+        followersDelta: null,
+        blocksDelta: null,
+      },
+    });
+    expect(body.data.accounts[0].errors).toEqual(['prevInsight']);
+  });
+
+  test('skips inactive accounts', async () => {
+    dbMocks.getLineAccounts.mockResolvedValue([
+      fakeAccount,
+      { ...fakeAccount, id: 'acc-2', name: '停止中', is_active: 0 },
+    ]);
+    lineClientMocks.getMessageQuota.mockResolvedValue({ type: 'limited', value: 200 });
+    lineClientMocks.getMessageQuotaConsumption.mockResolvedValue({ totalUsage: 0 });
+    mockInsightByDate({
+      [YESTERDAY]: { status: 'unready' },
+      [DAY_BEFORE]: { status: 'unready' },
+    });
+
+    const app = setupApp('owner', makeCountsDb({}));
+    const res = await app.request('/api/line-accounts/delivery-health');
+
+    const body = (await res.json()) as { data: { accounts: Array<{ lineAccountId: string }> } };
+    expect(body.data.accounts.map((a) => a.lineAccountId)).toEqual(['acc-1']);
   });
 });
 

--- a/apps/worker/src/routes/line-accounts.ts
+++ b/apps/worker/src/routes/line-accounts.ts
@@ -19,7 +19,8 @@ import {
 } from '../services/follower-import.js';
 import type { FollowerImportClient } from '../services/follower-import.js';
 import type { Env } from '../index.js';
-import { monthStartJst } from '../services/quota.js';
+import { countAccountMonthlyMessages, jstYyyyMmDd } from '../services/quota.js';
+import { countDeliverableAudience } from '../services/quota-alert.js';
 
 const lineAccounts = new Hono<Env>();
 
@@ -111,17 +112,10 @@ lineAccounts.get('/api/line-accounts', async (c) => {
              INNER JOIN friends f ON f.id = fs.friend_id
              WHERE fs.status = 'active' AND f.line_account_id = ?`,
           ).bind(item.id).first<{ count: number }>(),
-          db.prepare(
-            // 「今月送信」(messagesThisMonth) は LINE 公式ダッシュボードの「配信済みの無料メッセージ数」と
-            // 揃える設計: push 系のみ + 当月 1 日 00:00 以降。reply API 経由 (1-on-1 chat) は LINE quota 外なので
-            // delivery_type='push' で除外。以前は date('now', '-30 days') の rolling window で月初に bias 残って
-            // 公式 dashboard と数桁ズレてた (例: 公式 10 通 vs UI 10,609 通) → start of month に揃えた。
-            // month start is computed in JST to match created_at (SQLite's
-            // date('now') is UTC and lags 9h behind on the 1st of the month).
-            `SELECT COUNT(*) as count FROM messages_log ml
-             INNER JOIN friends f ON f.id = ml.friend_id
-             WHERE ml.direction = 'outgoing' AND (ml.delivery_type IS NULL OR ml.delivery_type = 'push') AND ml.created_at >= ? AND f.line_account_id = ?`,
-          ).bind(monthStartJst(), item.id).first<{ count: number }>(),
+          // 「今月送信」(messagesThisMonth) は LINE 公式ダッシュボードの「配信済みの無料メッセージ数」に
+          // 近い概算 (マルチアカウント運用では NULL プール分だけ上振れする —
+          // countAccountMonthlyMessages の注意書き参照)。定義は services/quota.ts に一本化。
+          countAccountMonthlyMessages(db, item.id),
         ]);
 
         return {
@@ -132,7 +126,7 @@ lineAccounts.get('/api/line-accounts', async (c) => {
           stats: {
             friendCount: friendCount?.count ?? 0,
             activeScenarios: scenarioCount?.count ?? 0,
-            messagesThisMonth: msgCount?.count ?? 0,
+            messagesThisMonth: msgCount,
           },
         };
       }),
@@ -140,6 +134,167 @@ lineAccounts.get('/api/line-accounts', async (c) => {
     return c.json({ success: true, data: results });
   } catch (err) {
     console.error('GET /api/line-accounts error:', err);
+    return c.json({ success: false, error: 'Internal server error' }, 500);
+  }
+});
+
+/**
+ * LINE's insight endpoints have a low rate limit (60 requests/hour), and a
+ * followers insight that reached status 'ready' for a past date never changes
+ * again — so 'ready' results are kept in the Workers Cache for 6h to stop
+ * dashboard reloads from burning the budget. Non-ready results are never
+ * cached (LINE finishes aggregating during the day and we must retry).
+ * caches.default is absent under vitest/node, where the guard falls through
+ * to the live (mocked) client.
+ */
+async function getFollowersInsightCached(
+  client: LineClient,
+  lineAccountId: string,
+  date: string,
+): Promise<Awaited<ReturnType<LineClient['getFollowersInsight']>>> {
+  type Insight = Awaited<ReturnType<LineClient['getFollowersInsight']>>;
+  const cache = (globalThis as { caches?: { default?: Cache } }).caches?.default;
+  const key = `https://line-harness.internal/insight-cache/${encodeURIComponent(lineAccountId)}/${date}`;
+  if (cache) {
+    try {
+      const hit = await cache.match(key);
+      if (hit) return (await hit.json()) as Insight;
+    } catch {
+      // Cache read failures must never break the endpoint.
+    }
+  }
+  const insight = await client.getFollowersInsight(date);
+  if (cache && insight.status === 'ready') {
+    try {
+      await cache.put(
+        key,
+        new Response(JSON.stringify(insight), {
+          headers: { 'Content-Type': 'application/json', 'Cache-Control': 'public, max-age=21600' },
+        }),
+      );
+    } catch {
+      // Best-effort: a failed put just means the next request refetches.
+    }
+  }
+  return insight;
+}
+
+// GET /api/line-accounts/delivery-health — per-account broadcast-health snapshot
+// for the dashboard: LINE plan quota vs. this month's consumption, follower /
+// block counts with day-over-day deltas, and the harness-side monthly send count.
+//
+// Born from the 2026-09-01 incident where two accounts ran out of monthly quota
+// and every all-target send failed silently — the quota was visible nowhere in
+// the UI. quotaAlert flags the state where the remaining quota can no longer
+// cover one all-target broadcast (remaining < deliverable audience).
+//
+// IMPORTANT: declared BEFORE the /:id routes below so Hono matches the literal
+// "delivery-health" segment first (same ordering rule as PATCH /order).
+lineAccounts.get('/api/line-accounts/delivery-health', async (c) => {
+  try {
+    const db = c.env.DB;
+    const items = (await getLineAccounts(db)).filter((item) => item.is_active);
+    // audience フォールバックの NULL 行ポリシーは監視 (ban-monitor) ・送信ガードと
+    // 同じ定義に揃える: 単一アカウント運用では legacy NULL 行こそが友だちの本体。
+    // ここだけ厳密一致で数えると、insight 未取得時に audience≈0 → quotaAlert=false
+    // となり、ban-monitor が warning を出している状態でダッシュボードだけ正常表示になる。
+    const singleAccountInstall = items.length <= 1;
+    // LINE's followers insight is only 'ready' for completed JST days: ask for
+    // yesterday, and the day before for the day-over-day delta.
+    const insightDate = jstYyyyMmDd(1);
+    const prevInsightDate = jstYyyyMmDd(2);
+
+    const accounts = await Promise.all(
+      items.map(async (account) => {
+        const client = new LineClient(account.channel_access_token);
+        const [quotaRes, consumptionRes, insightRes, prevInsightRes, msgCountRes, friendCountRes] =
+          await Promise.allSettled([
+            client.getMessageQuota(),
+            client.getMessageQuotaConsumption(),
+            getFollowersInsightCached(client, account.id, insightDate),
+            getFollowersInsightCached(client, account.id, prevInsightDate),
+            countAccountMonthlyMessages(db, account.id),
+            countDeliverableAudience(db, account.id, singleAccountInstall),
+          ]);
+
+        // Partial failures degrade to null fields (one revoked token must not
+        // blank the whole dashboard). take() records every failure in errors
+        // so value extraction and error bookkeeping cannot drift apart, and
+        // the UI can say 取得失敗 instead of rendering a silent zero.
+        const errors: string[] = [];
+        const take = <T>(r: PromiseSettledResult<T>, name: string): T | null => {
+          if (r.status === 'fulfilled') return r.value;
+          errors.push(name);
+          return null;
+        };
+
+        const quota = take(quotaRes, 'quota');
+        const consumptionData = take(consumptionRes, 'consumption');
+        const insightRaw = take(insightRes, 'insight');
+        const prevInsightRaw = take(prevInsightRes, 'prevInsight');
+        const messagesThisMonth = take(msgCountRes, 'messagesThisMonth');
+        const deliverableFriendCount = take(friendCountRes, 'friendCount');
+
+        const limit =
+          quota?.type === 'limited' && typeof quota.value === 'number' ? quota.value : null;
+        const consumption = consumptionData?.totalUsage ?? null;
+        const remaining =
+          limit !== null && consumption !== null ? Math.max(0, limit - consumption) : null;
+
+        // 'unready' (LINE has not aggregated the day yet) is a distinct state
+        // from a failed call: the UI must render "集計待ち", not "正常".
+        const insightStatus: 'ready' | 'unready' | 'error' =
+          insightRaw === null ? 'error' : insightRaw.status === 'ready' ? 'ready' : 'unready';
+        const insight = insightStatus === 'ready' ? insightRaw : null;
+        const prevInsight = prevInsightRaw?.status === 'ready' ? prevInsightRaw : null;
+        const followers = insight?.followers ?? null;
+        const targetedReaches = insight?.targetedReaches ?? null;
+        const blocks = insight?.blocks ?? null;
+        const prevFollowers = prevInsight?.followers ?? null;
+        const prevBlocks = prevInsight?.blocks ?? null;
+
+        // "全員配信が不可能" check: an all-target broadcast costs one message per
+        // deliverable friend — targetedReaches (followers minus blocked). When
+        // the insight is unavailable, fall back to the DB following count
+        // (close to targetedReaches; the raw followers number would include
+        // blocked users and over-alert). remaining === 0 always alerts: with
+        // nothing left to send, no audience estimate is needed to know bulk
+        // sends will fail.
+        const audience = targetedReaches ?? deliverableFriendCount ?? null;
+        const quotaAlert =
+          quota?.type === 'limited' &&
+          remaining !== null &&
+          (remaining === 0 || (audience !== null && remaining < audience));
+
+        return {
+          lineAccountId: account.id,
+          name: account.name,
+          quota: {
+            type: quota?.type ?? null,
+            limit,
+            consumption,
+            remaining,
+          },
+          quotaAlert,
+          insight: {
+            status: insightStatus,
+            date: insight ? insightDate : null,
+            followers,
+            targetedReaches,
+            blocks,
+            followersDelta:
+              followers !== null && prevFollowers !== null ? followers - prevFollowers : null,
+            blocksDelta: blocks !== null && prevBlocks !== null ? blocks - prevBlocks : null,
+          },
+          messagesThisMonth,
+          errors,
+        };
+      }),
+    );
+
+    return c.json({ success: true, data: { insightDate, accounts } });
+  } catch (err) {
+    console.error('GET /api/line-accounts/delivery-health error:', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });

--- a/apps/worker/src/routes/line-proxy.test.ts
+++ b/apps/worker/src/routes/line-proxy.test.ts
@@ -3,6 +3,8 @@ import { Hono } from 'hono';
 
 const lineClientMocks = vi.hoisted(() => ({
   getProfile: vi.fn(),
+  getMessageQuota: vi.fn(),
+  getMessageQuotaConsumption: vi.fn(),
 }));
 
 vi.mock('@line-crm/db', () => ({
@@ -26,6 +28,18 @@ vi.mock('@line-crm/line-sdk', async () => {
     LineClient: vi.fn().mockImplementation(() => lineClientMocks),
   };
 });
+
+// LINE プランクォータのガード面。デフォルトは「不足なし」(null) — 既存テストの
+// 挙動を変えない。個別テストで shortfall を差し込む。
+const quotaAlertMocks = vi.hoisted(() => ({
+  getLinePlanQuotaShortfall: vi.fn(),
+  notifyQuotaAlert: vi.fn(),
+  allTargetGuardAudience: vi.fn(),
+  readPlanQuotaSnapshot: vi.fn(),
+  LINE_MONTHLY_LIMIT_MESSAGE: 'You have reached your monthly limit.',
+}));
+
+vi.mock('../services/quota-alert.js', () => quotaAlertMocks);
 
 // Keep the real shape of messageToLogPayload without dragging in the whole
 // step-delivery dependency graph.
@@ -177,6 +191,13 @@ beforeEach(() => {
   vi.mocked(getChatByFriendId).mockResolvedValue({ id: 'chat-1', status: 'unread' } as never);
   vi.mocked(updateChat).mockResolvedValue(undefined as never);
   vi.mocked(authenticateApiToken).mockResolvedValue(null as never);
+  quotaAlertMocks.getLinePlanQuotaShortfall.mockResolvedValue(null);
+  quotaAlertMocks.notifyQuotaAlert.mockResolvedValue(true);
+  quotaAlertMocks.allTargetGuardAudience.mockReturnValue(async () => 0);
+  // デフォルトは「quota 再取得が失敗」— 429 事後通知が合成 shortfall (limit=0) に落ちる経路
+  quotaAlertMocks.readPlanQuotaSnapshot.mockRejectedValue(new Error('not stubbed'));
+  lineClientMocks.getMessageQuota.mockRejectedValue(new Error('not stubbed'));
+  lineClientMocks.getMessageQuotaConsumption.mockRejectedValue(new Error('not stubbed'));
 });
 
 afterEach(() => {
@@ -893,6 +914,73 @@ describe('usage limit gate', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  /**
+   * ゲートが返す 429 が「LINE が止めた」のか「harness が止めた」のかを、
+   * 応答本文だけで判別できること。
+   *
+   * message は LINE の limit レスポンスと同じ文面のままにする（既存クライアントは
+   * これを読む）。同じ文面のままだと運用中に取り違えるので、source / reason を
+   * 足して由来と理由が分かるようにした。実際、本番で 1:1 送信が 429 になった際に
+   * 「LINE のプラン枠を使い切った」と誤って切り分けかけている
+   * （実際は LINE 側の別要因で、枠は 30,000 中 200 しか使っていなかった）。
+   */
+  describe('429 の由来が判別できる', () => {
+    test('月次上限超過: message は LINE 互換のまま、source/reason で harness 由来と分かる', async () => {
+      const { db } = fakeDb({ counts: { monthly: 5000 } });
+      const res = await setupApp().request(broadcastRequest(), {}, { ...env(db), ...quotaEnv });
+      expect(res.status).toBe(429);
+      const body = await res.json() as { message: string; source?: string; reason?: string };
+      expect(body.message).toBe('You have reached your monthly limit.');
+      expect(body.source).toBe('line-harness');
+      expect(body.reason).toBe('monthly-messages-exceeded');
+    });
+
+    test('友だち数上限で止めたときは monthly ではなく friends の reason を返す', async () => {
+      // usage.exceeded は友だち数上限でも立つ。ここで monthly-messages-exceeded を
+      // 返すと、運用者を「追加メッセージを買う」という誤った対処に誘導してしまう。
+      const { db } = fakeDb({ counts: { monthly: 0, friends: 11 } });
+      const res = await setupApp().request(
+        broadcastRequest(),
+        {},
+        { ...env(db), QUOTA_FRIENDS_MAX: '10' },
+      );
+      expect(res.status).toBe(429);
+      const body = await res.json() as { message: string; source?: string; reason?: string };
+      expect(body.source).toBe('line-harness');
+      expect(body.reason).toBe('friends-exceeded');
+      // message は既存クライアント互換のため据え置き（挙動を変えない）
+      expect(body.message).toBe('You have reached your monthly limit.');
+    });
+
+    test('narrowcast 拒否にも source/reason が付く', async () => {
+      const { db } = fakeDb({ counts: { monthly: 0 } });
+      const res = await setupApp().request(narrowcastRequest(), {}, { ...env(db), ...quotaEnv });
+      expect(res.status).toBe(429);
+      const body = await res.json() as { source?: string; reason?: string };
+      expect(body.source).toBe('line-harness');
+      expect(body.reason).toBe('narrowcast-unrecordable');
+    });
+
+    test('未登録チャネルからの broadcast 拒否にも source/reason が付く', async () => {
+      vi.mocked(getLineAccounts).mockResolvedValue([ACCOUNT, ACCOUNT_2] as never);
+      const { db } = fakeDb({ counts: { monthly: 0, friends: 1 } });
+      const res = await setupApp().request(broadcastRequest('env-token'), {}, { ...env(db), ...quotaEnv });
+      expect(res.status).toBe(429);
+      const body = await res.json() as { source?: string; reason?: string };
+      expect(body.source).toBe('line-harness');
+      expect(body.reason).toBe('broadcast-unregistered-channel');
+    });
+
+    test('未登録受信者が多すぎる multicast 拒否にも source/reason が付く', async () => {
+      const { db } = fakeDb({ counts: { monthly: 0, knownRecipients: 0 } });
+      const res = await setupApp().request(multicastRequest(25), {}, { ...env(db), ...quotaEnv });
+      expect(res.status).toBe(429);
+      const body = await res.json() as { source?: string; reason?: string };
+      expect(body.source).toBe('line-harness');
+      expect(body.reason).toBe('too-many-unregistered-recipients');
+    });
+  });
+
   test('monthly limit active (not exceeded): 1:1 push still passes', async () => {
     const { db } = fakeDb({ counts: { monthly: 0 } });
     const res = await setupApp().request(pushRequest('acc-token'), {}, { ...env(db), ...quotaEnv });
@@ -906,5 +994,220 @@ describe('usage limit gate', () => {
     expect(res.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(executed.filter((e) => e.sql.includes('COUNT(*) as count'))).toEqual([]);
+  });
+});
+
+describe('LINE plan quota guard (proxy bulk sends)', () => {
+  const SHORTFALL = { limit: 1000, consumption: 950, remaining: 50, audience: 300 };
+
+  function broadcastRequest(token = 'acc-token') {
+    return new Request('http://worker.test/line-api/v2/bot/message/broadcast', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: [{ type: 'text', text: 'to everyone' }] }),
+    });
+  }
+
+  function multicastRequest(recipients: number) {
+    return new Request('http://worker.test/line-api/v2/bot/message/multicast', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer acc-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        to: Array.from({ length: recipients }, (_, i) => U(0x700 + i)),
+        messages: [{ type: 'text', text: 'hi' }],
+      }),
+    });
+  }
+
+  test('broadcast: プラン不足が確定 → 通知して 429、上流は呼ばない (quotaEnv 未設定でも)', async () => {
+    quotaAlertMocks.getLinePlanQuotaShortfall.mockResolvedValue(SHORTFALL);
+    const { db } = fakeDb();
+    const res = await setupApp().request(broadcastRequest(), {}, env(db));
+
+    expect(res.status).toBe(429);
+    const body = await res.json() as { message: string; reason: string; quota: unknown };
+    expect(body.message).toBe('You have reached your monthly limit.');
+    expect(body.reason).toBe('line-plan-quota-insufficient');
+    expect(body.quota).toEqual(SHORTFALL);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(quotaAlertMocks.notifyQuotaAlert).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        lineAccountId: 'acc-1',
+        accountName: 'Main',
+        shortfall: SHORTFALL,
+        source: 'proxy-pre-send',
+      }),
+    );
+  });
+
+  test('未登録 env トークンは通知キー default で通知する', async () => {
+    quotaAlertMocks.getLinePlanQuotaShortfall.mockResolvedValue(SHORTFALL);
+    const { db } = fakeDb();
+    const res = await setupApp().request(broadcastRequest('env-token'), {}, env(db));
+
+    expect(res.status).toBe(429);
+    expect(quotaAlertMocks.notifyQuotaAlert).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ lineAccountId: 'default', source: 'proxy-pre-send' }),
+    );
+  });
+
+  test('multicast: audience は to のユニーク受信者数 (重複は過大計上しない)', async () => {
+    const { db } = fakeDb();
+    const [u1, u2] = [U(0x700), U(0x701)];
+    const res = await setupApp().request(
+      new Request('http://worker.test/line-api/v2/bot/message/multicast', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer acc-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to: [u1, u2, u1, 42], messages: [{ type: 'text', text: 'hi' }] }),
+      }),
+      {},
+      env(db),
+    );
+
+    expect(res.status).toBe(200);
+    expect(quotaAlertMocks.getLinePlanQuotaShortfall).toHaveBeenCalledWith(expect.anything(), 2, expect.any(String));
+  });
+
+  test('broadcast: audience は共有の allTargetGuardAudience (lazy) — accountCount を single 判定に渡す', async () => {
+    const lazy = async () => 120;
+    quotaAlertMocks.allTargetGuardAudience.mockReturnValue(lazy);
+    const { db } = fakeDb();
+    const res = await setupApp().request(broadcastRequest(), {}, env(db));
+
+    expect(res.status).toBe(200);
+    expect(quotaAlertMocks.allTargetGuardAudience).toHaveBeenCalledWith(db, 'acc-1', true);
+    expect(quotaAlertMocks.getLinePlanQuotaShortfall).toHaveBeenCalledWith(expect.anything(), lazy, expect.any(String));
+  });
+
+  test('マルチアカウント + 未登録 env トークンの broadcast: audience=0 (remaining=0 のみブロック)', async () => {
+    vi.mocked(getLineAccounts).mockResolvedValue([ACCOUNT, ACCOUNT_2] as never);
+    const { db } = fakeDb();
+    const res = await setupApp().request(broadcastRequest('env-token'), {}, env(db));
+
+    expect(res.status).toBe(200);
+    expect(quotaAlertMocks.getLinePlanQuotaShortfall).toHaveBeenCalledWith(expect.anything(), 0, expect.any(String));
+    expect(quotaAlertMocks.allTargetGuardAudience).not.toHaveBeenCalled();
+  });
+
+  test('narrowcast: audience=0 で常時ガード対象 — remaining=0 なら通知して 429', async () => {
+    quotaAlertMocks.getLinePlanQuotaShortfall.mockResolvedValue({
+      limit: 200, consumption: 200, remaining: 0, audience: 0,
+    });
+    const { db } = fakeDb();
+    const res = await setupApp().request(
+      new Request('http://worker.test/line-api/v2/bot/message/narrowcast', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer acc-token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [{ type: 'text', text: 'targeted' }],
+          recipient: { type: 'audience', audienceGroupId: 1 },
+        }),
+      }),
+      {},
+      env(db),
+    );
+
+    expect(res.status).toBe(429);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(quotaAlertMocks.getLinePlanQuotaShortfall).toHaveBeenCalledWith(expect.anything(), 0, expect.any(String));
+    expect(quotaAlertMocks.notifyQuotaAlert).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ source: 'proxy-pre-send' }),
+    );
+  });
+
+  test('1:1 push はプランクォータのチェック対象外', async () => {
+    const { db } = fakeDb();
+    const res = await setupApp().request(pushRequest('acc-token'), {}, env(db));
+
+    expect(res.status).toBe(200);
+    expect(quotaAlertMocks.getLinePlanQuotaShortfall).not.toHaveBeenCalled();
+  });
+
+  test('上流 429 (LINE の月間上限文言) → proxy-upstream-429 で通知、応答は据え置き', async () => {
+    // 送信前ガードは fail-open で素通り (null)、429 後の残量再取得も失敗
+    // → limit=0 の合成 shortfall で通知される。
+    fetchMock.mockResolvedValue(
+      upstreamResponse(429, '{"message":"You have reached your monthly limit."}'),
+    );
+    const { db } = fakeDb();
+    const res = await setupApp().request(multicastRequest(2), {}, env(db));
+
+    expect(res.status).toBe(429);
+    const body = await res.json() as { message: string };
+    expect(body.message).toBe('You have reached your monthly limit.');
+    expect(quotaAlertMocks.notifyQuotaAlert).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        source: 'proxy-upstream-429',
+        lineAccountId: 'acc-1',
+        shortfall: { limit: 0, consumption: 0, remaining: 0, audience: 2 },
+      }),
+    );
+  });
+
+  test('上流 429: 残量再取得が成功したら実測値で通知する (不足判定は経ない — 429 の事実が優先)', async () => {
+    fetchMock.mockResolvedValue(
+      upstreamResponse(429, '{"message":"You have reached your monthly limit."}'),
+    );
+    // consumption API のラグで remaining(100) > audience(2) に見えても通知する。
+    quotaAlertMocks.readPlanQuotaSnapshot.mockResolvedValue({
+      limit: 30000,
+      consumption: 29900,
+      remaining: 100,
+    });
+    const { db } = fakeDb();
+    const res = await setupApp().request(multicastRequest(2), {}, env(db));
+
+    expect(res.status).toBe(429);
+    expect(quotaAlertMocks.notifyQuotaAlert).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        source: 'proxy-upstream-429',
+        shortfall: { limit: 30000, consumption: 29900, remaining: 100, audience: 2 },
+      }),
+    );
+  });
+
+  test('上流 429: broadcast の audience COUNT が失敗しても通知は audience=0 で生き残る', async () => {
+    fetchMock.mockResolvedValue(
+      upstreamResponse(429, '{"message":"You have reached your monthly limit."}'),
+    );
+    quotaAlertMocks.allTargetGuardAudience.mockReturnValue(async () => {
+      throw new Error('D1 down');
+    });
+    const { db } = fakeDb();
+    const res = await setupApp().request(broadcastRequest(), {}, env(db));
+
+    expect(res.status).toBe(429);
+    expect(quotaAlertMocks.notifyQuotaAlert).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        source: 'proxy-upstream-429',
+        shortfall: expect.objectContaining({ audience: 0 }),
+      }),
+    );
+  });
+
+  test('上流 429 (レート制限など別文言) では通知しない', async () => {
+    fetchMock.mockResolvedValue(upstreamResponse(429, '{"message":"Too many requests"}'));
+    const { db } = fakeDb();
+    const res = await setupApp().request(multicastRequest(2), {}, env(db));
+
+    expect(res.status).toBe(429);
+    expect(quotaAlertMocks.notifyQuotaAlert).not.toHaveBeenCalled();
+  });
+
+  test('1:1 push の上流 429 では通知しない (一斉送信経路のみ)', async () => {
+    fetchMock.mockResolvedValue(
+      upstreamResponse(429, '{"message":"You have reached your monthly limit."}'),
+    );
+    const { db } = fakeDb();
+    const res = await setupApp().request(pushRequest('acc-token'), {}, env(db));
+
+    expect(res.status).toBe(429);
+    expect(quotaAlertMocks.notifyQuotaAlert).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/routes/line-proxy.ts
+++ b/apps/worker/src/routes/line-proxy.ts
@@ -22,6 +22,14 @@ import {
   estimateSendAudience,
   wouldExceedMonthlyQuota,
 } from '../services/quota.js';
+import {
+  allTargetGuardAudience,
+  getLinePlanQuotaShortfall,
+  LINE_MONTHLY_LIMIT_MESSAGE,
+  notifyQuotaAlert,
+  readPlanQuotaSnapshot,
+  type PlanQuotaShortfall,
+} from '../services/quota-alert.js';
 
 /**
  * LINE Messaging API 互換プロキシ。
@@ -67,6 +75,19 @@ const MESSAGE_SEND_PATHS = new Set([
   '/v2/bot/message/narrowcast',
 ]);
 
+/**
+ * 送信ゲートが返す 429 の出どころ。
+ *
+ * ゲートの本文は LINE の limit レスポンスと同じ形にしてある（既存クライアントが
+ * そのまま扱えるように）。ただし `You have reached your monthly limit.` は
+ * LINE 自身が返す文面と一字一句同じなので、429 を見ても「LINE のプラン枠に
+ * 当たった」のか「harness が止めた」のかが応答から判別できなかった。
+ * 実際に本番で 1:1 送信の 429 を前者と誤って切り分けかけている
+ * （枠は 30,000 中 200 しか使っていなかった）。message は互換のため変えず、
+ * source と reason を足して由来と理由を機械可読にする。
+ */
+const LIMIT_SOURCE = 'line-harness';
+
 // Unknown recipients cost a getProfile subrequest plus ~4 D1 queries each; cap
 // them so a multicast full of strangers cannot exhaust the Workers subrequest
 // budget. Overflow is skipped WITH a console.warn — never silently.
@@ -107,6 +128,8 @@ type ResolvedCaller = {
   upstreamToken: string;
   /** line_accounts.id when the channel is DB-registered, else null (env default). */
   lineAccountId: string | null;
+  /** line_accounts.name for the resolved account (quota-alert display), else null. */
+  accountName: string | null;
   /** Total number of registered accounts — used to scope broadcast logging. */
   accountCount: number;
 };
@@ -136,11 +159,17 @@ async function resolveCaller(c: Context<Env>, token: string): Promise<ResolvedCa
     return {
       upstreamToken: token,
       lineAccountId: byChannelToken.id,
+      accountName: byChannelToken.name ?? null,
       accountCount: active.length,
     };
   }
   if (token === c.env.LINE_CHANNEL_ACCESS_TOKEN) {
-    return { upstreamToken: token, lineAccountId: null, accountCount: active.length };
+    return {
+      upstreamToken: token,
+      lineAccountId: null,
+      accountName: null,
+      accountCount: active.length,
+    };
   }
 
   // harness API キー経路 — worker 側でチャネルトークンを解決する。
@@ -167,6 +196,7 @@ async function resolveCaller(c: Context<Env>, token: string): Promise<ResolvedCa
     return {
       upstreamToken: account.channel_access_token,
       lineAccountId: account.id,
+      accountName: account.name ?? null,
       accountCount: active.length,
     };
   }
@@ -174,6 +204,7 @@ async function resolveCaller(c: Context<Env>, token: string): Promise<ResolvedCa
     return {
       upstreamToken: c.env.LINE_CHANNEL_ACCESS_TOKEN,
       lineAccountId: null,
+      accountName: null,
       accountCount: active.length,
     };
   }
@@ -444,6 +475,122 @@ async function logProxySend(
   }
 }
 
+// LINE 自身が月間クォータ超過時に返す 429 本文の message (一字一句)。上流応答が
+// クォータ起因かの判定に使う。レート制限の 429 とはこの文言で区別できる。
+// 定義は quota-alert.ts と共有 (worker 内部送信経路の 429 判定と単一定義)。
+
+/** waitUntil が使えない環境 (テスト等) では inline await にフォールバックする。 */
+async function runInBackground(c: Context<Env>, task: Promise<unknown>): Promise<void> {
+  try {
+    c.executionCtx.waitUntil(task);
+  } catch {
+    await task;
+  }
+}
+
+/**
+ * LINE プラン自体の月間クォータ (getMessageQuota) の送信前ガード。quotaEnv の
+ * harness 独自上限とは別物: 2026-09-01 の一斉配信事故 (プランクォータ不足で配信
+ * 全滅・誰も気づけず) は quotaEnv 未設定の環境でも起きるため、一斉送信
+ * (broadcast/multicast/narrowcast) は限度設定の有無に関わらず常時チェックする
+ * (1:1 push は止めない方針も quotaEnv ゲートと同じ)。不足が確定したら
+ * オペレーターに通知して 429 を返す。チェック API の失敗は fail-open —
+ * 送信は止めない (getLinePlanQuotaShortfall 内)。
+ */
+async function guardLinePlanQuota(
+  c: Context<Env>,
+  caller: ResolvedCaller,
+  audience: number | (() => Promise<number>),
+): Promise<Response | null> {
+  // cacheKey = トークン: multicast の 500人チャンクごとに quota API を2回叩かない
+  // よう 30秒 TTL のスナップショットキャッシュを効かせる (quota-alert.ts 参照)。
+  const shortfall = await getLinePlanQuotaShortfall(
+    new LineClient(caller.upstreamToken),
+    audience,
+    caller.upstreamToken,
+  );
+  if (!shortfall) return null;
+  // 通知は応答を待たせない — fireOutgoingWebhooks は外部 HTTP を含むため、
+  // 遅い webhook 先が 429 応答のレイテンシに化けるのを防ぐ (通知は best-effort
+  // で例外を握りつぶすので background 化しても失敗が失われる情報は変わらない)。
+  await runInBackground(c, notifyQuotaAlert(c.env.DB, {
+    lineAccountId: caller.lineAccountId ?? 'default',
+    accountName: caller.accountName,
+    shortfall,
+    source: 'proxy-pre-send',
+  }));
+  // message は LINE 自身のクォータ超過応答と同文言 (既存クライアントがそのまま
+  // 扱える)。原因は本当に LINE プランの残量だが、429 を返しているのは harness
+  // なので source を明示し (quotaEnv ゲートと同じ規約 — LIMIT_SOURCE 参照)、
+  // reason と quota で機械可読に詳細を添える。
+  return c.json(
+    {
+      message: LINE_MONTHLY_LIMIT_MESSAGE,
+      source: LIMIT_SOURCE,
+      reason: 'line-plan-quota-insufficient',
+      quota: shortfall,
+    },
+    429,
+  );
+}
+
+/** 上流 429 本文が LINE の月間クォータ超過応答かどうか。 */
+function isLineMonthlyLimitBody(bodyText: string): boolean {
+  try {
+    const parsed = JSON.parse(bodyText) as { message?: unknown };
+    return parsed.message === LINE_MONTHLY_LIMIT_MESSAGE;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * LINE がクォータ超過 429 で拒否した一斉送信をオペレーターに通知する (送信前
+ * ガードが fail-open で素通りした場合の最後の網)。429 の事実が確定しているので
+ * 通知は無条件 — 残量詳細は quota API から読み直して添える (不足判定は経ない:
+ * consumption API のラグで remaining > audience に見えても 429 は起きている)。
+ * 読み直しに失敗したら limit=0 の合成 shortfall で「超過の事実」だけ通知する
+ * (quota-alert.ts が文言を分ける)。audience の COUNT 失敗も通知は殺さず 0 に
+ * 落とす — 表示用の数字の欠落で最後の網ごと沈黙させない。
+ * best-effort: 例外は握りつぶす。
+ */
+async function notifyUpstreamPlanQuota429(
+  db: D1Database,
+  caller: ResolvedCaller,
+  audience: number | (() => Promise<number>),
+): Promise<void> {
+  try {
+    let audienceCount = 0;
+    try {
+      audienceCount = typeof audience === 'function' ? await audience() : audience;
+    } catch (err) {
+      console.error('[line-proxy] audience count for quota alert failed (using 0):', err);
+    }
+    let shortfall: PlanQuotaShortfall = {
+      limit: 0,
+      consumption: 0,
+      remaining: 0,
+      audience: audienceCount,
+    };
+    try {
+      // 429 直後の再読なので cacheKey は渡さない — ガード時の 30秒キャッシュを
+      // 引き当てると「超過前の残量」を通知に載せてしまう。
+      const snapshot = await readPlanQuotaSnapshot(new LineClient(caller.upstreamToken));
+      if (snapshot) shortfall = { ...snapshot, audience: audienceCount };
+    } catch (err) {
+      console.error('[line-proxy] quota re-read after upstream 429 failed:', err);
+    }
+    await notifyQuotaAlert(db, {
+      lineAccountId: caller.lineAccountId ?? 'default',
+      accountName: caller.accountName,
+      shortfall,
+      source: 'proxy-upstream-429',
+    });
+  } catch (err) {
+    console.error('[line-proxy] upstream 429 quota alert failed:', err);
+  }
+}
+
 function proxyHandler(prefix: string, upstreamBase: string, logSends: boolean) {
   return async (c: Context<Env>): Promise<Response> => {
     const url = new URL(c.req.url);
@@ -520,14 +667,28 @@ function proxyHandler(prefix: string, upstreamBase: string, logSends: boolean) {
     // count for broadcast) would cross the monthly limit. 1:1 push and reply
     // pass through untouched — one-to-one conversations are never paused.
     // With no limits configured this adds zero queries. The error shape
-    // mirrors the LINE API's own limit response so existing clients handle it.
-    if (
+    // mirrors the LINE API's own limit response so existing clients handle it —
+    // but that made a harness-side refusal indistinguishable from LINE's own
+    // (identical status and message), so each response also carries
+    // `source: 'line-harness'` and a `reason` code. See LIMIT_SOURCE.
+    // Bulk-send request body, parsed ONCE and shared by the quotaEnv gate and
+    // the LINE plan quota guard below (each used to run its own JSON.parse of
+    // the same rawBody, with subtly diverging recipient counts).
+    const isBulkSend =
       isMessageSend
       && (path === '/v2/bot/message/broadcast'
         || path === '/v2/bot/message/multicast'
-        || path === '/v2/bot/message/narrowcast')
-      && quotaEnabled(c.env)
-    ) {
+        || path === '/v2/bot/message/narrowcast');
+    let bulkParsed: ParsedSend = {};
+    if (isBulkSend && rawBody) {
+      try {
+        bulkParsed = JSON.parse(rawBody) as ParsedSend;
+      } catch {
+        // malformed body — no projection, let upstream reject it
+      }
+    }
+
+    if (isBulkSend && quotaEnabled(c.env)) {
       const usage = await getQuotaUsage(c.env.DB, c.env);
       let estimate: number | null = null;
       if (usage.monthlyMessages.max > 0) {
@@ -538,7 +699,11 @@ function proxyHandler(prefix: string, upstreamBase: string, logSends: boolean) {
         // monthly limit is active; without one it passes through as before.
         if (path === '/v2/bot/message/narrowcast') {
           return c.json(
-            { message: 'Sends without a determinable recipient list are not available while send limits are active.' },
+            {
+              message: 'Sends without a determinable recipient list are not available while send limits are active.',
+              source: LIMIT_SOURCE,
+              reason: 'narrowcast-unrecordable',
+            },
             429,
           );
         }
@@ -552,23 +717,24 @@ function proxyHandler(prefix: string, upstreamBase: string, logSends: boolean) {
           && caller.lineAccountId === null
           && caller.accountCount > 1
         ) {
-          return c.json({ message: 'Broadcast requires a registered channel account.' }, 429);
+          return c.json(
+            {
+              message: 'Broadcast requires a registered channel account.',
+              source: LIMIT_SOURCE,
+              reason: 'broadcast-unregistered-channel',
+            },
+            429,
+          );
         }
         // logProxySend inserts one row per recipient per message, so the
         // projection multiplies the audience by the messages array length
         // (LINE allows 1–5 per request). A missing/empty/non-array messages
         // field falls back to 1 — the upstream rejects such payloads anyway.
-        let toList: unknown[] | null = null;
-        let messageCount = 1;
-        try {
-          const parsed = JSON.parse(rawBody ?? '{}') as { to?: unknown; messages?: unknown };
-          if (Array.isArray(parsed.messages) && parsed.messages.length > 0) {
-            messageCount = parsed.messages.length;
-          }
-          if (Array.isArray(parsed.to)) toList = parsed.to;
-        } catch {
-          // malformed body — no projection, let upstream reject it
-        }
+        const toList: unknown[] | null = Array.isArray(bulkParsed.to) ? bulkParsed.to : null;
+        const messageCount =
+          Array.isArray(bulkParsed.messages) && bulkParsed.messages.length > 0
+            ? bulkParsed.messages.length
+            : 1;
         if (path === '/v2/bot/message/multicast') {
           estimate = toList === null ? null : toList.length * messageCount;
           // logProxySend stops creating friend rows for unknown recipients at
@@ -581,7 +747,14 @@ function proxyHandler(prefix: string, upstreamBase: string, logSends: boolean) {
           if (toList && toList.length > MAX_FRIEND_CREATIONS) {
             const unknown = await countUnknownRecipients(c.env.DB, toList as string[]);
             if (unknown > MAX_FRIEND_CREATIONS) {
-              return c.json({ message: 'Too many unregistered recipients.' }, 429);
+              return c.json(
+                {
+                  message: 'Too many unregistered recipients.',
+                  source: LIMIT_SOURCE,
+                  reason: 'too-many-unregistered-recipients',
+                },
+                429,
+              );
             }
           }
         } else {
@@ -593,8 +766,55 @@ function proxyHandler(prefix: string, upstreamBase: string, logSends: boolean) {
         }
       }
       if (usage.exceeded || wouldExceedMonthlyQuota(usage, estimate)) {
-        return c.json({ message: 'You have reached your monthly limit.' }, 429);
+        // usage.exceeded は友だち数上限でも立つ。message は既存クライアント
+        // 互換のため据え置くが、reason まで monthly と言ってしまうと運用者を
+        // 「追加メッセージを買う」という誤った対処に誘導する。実際に効いた
+        // 上限を見て分ける（境界は getQuotaUsage と同じ非対称: friends は超過、
+        // monthly は到達で打ち止め）。
+        const monthlyOver =
+          usage.monthlyMessages.max > 0 && usage.monthlyMessages.used >= usage.monthlyMessages.max;
+        const friendsOver = usage.friends.max > 0 && usage.friends.used > usage.friends.max;
+        return c.json(
+          {
+            message: 'You have reached your monthly limit.',
+            source: LIMIT_SOURCE,
+            reason: friendsOver && !monthlyOver ? 'friends-exceeded' : 'monthly-messages-exceeded',
+          },
+          429,
+        );
       }
+    }
+
+    // LINE プランクォータの送信前ガード (guardLinePlanQuota 参照)。audience は
+    // 上流 429 の通知 (下) でも使うためここで組み立てる。broadcast は lazy —
+    // 上限なしプランでは COUNT クエリ自体が走らない。
+    let bulkAudience: number | (() => Promise<number>) = 0;
+    if (isBulkSend) {
+      if (path === '/v2/bot/message/multicast') {
+        // LINE のクォータ消費は「ユニークな受信者数」ベース (1リクエストの複数
+        // メッセージは1通扱い、重複宛先は1人) なので Set で数える — 重複入りの
+        // payload を過大計上して送れる送信を誤ブロックしないため。
+        bulkAudience = Array.isArray(bulkParsed.to)
+          ? new Set(bulkParsed.to.filter((t): t is string => typeof t === 'string')).size
+          : 0;
+      } else if (path === '/v2/bot/message/broadcast') {
+        if (caller.lineAccountId || caller.accountCount <= 1) {
+          // broadcast の需要 = 配信可能友だち数。legacy NULL 行の扱いは worker
+          // 内部の一斉配信と同じ単一定義 (allTargetGuardAudience) を共有する。
+          bulkAudience = allTargetGuardAudience(
+            c.env.DB,
+            caller.lineAccountId,
+            caller.accountCount <= 1,
+          );
+        }
+        // else: マルチアカウント + 未登録 env トークン — 対象が確定しないため
+        // audience 0 のまま、remaining=0 (何も送れない) のときだけブロックする。
+      }
+      // narrowcast: LINE 側で対象が解決されるため audience 0 のまま —
+      // remaining=0 の「何も送れない」状態だけブロックし、上流 429 の検知 (下)
+      // で silent failure を拾う。
+      const blocked = await guardLinePlanQuota(c, caller, bulkAudience);
+      if (blocked) return blocked;
     }
 
     const headers: Record<string, string> = {
@@ -638,11 +858,7 @@ function proxyHandler(prefix: string, upstreamBase: string, logSends: boolean) {
       if (awaitBeforeResponse) {
         await logging;
       } else {
-        try {
-          c.executionCtx.waitUntil(logging);
-        } catch {
-          await logging;
-        }
+        await runInBackground(c, logging);
       }
     }
 
@@ -655,6 +871,25 @@ function proxyHandler(prefix: string, upstreamBase: string, logSends: boolean) {
     ]) {
       const value = upstream.headers.get(name);
       if (value) responseHeaders.set(name, value);
+    }
+
+    // LINE がクォータ超過 429 で拒否した一斉送信は、外部クライアントにエラーが
+    // 返るだけでオペレーターは気づけない (2026-09-01 事故の形)。LINE 自身の月間
+    // 上限文言に一致したときだけ通知する — レート制限の 429 では発火しない。
+    // 判定に本文が要るためこの分岐だけバッファする (429 本文は小さな JSON)。
+    // 応答はステータス・本文とも据え置きで、クライアントから見た挙動は不変。
+    if (isBulkSend && upstream.status === 429) {
+      const bodyText = await upstream.text();
+      if (isLineMonthlyLimitBody(bodyText)) {
+        await runInBackground(c, notifyUpstreamPlanQuota429(c.env.DB, caller, bulkAudience));
+      } else {
+        // 文言不一致の 429 は検知網の外に落ちる。LINE が将来文言を変えたときに
+        // 網の失効へ気づけるよう、レート制限も含め必ず痕跡を残す。
+        console.warn(
+          `[line-proxy] bulk send got a non-quota-matched 429 from LINE: ${bodyText.slice(0, 200)}`,
+        );
+      }
+      return new Response(bodyText, { status: upstream.status, headers: responseHeaders });
     }
 
     // Stream the body through — api-data downloads (images, video) can be

--- a/apps/worker/src/routes/openapi.ts
+++ b/apps/worker/src/routes/openapi.ts
@@ -95,6 +95,11 @@ const spec = {
           sentAt: { type: 'string', nullable: true },
           totalCount: { type: 'integer' },
           successCount: { type: 'integer' },
+          lastError: {
+            type: 'string',
+            nullable: true,
+            description: '直近の送信失敗理由 (LINE プランクォータ不足ガード等)。送信成功で null に戻る。',
+          },
           createdAt: { type: 'string', format: 'date-time' },
         },
       },
@@ -418,6 +423,15 @@ const spec = {
         summary: 'LINEアカウント登録',
         requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { channelId: { type: 'string' }, name: { type: 'string' }, channelAccessToken: { type: 'string' }, channelSecret: { type: 'string' } }, required: ['channelId', 'name', 'channelAccessToken', 'channelSecret'] } } } },
         responses: { '201': { description: 'Account created' } },
+      },
+    },
+    '/api/line-accounts/delivery-health': {
+      get: {
+        tags: ['LINE Accounts'],
+        summary: 'アカウント別 配信健全性 (クォータ残・友だち/ブロック前日比・今月配信数)',
+        description:
+          'アクティブな全アカウントについて、LINE 月間クォータ (上限/消費/残り) と前日時点の友だち数・ブロック数 (前日比つき)、当月の push 配信数を一括で返す。残クォータが配信可能友だち数を下回ると quotaAlert=true (全員配信が完走できない状態)。',
+        responses: { '200': { description: 'Per-account delivery health snapshot' } },
       },
     },
     '/api/line-accounts/order': {

--- a/apps/worker/src/scheduled.test.ts
+++ b/apps/worker/src/scheduled.test.ts
@@ -31,3 +31,18 @@ describe('isFiveMinuteTick', () => {
     expect(isFiveMinuteTick(tick('0 */6 * * *', 0))).toBe(false);
   });
 });
+
+import { isHourlyTick } from './scheduled.js';
+
+describe('isHourlyTick', () => {
+  test('分=0 の tick だけ true (分足・5分足どちらの cron でも)', () => {
+    expect(isHourlyTick(tick('* * * * *', 0))).toBe(true);
+    expect(isHourlyTick(tick('*/5 * * * *', 0))).toBe(true);
+    expect(isHourlyTick(tick('* * * * *', 5))).toBe(false);
+    expect(isHourlyTick(tick('*/5 * * * *', 30))).toBe(false);
+  });
+
+  test('6時間足の cron では false（同じ分に二重で走らせない）', () => {
+    expect(isHourlyTick(tick('0 */6 * * *', 0))).toBe(false);
+  });
+});

--- a/apps/worker/src/scheduled.ts
+++ b/apps/worker/src/scheduled.ts
@@ -43,6 +43,16 @@ export function isFiveMinuteTick(event: { cron: string; scheduledTime: number })
   return event.cron === '* * * * *' && new Date(event.scheduledTime).getUTCMinutes() % 5 === 0;
 }
 
+/**
+ * 毎時 (分=0) の tick か。月次粒度で十分な監視 (LINE プランクォータ) を分足・
+ * 5分足の tick から間引くのに使う。isFiveMinuteTick と同じく 6時間足 cron は
+ * 二重実行防止で弾く。
+ */
+export function isHourlyTick(event: { cron: string; scheduledTime: number }): boolean {
+  if (event.cron === '0 */6 * * *') return false;
+  return new Date(event.scheduledTime).getUTCMinutes() === 0;
+}
+
 // Scheduled handler — Cron Trigger と DO alarm (durable-objects/tenant-scheduler.ts)
 // の双方から呼ばれる共通ジョブ本体。index.ts から切り出しているのは、
 // tenant-scheduler.ts がこの関数を import する際に index.ts 自体との
@@ -202,7 +212,10 @@ export async function scheduled(
   // 分の LINE API (/v2/bot/info) を毎分叩くことになり (2026-08-26 実測: 43テナントで
   // 1日6.2万回)、そこまでの即時性は要らない — 403 の検知が最大5分遅れるだけ。
   if (isFiveMinuteTick(event)) {
-    jobs.push(checkAccountHealth(env.DB));
+    // クォータ残量は月次粒度の信号なので毎時 tick だけ確認する (checkQuota)。
+    // 5分毎に全アカウント分の quota API を叩くと bot/info を分足→5分に
+    // 落とした経緯 (上のコメント参照) と同じ過剰負荷になる。
+    jobs.push(checkAccountHealth(env.DB, { checkQuota: isHourlyTick(event) }));
     jobs.push(
       processPendingMileageEvents(env.DB, { limit: 100 }).then((result) => {
         if (result.claimed > 0) {

--- a/apps/worker/src/services/ban-monitor.test.ts
+++ b/apps/worker/src/services/ban-monitor.test.ts
@@ -10,6 +10,15 @@ vi.mock('@line-crm/db', () => ({
   getAccountHealthLogs: (...args: unknown[]) => getAccountHealthLogs(...args),
 }));
 
+const getLinePlanQuotaShortfall = vi.fn();
+const notifyQuotaAlert = vi.fn();
+const countDeliverableAudience = vi.fn(async (..._args: unknown[]) => 0);
+vi.mock('./quota-alert.js', () => ({
+  getLinePlanQuotaShortfall: (...args: unknown[]) => getLinePlanQuotaShortfall(...args),
+  notifyQuotaAlert: (...args: unknown[]) => notifyQuotaAlert(...args),
+  countDeliverableAudience: (...args: unknown[]) => countDeliverableAudience(...args),
+}));
+
 const { checkAccountHealth } = await import('./ban-monitor.js');
 
 /** messages_log の集計だけを返す最小の D1 スタブ。 */
@@ -38,6 +47,9 @@ describe('checkAccountHealth', () => {
     getLineAccounts.mockReset();
     createAccountHealthLog.mockReset();
     getAccountHealthLogs.mockReset();
+    getLinePlanQuotaShortfall.mockReset().mockResolvedValue(null);
+    notifyQuotaAlert.mockReset().mockResolvedValue(true);
+    countDeliverableAudience.mockClear();
     getLineAccounts.mockResolvedValue([
       { id: 'acc-1', channel_access_token: 'token', is_active: 1 },
     ]);
@@ -103,5 +115,69 @@ describe('checkAccountHealth', () => {
       errorCode: 500,
       riskLevel: 'normal',
     });
+  });
+
+  test('checkQuota 無し (5分 tick) はクォータチェックをスキップする', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+    getAccountHealthLogs.mockResolvedValue([log('normal', null)]);
+
+    await checkAccountHealth(dbStub());
+
+    expect(getLinePlanQuotaShortfall).not.toHaveBeenCalled();
+  });
+
+  test('クォータ残0 → danger で記録しオペレーターへ通知する', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+    getAccountHealthLogs.mockResolvedValue([log('normal', null)]);
+    getLinePlanQuotaShortfall.mockResolvedValue({
+      limit: 200, consumption: 200, remaining: 0, audience: 150,
+    });
+
+    await checkAccountHealth(dbStub(), { checkQuota: true });
+
+    expect(createAccountHealthLog).toHaveBeenCalledTimes(1);
+    expect(createAccountHealthLog.mock.calls[0][1]).toMatchObject({ riskLevel: 'danger' });
+    expect(notifyQuotaAlert).toHaveBeenCalledTimes(1);
+    expect(notifyQuotaAlert.mock.calls[0][1]).toMatchObject({
+      lineAccountId: 'acc-1',
+      source: 'health-check',
+    });
+  });
+
+  test('クォータ残があるが配信対象に足りない → warning', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+    getAccountHealthLogs.mockResolvedValue([log('normal', null)]);
+    getLinePlanQuotaShortfall.mockResolvedValue({
+      limit: 1000, consumption: 900, remaining: 100, audience: 500,
+    });
+
+    await checkAccountHealth(dbStub(), { checkQuota: true });
+
+    expect(createAccountHealthLog.mock.calls[0][1]).toMatchObject({ riskLevel: 'warning' });
+    expect(notifyQuotaAlert).toHaveBeenCalledTimes(1);
+  });
+
+  test('クォータ warning が継続中でもヘルスログは重複記録しない (通知 dedup は notifyQuotaAlert 側)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })));
+    getAccountHealthLogs.mockResolvedValue([log('warning', null)]);
+    getLinePlanQuotaShortfall.mockResolvedValue({
+      limit: 1000, consumption: 900, remaining: 100, audience: 500,
+    });
+
+    await checkAccountHealth(dbStub(), { checkQuota: true });
+
+    expect(createAccountHealthLog).not.toHaveBeenCalled();
+    // 通知の呼び出し自体は毎 tick 行われ、月次 dedup は notifyQuotaAlert が持つ
+    expect(notifyQuotaAlert).toHaveBeenCalledTimes(1);
+  });
+
+  test('bot/info が失敗しているときはクォータチェックをスキップする', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 403 })));
+    getAccountHealthLogs.mockResolvedValue([log('normal', null)]);
+
+    await checkAccountHealth(dbStub(), { checkQuota: true });
+
+    expect(getLinePlanQuotaShortfall).not.toHaveBeenCalled();
+    expect(notifyQuotaAlert).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/services/ban-monitor.ts
+++ b/apps/worker/src/services/ban-monitor.ts
@@ -3,6 +3,14 @@
  *
  * LINE APIのエラー率を監視し、BAN リスクを検出する
  * 403/429 エラーのパターンを分析してリスクレベルを判定
+ *
+ * 2026-09-01 事故対応: LINE プラン月間クォータの残量チェックも同居させる。
+ * 残量が配信可能友だち数を下回った時点で warning (残0なら danger) にし、
+ * notifyQuotaAlert でオペレーターに通知する (ダッシュボードを開かなくても
+ * 気づけるようにする — GET /api/line-accounts/delivery-health は受動的)。
+ * クォータは月次粒度の信号なので、opts.checkQuota が true の tick (毎時 —
+ * scheduled.ts 参照) だけ確認し、5分毎の bot/info チェックに API 呼び出しを
+ * 上乗せしない (bot/info を分足→5分に落とした経緯と同じ配慮)。
  */
 
 import {
@@ -10,17 +18,30 @@ import {
   createAccountHealthLog,
   getAccountHealthLogs,
 } from '@line-crm/db';
+import { LineClient } from '@line-crm/line-sdk';
+import {
+  countDeliverableAudience,
+  getLinePlanQuotaShortfall,
+  notifyQuotaAlert,
+} from './quota-alert.js';
 
 export async function checkAccountHealth(
   db: D1Database,
+  opts: { checkQuota?: boolean } = {},
 ): Promise<void> {
   const accounts = await getLineAccounts(db);
+  const activeAccounts = accounts.filter((a) => a.is_active);
+  // legacy な line_account_id NULL 行は単一アカウント運用でのみ audience に含める
+  // (マルチアカウントで全アカウントに加算すると共有 NULL プール分が水増しされ、
+  // 小プランのアカウントが恒常的に誤 warning になる)。
+  const includeLegacyNullRows = activeAccounts.length <= 1;
 
-  for (const account of accounts) {
-    if (!account.is_active) continue;
-
+  for (const account of activeAccounts) {
     try {
-      await checkSingleAccount(db, account);
+      await checkSingleAccount(db, account, {
+        checkQuota: opts.checkQuota ?? false,
+        includeLegacyNullRows,
+      });
     } catch (err) {
       console.error(`ヘルスチェックエラー (account ${account.id}):`, err);
     }
@@ -29,7 +50,8 @@ export async function checkAccountHealth(
 
 async function checkSingleAccount(
   db: D1Database,
-  account: { id: string; channel_access_token: string },
+  account: { id: string; name?: string | null; channel_access_token: string },
+  quotaOpts: { checkQuota: boolean; includeLegacyNullRows: boolean },
 ): Promise<void> {
   const jstMs = Date.now() + 9 * 60 * 60_000;
   const now = new Date(jstMs);
@@ -77,6 +99,42 @@ async function checkSingleAccount(
     riskLevel = 'warning'; // 大量送信の警告
   }
 
+  // LINE プラン月間クォータの残量チェック (2026-09-01 事故対応)。毎時 tick のみ。
+  // bot/info が失敗しているときはトークン自体が死んでいて quota API も
+  // 失敗するだけなのでスキップする。チェック自体の失敗は fail-open
+  // (getLinePlanQuotaShortfall 内) — 監視の一時障害で誤警報を出さない。
+  // audience は lazy に渡す: 上限なしプランのアカウントでは COUNT 自体走らない。
+  if (quotaOpts.checkQuota && errorCode === null) {
+    const shortfall = await getLinePlanQuotaShortfall(
+      new LineClient(account.channel_access_token),
+      () => countDeliverableAudience(db, account.id, quotaOpts.includeLegacyNullRows),
+    );
+    if (shortfall) {
+      // 残0 = 一括配信が全滅する状態なので danger。残があるが全員分に足りない
+      // 段階は warning (403 由来の danger はそのまま維持)。
+      if (shortfall.remaining === 0) {
+        riskLevel = 'danger';
+      } else if (riskLevel === 'normal') {
+        riskLevel = 'warning';
+      }
+      // 通知は月次 dedup (notifyQuotaAlert 内)。ヘルスログの「状態変化時のみ
+      // 記録」とは独立に判定されるので、ログが抑制されても通知は漏れない。
+      const notified = await notifyQuotaAlert(db, {
+        lineAccountId: account.id,
+        accountName: account.name ?? null,
+        shortfall,
+        source: 'health-check',
+      });
+      // 不足が続く限り毎時ここを通るので、ログは実際に通知した回だけに絞る
+      // (dedup で抑制された tick まで吐くと 1インシデントでログが埋まる)。
+      if (notified) {
+        console.error(
+          `⚠️ クォータ不足検知: アカウント ${account.id} 残り${shortfall.remaining}通 / 配信対象${shortfall.audience}人`,
+        );
+      }
+    }
+  }
+
   // 直前の記録と同じ状態なら書かない。この関数は分足の tick ごとに呼ばれるので、
   // 毎回 INSERT すると異常が1件も無いアカウントでも 1日1,440行のゴミが積み上がる
   // (2026-08-26 実測: 43テナント・24時間で 53,908行)。ヘルスログは「チェックした
@@ -88,6 +146,22 @@ async function checkSingleAccount(
     return;
   }
 
+  // checkQuota=false の tick はクォータを再評価していないので、error_code なしの
+  // warning/danger (クォータ不足または大量送信由来) を 'normal' で上書きしない。
+  // 上書きすると不足継続中に毎時 warning↔normal の振動行が積まれ (状態変化 dedup が
+  // 防ぐはずだったログ洪水)、最新行を読む health UI が毎時55分間 normal を表示する。
+  // 解除判定は次の毎時 tick (checkQuota=true) が行う。403/429 等 error_code 付きの
+  // 状態は quota と無関係なので従来どおり即時解除される。
+  if (
+    !quotaOpts.checkQuota &&
+    riskLevel === 'normal' &&
+    latest &&
+    latest.risk_level !== 'normal' &&
+    (latest.error_code ?? null) === null
+  ) {
+    return;
+  }
+
   await createAccountHealthLog(db, {
     lineAccountId: account.id,
     errorCode: errorCode ?? undefined,
@@ -96,7 +170,9 @@ async function checkSingleAccount(
     riskLevel,
   });
 
-  if (riskLevel === 'danger') {
+  // danger はクォータ残0 でも立つようになったため、BAN 警告は 403 のときだけ出す
+  // (クォータ側は上の quota チェック内で専用メッセージを出している)。
+  if (riskLevel === 'danger' && errorCode === 403) {
     console.error(`⚠️ BAN検知: アカウント ${account.id} で403エラー発生。即座に確認が必要。`);
   }
 }

--- a/apps/worker/src/services/broadcast.ts
+++ b/apps/worker/src/services/broadcast.ts
@@ -9,6 +9,7 @@ import {
   jstNow,
   updateBroadcastLineRequestId,
   createBroadcastInsight,
+  setBroadcastLastError,
 } from '@line-crm/db';
 import type { Broadcast } from '@line-crm/db';
 import type { LineClient } from '@line-crm/line-sdk';
@@ -31,8 +32,145 @@ import {
   type QuotaEnv,
 } from './quota.js';
 
+import {
+  allTargetGuardAudience,
+  getLinePlanQuotaShortfall,
+  isLineMonthlyLimit429,
+  LinePlanQuotaError,
+  notifyQuotaAlert,
+  readPlanQuotaSnapshot,
+} from './quota-alert.js';
+
 const MULTICAST_BATCH_SIZE = 500;
 const PERSONALIZED_PUSH_BATCH_SIZE = 10;
+
+/**
+ * LINE プラン月間クォータの送信前ガード (2026-09-01 事故対応)。
+ * 不足が確定したら broadcasts.last_error に理由を記録し、オペレーターへ通知した
+ * 上で LinePlanQuotaError を投げる。足りていれば何もしない。
+ * クォータ確認 API の失敗は fail-open (getLinePlanQuotaShortfall 内) — 送信は
+ * 止めない。audience は lazy 関数でも渡せる (上限なしプランなら COUNT が走らない)。
+ */
+async function assertLinePlanQuota(
+  db: D1Database,
+  lineClient: LineClient,
+  broadcast: Broadcast,
+  audience: number | (() => Promise<number>),
+): Promise<void> {
+  const shortfall = await getLinePlanQuotaShortfall(lineClient, audience);
+  if (!shortfall) return;
+
+  const accountId = broadcast.line_account_id ?? null;
+  let accountName: string | null = null;
+  if (accountId) {
+    try {
+      const { getLineAccountById } = await import('@line-crm/db');
+      accountName = (await getLineAccountById(db, accountId))?.name ?? null;
+    } catch {
+      // 名前解決は通知の見栄えのためだけ。失敗しても ID 表記で続行する。
+    }
+  }
+
+  const reason =
+    `LINEプラン月間クォータ不足のため送信を中止: ` +
+    `残り${shortfall.remaining}通 < 配信対象${shortfall.audience}人 ` +
+    `(上限${shortfall.limit}通・消費${shortfall.consumption}通)`;
+  await setBroadcastLastError(db, broadcast.id, reason);
+  // 単一アカウント運用 (line_account_id NULL) は通知キーとして 'default' を使う
+  // (env トークンの既定アカウントに相当)。pre-send 通知は dedup されないので、
+  // ban-monitor 側の実 ID キーと分かれていても通知が消えることはない。
+  await notifyQuotaAlert(db, {
+    lineAccountId: accountId ?? 'default',
+    accountName,
+    shortfall,
+    source: 'pre-send',
+    broadcastId: broadcast.id,
+    broadcastTitle: broadcast.title,
+  });
+  throw new LinePlanQuotaError(shortfall);
+}
+
+/**
+ * queue 経路用の送信前ガード。throw するとロック (batch_offset=-1) が残って
+ * recover 待ちになるため、不足時は draft へ戻して true を返す (理由は
+ * last_error + 通知に記録済み。draft なので次 tick 以降は拾われない)。
+ */
+async function revertQueuedBroadcastOnQuotaShortfall(
+  db: D1Database,
+  lineClient: LineClient,
+  broadcast: Broadcast,
+  audience: number | (() => Promise<number>),
+): Promise<boolean> {
+  try {
+    await assertLinePlanQuota(db, lineClient, broadcast, audience);
+    return false;
+  } catch (err) {
+    if (!(err instanceof LinePlanQuotaError)) throw err;
+    await db.prepare(
+      `UPDATE broadcasts SET status = 'draft', batch_offset = 0, batch_lock_at = NULL WHERE id = ?`,
+    ).bind(broadcast.id).run();
+    return true;
+  }
+}
+
+/**
+ * ガード通過後に LINE 本体がクォータ超過 429 を返したときの記録 + 通知。
+ * ここに来るのは送信前ガードが fail-open した (quota API の一時失敗) か、
+ * audience を過小見積もりしたケース — 記録しないと「配信が silent に draft へ
+ * 落ちた」という 2026-09-01 事故の形が内部経路で再演される (プロキシ経路には
+ * line-proxy.ts に同種の網がある)。best-effort: この関数の失敗が本来のエラー
+ * 処理 (draft 戻し) を壊さないよう例外はすべて握りつぶす。
+ */
+async function recordInternalUpstreamQuota429(
+  db: D1Database,
+  lineClient: LineClient,
+  broadcast: Broadcast,
+  outcome: { kind: 'reverted' } | { kind: 'partial'; successCount: number; totalCount: number },
+): Promise<void> {
+  try {
+    let snapshot: Awaited<ReturnType<typeof readPlanQuotaSnapshot>> = null;
+    try {
+      snapshot = await readPlanQuotaSnapshot(lineClient);
+    } catch {
+      // 残量詳細が取れなくても「超過した」事実は通知する (limit=0 の合成 shortfall)
+    }
+    // audience=0 は「対象人数は算出していない」印 (notifyQuotaAlert が人数の節を省く)。
+    const shortfall = snapshot
+      ? { ...snapshot, audience: 0 }
+      : { limit: 0, consumption: 0, remaining: 0, audience: 0 };
+
+    const accountId = broadcast.line_account_id ?? null;
+    let accountName: string | null = null;
+    if (accountId) {
+      try {
+        const { getLineAccountById } = await import('@line-crm/db');
+        accountName = (await getLineAccountById(db, accountId))?.name ?? null;
+      } catch {
+        // 名前解決は見栄えのためだけ。失敗しても ID 表記で続行する。
+      }
+    }
+
+    const quotaNote = snapshot ? ` (残り${snapshot.remaining}通 / 上限${snapshot.limit}通)` : '';
+    await setBroadcastLastError(
+      db,
+      broadcast.id,
+      outcome.kind === 'reverted'
+        ? `LINEがクォータ超過 (429) で送信を拒否したため下書きに戻しました${quotaNote}`
+        : `LINEがクォータ超過 (429) を返したため残りのバッチを中止しました` +
+            ` (送信済み${outcome.successCount}/${outcome.totalCount}人)${quotaNote}`,
+    );
+    await notifyQuotaAlert(db, {
+      lineAccountId: accountId ?? 'default',
+      accountName,
+      shortfall,
+      source: 'upstream-429',
+      broadcastId: broadcast.id,
+      broadcastTitle: broadcast.title,
+    });
+  } catch (err) {
+    console.error(`upstream 429 の記録に失敗 (broadcast ${broadcast.id}):`, err);
+  }
+}
 
 export async function processBroadcastSend(
   db: D1Database,
@@ -148,6 +286,9 @@ export async function processBroadcastSend(
   const message = buildMessage(finalType, finalContent, altText || undefined);
   let totalCount = 0;
   let successCount = 0;
+  // tag 経路のバッチ送信中に LINE の月間クォータ超過 429 に当たった印。
+  // partial 確定 (status='sent') 後に理由の記録と通知を行う。
+  let hitUpstreamQuota429 = false;
 
   try {
     if (broadcast.target_type === 'all') {
@@ -172,6 +313,9 @@ export async function processBroadcastSend(
         : await db
             .prepare('SELECT COUNT(*) as count FROM friends WHERE is_following = 1')
             .first<{ count: number }>();
+      // 送信前クォータガード: 残量が全員配信1回分に満たなければ中止する。
+      // throw → 下の catch が draft へ戻す (last_error に理由記録済み)。
+      await assertLinePlanQuota(db, lineClient, broadcast, allTargetGuardAudience(db, broadcastAccountId));
       // Use LINE broadcast API (sends to all followers)
       const retryKey = await createBroadcastRetryKey(
         broadcast.id,
@@ -191,6 +335,11 @@ export async function processBroadcastSend(
       const friends = await getFriendsByTag(db, broadcast.target_tag_id);
       const followingFriends = friends.filter((f) => f.is_following);
       totalCount = followingFriends.length;
+
+      // 送信前クォータガード (all と同じ)。バッチ途中でのクォータ切れによる
+      // 部分送信をここで未然に防ぐ (タグ対象は followingFriends が実母数なので
+      // そのまま渡す)。
+      await assertLinePlanQuota(db, lineClient, broadcast, totalCount);
 
       // Send in batches with stealth delays to mimic human patterns
       const now = jstNow();
@@ -235,6 +384,18 @@ export async function processBroadcastSend(
           );
           await db.batch(logStmts);
         } catch (err) {
+          // LINE 由来の月間クォータ超過はバッチ個別の一過性エラーではない —
+          // 残りのバッチも全て 429 になるので続行せず中止し、通知して残りを
+          // 諦める (status は 'sent' のまま partial として確定。draft へ戻すと
+          // リトライで送信済みバッチの友だちに重複配信される)。理由は
+          // updateBroadcastStatus('sent') が last_error を clear した後に書く。
+          if (isLineMonthlyLimit429(err)) {
+            console.error(
+              `Multicast aborted at batch ${i / MULTICAST_BATCH_SIZE}: LINE monthly quota exceeded`,
+            );
+            hitUpstreamQuota429 = true;
+            break;
+          }
           console.error(`Multicast batch ${i / MULTICAST_BATCH_SIZE} failed:`, err);
           // Continue with next batch; failed batch is not logged
         }
@@ -245,7 +406,21 @@ export async function processBroadcastSend(
 
     await createBroadcastInsight(db, broadcast.id);
     await updateBroadcastStatus(db, broadcastId, 'sent', { totalCount, successCount });
+    // 'sent' 遷移が last_error を clear するので、クォータ 429 の記録はその後に書く。
+    if (hitUpstreamQuota429) {
+      await recordInternalUpstreamQuota429(db, lineClient, broadcast, {
+        kind: 'partial',
+        successCount,
+        totalCount,
+      });
+    }
   } catch (err) {
+    // ガードを通過した後に LINE 本体がクォータ超過 429 を返したケース
+    // ('all' の broadcast API 等)。silent に draft へ落とすと 2026-09-01 事故の
+    // 再演になるため、理由の記録と通知を済ませてから戻す。
+    if (isLineMonthlyLimit429(err)) {
+      await recordInternalUpstreamQuota429(db, lineClient, broadcast, { kind: 'reverted' });
+    }
     // On failure, reset to draft so it can be retried
     await updateBroadcastStatus(db, broadcastId, 'draft');
     throw err;
@@ -481,6 +656,11 @@ async function processQueuedBroadcastBatches(
       totalCount: result.totalCount,
       successCount: result.successCount,
     });
+    // 'sent' 遷移は last_error を clear するので、クォータ不足による一部アカウント
+    // スキップの理由はその後に書き戻す (部分完了の caveat として UI に残す)。
+    if (result.quotaSkippedSummary) {
+      await setBroadcastLastError(db, broadcast.id, result.quotaSkippedSummary);
+    }
     return;
   }
 
@@ -529,6 +709,12 @@ async function processQueuedBroadcastBatches(
           .prepare('SELECT COUNT(*) as count FROM friends WHERE is_following = 1')
           .first<{ count: number }>();
     const followerCount = followerRow?.count ?? 0;
+    // 送信前クォータガード (queue 経路は draft 戻しで中止)。
+    if (await revertQueuedBroadcastOnQuotaShortfall(
+      db, lineClient, broadcast, allTargetGuardAudience(db, accountId),
+    )) {
+      return;
+    }
     const retryKey = await createBroadcastRetryKey(
       broadcast.id,
       'queued-broadcast',
@@ -546,6 +732,12 @@ async function processQueuedBroadcastBatches(
   if (batchOffset === 0) {
     await db.prepare('UPDATE broadcasts SET total_count = ? WHERE id = ?')
       .bind(friends.length, broadcast.id).run();
+
+    // 送信前クォータガード (fresh 開始時のみ — まだ1通も送っていないので draft へ
+    // 戻して安全に中止できる。resume 中の row は既存のバッチ単位失敗処理に任せる)。
+    if (await revertQueuedBroadcastOnQuotaShortfall(db, lineClient, broadcast, friends.length)) {
+      return;
+    }
   }
 
   const now = jstNow();

--- a/apps/worker/src/services/dedup-broadcast.test.ts
+++ b/apps/worker/src/services/dedup-broadcast.test.ts
@@ -338,6 +338,15 @@ class MockLineClient {
     this.calls.push({ method: 'push', args: [to, messages, retryKey, units, this.token] });
     return {};
   }
+  // 送信前プランクォータガード用。デフォルトは上限なしプラン (= ガード素通り)。
+  quota: { type: string; value?: number } = { type: 'none' };
+  quotaConsumption = 0;
+  async getMessageQuota() {
+    return this.quota;
+  }
+  async getMessageQuotaConsumption() {
+    return { totalUsage: this.quotaConsumption };
+  }
 }
 
 // fakeDb for send-side: handles `db.prepare(...).bind(...).run()` for the
@@ -451,11 +460,70 @@ describe('processMultiAccountDedupBroadcast', () => {
     );
 
     expect(result.failedAccountIds).toEqual([]);
+    expect(result.quotaSkippedSummary).toBeNull();
     expect(result.successCount).toBe(4);
     expect(result.totalCount).toBe(4);
     expect(clients).toHaveLength(2);
     expect(clients[0].calls).toHaveLength(1);
     expect(clients[1].calls).toHaveLength(1);
+  });
+
+  it('プランクォータ不足のアカウントは送信せずスキップし failed + last_error 要約に記録する', async () => {
+    const { db } = makeSendDb({
+      selectedCounts: [
+        { line_account_id: 'acc1', cnt: 2 },
+        { line_account_id: 'acc2', cnt: 2 },
+      ],
+      rankedRows: [
+        { friend_id: 'f1', line_user_id: 'u1', line_account_id: 'acc1' },
+        { friend_id: 'f2', line_user_id: 'u2', line_account_id: 'acc1' },
+        { friend_id: 'f3', line_user_id: 'u3', line_account_id: 'acc2' },
+        { friend_id: 'f4', line_user_id: 'u4', line_account_id: 'acc2' },
+      ],
+      accountMeta: [
+        { id: 'acc1', name: 'A1', country: 'JP' },
+        { id: 'acc2', name: 'A2', country: 'TH' },
+      ],
+    });
+
+    vi.mocked(getLineAccountById).mockImplementation(async (_db: D1Database, id: string) => {
+      if (id === 'acc1') return { id, channel_access_token: 'tok1', is_active: 1 } as never;
+      if (id === 'acc2') return { id, name: 'A2', channel_access_token: 'tok2', is_active: 1 } as never;
+      return null;
+    });
+
+    const clients: MockLineClient[] = [];
+    const factory = (token: string) => {
+      const c = new MockLineClient(token);
+      if (token === 'tok2') {
+        // acc2 は上限200通のプランで残り1通 (< 対象2人) → スキップされるべき
+        c.quota = { type: 'limited', value: 200 };
+        c.quotaConsumption = 199;
+      }
+      clients.push(c);
+      return c as unknown as LineClient;
+    };
+
+    const result = await processMultiAccountDedupBroadcast(
+      db,
+      {
+        id: 'b1',
+        account_ids: '["acc1","acc2"]',
+        dedup_priority: '["acc1","acc2"]',
+        message_type: 'text',
+        message_content: 'hello',
+      },
+      factory,
+    );
+
+    expect(result.failedAccountIds).toEqual(['acc2']);
+    expect(result.quotaSkippedSummary).toContain('A2');
+    expect(result.quotaSkippedSummary).toContain('残り1通');
+    // acc1 は通常配信、acc2 は multicast/push を一切呼ばれない
+    expect(result.successCount).toBe(2);
+    const acc2Client = clients.find((c) => c.token === 'tok2')!;
+    expect(acc2Client.calls).toHaveLength(0);
+    expect(result.complete).toBe(true);
   });
 
   it('one account multicast throws: other succeeds, failedAccountIds = [thrower]', async () => {

--- a/apps/worker/src/services/dedup-broadcast.ts
+++ b/apps/worker/src/services/dedup-broadcast.ts
@@ -191,7 +191,8 @@ export async function computeDedupBroadcastPreview(
 }
 
 import { LineClient, type Message } from '@line-crm/line-sdk';
-import { getLineAccountById, jstNow, updateBroadcastLineRequestId } from '@line-crm/db';
+import { getLineAccountById, jstNow, updateBroadcastLineRequestId, setBroadcastLastError } from '@line-crm/db';
+import { getLinePlanQuotaShortfall, notifyQuotaAlert } from './quota-alert.js';
 import { calculateStaggerDelay, sleep, addMessageVariation } from './stealth.js';
 import {
   assertNoUnresolvedBroadcastVariables,
@@ -209,6 +210,10 @@ export interface ProcessMultiAccountDedupResult {
   totalCount: number;
   successCount: number;
   failedAccountIds: string[];
+  // クォータ不足でスキップしたアカウントの要約 (last_error 用)。無ければ null。
+  // caller は status='sent' 遷移 (last_error が clear される) の後にこれを
+  // last_error へ書き戻す。
+  quotaSkippedSummary: string | null;
   // false = この実行は時間バジェットに達して途中で yield した (まだ未送の人が残る)。
   // caller は status='sent' にせず batch_offset=0 に戻して次の cron tick に継続させる。
   // true = 全 account を送り切った (= 完了)。caller が status='sent' にする。
@@ -266,6 +271,14 @@ const MAX_RUN_MS = 10_000;
  */
 interface DedupProgress {
   sentIdentKeys: string[];
+  /**
+   * この broadcast で既にクォータ不足通知を出したアカウント ID。
+   * multi-tick resume (timeExceeded → 次 cron tick で再入場) では不足アカウントが
+   * 毎 tick 再評価されるため、これが無いと dedup なしの 'pre-send' 通知が tick
+   * ごとに連打される (1時間かかる配信で ~12 重複 Slack 通知)。クォータの再チェック
+   * 自体は毎 tick 行う — 配信中に追加購入されたら当該アカウントも再開できる。
+   */
+  quotaNotifiedAccountIds?: string[];
 }
 
 function parseProgress(raw: string | null | undefined): DedupProgress {
@@ -274,9 +287,13 @@ function parseProgress(raw: string | null | undefined): DedupProgress {
   try {
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { sentIdentKeys?: unknown }).sentIdentKeys)) {
+      const notified = (parsed as { quotaNotifiedAccountIds?: unknown }).quotaNotifiedAccountIds;
       return {
         sentIdentKeys: (parsed as { sentIdentKeys: unknown[] }).sentIdentKeys
           .filter((s): s is string => typeof s === 'string'),
+        ...(Array.isArray(notified)
+          ? { quotaNotifiedAccountIds: notified.filter((s): s is string => typeof s === 'string') }
+          : {}),
       };
     }
   } catch {
@@ -321,6 +338,7 @@ export async function processMultiAccountDedupBroadcast(
   db: D1Database,
   broadcast: {
     id: string;
+    title?: string | null;
     account_ids: string | null;
     dedup_priority: string | null;
     target_tag_id?: string | null;
@@ -367,6 +385,13 @@ export async function processMultiAccountDedupBroadcast(
   const allIdentKeys = new Set<string>(progress.sentIdentKeys);
 
   const failedAccountIds: string[] = [];
+  // クォータ不足でスキップしたアカウント (failed_account_ids に加えて last_error に
+  // 理由を残すため別トラック)。
+  const quotaSkippedAccounts: Array<{
+    id: string;
+    name: string | null;
+    shortfall: { remaining: number; audience: number };
+  }> = [];
 
   // 単一 broadcast-wide unit を全アカウント multicast で共有する。各 LINE
   // チャネルは独立した unit namespace を持つので「同じ名前で別カウント」が
@@ -401,6 +426,42 @@ export async function processMultiAccountDedupBroadcast(
     if (remaining.length === 0) continue; // このアカに残作業なし
 
     const client = lineClientFactory(account.channel_access_token);
+
+    // LINE プランクォータの送信前ガード (2026-09-01 事故 — 複数アカウント一斉配信で
+    // 一部アカウントがクォータ不足のまま送信して全滅した形そのもの)。このアカウントの
+    // 残差 (remaining) を賄えなければ、そのアカウントだけスキップして failed に記録し、
+    // 他アカウントの配信は続行する。resume 時も残差基準で再評価される。
+    // クォータ確認 API の失敗は fail-open (getLinePlanQuotaShortfall 内)。
+    const planShortfall = await getLinePlanQuotaShortfall(client, remaining.length);
+    if (planShortfall) {
+      console.error(
+        `[multi-account-dedup] account ${account.id} skipped: plan quota insufficient ` +
+        `(remaining=${planShortfall.remaining} audience=${remaining.length})`,
+      );
+      failedAccountIds.push(account.id);
+      quotaSkippedAccounts.push({ id: account.id, name: account.name, shortfall: planShortfall });
+      // 通知はこの broadcast につきアカウントごとに1回だけ。multi-tick resume では
+      // 不足アカウントが毎 tick ここを通るため、進捗 JSON に通知済みを永続化しないと
+      // dedup なしの 'pre-send' 通知が tick ごとに連打される (DedupProgress 参照)。
+      const notifiedIds = new Set(progress.quotaNotifiedAccountIds ?? []);
+      if (!notifiedIds.has(account.id)) {
+        await notifyQuotaAlert(db, {
+          lineAccountId: account.id,
+          accountName: account.name,
+          shortfall: planShortfall,
+          source: 'pre-send',
+          broadcastId: broadcast.id,
+          broadcastTitle: broadcast.title ?? undefined,
+        });
+        notifiedIds.add(account.id);
+        progress.quotaNotifiedAccountIds = [...notifiedIds];
+        await db.prepare(
+          `UPDATE broadcasts SET dedup_progress = ? WHERE id = ?`,
+        ).bind(JSON.stringify(progress), broadcast.id).run();
+      }
+      continue;
+    }
+
     const accountContent = renderBroadcastMessageContent(
       broadcast.message_type,
       broadcast.message_content,
@@ -539,6 +600,19 @@ export async function processMultiAccountDedupBroadcast(
     `UPDATE broadcasts SET failed_account_ids = ? WHERE id = ?`,
   ).bind(failedAccountIds.length > 0 ? JSON.stringify(failedAccountIds) : null, broadcast.id).run();
 
+  // クォータ不足でスキップしたアカウントがあれば理由を last_error に残す
+  // (failed_account_ids は「どのアカが失敗したか」だけで理由を持てない)。
+  // 完了時は caller が status='sent' で last_error を clear した後に
+  // quotaSkippedSummary から書き戻す (途中 yield 時のためここでも書いておく)。
+  let quotaSkippedSummary: string | null = null;
+  if (quotaSkippedAccounts.length > 0) {
+    const detail = quotaSkippedAccounts
+      .map((a) => `${a.name || a.id} (残り${a.shortfall.remaining}通 < 対象${a.shortfall.audience}人)`)
+      .join('、');
+    quotaSkippedSummary = `LINEプラン月間クォータ不足のため一部アカウントをスキップ: ${detail}`;
+    await setBroadcastLastError(db, broadcast.id, quotaSkippedSummary);
+  }
+
   const successCount = progress.sentIdentKeys.length;
   const totalCount = allIdentKeys.size;
 
@@ -557,5 +631,5 @@ export async function processMultiAccountDedupBroadcast(
   //
   // complete=false (timeExceeded) のときは caller が status='sent' にせず batch_offset=0 に
   // 戻し、次の cron tick が getQueuedBroadcasts で拾って残りを送る (= 分割送信)。
-  return { totalCount, successCount, failedAccountIds, complete: !timeExceeded };
+  return { totalCount, successCount, failedAccountIds, quotaSkippedSummary, complete: !timeExceeded };
 }

--- a/apps/worker/src/services/event-bus.ts
+++ b/apps/worker/src/services/event-bus.ts
@@ -75,14 +75,22 @@ export async function fireEvent(
   await processAutomations(db, eventType, enrichedPayload, lineAccessToken, lineAccountId);
 }
 
-/** 送信Webhookへの通知 */
-async function fireOutgoingWebhooks(
+/**
+ * 送信Webhookへの通知。fireEvent の Phase 1 で呼ばれるほか、friend を伴わない
+ * システムイベント (quota_alert 等) の単独発火にも使う (services/quota-alert.ts)。
+ * 失敗はすべて握りつぶす (best-effort)。戻り値は 2xx で受理された配信数 —
+ * 呼び出し元 (quota-alert 等) が「実際に届いたか」を記録に反映できるようにする。
+ * prefetched: 呼び出し元が購読者リストを取得済みなら渡すと再クエリを省ける。
+ */
+export async function fireOutgoingWebhooks(
   db: D1Database,
   eventType: string,
   payload: EventPayload,
-): Promise<void> {
+  prefetched?: Awaited<ReturnType<typeof getActiveOutgoingWebhooksByEvent>>,
+): Promise<number> {
+  let delivered = 0;
   try {
-    const webhooks = await getActiveOutgoingWebhooksByEvent(db, eventType);
+    const webhooks = prefetched ?? (await getActiveOutgoingWebhooksByEvent(db, eventType));
     for (const wh of webhooks) {
       try {
         const body = JSON.stringify({
@@ -110,7 +118,12 @@ async function fireOutgoingWebhooks(
           headers['X-Webhook-Signature'] = hexSignature;
         }
 
-        await fetch(wh.url, { method: 'POST', headers, body });
+        const res = await fetch(wh.url, { method: 'POST', headers, body });
+        if (res.ok) {
+          delivered += 1;
+        } else {
+          console.error(`送信Webhook ${wh.id} への通知失敗: HTTP ${res.status}`);
+        }
       } catch (err) {
         console.error(`送信Webhook ${wh.id} への通知失敗:`, err);
       }
@@ -118,6 +131,7 @@ async function fireOutgoingWebhooks(
   } catch (err) {
     console.error('fireOutgoingWebhooks error:', err);
   }
+  return delivered;
 }
 
 /** スコアリングルール適用 */

--- a/apps/worker/src/services/quota-alert.test.ts
+++ b/apps/worker/src/services/quota-alert.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { monthStartJst } from './quota.js';
+
+const createNotification = vi.fn();
+const hasNotificationSince = vi.fn();
+const getActiveNotificationRulesByEvent = vi.fn();
+const getActiveOutgoingWebhooksByEvent = vi.fn();
+
+vi.mock('@line-crm/db', () => ({
+  createNotification: (...args: unknown[]) => createNotification(...args),
+  hasNotificationSince: (...args: unknown[]) => hasNotificationSince(...args),
+  getActiveNotificationRulesByEvent: (...args: unknown[]) =>
+    getActiveNotificationRulesByEvent(...args),
+  getActiveOutgoingWebhooksByEvent: (...args: unknown[]) =>
+    getActiveOutgoingWebhooksByEvent(...args),
+  // 実実装と同形式 (JST +09:00 サフィックス) — dedup の since 形式検証に使う。
+  toJstString: (date: Date) =>
+    new Date(date.getTime() + 9 * 3600_000).toISOString().slice(0, -1) + '+09:00',
+}));
+
+const fireOutgoingWebhooks = vi.fn();
+vi.mock('./event-bus.js', () => ({
+  fireOutgoingWebhooks: (...args: unknown[]) => fireOutgoingWebhooks(...args),
+}));
+
+const { getLinePlanQuotaShortfall, notifyQuotaAlert, countDeliverableAudience, allTargetGuardAudience } =
+  await import('./quota-alert.js');
+
+function client(quota: { type: string; value?: number }, totalUsage: number) {
+  return {
+    getMessageQuota: async () => quota,
+    getMessageQuotaConsumption: async () => ({ totalUsage }),
+  };
+}
+
+const db = {} as D1Database;
+
+describe('getLinePlanQuotaShortfall', () => {
+  test('上限なしプラン (type=none) は常に null', async () => {
+    expect(await getLinePlanQuotaShortfall(client({ type: 'none' }, 99999), 500)).toBeNull();
+  });
+
+  test('残量が配信対象以上なら null', async () => {
+    expect(await getLinePlanQuotaShortfall(client({ type: 'limited', value: 1000 }, 400), 600)).toBeNull();
+  });
+
+  test('残量が配信対象未満なら不足情報を返す', async () => {
+    const shortfall = await getLinePlanQuotaShortfall(client({ type: 'limited', value: 1000 }, 700), 500);
+    expect(shortfall).toEqual({ limit: 1000, consumption: 700, remaining: 300, audience: 500 });
+  });
+
+  test('残り0は audience=0 でも不足扱い (全一括送信が失敗する状態)', async () => {
+    const shortfall = await getLinePlanQuotaShortfall(client({ type: 'limited', value: 200 }, 200), 0);
+    expect(shortfall).toMatchObject({ remaining: 0 });
+  });
+
+  test('消費が上限を超過していても remaining は 0 で clamp される', async () => {
+    const shortfall = await getLinePlanQuotaShortfall(client({ type: 'limited', value: 200 }, 350), 10);
+    expect(shortfall).toMatchObject({ remaining: 0, consumption: 350 });
+  });
+
+  test('lazy audience: 上限なしプランでは audience 関数を評価しない', async () => {
+    const audienceFn = vi.fn(async () => 500);
+    expect(await getLinePlanQuotaShortfall(client({ type: 'none' }, 0), audienceFn)).toBeNull();
+    expect(audienceFn).not.toHaveBeenCalled();
+  });
+
+  test('lazy audience: 上限ありプランでは評価して比較する', async () => {
+    const audienceFn = vi.fn(async () => 500);
+    const shortfall = await getLinePlanQuotaShortfall(
+      client({ type: 'limited', value: 1000 }, 900),
+      audienceFn,
+    );
+    expect(audienceFn).toHaveBeenCalledTimes(1);
+    expect(shortfall).toMatchObject({ remaining: 100, audience: 500 });
+  });
+
+  test('クォータ API の失敗は fail-open (null)', async () => {
+    const broken = {
+      getMessageQuota: async () => {
+        throw new Error('401');
+      },
+      getMessageQuotaConsumption: async () => ({ totalUsage: 0 }),
+    };
+    expect(await getLinePlanQuotaShortfall(broken, 500)).toBeNull();
+  });
+});
+
+describe('countDeliverableAudience', () => {
+  function dbWithSql() {
+    const captured: { sql?: string; binds?: unknown[] } = {};
+    const stub = {
+      prepare(sql: string) {
+        captured.sql = sql;
+        return {
+          bind(...binds: unknown[]) {
+            captured.binds = binds;
+            return { first: async () => ({ count: 42 }) };
+          },
+        };
+      },
+    } as unknown as D1Database;
+    return { stub, captured };
+  }
+
+  test('includeLegacyNullRows=true は NULL 行込みで数える', async () => {
+    const { stub, captured } = dbWithSql();
+    expect(await countDeliverableAudience(stub, 'acc-1', true)).toBe(42);
+    expect(captured.sql).toContain('line_account_id = ? OR line_account_id IS NULL');
+  });
+
+  test('includeLegacyNullRows=false は厳密一致で数える', async () => {
+    const { stub, captured } = dbWithSql();
+    await countDeliverableAudience(stub, 'acc-1', false);
+    expect(captured.sql).toContain('line_account_id = ?');
+    expect(captured.sql).not.toContain('IS NULL');
+  });
+});
+
+describe('allTargetGuardAudience', () => {
+  function dbCapture(counts: { accounts?: number; friends?: number } = {}) {
+    const sqls: string[] = [];
+    const stub = {
+      prepare(sql: string) {
+        sqls.push(sql);
+        const exec = {
+          bind: (..._binds: unknown[]) => exec,
+          first: async () => ({
+            count: sql.includes('line_accounts') ? counts.accounts ?? 1 : counts.friends ?? 0,
+          }),
+        };
+        return exec;
+      },
+    } as unknown as D1Database;
+    return { stub, sqls };
+  }
+
+  test('knownSingleInstall を渡すと line_accounts の COUNT を省略する', async () => {
+    const { stub, sqls } = dbCapture({ friends: 7 });
+    await expect(allTargetGuardAudience(stub, 'acc-1', true)()).resolves.toBe(7);
+    expect(sqls.some((s) => s.includes('line_accounts'))).toBe(false);
+    expect(sqls[0]).toContain('line_account_id = ? OR line_account_id IS NULL');
+  });
+
+  test('knownSingleInstall 省略時は isSingleAccountInstall で判定する (マルチアカは厳密一致)', async () => {
+    const { stub, sqls } = dbCapture({ accounts: 2, friends: 5 });
+    await expect(allTargetGuardAudience(stub, 'acc-1')()).resolves.toBe(5);
+    expect(sqls.some((s) => s.includes('line_accounts'))).toBe(true);
+    const friendsSql = sqls.find((s) => s.includes('FROM friends'))!;
+    expect(friendsSql).not.toContain('IS NULL');
+  });
+
+  test('accountId null は NULL 行込みの全件 (単一アカウント運用の本体)', async () => {
+    const { stub, sqls } = dbCapture({ friends: 3 });
+    await expect(allTargetGuardAudience(stub, null)()).resolves.toBe(3);
+    expect(sqls).toHaveLength(1);
+    expect(sqls[0]).not.toContain('line_account_id');
+  });
+});
+
+describe('notifyQuotaAlert', () => {
+  const shortfall = { limit: 1000, consumption: 900, remaining: 100, audience: 500 };
+
+  beforeEach(() => {
+    createNotification.mockReset().mockResolvedValue({});
+    hasNotificationSince.mockReset().mockResolvedValue(false);
+    getActiveNotificationRulesByEvent.mockReset().mockResolvedValue([]);
+    getActiveOutgoingWebhooksByEvent.mockReset().mockResolvedValue([{ id: 'wh-1' }]);
+    // fireOutgoingWebhooks は 2xx で受理された配信数を返す (webhook 行の sent/failed 判定に使う)
+    fireOutgoingWebhooks.mockReset().mockResolvedValue(1);
+  });
+
+  test('health-check は同月に通知済みなら何もしない (月次 dedup)', async () => {
+    hasNotificationSince.mockResolvedValue(true);
+
+    const sent = await notifyQuotaAlert(db, {
+      lineAccountId: 'acc-1',
+      shortfall,
+      source: 'health-check',
+    });
+
+    expect(sent).toBe(false);
+    expect(hasNotificationSince).toHaveBeenCalledWith(db, {
+      eventType: 'quota_alert',
+      lineAccountId: 'acc-1',
+      since: monthStartJst(),
+    });
+    expect(createNotification).not.toHaveBeenCalled();
+    expect(fireOutgoingWebhooks).not.toHaveBeenCalled();
+  });
+
+  test('pre-send は月次 dedup の対象外 (配信中止は毎回通知する)', async () => {
+    hasNotificationSince.mockResolvedValue(true);
+
+    const sent = await notifyQuotaAlert(db, {
+      lineAccountId: 'acc-1',
+      shortfall,
+      source: 'pre-send',
+      broadcastId: 'bc-1',
+      broadcastTitle: '9月キャンペーン',
+    });
+
+    expect(sent).toBe(true);
+    expect(hasNotificationSince).not.toHaveBeenCalled();
+    expect(createNotification).toHaveBeenCalled();
+    expect(fireOutgoingWebhooks).toHaveBeenCalled();
+  });
+
+  test('ルール未設定でも dashboard 行を必ず残し webhook を発火する', async () => {
+    const sent = await notifyQuotaAlert(db, {
+      lineAccountId: 'acc-1',
+      accountName: 'L Harness ①',
+      shortfall,
+      source: 'health-check',
+    });
+
+    expect(sent).toBe(true);
+    expect(createNotification).toHaveBeenCalledTimes(1);
+    expect(createNotification.mock.calls[0][1]).toMatchObject({
+      eventType: 'quota_alert',
+      channel: 'dashboard',
+      status: 'sent',
+      lineAccountId: 'acc-1',
+    });
+    expect(createNotification.mock.calls[0][1].title).toContain('L Harness ①');
+    expect(fireOutgoingWebhooks).toHaveBeenCalledWith(
+      db,
+      'quota_alert',
+      expect.objectContaining({
+        eventData: expect.objectContaining({ lineAccountId: 'acc-1', remaining: 100 }),
+      }),
+      [{ id: 'wh-1' }], // 取得済み購読者リストを渡して二重クエリを避ける
+    );
+  });
+
+  test('webhook が1件も届かなかったら webhook 行は failed で記録する', async () => {
+    fireOutgoingWebhooks.mockResolvedValue(0); // エンドポイント down / 非2xx
+    getActiveNotificationRulesByEvent.mockResolvedValue([
+      { id: 'rule-1', channels: '["webhook"]', line_account_id: null },
+    ]);
+
+    await notifyQuotaAlert(db, { lineAccountId: 'acc-1', shortfall, source: 'pre-send' });
+
+    const rows = createNotification.mock.calls.map((c) => c[1]);
+    expect(rows.map((r) => [r.channel, r.status])).toEqual([
+      ['dashboard', 'sent'],
+      ['webhook', 'failed'],
+    ]);
+  });
+
+  test('有効ルールのチャネルを記録する (未実装チャネルは pending)', async () => {
+    getActiveNotificationRulesByEvent.mockResolvedValue([
+      { id: 'rule-1', channels: '["webhook","email"]', line_account_id: null },
+    ]);
+
+    await notifyQuotaAlert(db, { lineAccountId: 'acc-1', shortfall, source: 'pre-send' });
+
+    const rows = createNotification.mock.calls.map((c) => c[1]);
+    expect(rows.map((r) => [r.channel, r.status])).toEqual([
+      ['dashboard', 'sent'],
+      ['webhook', 'sent'],
+      ['email', 'pending'],
+    ]);
+    expect(rows[1].ruleId).toBe('rule-1');
+  });
+
+  test('webhook 購読者ゼロなら webhook 行は failed で記録し発火もしない', async () => {
+    getActiveOutgoingWebhooksByEvent.mockResolvedValue([]);
+    getActiveNotificationRulesByEvent.mockResolvedValue([
+      { id: 'rule-1', channels: '["webhook"]', line_account_id: null },
+    ]);
+
+    await notifyQuotaAlert(db, { lineAccountId: 'acc-1', shortfall, source: 'health-check' });
+
+    const rows = createNotification.mock.calls.map((c) => c[1]);
+    expect(rows.map((r) => [r.channel, r.status])).toEqual([
+      ['dashboard', 'sent'],
+      ['webhook', 'failed'],
+    ]);
+    expect(fireOutgoingWebhooks).not.toHaveBeenCalled();
+  });
+
+  test('別アカウント限定のルールは無視する', async () => {
+    getActiveNotificationRulesByEvent.mockResolvedValue([
+      { id: 'rule-1', channels: '["webhook"]', line_account_id: 'acc-OTHER' },
+    ]);
+
+    await notifyQuotaAlert(db, { lineAccountId: 'acc-1', shortfall, source: 'health-check' });
+
+    expect(createNotification).toHaveBeenCalledTimes(1);
+    expect(createNotification.mock.calls[0][1].channel).toBe('dashboard');
+  });
+
+  test('pre-send 由来は broadcast 情報を本文と metadata に含める', async () => {
+    await notifyQuotaAlert(db, {
+      lineAccountId: 'acc-1',
+      shortfall,
+      source: 'pre-send',
+      broadcastId: 'bc-1',
+      broadcastTitle: '9月キャンペーン',
+    });
+
+    const row = createNotification.mock.calls[0][1];
+    expect(row.body).toContain('9月キャンペーン');
+    expect(JSON.parse(row.metadata)).toMatchObject({ broadcastId: 'bc-1', source: 'pre-send' });
+  });
+
+  test('proxy-pre-send は1時間以内の同種 (proxy-*) 通知があれば何もしない (時間 dedup)', async () => {
+    hasNotificationSince.mockResolvedValue(true);
+
+    const sent = await notifyQuotaAlert(db, {
+      lineAccountId: 'acc-1',
+      shortfall,
+      source: 'proxy-pre-send',
+    });
+
+    expect(sent).toBe(false);
+    // since は「約1時間前」(created_at と同じ +09:00 付き JST 形式)。
+    // sourcePrefix で proxy-* の既通知だけを重複と見なす — 直前の cron 警告
+    // (health-check) が実失敗の通知を握りつぶさないように。
+    const arg = hasNotificationSince.mock.calls[0][1] as { since: string; sourcePrefix?: string };
+    expect(arg.sourcePrefix).toBe('proxy-');
+    expect(arg.since).toContain('+09:00');
+    expect(Math.abs(Date.now() - 3600_000 - new Date(arg.since).getTime())).toBeLessThan(10_000);
+    expect(createNotification).not.toHaveBeenCalled();
+  });
+
+  test('proxy-upstream-429 も時間 dedup、タイトルは「失敗」を伝える', async () => {
+    const sent = await notifyQuotaAlert(db, {
+      lineAccountId: 'acc-1',
+      accountName: 'Main',
+      shortfall,
+      source: 'proxy-upstream-429',
+    });
+
+    expect(sent).toBe(true);
+    expect(hasNotificationSince).toHaveBeenCalled();
+    const row = createNotification.mock.calls[0][1];
+    expect(row.title).toContain('失敗');
+    expect(row.title).toContain('Main');
+    expect(JSON.parse(row.metadata)).toMatchObject({ source: 'proxy-upstream-429' });
+  });
+
+  test('limit=0 の合成 shortfall は数字を出さず超過の事実だけ伝える', async () => {
+    await notifyQuotaAlert(db, {
+      lineAccountId: 'acc-1',
+      shortfall: { limit: 0, consumption: 0, remaining: 0, audience: 500 },
+      source: 'proxy-upstream-429',
+    });
+
+    const row = createNotification.mock.calls[0][1];
+    expect(row.body).toContain('取得できませんでした');
+    expect(row.body).not.toContain('上限0通');
+  });
+
+  test('通知処理の失敗は握りつぶして false を返す (best-effort)', async () => {
+    createNotification.mockRejectedValue(new Error('D1 down'));
+
+    await expect(
+      notifyQuotaAlert(db, { lineAccountId: 'acc-1', shortfall, source: 'health-check' }),
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/worker/src/services/quota-alert.ts
+++ b/apps/worker/src/services/quota-alert.ts
@@ -1,0 +1,437 @@
+/**
+ * LINE プラン月間クォータ不足の検知・通知
+ *
+ * 2026-09-01 の一斉配信事故 (2アカウントがクォータ不足で全滅・誰も気づけず)
+ * への恒久対応。検知点は3つ:
+ *   1. cron 監視 (ban-monitor.ts) — 定期チェック (毎時)
+ *   2. 送信前ガード (broadcast.ts / dedup-broadcast.ts) — 一括送信の直前チェック
+ *   3. プロキシ経由の一斉送信 (routes/line-proxy.ts) — 外部 MCP/SDK クライアントの
+ *      broadcast/multicast パススルー (送信前チェック + LINE 由来 429 の検知)
+ * いずれも本モジュールの notifyQuotaAlert で通知に合流する。
+ *
+ * 通知チャネル:
+ *   - notifications テーブル (dashboard 行 + 有効な notification_rules のチャネル)
+ *     GET /api/notifications から参照できる記録。通知ルール未設定でも必ず残す。
+ *   - outgoing webhooks (event-bus) — event_type 'quota_alert' (または '*') を
+ *     購読する外部 Webhook (Slack 連携等) へ実際にプッシュされる能動経路。
+ *
+ * dedup: cron 監視 (health-check) 由来は同一アカウントにつき JST 月1回。
+ * LINE のクォータは月初にリセットされるため月替わりで自然に再武装される。
+ * pre-send (配信を実際に中止した) 通知は dedup しない — 中止は毎回オペレーターの
+ * 操作/予約に紐づく具体的な事象で、握りつぶすと「配信が silent に draft へ落ちた」
+ * という事故の再演になる。頻度は送信試行回数で自然に抑制される (中止された
+ * broadcast は draft に戻り、自動リトライはされない)。
+ * proxy-* 由来は同一アカウントにつき1時間に1回 — プロキシの呼び出し元は外部の
+ * 自動クライアントで、429 を受けて機械的にリトライし得る (pre-send と違い試行
+ * 回数で抑制されない) ため、時間 dedup で通知爆撃を防ぐ。
+ */
+
+import {
+  createNotification,
+  hasNotificationSince,
+  getActiveNotificationRulesByEvent,
+  getActiveOutgoingWebhooksByEvent,
+  toJstString,
+} from '@line-crm/db';
+import { LineApiError } from '@line-crm/line-sdk';
+import { monthStartJst } from './quota.js';
+import { fireOutgoingWebhooks } from './event-bus.js';
+
+export const QUOTA_ALERT_EVENT = 'quota_alert';
+
+/** 送信前ガードがクォータ不足で送信を中止したことを表す typed error。 */
+export class LinePlanQuotaError extends Error {
+  constructor(public readonly shortfall: PlanQuotaShortfall) {
+    super(
+      `line_plan_quota_insufficient: remaining=${shortfall.remaining} audience=${shortfall.audience}`,
+    );
+    this.name = 'LinePlanQuotaError';
+  }
+}
+
+/** getMessageQuota / getMessageQuotaConsumption だけを要求する最小クライアント面。 */
+export interface PlanQuotaClient {
+  getMessageQuota(): Promise<{ type: string; value?: number }>;
+  getMessageQuotaConsumption(): Promise<{ totalUsage: number }>;
+}
+
+export interface PlanQuotaShortfall {
+  limit: number;
+  consumption: number;
+  remaining: number;
+  audience: number;
+}
+
+/** LINE が月間上限超過の 429 で返す message (一字一句この文言)。 */
+export const LINE_MONTHLY_LIMIT_MESSAGE = 'You have reached your monthly limit.';
+
+/**
+ * LINE 由来の「月間クォータ超過」429 か。worker 内部の送信経路 (broadcast.ts) が
+ * ガード通過後の上流 429 を検知して last_error + 通知に落とすための判別。
+ * LINE がこの文言を変えたら検知は落ちる (通知が消えるだけで送信自体は従来どおり
+ * エラー処理される) — 文言はプロキシ側 (line-proxy.ts) と共有の単一定義。
+ */
+export function isLineMonthlyLimit429(err: unknown): boolean {
+  return (
+    err instanceof LineApiError &&
+    err.status === 429 &&
+    err.responseBody.includes(LINE_MONTHLY_LIMIT_MESSAGE)
+  );
+}
+
+export interface PlanQuotaSnapshot {
+  limit: number;
+  consumption: number;
+  remaining: number;
+}
+
+/**
+ * quota / consumption スナップショットの per-isolate TTL キャッシュ。
+ * プロキシの一斉送信ガードは multicast の 500人チャンクごとに呼ばれるため、
+ * 素通しだと 1 キャンペーンで数十回 quota API を叩く。consumption API は
+ * そもそも反映が遅延する (LINE 側仕様) ので、30秒の鮮度低下は判定品質を
+ * 変えない。isolate ローカルなので厳密な単一キャッシュではないが、
+ * ホットパスの連続チャンクは同一 isolate で処理されるため実効性がある。
+ */
+const QUOTA_SNAPSHOT_TTL_MS = 30_000;
+const QUOTA_SNAPSHOT_CACHE_MAX = 200;
+const quotaSnapshotCache = new Map<
+  string,
+  { expires: number; value: PlanQuotaSnapshot | null }
+>();
+
+/**
+ * LINE プランの limit / consumption / remaining を読む共通ヘルパー。
+ * 上限なしプラン (type !== 'limited') は null。API エラーは throw する —
+ * fail-open にするか合成 shortfall にするかは呼び出し元の責務
+ * (送信前ガードは fail-open、429 事後通知は limit=0 の合成 shortfall)。
+ *
+ * cacheKey (通常はチャネルトークン) を渡すと TTL キャッシュが効く。
+ * 省略時は毎回 API を読む (テスト・鮮度必須の呼び出し用)。
+ */
+export async function readPlanQuotaSnapshot(
+  client: PlanQuotaClient,
+  cacheKey?: string,
+): Promise<PlanQuotaSnapshot | null> {
+  if (cacheKey) {
+    const cached = quotaSnapshotCache.get(cacheKey);
+    if (cached && cached.expires > Date.now()) return cached.value;
+  }
+
+  const [quota, consumption] = await Promise.all([
+    client.getMessageQuota(),
+    client.getMessageQuotaConsumption(),
+  ]);
+  const value =
+    quota.type !== 'limited' || typeof quota.value !== 'number'
+      ? null
+      : {
+          limit: quota.value,
+          consumption: consumption.totalUsage,
+          remaining: Math.max(0, quota.value - consumption.totalUsage),
+        };
+  if (cacheKey) {
+    if (quotaSnapshotCache.size >= QUOTA_SNAPSHOT_CACHE_MAX) quotaSnapshotCache.clear();
+    quotaSnapshotCache.set(cacheKey, { expires: Date.now() + QUOTA_SNAPSHOT_TTL_MS, value });
+  }
+  return value;
+}
+
+/**
+ * LINE プランの残りクォータが audience 人への一括送信に足りない場合に不足情報を
+ * 返す。足りている・上限なしプラン・API エラー (トークン失効等) は null。
+ *
+ * audience は関数でも渡せる (lazy)。上限なしプランでは評価されないので、
+ * COUNT クエリを「上限ありプランで残量比較が必要になったとき」だけに遅延できる。
+ *
+ * fail-open: クォータ確認自体の失敗で送信を止めてはいけない (確認 API の一時
+ * 障害が全配信停止に化ける)。ブロックするのは「不足が確定した」ときだけ。
+ * ただし remaining === 0 は quota API だけで不足が確定するため、audience の
+ * COUNT が失敗しても fail-open せずブロックする (audience は表示用に 0 で埋める)。
+ */
+export async function getLinePlanQuotaShortfall(
+  client: PlanQuotaClient,
+  audience: number | (() => Promise<number>),
+  cacheKey?: string,
+): Promise<PlanQuotaShortfall | null> {
+  let snapshot: PlanQuotaSnapshot | null;
+  try {
+    snapshot = await readPlanQuotaSnapshot(client, cacheKey);
+  } catch (err) {
+    console.error('LINE plan quota check failed (fail-open):', err);
+    return null;
+  }
+  if (!snapshot) return null;
+
+  // remaining === 0 は audience に依らず不足が確定 (何も送れない)。audience の
+  // COUNT はここでは表示用でしかないので、その失敗で確定ブロックを取り消さない。
+  if (snapshot.remaining === 0) {
+    let audienceCount = 0;
+    try {
+      audienceCount = typeof audience === 'function' ? await audience() : audience;
+    } catch (err) {
+      console.error('quota shortfall audience count failed (blocking anyway):', err);
+    }
+    return { ...snapshot, audience: audienceCount };
+  }
+
+  try {
+    const audienceCount = typeof audience === 'function' ? await audience() : audience;
+    if (audienceCount > 0 && snapshot.remaining < audienceCount) {
+      return { ...snapshot, audience: audienceCount };
+    }
+    return null;
+  } catch (err) {
+    console.error('LINE plan quota audience count failed (fail-open):', err);
+    return null;
+  }
+}
+
+/**
+ * 「全員配信1回分」の需要 = 配信可能友だち数。
+ * legacy な line_account_id NULL 行の扱いが要点:
+ *   - 単一アカウント運用では NULL 行こそが友だちの本体 (migration 008 以前の行)
+ *     なので含める。
+ *   - マルチアカウント運用で全アカウントに NULL 行を加算すると、共有 NULL プール
+ *     の分だけ全アカウントの需要が同時に水増しされ、小プランのアカウントが恒常的に
+ *     誤 warning / 誤ブロックになる (over-count は「送らせない」方向に働くため、
+ *     ブロック用途では危険側)。→ includeLegacyNullRows=false で厳密一致にする。
+ */
+export async function countDeliverableAudience(
+  db: D1Database,
+  lineAccountId: string | null,
+  includeLegacyNullRows: boolean,
+): Promise<number> {
+  let where = 'is_following = 1';
+  const binds: unknown[] = [];
+  if (lineAccountId) {
+    where += includeLegacyNullRows
+      ? ' AND (line_account_id = ? OR line_account_id IS NULL)'
+      : ' AND line_account_id = ?';
+    binds.push(lineAccountId);
+  }
+  const row = await db
+    .prepare(`SELECT COUNT(*) as count FROM friends WHERE ${where}`)
+    .bind(...binds)
+    .first<{ count: number }>();
+  return row?.count ?? 0;
+}
+
+/** アクティブな LINE アカウントが1つ以下の運用か (NULL 行加算の可否判定に使う)。 */
+export async function isSingleAccountInstall(db: D1Database): Promise<boolean> {
+  const row = await db
+    .prepare(`SELECT COUNT(*) as count FROM line_accounts WHERE is_active = 1`)
+    .first<{ count: number }>();
+  return (row?.count ?? 0) <= 1;
+}
+
+/**
+ * 'all' 送信のガード用 audience (lazy)。total_count 記録用のフォロワー数
+ * (legacy NULL 行込みの多め見積もり) と違い、ブロック判定は「送らせない」方向に
+ * 働くため、マルチアカウント運用では NULL 行を除いた厳密一致で数える — 共有
+ * NULL プールの水増しで実際は送れる配信を誤ブロックしないため。
+ * worker 内部の一斉配信 (broadcast.ts) と LINE API プロキシ (line-proxy.ts) が
+ * 共有する単一定義 — NULL 行ポリシーが二箇所で乖離しないように。
+ * knownSingleInstall: 呼び出し元がアクティブアカウント数を既に知っている場合に
+ * 渡すと isSingleAccountInstall の COUNT クエリを省ける。
+ */
+export function allTargetGuardAudience(
+  db: D1Database,
+  accountId: string | null,
+  knownSingleInstall?: boolean,
+): () => Promise<number> {
+  return async () => {
+    if (!accountId) return countDeliverableAudience(db, null, true);
+    const single = knownSingleInstall ?? (await isSingleAccountInstall(db));
+    return countDeliverableAudience(db, accountId, single);
+  };
+}
+
+export interface QuotaAlertInput {
+  lineAccountId: string;
+  accountName?: string | null;
+  shortfall: PlanQuotaShortfall;
+  /**
+   * 検知元:
+   *   - health-check: cron 監視 (ban-monitor.ts)
+   *   - pre-send: worker 内部の一斉配信の送信前ガード (配信を中止した)
+   *   - upstream-429: worker 内部の一斉配信をガード通過後に LINE がクォータ超過 429 で拒否した
+   *     (ガードの fail-open / audience 過小見積もりを LINE 側が最終的に止めたケース)
+   *   - proxy-pre-send: LINE API プロキシが外部クライアントの一斉送信を送信前に拒否した
+   *   - proxy-upstream-429: プロキシ転送した一斉送信を LINE がクォータ超過 429 で拒否した
+   */
+  source: 'health-check' | 'pre-send' | 'upstream-429' | 'proxy-pre-send' | 'proxy-upstream-429';
+  broadcastId?: string;
+  broadcastTitle?: string;
+}
+
+/** created_at と同形式 (jstNow) で hours 時間前を返す。 */
+function jstHoursAgo(hours: number): string {
+  return toJstString(new Date(Date.now() - hours * 3600_000));
+}
+
+/** proxy-* 通知の時間 dedup 幅。 */
+const PROXY_ALERT_DEDUP_HOURS = 1;
+
+/**
+ * source ごとの dedup ポリシー (null = dedup なし)。sourcePrefix を持つ source は
+ * 同種 (metadata.source が prefix 一致) の既通知だけを重複と見なす — proxy 由来の
+ * 「実際に送信が失敗した/中止した」通知が、直前の cron 警告 (health-check) に
+ * 握りつぶされないように。health-check 側は source 無差別のまま: どの経路であれ
+ * 同月に通知済みなら月次の再警告は不要。
+ * Record にしているのは網羅性のため — source を追加するとここも型エラーで
+ * 気づける (暗黙のフォールバックに落ちない)。
+ */
+const QUOTA_ALERT_DEDUP: Record<
+  QuotaAlertInput['source'],
+  { since: () => string; sourcePrefix?: string } | null
+> = {
+  'health-check': { since: () => monthStartJst() },
+  'pre-send': null, // 配信中止は毎回通知 (冒頭コメント参照)
+  'upstream-429': null, // 429 で draft へ戻った配信は自動リトライされない — pre-send と同じ理由
+  'proxy-pre-send': { since: () => jstHoursAgo(PROXY_ALERT_DEDUP_HOURS), sourcePrefix: 'proxy-' },
+  'proxy-upstream-429': { since: () => jstHoursAgo(PROXY_ALERT_DEDUP_HOURS), sourcePrefix: 'proxy-' },
+};
+
+/** source ごとの通知タイトル (網羅 Record — dedup と同じ理由)。 */
+const QUOTA_ALERT_TITLES: Record<QuotaAlertInput['source'], (name: string) => string> = {
+  'health-check': (name) => `LINEプラン月間クォータ不足: ${name}`,
+  'pre-send': (name) => `一斉配信を中止: LINEプランクォータ不足 (${name})`,
+  'upstream-429': (name) => `一斉配信がLINEクォータ超過で失敗 (${name})`,
+  'proxy-pre-send': (name) => `プロキシ経由の一斉送信を中止: LINEプランクォータ不足 (${name})`,
+  'proxy-upstream-429': (name) => `プロキシ経由の一斉送信がLINEクォータ超過で失敗 (${name})`,
+};
+
+/**
+ * クォータ不足をオペレーターに通知する。通知したら true。
+ * dedup は source ごと (QUOTA_ALERT_DEDUP 参照): health-check は月次、proxy-* は
+ * 同種通知に対して1時間、pre-send は毎回通知。dedup は check-then-insert で
+ * 非アトミック — 完全並行のバーストは複数通知し得るが、以後1時間は抑制される
+ * ので best-effort で足りる。
+ * best-effort: 通知の失敗が呼び出し元 (ヘルスチェック / 送信処理) を壊さない
+ * よう、例外はすべて握りつぶす。
+ */
+export async function notifyQuotaAlert(
+  db: D1Database,
+  input: QuotaAlertInput,
+): Promise<boolean> {
+  try {
+    const dedup = QUOTA_ALERT_DEDUP[input.source];
+    if (dedup) {
+      const already = await hasNotificationSince(db, {
+        eventType: QUOTA_ALERT_EVENT,
+        lineAccountId: input.lineAccountId,
+        since: dedup.since(),
+        sourcePrefix: dedup.sourcePrefix,
+      });
+      if (already) return false;
+    }
+
+    const { shortfall } = input;
+    const name = input.accountName || input.lineAccountId;
+    const title = QUOTA_ALERT_TITLES[input.source](name);
+    // limit=0 は「不足の事実だけ分かって残量詳細が取れなかった」合成 shortfall
+    // (LINE が 429 を返した後に quota API まで失敗したケース)。0通/0通 という
+    // 誤解を招く数字を出さず、事実だけ伝える。
+    // audience=0 は「対象人数は算出していない/できなかった」印 (upstream-429 の
+    // 事後通知等)。0人と偽らず、人数の節ごと省く。
+    const audienceClause =
+      shortfall.audience > 0
+        ? `配信対象 約${shortfall.audience}人に足りず、一括配信が失敗します。`
+        : `一括配信が失敗します。`;
+    const detail =
+      shortfall.limit > 0
+        ? `残り${shortfall.remaining}通 / 上限${shortfall.limit}通 (消費${shortfall.consumption}通)。` +
+          audienceClause +
+          `LINE Official Account Manager で追加メッセージ購入かプラン変更を検討してください。`
+        : `LINEプランの月間クォータを超過しています (残量の詳細は取得できませんでした)。` +
+          `LINE Official Account Manager で消費状況を確認し、追加メッセージ購入かプラン変更を検討してください。`;
+    const body =
+      input.broadcastTitle && input.source === 'pre-send'
+        ? `一斉配信「${input.broadcastTitle}」を送信前に中止しました。${detail}`
+        : input.broadcastTitle && input.source === 'upstream-429'
+          ? `一斉配信「${input.broadcastTitle}」がLINEのクォータ超過 (429) で失敗し、下書きに戻しました。${detail}`
+          : detail;
+    const metadata = JSON.stringify({
+      lineAccountId: input.lineAccountId,
+      source: input.source,
+      ...shortfall,
+      ...(input.broadcastId ? { broadcastId: input.broadcastId } : {}),
+    });
+
+    // 有効な quota_alert ルールのチャネルを集める (channel → 最初に要求した ruleId)。
+    // ルールが1つも無くても dashboard 行は必ず残す (事故の教訓: どこにも出ないのが
+    // 最悪)。
+    const rules = (await getActiveNotificationRulesByEvent(db, QUOTA_ALERT_EVENT)).filter(
+      (r) => !r.line_account_id || r.line_account_id === input.lineAccountId,
+    );
+    const byChannel = new Map<string, string | undefined>([['dashboard', undefined]]);
+    for (const rule of rules) {
+      let channels: unknown = [];
+      try {
+        channels = JSON.parse(rule.channels);
+      } catch {
+        channels = [];
+      }
+      if (!Array.isArray(channels)) continue;
+      for (const channel of channels) {
+        if (typeof channel === 'string' && !byChannel.has(channel)) {
+          byChannel.set(channel, rule.id);
+        }
+      }
+    }
+
+    // webhook チャネルの実配信は outgoing_webhooks の購読 (event_types) に依存する。
+    // outgoing webhook は notification_rules と独立した購読系で、quota_alert (または
+    // '*') を購読している外部 Webhook があれば常に発火する。実際に配信してから
+    // 結果を記録する — 「購読者が居る」だけで sent と書くと、エンドポイントが
+    // 落ちていても配信済みに見える (「通知したつもり」の再演)。
+    const webhookSubscribers = await getActiveOutgoingWebhooksByEvent(db, QUOTA_ALERT_EVENT);
+    let webhookDelivered = 0;
+    if (webhookSubscribers.length > 0) {
+      webhookDelivered = await fireOutgoingWebhooks(
+        db,
+        QUOTA_ALERT_EVENT,
+        {
+          eventData: {
+            lineAccountId: input.lineAccountId,
+            accountName: input.accountName ?? null,
+            source: input.source,
+            title,
+            body,
+            ...shortfall,
+            ...(input.broadcastId ? { broadcastId: input.broadcastId } : {}),
+          },
+        },
+        webhookSubscribers,
+      );
+    }
+
+    for (const [channel, ruleId] of byChannel) {
+      // dashboard は GET /api/notifications で読める記録なので記録時点で「配信済み」。
+      // webhook は1件以上実際に届いたときだけ sent。email 等の未実装チャネルは
+      // pending のまま残し、未配信を偽らない。
+      const status =
+        channel === 'dashboard'
+          ? 'sent'
+          : channel === 'webhook'
+            ? webhookDelivered > 0 ? 'sent' : 'failed'
+            : 'pending';
+      await createNotification(db, {
+        ruleId,
+        eventType: QUOTA_ALERT_EVENT,
+        title,
+        body,
+        channel,
+        status,
+        metadata,
+        lineAccountId: input.lineAccountId,
+      });
+    }
+
+    return true;
+  } catch (err) {
+    console.error(`notifyQuotaAlert failed (account ${input.lineAccountId}):`, err);
+    return false;
+  }
+}

--- a/apps/worker/src/services/quota.test.ts
+++ b/apps/worker/src/services/quota.test.ts
@@ -3,6 +3,8 @@ import {
   quotaConfig,
   quotaEnabled,
   monthStartJst,
+  jstYyyyMmDd,
+  countAccountMonthlyMessages,
   getQuotaUsage,
   isQuotaExceeded,
   wouldExceedMonthlyQuota,
@@ -58,6 +60,31 @@ describe('monthStartJst', () => {
     expect(monthStartJst(new Date('2026-07-31T20:00:00Z'))).toBe('2026-08-01T00:00:00.000');
     // 2026-08-01T05:00:00Z = 2026-08-01T14:00 JST → still August
     expect(monthStartJst(new Date('2026-08-01T05:00:00Z'))).toBe('2026-08-01T00:00:00.000');
+  });
+});
+
+describe('jstYyyyMmDd', () => {
+  test('JST day boundary: UTC evening is already the next JST day', () => {
+    // 2026-08-31T20:00:00Z = 2026-09-01T05:00 JST
+    expect(jstYyyyMmDd(0, new Date('2026-08-31T20:00:00Z'))).toBe('20260901');
+    expect(jstYyyyMmDd(1, new Date('2026-08-31T20:00:00Z'))).toBe('20260831');
+    expect(jstYyyyMmDd(2, new Date('2026-08-31T20:00:00Z'))).toBe('20260830');
+  });
+});
+
+describe('countAccountMonthlyMessages', () => {
+  test('sums per-account log rows and all-target broadcast successes, JST month window', async () => {
+    const { db, executed } = makeDb({ monthly: 40, allBroadcasts: 2 });
+    const total = await countAccountMonthlyMessages(db, 'acc-1', new Date('2026-08-21T00:00:00Z'));
+    expect(total).toBe(42);
+    const ml = executed.find((e) => e.sql.includes('FROM messages_log'))!;
+    expect(ml.sql).toContain('f.line_account_id = ?');
+    expect(ml.params).toEqual(['2026-08-01T00:00:00.000', 'acc-1']);
+    const bc = executed.find((e) => e.sql.includes('FROM broadcasts'))!;
+    expect(bc.sql).toContain(`target_type = 'all'`);
+    expect(bc.sql).toContain('line_request_id IS NOT NULL');
+    expect(bc.sql).toContain('line_account_id = ?');
+    expect(bc.params).toEqual(['2026-08-01T00:00:00.000', 'acc-1']);
   });
 });
 

--- a/apps/worker/src/services/quota.ts
+++ b/apps/worker/src/services/quota.ts
@@ -43,6 +43,61 @@ export function monthStartJst(now: Date = new Date()): string {
   return jst.toISOString().slice(0, 7) + '-01T00:00:00.000';
 }
 
+/** yyyyMMdd of the JST day `daysAgo` days in the past (0 = today). */
+export function jstYyyyMmDd(daysAgo: number, now: Date = new Date()): string {
+  const jst = new Date(now.getTime() + 9 * 3600_000 - daysAgo * 86_400_000);
+  return jst.toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+/**
+ * Per-account count of messages sent this JST month, approximating LINE's
+ * official 「配信済みメッセージ数」: push-type messages_log rows (joined through
+ * friends.line_account_id — legacy rows carry no ml.line_account_id) plus the
+ * success_count of all-target broadcasts sent through LINE's broadcast API,
+ * which write no per-recipient messages_log rows (same term as getQuotaUsage
+ * below). Broadcast rows with a NULL line_account_id (single-account era) are
+ * deliberately excluded — they cannot be attributed to one account.
+ *
+ * ⚠️ 概算 (上振れ側): all-target broadcast の success_count は送信直前の
+ * `line_account_id = ? OR IS NULL` COUNT のスナップショットで、マルチアカウント
+ * 運用では共有 legacy NULL プールが各アカウントの配信に重複計上される
+ * (broadcast.ts の followerRow コメント参照 — 制限用途では over-count が安全側)。
+ * 正確な消費量は同じ delivery-health 応答の LINE 公式 consumption を見ること。
+ *
+ * Single definition shared by GET /api/line-accounts (stats.messagesThisMonth)
+ * and GET /api/line-accounts/delivery-health so the two dashboard numbers
+ * never disagree.
+ */
+export async function countAccountMonthlyMessages(
+  db: D1Database,
+  lineAccountId: string,
+  now: Date = new Date(),
+): Promise<number> {
+  const cutoff = monthStartJst(now);
+  const [logRow, bcRow] = await Promise.all([
+    db
+      .prepare(
+        `SELECT COUNT(*) as count FROM messages_log ml
+          INNER JOIN friends f ON f.id = ml.friend_id
+          WHERE ml.direction = 'outgoing'
+            AND (ml.delivery_type IS NULL OR ml.delivery_type = 'push')
+            AND ml.created_at >= ? AND f.line_account_id = ?`,
+      )
+      .bind(cutoff, lineAccountId)
+      .first<{ count: number }>(),
+    db
+      .prepare(
+        `SELECT COALESCE(SUM(success_count), 0) as count FROM broadcasts
+          WHERE target_type = 'all'
+            AND line_request_id IS NOT NULL
+            AND sent_at >= ? AND line_account_id = ?`,
+      )
+      .bind(cutoff, lineAccountId)
+      .first<{ count: number }>(),
+  ]);
+  return (logRow?.count ?? 0) + (bcRow?.count ?? 0);
+}
+
 export type QuotaUsage = {
   friends: { used: number; max: number };
   monthlyMessages: { used: number; max: number };

--- a/docs/LINE-API-PROXY.md
+++ b/docs/LINE-API-PROXY.md
@@ -53,6 +53,15 @@ curl -X POST "https://<WORKER_URL>/line-api/v2/bot/message/push" \
 - **未知の宛先**: DB に friend が居ない userId への push/multicast は、プロフィール取得の上で friend 行を自動作成する(webhook の自動登録と同じ挙動)。1リクエストあたりの自動作成は 20 件まで(subrequest 予算保護)。超過分は記録スキップ + warn ログ。
 - **ログ失敗は送信を壊さない**: 記録に失敗しても LINE 側の送信は成功済みなので、レスポンスは 200 のまま返す(クライアント再送 = 二重送信を防ぐ)。
 
+### 一斉送信の 429 (クォータ関連)
+
+一斉送信 (broadcast / multicast / narrowcast) だけは完全な透過転送ではなく、2種類の 429 を返し得る:
+
+1. **harness 独自の月間上限** (`QUOTA_MONTHLY_MESSAGES_MAX` 設定時のみ) — 上限超過・超過見込みの一斉送信を転送前に拒否する。
+2. **LINE プランクォータの送信前ガード** (常時有効) — LINE プラン自体の残りメッセージ数が配信対象数に足りないことが確定した場合、転送前に拒否してオペレーターへ通知する (`quota_alert`)。レスポンスは LINE 互換の `message` に加えて `reason: "line-plan-quota-insufficient"` と `quota: {limit, consumption, remaining, audience}` を含む。この 429 は月替わり・追加メッセージ購入・プラン変更まで解消しないため、**Retry-After 前提の自動リトライはしないこと**。クォータ確認 API の失敗時は fail-open (送信を止めない)。
+
+また、転送した一斉送信に LINE 自身がクォータ超過の 429 (`You have reached your monthly limit.`) を返した場合も、応答をそのまま返しつつオペレーターへ通知する。プロキシ由来のクォータ通知は同一アカウントにつき1時間に1回に dedup される。
+
 ## 運用ルール(これをやらないと根本解決にならない)
 
 チャネルトークン認証(系統2)は移行用の互換モード。**トークンを持っているエージェントは api.line.me を直接叩けてしまう**ので、プロキシの存在だけでは強制力がない。以下の手順で直接送信の経路を潰す:

--- a/docs/OSS-SYNC-CHARTER.md
+++ b/docs/OSS-SYNC-CHARTER.md
@@ -240,11 +240,14 @@ semver に従う。**root `package.json` を唯一の真実**とし、umbrella p
 
 ### 7.2 リリース手順
 
+**publish は手元から実行できない。GitHub Actions の `publish-npm.yml` が trusted publishing (OIDC) で行う。**
+npm アカウントはパスキー運用で TOTP コードが出せないため、手元の `npm publish` / `pnpm publish` は 2FA を満たせず実行不可能。
+
 ```bash
 # 1. CHANGELOG.md にエントリ追加
 
-# 2. root package.json のバージョンを bump (例: 0.12.0 → 0.13.0)
-node -e "const fs=require('fs');const p=require('./package.json');p.version='0.13.0';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
+# 2. root package.json のバージョンを bump (例: 0.22.0 → 0.23.0)
+node -e "const fs=require('fs');const p=require('./package.json');p.version='0.23.0';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n');"
 
 # 3. umbrella packages を同期 (apps/web, apps/worker, packages/sdk, packages/mcp-server)
 bash scripts/sync-versions.sh
@@ -253,22 +256,36 @@ bash scripts/sync-versions.sh
 pnpm --filter @line-harness/sdk build && pnpm --filter @line-harness/sdk test
 pnpm --filter @line-harness/mcp-server build
 
-# 5. npm publish (pnpm で)
-cd packages/sdk && pnpm publish --access public --no-git-checks
-cd packages/mcp-server && pnpm publish --access public --no-git-checks
-
-# 6. commit + push (pre-push hook が版差を再検証 → 不一致なら拒否)
+# 5. commit + push → PR を main にマージ
+#    (pre-push hook が版差を再検証 → 不一致なら拒否)
 git add -A
-git commit -m "chore: release v0.13.0"
+git commit -m "chore: release v0.23.0"
 git push  # GitHub Actions が deploy を走らせる
 
+# 6. main にマージされた後に publish workflow を dispatch
+gh workflow run publish-npm.yml --ref main -f target=all -f dry_run=false
+gh run watch  # 完走を確認
+
 # 7. OSS リポに GitHub Release 作成
-gh release create v0.13.0 --repo Shudesu/line-harness-oss --title "v0.13.0" --notes "..."
+gh release create v0.23.0 --repo Shudesu/line-harness-oss --title "v0.23.0" --notes "..."
 ```
 
-### 7.3 npm publish は pnpm で
+**順序が重要**: publish workflow は `main` の内容を checkout する。バージョン bump が main に入る前に dispatch しても、古いバージョンを publish する（もしくは publish 済み扱いで skip する）だけで意味がない。必ず「commit + push（PR マージ）→ workflow_dispatch」の順にすること。2026-08-25 の v0.23.0 リリースはこの順で実施した。
 
-`npm publish` ではなく `pnpm publish` を使う。`workspace:*` が自動で実バージョンに変換される。
+### 7.3 publish workflow (`publish-npm.yml`)
+
+手元 publish は禁止ではなく、そもそも不可能。すべて `.github/workflows/publish-npm.yml` 経由で行う（前提・ハマりどころは workflow 冒頭のコメントに詳述）。
+
+| input | 値 |
+|-------|-----|
+| `target` | `all` / `sdk-only` / `mcp-server-only` / `create-line-harness-only` |
+| `dry_run` | `true` なら build + pack までで publish しない |
+
+- **通常は `target=all` を使う。** `packages/mcp-server` の `@line-harness/sdk` 依存は `workspace:*` で、`pnpm pack` 時に厳密バージョン（例 `0.23.0`）へ書き換わる。したがって **mcp-server だけを publish することはできず、sdk も同じバージョンで同時に publish する必要がある**
+- workflow は「既に npm 上にあるバージョンは skip」する冪等実装。`target=all` に未変更パッケージが混ざっても no-op になるので、迷ったら `all` でよい。部分失敗しても同じ dispatch を再実行できる
+- 内部は `pnpm pack` でパックして `npm publish <tarball>` する。pnpm 9 の publish パスが OIDC ハンドシェイクをしないため、pack は pnpm・publish は npm という組み合わせにしている
+- `create-line-harness` は umbrella 外の独立バージョンで、`@line-harness/update-engine` に `workspace:^` 依存する。update-engine はこの workflow では publish されないため、参照先バージョンが npm 上に存在しないと install が壊れる。`npm view @line-harness/update-engine version` で先に確認すること
+- 事前確認したいときは `gh workflow run publish-npm.yml --ref main -f target=all -f dry_run=true`
 
 ### 7.4 ダッシュボード表示バージョン
 
@@ -308,7 +325,8 @@ MCP や Claude Code で操作する際の追加ルール。
 - **OSS に sync されるファイルにシークレットを書かない**
 - **CLAUDE.md にアカウント ID・DB ID・メールアドレスの実値を書かない**
 - **外部 PR がマージされたら、次の作業前に Private に取り込む**
-- **npm publish は `pnpm publish` を使う**
+- **npm publish を手元で実行しない**（パスキー 2FA のため不可能） — `gh workflow run publish-npm.yml --ref main -f target=all -f dry_run=false` で GitHub Actions に任せる
+- **publish workflow の dispatch は main へのマージ後**（workflow は main を checkout する）
 
 ---
 
@@ -334,6 +352,8 @@ MCP や Claude Code で操作する際の追加ルール。
 
 - [ ] CHANGELOG.md 更新した
 - [ ] SDK と MCP のバージョンを揃えた
-- [ ] pnpm publish した（npm publish ではない）
+- [ ] バージョン bump を main にマージしてから publish workflow を dispatch した（手元 publish ではない）
+- [ ] `target=all` で dispatch した（mcp-server 単独 publish は不可）
+- [ ] workflow run が成功し、npm 上に新バージョンが出たことを確認した
 - [ ] OSS に GitHub Release を作成した
 - [ ] 本番デプロイした（必要な場合）

--- a/packages/db/bootstrap-meta.json
+++ b/packages/db/bootstrap-meta.json
@@ -75,7 +75,9 @@
     "068_media_inquiries.sql",
     "069_rich_menu_selected.sql",
     "070_admin_sso_jti.sql",
+    "071_quota_alerts.sql",
+    "072_broadcast_last_error.sql",
     "072_health_logs_composite_index.sql"
   ],
-  "migrationCount": 76
+  "migrationCount": 78
 }

--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -228,7 +228,7 @@ CREATE TABLE IF NOT EXISTS "broadcasts" (
   account_ids        TEXT CHECK (account_ids IS NULL OR json_valid(account_ids)),
   dedup_priority     TEXT CHECK (dedup_priority IS NULL OR json_valid(dedup_priority)),
   failed_account_ids TEXT CHECK (failed_account_ids IS NULL OR json_valid(failed_account_ids))
-, dedup_progress TEXT, batch_lock_at TEXT, track_links INTEGER NOT NULL DEFAULT 1);
+, dedup_progress TEXT, batch_lock_at TEXT, track_links INTEGER NOT NULL DEFAULT 1, last_error TEXT);
 
 CREATE TABLE IF NOT EXISTS calendar_bookings (
   id             TEXT PRIMARY KEY,
@@ -707,17 +707,18 @@ CREATE TABLE IF NOT EXISTS mileage_rules (
 );
 
 CREATE TABLE IF NOT EXISTS notification_rules (
-  id           TEXT PRIMARY KEY,
-  name         TEXT NOT NULL,
-  event_type   TEXT NOT NULL,
-  conditions   TEXT NOT NULL DEFAULT '{}',
-  channels     TEXT NOT NULL DEFAULT '["webhook"]',
-  is_active    INTEGER NOT NULL DEFAULT 1,
-  created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
-  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+  id              TEXT PRIMARY KEY,
+  name            TEXT NOT NULL,
+  event_type      TEXT NOT NULL,
+  conditions      TEXT NOT NULL DEFAULT '{}',
+  channels        TEXT NOT NULL DEFAULT '["webhook"]',
+  is_active       INTEGER NOT NULL DEFAULT 1,
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  line_account_id TEXT
 );
 
-CREATE TABLE IF NOT EXISTS notifications (
+CREATE TABLE IF NOT EXISTS "notifications" (
   id              TEXT PRIMARY KEY,
   rule_id         TEXT REFERENCES notification_rules (id) ON DELETE SET NULL,
   event_type      TEXT NOT NULL,
@@ -726,7 +727,8 @@ CREATE TABLE IF NOT EXISTS notifications (
   channel         TEXT NOT NULL,
   status          TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'sent', 'failed')),
   metadata        TEXT,
-  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  line_account_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS operators (
@@ -1332,6 +1334,8 @@ CREATE INDEX IF NOT EXISTS idx_mileage_rules_match
   ON mileage_rules(program_id, event_type, source, is_active);
 
 CREATE INDEX IF NOT EXISTS idx_notifications_created ON notifications (created_at);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_event_account ON notifications (event_type, line_account_id, created_at);
 
 CREATE INDEX IF NOT EXISTS idx_notifications_status ON notifications (status);
 

--- a/packages/db/migrations/071_quota_alerts.sql
+++ b/packages/db/migrations/071_quota_alerts.sql
@@ -1,0 +1,26 @@
+-- Migration 071: notifications / notification_rules に line_account_id 列を追加
+-- (072 のクォータ通知が使う。072_broadcast_last_error.sql とセットで
+--  2026-09-01 の一斉配信事故への恒久対応)
+--
+-- 両テーブルの line_account_id は本番 DB には out-of-band で追加済みだが
+-- migration 履歴には存在しない (002 の CREATE には無い)。この migration は
+-- 「列が無い環境 (OSS の既存インストール等)」に列を足すためのもの。
+--
+-- ⚠️ 本番 (private prod) では列が既に存在するため、この ADD COLUMN は
+-- duplicate column エラーになる。CI (deploy-worker.yml) はファイル単位で
+-- 適用するので、本番の _migrations には本ファイルを適用済みとして事前マーク
+-- してある (INSERT INTO _migrations — 2026-09-02 実施)。update-engine
+-- (OSS セルフアップデート) はステートメント単位で適用し duplicate column を
+-- benign skip するため対処不要。
+--
+-- 当初案はテーブル再構築 (RENAME ベース) で JST デフォルトや status CHECK ごと
+-- 両環境を揃えるものだったが、update-engine の安全スプリッタが RENAME TO /
+-- DROP TABLE を拒否するため (packages/update-engine/src/migrations.ts)、その形は
+-- OSS セルフアップデートを適用不能にする。additive-only ポリシー
+-- (scripts/check-migrations.ts, カットオフ 041) にも反する。スキーマの正規形は
+-- 新規環境の bootstrap.sql / schema.sql 側で担保し、既存環境は列追加のみに
+-- 留める (コードは常に値を明示 bind するためデフォルト差異の影響は無い。
+-- notifications.status の CHECK は 002 時点から pending/sent/failed で同一)。
+
+ALTER TABLE notifications ADD COLUMN line_account_id TEXT;
+ALTER TABLE notification_rules ADD COLUMN line_account_id TEXT;

--- a/packages/db/migrations/072_broadcast_last_error.sql
+++ b/packages/db/migrations/072_broadcast_last_error.sql
@@ -1,0 +1,17 @@
+-- Migration 072: LINE プランクォータ監視 + 配信失敗理由の記録
+--
+-- 2026-09-01 の一斉配信事故 (2アカウントがクォータ不足で全滅・どこにも
+-- 表示されず誰も気づけなかった) への恒久対応。cron 監視 (ban-monitor) と
+-- 送信前ガード (services/broadcast.ts) がクォータ不足を検知し、
+-- notifications へ記録 + outgoing webhook で通知する。
+-- 071 (line_account_id 列の追加) の後に適用されること — 下のインデックスが
+-- その列を参照する。
+
+-- broadcasts.last_error: 直近の送信失敗理由 (クォータ不足ガード等)。
+-- 送信開始・送信成功で NULL に戻る。
+ALTER TABLE broadcasts ADD COLUMN last_error TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_notifications_status ON notifications (status);
+CREATE INDEX IF NOT EXISTS idx_notifications_created ON notifications (created_at);
+-- クォータ通知の月次 dedup 判定 (event_type + line_account_id + created_at) 用
+CREATE INDEX IF NOT EXISTS idx_notifications_event_account ON notifications (event_type, line_account_id, created_at);

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -136,7 +136,8 @@ CREATE TABLE IF NOT EXISTS broadcasts (
   failed_account_ids TEXT CHECK (failed_account_ids IS NULL OR json_valid(failed_account_ids)),
   dedup_progress     TEXT CHECK (dedup_progress IS NULL OR json_valid(dedup_progress)),
   batch_lock_at      TEXT,
-  track_links        INTEGER NOT NULL DEFAULT 1
+  track_links        INTEGER NOT NULL DEFAULT 1,
+  last_error         TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_broadcasts_status ON broadcasts (status);
@@ -762,7 +763,8 @@ CREATE TABLE IF NOT EXISTS notification_rules (
   channels     TEXT NOT NULL DEFAULT '["webhook"]',
   is_active    INTEGER NOT NULL DEFAULT 1,
   created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
-  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  line_account_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS notifications (
@@ -774,11 +776,13 @@ CREATE TABLE IF NOT EXISTS notifications (
   channel         TEXT NOT NULL,
   status          TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'sent', 'failed')),
   metadata        TEXT,
-  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours'))
+  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  line_account_id TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_notifications_status ON notifications (status);
 CREATE INDEX IF NOT EXISTS idx_notifications_created ON notifications (created_at);
+CREATE INDEX IF NOT EXISTS idx_notifications_event_account ON notifications (event_type, line_account_id, created_at);
 
 -- ============================================================
 -- Round 3: Stripe決済連携

--- a/packages/db/src/broadcasts.ts
+++ b/packages/db/src/broadcasts.ts
@@ -24,6 +24,8 @@ export interface Broadcast {
   track_links: number;
   line_account_id?: string | null;
   alt_text?: string | null;
+  /** 直近の送信失敗理由 (クォータ不足ガード等)。送信成功で NULL に戻る。 */
+  last_error?: string | null;
 }
 
 export async function getBroadcasts(db: D1Database, accountId?: string): Promise<Broadcast[]> {
@@ -478,6 +480,13 @@ export async function updateBroadcastStatus(
     fields.push('dedup_progress = NULL');
     // batch_lock_at もクリア (sent 後は recover の対象外なので影響はないが綺麗に).
     fields.push('batch_lock_at = NULL');
+    // 送信が成功した以上、過去の失敗理由 (クォータ不足等) は解消済み。
+    fields.push('last_error = NULL');
+  }
+  if (status === 'sending') {
+    // 新しい送信試行の開始。前回試行の失敗理由を残すと、今回別の原因で失敗した
+    // ときに古い理由 (例: クォータ不足) が実際の原因を偽装する。
+    fields.push('last_error = NULL');
   }
   // 注: status='draft' では dedup_progress / batch_lock_at をクリアしない。
   // 失敗 rollback (processBroadcastSend の catch) で draft に戻すケースで partial
@@ -498,6 +507,17 @@ export async function updateBroadcastStatus(
   await db
     .prepare(`UPDATE broadcasts SET ${fields.join(', ')} WHERE id = ?`)
     .bind(...values)
+    .run();
+}
+
+/** 送信失敗理由を記録する (成功時のクリアは updateBroadcastStatus('sent') が行う)。 */
+export async function setBroadcastLastError(
+  db: D1Database,
+  broadcastId: string,
+  error: string,
+): Promise<void> {
+  await db.prepare(`UPDATE broadcasts SET last_error = ? WHERE id = ?`)
+    .bind(error, broadcastId)
     .run();
 }
 

--- a/packages/db/src/notifications.ts
+++ b/packages/db/src/notifications.ts
@@ -22,6 +22,7 @@ export interface NotificationRow {
   channel: string;
   status: string;
   metadata: string | null;
+  line_account_id: string | null;
   created_at: string;
 }
 
@@ -86,13 +87,34 @@ export async function getNotifications(db: D1Database, opts: { status?: string; 
 
 export async function createNotification(
   db: D1Database,
-  input: { ruleId?: string; eventType: string; title: string; body: string; channel: string; metadata?: string },
+  input: { ruleId?: string; eventType: string; title: string; body: string; channel: string; metadata?: string; status?: string; lineAccountId?: string | null },
 ): Promise<NotificationRow> {
   const id = crypto.randomUUID();
   const now = jstNow();
-  await db.prepare(`INSERT INTO notifications (id, rule_id, event_type, title, body, channel, metadata, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
-    .bind(id, input.ruleId ?? null, input.eventType, input.title, input.body, input.channel, input.metadata ?? null, now).run();
+  await db.prepare(`INSERT INTO notifications (id, rule_id, event_type, title, body, channel, status, metadata, line_account_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+    .bind(id, input.ruleId ?? null, input.eventType, input.title, input.body, input.channel, input.status ?? 'pending', input.metadata ?? null, input.lineAccountId ?? null, now).run();
   return (await db.prepare(`SELECT * FROM notifications WHERE id = ?`).bind(id).first<NotificationRow>())!;
+}
+
+/**
+ * 指定イベント × アカウントの通知が since (created_at 比較) 以降に存在するか。
+ * クォータ通知の「同一アカウントにつき月1回」dedup 判定に使う。
+ * sourcePrefix を渡すと metadata JSON の source フィールドが prefix 一致する
+ * 通知だけを数える (別 source の通知に dedup を食われないための絞り込み)。
+ */
+export async function hasNotificationSince(
+  db: D1Database,
+  input: { eventType: string; lineAccountId: string; since: string; sourcePrefix?: string },
+): Promise<boolean> {
+  let sql = `SELECT 1 as one FROM notifications
+      WHERE event_type = ? AND line_account_id = ? AND created_at >= ?`;
+  const binds: unknown[] = [input.eventType, input.lineAccountId, input.since];
+  if (input.sourcePrefix) {
+    sql += ` AND json_extract(metadata, '$.source') LIKE ?`;
+    binds.push(`${input.sourcePrefix}%`);
+  }
+  const row = await db.prepare(`${sql} LIMIT 1`).bind(...binds).first<{ one: number }>();
+  return row !== null;
 }
 
 export async function updateNotificationStatus(db: D1Database, id: string, status: string): Promise<void> {

--- a/packages/line-sdk/src/client.ts
+++ b/packages/line-sdk/src/client.ts
@@ -23,6 +23,32 @@ export interface FollowerIdsPage {
   next?: string;
 }
 
+export interface MessageQuota {
+  /** 'limited' (value holds the plan's monthly cap) or 'none' (no cap). */
+  type: string;
+  value?: number;
+}
+
+export interface MessageQuotaConsumption {
+  totalUsage: number;
+}
+
+/**
+ * LINE API が非 2xx を返したときの typed error。status とレスポンス本文を
+ * 機械可読に保持する — 呼び出し元が「429 かつ月間上限超過」のような判別を
+ * message 文字列のパースなしで行えるようにする。
+ */
+export class LineApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly responseBody: string,
+  ) {
+    super(`LINE API error: ${status} ${statusText} — ${responseBody}`);
+    this.name = 'LineApiError';
+  }
+}
+
 export class LineClient {
   constructor(private readonly channelAccessToken: string) {}
 
@@ -60,9 +86,7 @@ export class LineClient {
 
     if (!res.ok) {
       const text = await res.text().catch(() => '');
-      throw new Error(
-        `LINE API error: ${res.status} ${res.statusText} — ${text}`,
-      );
+      throw new LineApiError(res.status, res.statusText, text);
     }
 
     // Some endpoints (e.g. push, reply) return an empty body with 200.
@@ -214,7 +238,7 @@ export class LineClient {
     if (res.status === 404) return null;
     if (!res.ok) {
       const text = await res.text().catch(() => '');
-      throw new Error(`LINE API error: ${res.status} ${res.statusText} — ${text}`);
+      throw new LineApiError(res.status, res.statusText, text);
     }
     const data = (await res.json()) as { richMenuId: string };
     return data.richMenuId;
@@ -261,9 +285,7 @@ export class LineClient {
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');
-      throw new Error(
-        `LINE API error: ${res.status} ${res.statusText} — ${text}`,
-      );
+      throw new LineApiError(res.status, res.statusText, text);
     }
   }
 
@@ -309,6 +331,24 @@ export class LineClient {
       `/v2/bot/insight/followers?date=${encodeURIComponent(date)}`,
     );
     return data as FollowersInsight;
+  }
+
+  /**
+   * Get the monthly message quota of the LINE Official Account's plan.
+   * GET only — no messages are sent.
+   */
+  async getMessageQuota(): Promise<MessageQuota> {
+    const { data } = await this.request('GET', '/v2/bot/message/quota');
+    return data as MessageQuota;
+  }
+
+  /**
+   * Get the number of messages already counted against this month's quota.
+   * GET only — no messages are sent.
+   */
+  async getMessageQuotaConsumption(): Promise<MessageQuotaConsumption> {
+    const { data } = await this.request('GET', '/v2/bot/message/quota/consumption');
+    return data as MessageQuotaConsumption;
   }
 
   /**

--- a/packages/line-sdk/src/index.ts
+++ b/packages/line-sdk/src/index.ts
@@ -1,4 +1,10 @@
-export { LineClient } from './client.js';
+export { LineClient, LineApiError } from './client.js';
+export type {
+  FollowersInsight,
+  FollowerIdsPage,
+  MessageQuota,
+  MessageQuotaConsumption,
+} from './client.js';
 export { verifySignature } from './webhook.js';
 export {
   textMessage,

--- a/packages/mcp-server/src/tools/send-message.ts
+++ b/packages/mcp-server/src/tools/send-message.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getClient } from "../client.js";
+import { addTestBannerToFlex } from "./test-banner.js";
 
 export function registerSendMessage(server: McpServer): void {
   server.tool(
@@ -48,23 +49,8 @@ export function registerSendMessage(server: McpServer): void {
           if (messageType === "text") {
             finalContent = `【テスト配信】\n${content}`;
           } else if (messageType === "flex") {
-            try {
-              const flex = JSON.parse(content);
-              // Wrap in a carousel with a test banner
-              finalContent = JSON.stringify({
-                type: "bubble",
-                header: {
-                  type: "box",
-                  layout: "vertical",
-                  backgroundColor: "#FFE066",
-                  paddingAll: "8px",
-                  contents: [{ type: "text", text: "⚠️ テスト配信", size: "sm", weight: "bold", color: "#333", align: "center" }],
-                },
-                ...(flex.type === "bubble" ? { body: flex.body, footer: flex.footer } : { body: { type: "box", layout: "vertical", contents: [{ type: "text", text: "テスト配信", wrap: true }] } }),
-              });
-            } catch {
-              finalContent = content;
-            }
+            // 元の Flex を保ったまま、各 bubble の header にテストバナーを足す。
+            finalContent = addTestBannerToFlex(content);
           }
         }
 

--- a/packages/mcp-server/src/tools/test-banner.ts
+++ b/packages/mcp-server/src/tools/test-banner.ts
@@ -1,0 +1,83 @@
+/**
+ * isTest:true の Flex メッセージに「テスト配信」バナーを被せる。
+ *
+ * 原則は「元の中身を絶対に捨てない」。テスト送信は本番と同じものが届いて
+ * 初めて意味があるので、バナーは header に足すだけで、body/hero/footer/styles
+ * などには一切触らない。読めない・知らない形は加工せずそのまま返す
+ * （バナーを諦める方が、別物を送るよりましなため）。
+ *
+ * 色は必ず 6桁 hex。LINE Messaging API の Flex は 3桁 hex (#333) を受け付けず、
+ * "invalid property /header/contents/0/color" で 400 になる。
+ */
+
+type FlexNode = Record<string, unknown>;
+
+const BANNER_BACKGROUND = "#FFE066";
+const BANNER_TEXT_COLOR = "#333333";
+
+/** バナー box。呼び出しごとに新しいオブジェクトを返す（共有参照を作らない） */
+function bannerBox(): FlexNode {
+  return {
+    type: "box",
+    layout: "vertical",
+    backgroundColor: BANNER_BACKGROUND,
+    paddingAll: "8px",
+    contents: [
+      {
+        type: "text",
+        text: "⚠️ テスト配信",
+        size: "sm",
+        weight: "bold",
+        color: BANNER_TEXT_COLOR,
+        align: "center",
+      },
+    ],
+  };
+}
+
+function isPlainObject(value: unknown): value is FlexNode {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * bubble の header にバナーを足す。元の header がある場合は捨てずに
+ * バナーの下へネストする（header は box なので box を子に持てる）。
+ */
+function bubbleWithBanner(bubble: FlexNode): FlexNode {
+  const original = bubble.header;
+  const header = isPlainObject(original)
+    ? { type: "box", layout: "vertical", contents: [bannerBox(), original] }
+    : bannerBox();
+  return { ...bubble, header };
+}
+
+/**
+ * Flex コンテナ JSON 文字列にテストバナーを付けて返す。
+ * bubble / carousel 以外、または JSON として読めない入力は無加工で返す。
+ */
+export function addTestBannerToFlex(content: string): string {
+  let flex: unknown;
+  try {
+    flex = JSON.parse(content);
+  } catch {
+    return content;
+  }
+  if (!isPlainObject(flex)) return content;
+
+  if (flex.type === "bubble") {
+    return JSON.stringify(bubbleWithBanner(flex));
+  }
+
+  if (flex.type === "carousel" && Array.isArray(flex.contents)) {
+    // どの bubble から見てもテスト送信だと分かるよう全枚数に付ける。
+    // 枚数も並び順も変えない（carousel は最大12枚なので差し込みは危険）。
+    return JSON.stringify({
+      ...flex,
+      contents: flex.contents.map((bubble) =>
+        isPlainObject(bubble) && bubble.type === "bubble" ? bubbleWithBanner(bubble) : bubble,
+      ),
+    });
+  }
+
+  return content;
+}

--- a/packages/mcp-server/test/test-banner.test.ts
+++ b/packages/mcp-server/test/test-banner.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { addTestBannerToFlex } from '../src/tools/test-banner.js';
+
+/**
+ * isTest:true の Flex に「テスト配信」バナーを付ける処理の回帰テスト。
+ *
+ * 過去にここで2つ壊れていた:
+ *   1. バナーの色が 3桁 hex (#333) で、LINE が必ず 400 を返していた
+ *      （Flex は 6桁/8桁 hex しか受け付けない）
+ *   2. carousel を丸ごと「テスト配信」プレースホルダ bubble に差し替えていた。
+ *      エラーは出ないので、送った本人は本物を送ったつもりで別物が届く。
+ *
+ * どちらも「テスト送信だから」で見逃せる壊れ方ではないので、
+ * 元の中身が保存されることを構造で固定する。
+ */
+
+const HEX6 = /^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$/;
+
+/** オブジェクトツリー内の color 値をすべて集める */
+function collectColors(node: unknown, acc: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const child of node) collectColors(child, acc);
+    return acc;
+  }
+  if (node && typeof node === 'object') {
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (typeof value === 'string' && /color$/i.test(key)) acc.push(value);
+      else collectColors(value, acc);
+    }
+  }
+  return acc;
+}
+
+/** ツリー内に指定 text を持つ text コンポーネントがあるか */
+function hasText(node: unknown, text: string): boolean {
+  if (Array.isArray(node)) return node.some((child) => hasText(child, text));
+  if (node && typeof node === 'object') {
+    const obj = node as Record<string, unknown>;
+    if (obj.type === 'text' && obj.text === text) return true;
+    return Object.values(obj).some((value) => hasText(value, text));
+  }
+  return false;
+}
+
+const BANNER_TEXT = '⚠️ テスト配信';
+
+describe('addTestBannerToFlex: 色指定', () => {
+  it('バナーの色は 6桁 hex（3桁だと LINE が 400 を返す）', () => {
+    const out = JSON.parse(
+      addTestBannerToFlex(JSON.stringify({ type: 'bubble', body: { type: 'box', layout: 'vertical', contents: [] } })),
+    );
+    const colors = collectColors(out);
+    expect(colors.length).toBeGreaterThan(0);
+    for (const color of colors) expect(color).toMatch(HEX6);
+  });
+});
+
+describe('addTestBannerToFlex: bubble', () => {
+  const bubble = {
+    type: 'bubble',
+    size: 'giga',
+    hero: { type: 'image', url: 'https://example.com/a.png' },
+    body: { type: 'box', layout: 'vertical', contents: [{ type: 'text', text: '本文' }] },
+    footer: { type: 'box', layout: 'vertical', contents: [{ type: 'text', text: 'フッター' }] },
+    styles: { body: { backgroundColor: '#FFFFFF' } },
+  };
+
+  it('body / footer 以外（hero, styles, size）も捨てない', () => {
+    const out = JSON.parse(addTestBannerToFlex(JSON.stringify(bubble)));
+    expect(out.hero).toEqual(bubble.hero);
+    expect(out.styles).toEqual(bubble.styles);
+    expect(out.size).toBe('giga');
+    expect(out.body).toEqual(bubble.body);
+    expect(out.footer).toEqual(bubble.footer);
+  });
+
+  it('バナーが header に入る', () => {
+    const out = JSON.parse(addTestBannerToFlex(JSON.stringify(bubble)));
+    expect(out.header).toBeDefined();
+    expect(hasText(out.header, BANNER_TEXT)).toBe(true);
+  });
+
+  it('元の header がある場合も中身を残したままバナーを足す', () => {
+    const withHeader = {
+      ...bubble,
+      header: { type: 'box', layout: 'vertical', contents: [{ type: 'text', text: '元ヘッダー' }] },
+    };
+    const out = JSON.parse(addTestBannerToFlex(JSON.stringify(withHeader)));
+    expect(hasText(out.header, BANNER_TEXT)).toBe(true);
+    expect(hasText(out.header, '元ヘッダー')).toBe(true);
+    expect(out.header.type).toBe('box');
+  });
+});
+
+describe('addTestBannerToFlex: carousel', () => {
+  const carousel = {
+    type: 'carousel',
+    contents: [
+      { type: 'bubble', body: { type: 'box', layout: 'vertical', contents: [{ type: 'text', text: '1枚目' }] } },
+      { type: 'bubble', body: { type: 'box', layout: 'vertical', contents: [{ type: 'text', text: '2枚目' }] } },
+      { type: 'bubble', body: { type: 'box', layout: 'vertical', contents: [{ type: 'text', text: '3枚目' }] } },
+    ],
+  };
+
+  it('bubble の枚数と中身をそのまま保つ（プレースホルダに差し替えない）', () => {
+    const out = JSON.parse(addTestBannerToFlex(JSON.stringify(carousel)));
+    expect(out.type).toBe('carousel');
+    expect(out.contents).toHaveLength(3);
+    for (const [i, original] of carousel.contents.entries()) {
+      expect(out.contents[i].body).toEqual(original.body);
+    }
+    expect(hasText(out, BANNER_TEXT)).toBe(true);
+    expect(hasText(out, '1枚目')).toBe(true);
+    expect(hasText(out, '3枚目')).toBe(true);
+  });
+
+  it('どの bubble を見てもテスト送信だと分かる', () => {
+    const out = JSON.parse(addTestBannerToFlex(JSON.stringify(carousel)));
+    for (const bubble of out.contents) {
+      expect(hasText(bubble.header, BANNER_TEXT)).toBe(true);
+    }
+  });
+
+  it('carousel でも色は 6桁 hex', () => {
+    const out = JSON.parse(addTestBannerToFlex(JSON.stringify(carousel)));
+    for (const color of collectColors(out)) expect(color).toMatch(HEX6);
+  });
+});
+
+describe('addTestBannerToFlex: 壊れた入力', () => {
+  it('JSON として読めなければそのまま返す（送信前に握りつぶさない）', () => {
+    expect(addTestBannerToFlex('not json')).toBe('not json');
+  });
+
+  it('bubble でも carousel でもない形はそのまま返す', () => {
+    const unknown = JSON.stringify({ type: 'flex', altText: 'a', contents: { type: 'bubble' } });
+    expect(addTestBannerToFlex(unknown)).toBe(unknown);
+  });
+
+  it('contents が配列でない carousel はそのまま返す', () => {
+    const broken = JSON.stringify({ type: 'carousel', contents: 'oops' });
+    expect(addTestBannerToFlex(broken)).toBe(broken);
+  });
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -271,6 +271,8 @@ export interface Broadcast {
   totalCount: number;
   /** 配信成功人数 */
   successCount: number;
+  /** 直近の送信失敗理由 (クォータ不足ガード等)。送信成功で null に戻る */
+  lastError?: string | null;
   /** 作成日時 (ISO 8601) */
   createdAt: string;
 }


### PR DESCRIPTION
private → OSS の定期同期。内容:

- LINE プランクォータの cron 監視・送信前ガード・通知 (migration 071/072 は additive-only — update-engine のセルフアップデートで適用可能)
- プロキシ 429 の source/reason 付与 (LINE 由来か harness 由来か判別可能に)
- MCP テスト配信バナーの Flex 修正 (test-banner.ts + 回帰テスト)
- OSS-SYNC-CHARTER のリリース手順更新
- update-engine テスト CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)