### PR TITLE
sync: v0.24.0 — 未スタンプ環境の adoption 停止バグ修正

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/worker/src/routes/capabilities.ts
+++ b/apps/worker/src/routes/capabilities.ts
@@ -3,7 +3,7 @@ import type { Env } from '../index.js';
 
 // Kept in lockstep with root package.json by scripts/sync-versions.sh, which the
 // pre-push hook verifies. Bumping this by hand alone will fail that check.
-export const HARNESS_VERSION = '0.23.2';
+export const HARNESS_VERSION = '0.24.0';
 export const API_VERSION = 1;
 export const CONNECTOR_VERSION = '2026-05-20';
 export const MIN_APP_VERSION = '1.0.0';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "line-oss-crm",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "private": true,
   "description": "Open-source LINE Official Account CRM/marketing automation",
   "homepage": "https://the-harness.com/line-harness/",

--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Set up L Harness — AI-operated LINE CRM — with one command",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@line-harness/update-engine": "workspace:^0.0.11",
+    "@line-harness/update-engine": "workspace:^0.0.12",
     "execa": "^9.5.2",
     "picocolors": "^1.1.1"
   },

--- a/packages/create-line-harness/src/commands/update.ts
+++ b/packages/create-line-harness/src/commands/update.ts
@@ -852,11 +852,14 @@ async function applyMigrations(opts: {
   names: string[];
   bundle: ParsedBundle;
   s: Spinner;
+  /** adoption 専用: 破壊的な旧世代 migration を probe + 記録のみで通す (エンジン側 doc 参照)。 */
+  adoptGrandfathered?: boolean;
 }): Promise<void> {
   const { creds, d1DatabaseId, names, bundle, s } = opts;
   try {
     await applyD1Migrations({
       creds,
+      adoptGrandfathered: opts.adoptGrandfathered,
       databaseId: d1DatabaseId,
       names,
       migrations: bundle.migrations,
@@ -866,6 +869,10 @@ async function applyMigrations(opts: {
       onMigrationDone(result) {
         if (result.alreadyApplied) {
           s.stop(pc.dim(`Migration ${result.name}: 適用済み`));
+        } else if (result.adopted) {
+          // grandfathered 世代 (カットオフ 041 未満): 破壊的 SQL を含み得るため
+          // 実行せず、適用済みとして台帳へ記録のみ (既存 DB は適用後の構造が前提)。
+          s.stop(pc.dim(`Migration ${result.name}: 旧世代のため記録のみ (実行なし)`));
         } else if (result.skippedStatements > 0) {
           s.stop(
             `Migration ${result.name} 完了 (${result.executedStatements}文実行・${result.skippedStatements}文適用済み)`,
@@ -1218,10 +1225,13 @@ async function runAdoption(opts: {
   const bundle = await downloadAndVerifyBundle(target, s);
 
   // Replay every migration in the bundle, oldest first. Duplicates are
-  // skipped via the benign-error policy inside applyMigrations.
+  // skipped via the benign-error policy inside applyMigrations. 破壊的な
+  // 旧世代 migration (027/029) は再実行できないため、スキーマ実在を probe した
+  // 上で「適用済み記録のみ」で通す (adoptGrandfathered — エンジン側 doc 参照)。
   const allMigrations = Array.from(bundle.migrations.keys()).sort();
   p.log.info(
-    `全 ${allMigrations.length} migration を確認します（適用済みはスキップされます）`,
+    `全 ${allMigrations.length} migration を確認します（適用済みはスキップ、` +
+      `再実行不能な旧世代の再構築 migration は記録のみになります）`,
   );
   await applyMigrations({
     creds,
@@ -1229,6 +1239,7 @@ async function runAdoption(opts: {
     names: allMigrations,
     bundle,
     s,
+    adoptGrandfathered: true,
   });
 
   await deployWorkerFromBundle(creds, cfg, bundle, s);

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/mcp-server",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "MCP server for L Harness — operate a LINE official account from AI agents over MCP",
   "type": "module",
   "bin": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/sdk",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "AI-native SDK for L Harness — programmatic LINE official account automation",
   "type": "module",
   "exports": {

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/update-engine",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Self-update engine for L Harness — shared between Worker (cloud-side self-update) and CLI (npx create-line-harness update)",
   "repository": {
     "type": "git",

--- a/packages/update-engine/src/migrations.ts
+++ b/packages/update-engine/src/migrations.ts
@@ -7,11 +7,56 @@ const MIGRATION_STATE_TABLE = '_line_harness_migrations';
 
 type D1Executor = typeof executeD1Query;
 
+/**
+ * Additive-only ポリシーのカットオフ。scripts/check-migrations.ts は
+ * この定数を import して単一ソースにしている (リポ専用スクリプト → published
+ * パッケージ方向の依存なので成立する。逆方向は不可)。
+ *
+ * これ未満の migration のうち**破壊的なもの (027/029 — DROP TABLE /
+ * ALTER TABLE ... RENAME TO を含むテーブル再構築)** は、安全スプリッタが
+ * 拒否するし、仮に通しても live DB での再実行は安全ではない。adoption
+ * (adoptGrandfathered) では、実 DB がその再構築後の形を持つことをセンチネルで
+ * 確認した上で、実行せず台帳へ「適用済み」と記録するだけにする (adopt-stamp)。
+ * 破壊的でない pre-041 (030-040 等の additive DDL) は従来どおり実行する —
+ * migration 027 より前から存在する旧 CLI インストールには 030-040 が本当に
+ * 未適用の DB があり得るため、一律 stamp すると静かなスキーマ欠落を作る。
+ *
+ * これが無いと、未スタンプ (0.0.0-dev) 環境の adoption が bundle 内の
+ * 027/029 の検証で必ず throw し、v0.23.x へ一切更新できない
+ * (2026-09-02 に OSS 利用者報告で発覚)。
+ */
+export const GRANDFATHERED_CUTOFF_PREFIX = '041';
+
+/** 数字3桁プレフィックスがカットオフ未満の grandfathered migration か。 */
+export function isGrandfatheredMigration(name: string): boolean {
+  const prefix = name.slice(0, 3);
+  return /^\d{3}$/.test(prefix) && prefix < GRANDFATHERED_CUTOFF_PREFIX;
+}
+
+/**
+ * 破壊的スキーマ変更 (DROP TABLE/COLUMN, RENAME TO/COLUMN) を含むか。
+ * splitSqlStatements の拒否条件と同一定義 — adopt-stamp の対象判定と
+ * スプリッタのガードがずれないよう、双方がこの関数を使う。
+ */
+export function containsDestructiveSchemaChanges(sql: string): boolean {
+  const uncommented = stripSqlComments(sql);
+  return (
+    /\bDROP\s+(?:TABLE|COLUMN)\b/i.test(uncommented) ||
+    /\bRENAME\s+(?:TO|COLUMN)\b/i.test(uncommented)
+  );
+}
+
 export interface MigrationApplyResult {
   name: string;
   alreadyApplied: boolean;
   executedStatements: number;
   skippedStatements: number;
+  /**
+   * true = 破壊的な grandfathered migration のため SQL は実行せず台帳に
+   * 記録だけした (センチネル probe で適用済み構造を確認済み。
+   * GRANDFATHERED_CUTOFF_PREFIX 参照)。
+   */
+  adopted?: boolean;
 }
 
 export interface ApplyD1MigrationsOptions {
@@ -21,6 +66,19 @@ export interface ApplyD1MigrationsOptions {
   migrations: Map<string, Buffer>;
   onMigrationStart?: (name: string) => void | Promise<void>;
   onMigrationDone?: (result: MigrationApplyResult) => void | Promise<void>;
+  /**
+   * adoption (未スタンプ環境の全 replay) 専用オプトイン。true のとき、
+   * 「grandfathered (GRANDFATHERED_CUTOFF_PREFIX 未満) かつ破壊的」な
+   * migration (027/029) だけを実行せず台帳へ記録のみ行う (adopt-stamp)。
+   * 破壊的でない pre-041 は従来どおり実行する (旧インストールへの additive
+   * ブリッジを保つ)。記録の前に実 DB が再構築後のスキーマを本当に持っているか
+   * センチネル probe で確認し、持っていなければ台帳に一切書かず明示エラーで
+   * 停止する — 旧 CLI 期 (migration 027 以前) の取り残しインストールに
+   * 存在しないスキーマを「適用済み」と偽記録しないため。
+   * false (既定) では従来どおり: 破壊的 migration が混ざっていれば検証段階で
+   * 停止する (通常の差分更新に現れるのは異常なので loud に落とす)。
+   */
+  adoptGrandfathered?: boolean;
   /** Test seam. Production callers use the Cloudflare D1 HTTP API. */
   execute?: D1Executor;
 }
@@ -43,10 +101,7 @@ export function splitSqlStatements(sql: string): string[] {
   if (/\bCREATE\s+(?:TEMP(?:ORARY)?\s+)?TRIGGER\b/i.test(uncommented)) {
     throw new Error('CREATE TRIGGER migrations are not supported by the safe D1 splitter');
   }
-  if (
-    /\bDROP\s+(?:TABLE|COLUMN)\b/i.test(uncommented) ||
-    /\bRENAME\s+(?:TO|COLUMN)\b/i.test(uncommented)
-  ) {
+  if (containsDestructiveSchemaChanges(sql)) {
     throw new Error('destructive schema changes are not supported by safe D1 updates');
   }
 
@@ -124,6 +179,10 @@ export function splitSqlStatements(sql: string): string[] {
  * prevents later ALTERs in the same file from running. A checksum ledger is
  * written only after every statement succeeds or is confirmed benign; later
  * releases can then skip the immutable migration without replaying its DML.
+ *
+ * 例外: adoptGrandfathered 時の「grandfathered かつ破壊的」な migration
+ * (027/029) は文単位の修復対象ではなく、センチネル probe で適用済みを確認の上
+ * 記録のみ行う (adopt-stamp — options の doc 参照)。
  */
 export async function applyD1Migrations(
   opts: ApplyD1MigrationsOptions,
@@ -131,17 +190,32 @@ export async function applyD1Migrations(
   const execute = opts.execute ?? executeD1Query;
   const base = { creds: opts.creds, databaseId: opts.databaseId };
 
+  const adoptGrandfathered = opts.adoptGrandfathered === true;
+
   // Validate the whole manifest before touching D1. A malformed release must
   // fail without leaving even the migration ledger behind.
+  // adoption 時のみ、「grandfathered かつ破壊的」な migration (027/029) は
+  // 実行しない (adopt-stamp) ので splitSqlStatements の破壊的変更ガードには
+  // かけない — かけると DROP/RENAME でここが throw し、全 migration を replay
+  // する adoption 経路が常に失敗する。破壊的でない pre-041 は通常どおり検証・
+  // 実行する (旧インストールへの additive ブリッジ)。フラグなしの通常更新は
+  // 従来どおり検証で loud に落とす。
   const parsedStatements = new Map<string, string[]>();
+  const adoptable = new Set<string>();
   for (const name of opts.names) {
     if (!opts.migrations.has(name)) {
       throw new Error(`migration ${name} missing in bundle`);
     }
-    parsedStatements.set(
-      name,
-      splitSqlStatements((opts.migrations.get(name) as Buffer).toString('utf8')),
-    );
+    const sql = (opts.migrations.get(name) as Buffer).toString('utf8');
+    if (
+      adoptGrandfathered &&
+      isGrandfatheredMigration(name) &&
+      containsDestructiveSchemaChanges(sql)
+    ) {
+      adoptable.add(name);
+      continue;
+    }
+    parsedStatements.set(name, splitSqlStatements(sql));
   }
   if (opts.names.length === 0) return [];
 
@@ -157,6 +231,7 @@ export async function applyD1Migrations(
   });
 
   const results: MigrationApplyResult[] = [];
+  let schemaProbeDone = false;
   for (let migrationIndex = 0; migrationIndex < opts.names.length; migrationIndex += 1) {
     const name = opts.names[migrationIndex];
     const source = opts.migrations.get(name) as Buffer;
@@ -170,9 +245,18 @@ export async function applyD1Migrations(
     });
     const priorChecksum = firstResultValue(recorded, 'checksum');
     if (typeof priorChecksum === 'string') {
+      // adopt-stamp 対象は checksum 不一致でもブロックしない: このエンジンは
+      // 中身を一度も実行しない (記録のみ) ので、ファイル差分は挙動に影響しない。
+      // ただし fork 検知の材料にはなるので黙殺せず warn は残す。それ以外は
+      // 従来どおり「適用後に書き換わった migration」は事故なので停止する。
       if (priorChecksum !== checksum) {
-        throw new Error(
-          `migration ${name} changed after it was applied (${priorChecksum} != ${checksum})`,
+        if (!adoptable.has(name)) {
+          throw new Error(
+            `migration ${name} changed after it was applied (${priorChecksum} != ${checksum})`,
+          );
+        }
+        console.warn(
+          `migration ${name}: recorded checksum differs from bundle (never executed by this engine — continuing)`,
         );
       }
       const result: MigrationApplyResult = {
@@ -180,6 +264,36 @@ export async function applyD1Migrations(
         alreadyApplied: true,
         executedStatements: 0,
         skippedStatements: 0,
+      };
+      results.push(result);
+      await opts.onMigrationDone?.(result);
+      continue;
+    }
+
+    if (adoptable.has(name)) {
+      // 初回の stamp 前に、実 DB が破壊的 migration (027/029) 適用後の形を
+      // 本当に持っているか確認する。持っていない DB (migration 027 以前の
+      // 取り残しインストール) に「適用済み」と偽記録すると、以後のリトライが
+      // alreadyApplied で素通りして自己修復不能になるため、台帳に書く前に
+      // 明示エラーで止める。
+      if (!schemaProbeDone) {
+        await assertAdoptableSchemaPresent(execute, base);
+        schemaProbeDone = true;
+      }
+      // 実行せず台帳に記録だけ (adopt-stamp)。GRANDFATHERED_CUTOFF_PREFIX 参照。
+      await execute({
+        ...base,
+        sql:
+          `INSERT INTO ${MIGRATION_STATE_TABLE} (name, checksum, applied_at) ` +
+          "VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+        params: [name, checksum],
+      });
+      const result: MigrationApplyResult = {
+        name,
+        alreadyApplied: false,
+        executedStatements: 0,
+        skippedStatements: 0,
+        adopted: true,
       };
       results.push(result);
       await opts.onMigrationDone?.(result);
@@ -223,6 +337,50 @@ export async function applyD1Migrations(
     await opts.onMigrationDone?.(result);
   }
   return results;
+}
+
+/**
+ * adopt-stamp の前提検証。破壊的 migration 027/029 が適用済みであることを
+ * 実 DB のセンチネルで確認する:
+ *   - line_accounts テーブル …… bootstrap 済みか (無ければそもそも空 DB)
+ *   - friend_scenarios の CHECK に 'delivering' …… 027 の再構築後の形
+ *   - line_accounts.display_order 列 …… 029 が追加した列
+ * 1つでも欠けていれば、その DB は破壊的 migration より古い時代の取り残しで、
+ * stamp すると存在しないスキーマを「適用済み」と偽記録することになるため、
+ * 台帳に書く前に明示エラーで停止する (手動移行が必要)。
+ */
+async function assertAdoptableSchemaPresent(
+  execute: D1Executor,
+  base: { creds: CfApiCreds; databaseId: string },
+): Promise<void> {
+  const res = await execute({
+    ...base,
+    sql:
+      'SELECT ' +
+      "(SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='line_accounts') AS bootstrapped, " +
+      "(SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='friend_scenarios' AND sql LIKE '%delivering%') AS m027, " +
+      "(SELECT COUNT(*) FROM pragma_table_info('line_accounts') WHERE name='display_order') AS m029",
+  });
+  const first = res.result?.[0];
+  const rows = first && typeof first === 'object' ? (first as { results?: unknown[] }).results : undefined;
+  const row = (Array.isArray(rows) ? rows[0] : undefined) as
+    | { bootstrapped?: number; m027?: number; m029?: number }
+    | undefined;
+
+  const missing: string[] = [];
+  if (!row || !Number(row.bootstrapped)) {
+    missing.push('line_accounts (DB が bootstrap されていません)');
+  } else {
+    if (!Number(row.m027)) missing.push("friend_scenarios の 'delivering' status (migration 027)");
+    if (!Number(row.m029)) missing.push('line_accounts.display_order (migration 029)');
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      'adoption を中止しました: データベースのスキーマが旧世代 migration の適用前の形です ' +
+        `(不足: ${missing.join(' / ')})。この世代のテーブル再構築は自動では再実行できないため、` +
+        '手動での更新が必要です: https://github.com/Shudesu/line-harness-oss/blob/main/docs/wiki/26-Manual-Update.md',
+    );
+  }
 }
 
 function pushSqlStatement(statements: string[], candidate: string): void {

--- a/packages/update-engine/src/phases/apply.ts
+++ b/packages/update-engine/src/phases/apply.ts
@@ -72,7 +72,9 @@ export async function runApply(
         status: 'done',
         name: result.alreadyApplied
           ? `${result.name} (already applied)`
-          : result.name,
+          : result.adopted
+            ? `${result.name} (adopted, not executed)`
+            : result.name,
       }),
   });
 

--- a/packages/update-engine/test/migrations.test.ts
+++ b/packages/update-engine/test/migrations.test.ts
@@ -145,3 +145,159 @@ describe('applyD1Migrations', () => {
     ).rejects.toThrow(/changed after it was applied/);
   });
 });
+
+// grandfathered (< 041) かつ破壊的な migration (027/029 の DROP TABLE / RENAME TO):
+// adoption (adoptGrandfathered) では probe でスキーマ実在を確認の上「記録のみ」で通し、
+// 破壊的でない pre-041 は従来どおり実行する。2026-09-02 に 0.0.0-dev 環境の adoption が
+// 検証段階の throw で必ず停止する報告があった。
+describe('grandfathered migrations (adopt-stamp)', () => {
+  const DESTRUCTIVE_027 = Buffer.from(
+    'CREATE TABLE friend_scenarios_new (id TEXT PRIMARY KEY);\n' +
+      'DROP TABLE friend_scenarios;\n' +
+      'ALTER TABLE friend_scenarios_new RENAME TO friend_scenarios;',
+  );
+
+  /** probe (センチネル確認) に成功応答を返す記録付き executor。 */
+  function recordingExecute(opts: { probeRow?: Record<string, number> | null; priorChecksum?: string } = {}) {
+    const calls: Array<{ sql: string; params?: any[] }> = [];
+    const execute = vi.fn(async (req: { sql: string; params?: any[] }) => {
+      calls.push({ sql: req.sql, params: req.params });
+      if (req.sql.includes('SELECT checksum')) {
+        return {
+          success: true,
+          result: [{ results: opts.priorChecksum ? [{ checksum: opts.priorChecksum }] : [] }],
+        };
+      }
+      if (req.sql.includes('AS bootstrapped')) {
+        const row = opts.probeRow === undefined
+          ? { bootstrapped: 1, m027: 1, m029: 1 }
+          : opts.probeRow;
+        return { success: true, result: [{ results: row ? [row] : [] }] };
+      }
+      return { success: true, result: [] };
+    });
+    return { calls, execute };
+  }
+
+  it('stamps a destructive pre-041 migration into the ledger without executing it', async () => {
+    const { calls, execute } = recordingExecute();
+
+    const [result] = await applyD1Migrations({
+      creds,
+      databaseId: 'db',
+      names: ['027_dedup_delivery.sql'],
+      migrations: new Map([['027_dedup_delivery.sql', DESTRUCTIVE_027]]),
+      adoptGrandfathered: true,
+      execute: execute as any,
+    });
+
+    expect(result).toMatchObject({
+      name: '027_dedup_delivery.sql',
+      alreadyApplied: false,
+      adopted: true,
+      executedStatements: 0,
+      skippedStatements: 0,
+    });
+    // 破壊的 SQL は 1 文も D1 に送られていない
+    expect(calls.some((c) => /DROP TABLE|RENAME TO/i.test(c.sql))).toBe(false);
+    // probe が走り、台帳には記録されている
+    expect(calls.some((c) => c.sql.includes('AS bootstrapped'))).toBe(true);
+    expect(
+      calls.some(
+        (c) =>
+          c.sql.includes('INSERT INTO _line_harness_migrations') &&
+          c.params?.[0] === '027_dedup_delivery.sql',
+      ),
+    ).toBe(true);
+  });
+
+  it('additive pre-041 migrations still EXECUTE under adoption (no stamp)', async () => {
+    // 旧 CLI インストール (migration 027 以前から存在) には 030-040 が本当に
+    // 未適用の DB があり得る。additive はブリッジとして実行されねばならない。
+    const { calls, execute } = recordingExecute();
+
+    const results = await applyD1Migrations({
+      creds,
+      databaseId: 'db',
+      names: ['027_dedup_delivery.sql', '031_batch_lock_at.sql'],
+      migrations: new Map([
+        ['027_dedup_delivery.sql', DESTRUCTIVE_027],
+        ['031_batch_lock_at.sql', Buffer.from('ALTER TABLE broadcasts ADD COLUMN batch_lock_at TEXT;')],
+      ]),
+      adoptGrandfathered: true,
+      execute: execute as any,
+    });
+
+    expect(results.map((r) => ({ name: r.name, adopted: r.adopted ?? false }))).toEqual([
+      { name: '027_dedup_delivery.sql', adopted: true },
+      { name: '031_batch_lock_at.sql', adopted: false },
+    ]);
+    expect(calls.some((c) => c.sql.includes('ADD COLUMN batch_lock_at'))).toBe(true);
+    expect(calls.some((c) => /DROP TABLE/i.test(c.sql))).toBe(false);
+  });
+
+  it('refuses to stamp when the DB predates the destructive migrations (probe fails)', async () => {
+    // probe 失敗 = 027/029 適用前の取り残し DB。台帳へは一切書かず明示エラー。
+    const { calls, execute } = recordingExecute({
+      probeRow: { bootstrapped: 1, m027: 0, m029: 1 },
+    });
+
+    await expect(
+      applyD1Migrations({
+        creds,
+        databaseId: 'db',
+        names: ['027_dedup_delivery.sql'],
+        migrations: new Map([['027_dedup_delivery.sql', DESTRUCTIVE_027]]),
+        adoptGrandfathered: true,
+        execute: execute as any,
+      }),
+    ).rejects.toThrow(/adoption を中止しました/);
+    expect(calls.some((c) => c.sql.includes('INSERT INTO _line_harness_migrations'))).toBe(false);
+  });
+
+  it('does not block on a checksum mismatch for an adoptable migration (never executed anyway)', async () => {
+    const { execute } = recordingExecute({ priorChecksum: 'sha256:old-bytes' });
+
+    const [result] = await applyD1Migrations({
+      creds,
+      databaseId: 'db',
+      names: ['029_account_management_v2.sql'],
+      migrations: new Map([
+        ['029_account_management_v2.sql', Buffer.from('DROP TABLE broadcasts_old;')],
+      ]),
+      adoptGrandfathered: true,
+      execute: execute as any,
+    });
+    expect(result).toMatchObject({ alreadyApplied: true });
+  });
+
+  it('without adoptGrandfathered, destructive pre-041 still fails validation (normal updates unchanged)', async () => {
+    const execute = vi.fn(async () => ({ success: true, result: [] }));
+    await expect(
+      applyD1Migrations({
+        creds,
+        databaseId: 'db',
+        names: ['027_dedup_delivery.sql'],
+        migrations: new Map([['027_dedup_delivery.sql', DESTRUCTIVE_027]]),
+        execute: execute as any,
+      }),
+    ).rejects.toThrow(/destructive schema changes/);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('still rejects destructive SQL in post-cutoff migrations even under adoption', async () => {
+    const execute = vi.fn(async () => ({ success: true, result: [] }));
+    await expect(
+      applyD1Migrations({
+        creds,
+        databaseId: 'db',
+        names: ['071_bad.sql'],
+        migrations: new Map([['071_bad.sql', Buffer.from('DROP TABLE friends;')]]),
+        adoptGrandfathered: true,
+        execute: execute as any,
+      }),
+    ).rejects.toThrow(/destructive schema changes/);
+    // 検証段階で止まるので D1 には何も送られていない
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@line-harness/update-engine':
-        specifier: workspace:^0.0.11
+        specifier: workspace:^0.0.12
         version: link:../update-engine
       execa:
         specifier: ^9.5.2


### PR DESCRIPTION
private → OSS 同期 (v0.24.0)。0.0.0-dev 環境の `npx create-line-harness@latest update` が旧 migration 027/029 の安全ガードで停止する問題 (利用者報告) の修正。update-engine 0.0.12 / create-line-harness 0.2.11。

🤖 Generated with [Claude Code](https://claude.com/claude-code)