### PR TITLE
sync: bootstrap.sql 再生成 (v0.24.0 release の --check 失敗対応)

### DIFF
--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -707,18 +707,18 @@ CREATE TABLE IF NOT EXISTS mileage_rules (
 );
 
 CREATE TABLE IF NOT EXISTS notification_rules (
-  id              TEXT PRIMARY KEY,
-  name            TEXT NOT NULL,
-  event_type      TEXT NOT NULL,
-  conditions      TEXT NOT NULL DEFAULT '{}',
-  channels        TEXT NOT NULL DEFAULT '["webhook"]',
-  is_active       INTEGER NOT NULL DEFAULT 1,
-  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
-  updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  id           TEXT PRIMARY KEY,
+  name         TEXT NOT NULL,
+  event_type   TEXT NOT NULL,
+  conditions   TEXT NOT NULL DEFAULT '{}',
+  channels     TEXT NOT NULL DEFAULT '["webhook"]',
+  is_active    INTEGER NOT NULL DEFAULT 1,
+  created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   line_account_id TEXT
 );
 
-CREATE TABLE IF NOT EXISTS "notifications" (
+CREATE TABLE IF NOT EXISTS notifications (
   id              TEXT PRIMARY KEY,
   rule_id         TEXT REFERENCES notification_rules (id) ON DELETE SET NULL,
   event_type      TEXT NOT NULL,


### PR DESCRIPTION
release.yml の bootstrap 同期テストが v0.24.0 タグで失敗したため、正規ジェネレータで再生成した private #190 を同期。差分は整形のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)