### PR TITLE
fix(forms): allow webhook notifications without LINE replies

### DIFF
--- a/apps/worker/src/client/form.test.ts
+++ b/apps/worker/src/client/form.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { shouldUseXEngagementGate } from './form.js';
+
+describe('shouldUseXEngagementGate', () => {
+  it('does not turn a generic submit webhook into an X gate', () => {
+    expect(shouldUseXEngagementGate({
+      webhookGateId: null,
+      fields: [{ name: 'customer_name', label: 'お名前', type: 'text' }],
+    })).toBe(false);
+  });
+
+  it('uses the X gate only when the form asks for x_username', () => {
+    expect(shouldUseXEngagementGate({
+      webhookGateId: 'gate-1',
+      fields: [{ name: 'x_username', label: 'Xユーザー名', type: 'text' }],
+    })).toBe(true);
+  });
+});

--- a/apps/worker/src/client/form.ts
+++ b/apps/worker/src/client/form.ts
@@ -101,6 +101,13 @@ interface FormState {
   refTrackedLinkId: string | null;
 }
 
+export function shouldUseXEngagementGate(formDef: Pick<FormDef, 'fields' | 'webhookGateId'>): boolean {
+  return Boolean(
+    formDef.webhookGateId &&
+    formDef.fields.some((field) => field.name === 'x_username'),
+  );
+}
+
 const state: FormState = {
   formDef: null,
   xHarnessBaseUrl: null,
@@ -449,7 +456,7 @@ function render(): void {
   // Split fields: survey fields (page 1) vs x_username field (page 2)
   const surveyFields = formDef.fields.filter((f) => f.name !== 'x_username');
   const xUsernameField = formDef.fields.find((f) => f.name === 'x_username');
-  const hasTwoPages = !!xUsernameField && formDef.hasSubmitWebhook;
+  const hasTwoPages = shouldUseXEngagementGate(formDef);
 
   const surveyFieldsHtml = surveyFields.map(renderField).join('');
   const xFieldHtml = xUsernameField ? renderField(xUsernameField) : '';
@@ -460,7 +467,7 @@ function render(): void {
       <div class="form-page">
         <div class="form-header">
           <h1>${escapeHtml(formDef.name).replace(/\\n|\n/g, '<br>')}</h1>
-          ${formDef.description && !formDef.hasSubmitWebhook ? `<p class="form-description">${escapeHtml(formDef.description).replace(/\\n|\n/g, '<br>')}</p>` : ''}
+          ${formDef.description && !hasTwoPages ? `<p class="form-description">${escapeHtml(formDef.description).replace(/\\n|\n/g, '<br>')}</p>` : ''}
           ${profileHtml}
         </div>
         <!-- Page 1: Survey -->
@@ -562,7 +569,7 @@ function render(): void {
       <div class="form-page">
         <div class="form-header">
           <h1>${escapeHtml(formDef.name).replace(/\\n|\n/g, '<br>')}</h1>
-          ${formDef.description && !formDef.hasSubmitWebhook ? `<p class="form-description">${escapeHtml(formDef.description).replace(/\\n|\n/g, '<br>')}</p>` : ''}
+          ${formDef.description && !hasTwoPages ? `<p class="form-description">${escapeHtml(formDef.description).replace(/\\n|\n/g, '<br>')}</p>` : ''}
           ${profileHtml}
         </div>
         <form id="liff-form" class="form-body" novalidate>
@@ -1017,7 +1024,7 @@ async function submitForm(): Promise<void> {
     console.log('Form data collected:', JSON.stringify(data));
 
     // Webhook gate — pre-verified by /repliers endpoint
-    if (state.formDef.hasSubmitWebhook) {
+    if (shouldUseXEngagementGate(state.formDef)) {
       // Check that user was selected from pre-verified repliers list
       const xField = ((data.x_username as string) ?? '').trim().replace(/^@/, '');
       if (!xField || xField !== state.verifiedXUsername) {

--- a/apps/worker/src/routes/forms.ts
+++ b/apps/worker/src/routes/forms.ts
@@ -19,6 +19,7 @@ import { attachTagAndFireSideEffects } from '../services/friend-tag-attach.js';
 import { verifyCallerLineUserId } from '../services/liff-auth.js';
 import { pushViaHarnessProxy } from '../services/line-proxy-send.js';
 import { dispatchLineProxyLocally } from '../services/local-line-proxy.js';
+import { shouldSendFormReply } from '../services/form-reply-policy.js';
 import type {
   Form as DbForm,
   FormSubmission as DbFormSubmission,
@@ -81,6 +82,7 @@ function serializeForm(
     onSubmitScenarioId: row.on_submit_scenario_id,
     onSubmitMessageType: row.on_submit_message_type,
     onSubmitMessageContent: row.on_submit_message_content,
+    sendSubmitMessage: row.send_submit_message !== 0,
     onSubmitWebhookUrl: row.on_submit_webhook_url,
     onSubmitWebhookHeaders: row.on_submit_webhook_headers,
     onSubmitWebhookFailMessage: row.on_submit_webhook_fail_message,
@@ -230,6 +232,7 @@ forms.post('/api/forms', async (c) => {
       onSubmitScenarioId?: string | null;
       onSubmitMessageType?: 'text' | 'flex' | null;
       onSubmitMessageContent?: string | null;
+      sendSubmitMessage?: boolean;
       onSubmitWebhookUrl?: string | null;
       onSubmitWebhookHeaders?: string | null;
       onSubmitWebhookFailMessage?: string | null;
@@ -251,6 +254,7 @@ forms.post('/api/forms', async (c) => {
       onSubmitScenarioId: body.onSubmitScenarioId ?? null,
       onSubmitMessageType: body.onSubmitMessageType ?? null,
       onSubmitMessageContent: body.onSubmitMessageContent ?? null,
+      sendSubmitMessage: body.sendSubmitMessage,
       onSubmitWebhookUrl: body.onSubmitWebhookUrl ?? null,
       onSubmitWebhookHeaders: body.onSubmitWebhookHeaders ?? null,
       onSubmitWebhookFailMessage: body.onSubmitWebhookFailMessage ?? null,
@@ -280,6 +284,7 @@ forms.put('/api/forms/:id', async (c) => {
       onSubmitScenarioId?: string | null;
       onSubmitMessageType?: 'text' | 'flex' | null;
       onSubmitMessageContent?: string | null;
+      sendSubmitMessage?: boolean;
       onSubmitWebhookUrl?: string | null;
       onSubmitWebhookHeaders?: string | null;
       onSubmitWebhookFailMessage?: string | null;
@@ -299,6 +304,7 @@ forms.put('/api/forms/:id', async (c) => {
     if (body.onSubmitScenarioId !== undefined) updates.onSubmitScenarioId = body.onSubmitScenarioId;
     if (body.onSubmitMessageType !== undefined) updates.onSubmitMessageType = body.onSubmitMessageType;
     if (body.onSubmitMessageContent !== undefined) updates.onSubmitMessageContent = body.onSubmitMessageContent;
+    if (body.sendSubmitMessage !== undefined) updates.sendSubmitMessage = body.sendSubmitMessage;
     if (body.onSubmitWebhookUrl !== undefined) updates.onSubmitWebhookUrl = body.onSubmitWebhookUrl;
     if (body.onSubmitWebhookHeaders !== undefined) updates.onSubmitWebhookHeaders = body.onSubmitWebhookHeaders;
     if (body.onSubmitWebhookFailMessage !== undefined) updates.onSubmitWebhookFailMessage = body.onSubmitWebhookFailMessage;
@@ -637,8 +643,9 @@ forms.post('/api/forms/:id/submit', async (c) => {
         );
       }
 
-      // Send confirmation message with submitted data back to user
-      sideEffects.push(
+      // Send confirmation only when enabled. Operational forms can still save,
+      // tag, and call a webhook without consuming a LINE message per response.
+      if (shouldSendFormReply(form)) sideEffects.push(
         (async () => {
           console.log('Form reply: starting for friendId', friendId);
           const friend = await getFriendById(db, friendId!);

--- a/apps/worker/src/services/form-reply-policy.test.ts
+++ b/apps/worker/src/services/form-reply-policy.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { shouldSendFormReply } from './form-reply-policy.js';
+
+describe('shouldSendFormReply', () => {
+  it('suppresses the default LINE reply when disabled', () => {
+    expect(shouldSendFormReply({ send_submit_message: 0 })).toBe(false);
+  });
+
+  it('preserves the existing default for migrated forms', () => {
+    expect(shouldSendFormReply({ send_submit_message: 1 })).toBe(true);
+  });
+});

--- a/apps/worker/src/services/form-reply-policy.ts
+++ b/apps/worker/src/services/form-reply-policy.ts
@@ -1,0 +1,7 @@
+export interface FormReplyPolicyInput {
+  send_submit_message: number;
+}
+
+export function shouldSendFormReply(form: FormReplyPolicyInput): boolean {
+  return form.send_submit_message !== 0;
+}

--- a/packages/db/bootstrap-meta.json
+++ b/packages/db/bootstrap-meta.json
@@ -77,7 +77,8 @@
     "070_admin_sso_jti.sql",
     "071_quota_alerts.sql",
     "072_broadcast_last_error.sql",
-    "072_health_logs_composite_index.sql"
+    "072_health_logs_composite_index.sql",
+    "073_form_submit_message_toggle.sql"
   ],
-  "migrationCount": 78
+  "migrationCount": 79
 }

--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -421,7 +421,7 @@ CREATE TABLE IF NOT EXISTS forms (
   submit_count INTEGER NOT NULL DEFAULT 0,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-, on_submit_message_type TEXT CHECK (on_submit_message_type IN ('text', 'flex')) DEFAULT NULL, on_submit_message_content TEXT DEFAULT NULL, on_submit_webhook_url TEXT, on_submit_webhook_headers TEXT, on_submit_webhook_fail_message TEXT, og_title TEXT, og_description TEXT, og_image_url TEXT);
+, on_submit_message_type TEXT CHECK (on_submit_message_type IN ('text', 'flex')) DEFAULT NULL, on_submit_message_content TEXT DEFAULT NULL, on_submit_webhook_url TEXT, on_submit_webhook_headers TEXT, on_submit_webhook_fail_message TEXT, og_title TEXT, og_description TEXT, og_image_url TEXT, send_submit_message INTEGER NOT NULL DEFAULT 1);
 
 CREATE TABLE IF NOT EXISTS friend_reminder_deliveries (
   id                TEXT PRIMARY KEY,

--- a/packages/db/migrations/073_form_submit_message_toggle.sql
+++ b/packages/db/migrations/073_form_submit_message_toggle.sql
@@ -1,0 +1,1 @@
+ALTER TABLE forms ADD COLUMN send_submit_message INTEGER NOT NULL DEFAULT 1;

--- a/packages/db/src/forms.ts
+++ b/packages/db/src/forms.ts
@@ -12,6 +12,7 @@ export interface Form {
   on_submit_scenario_id: string | null;
   on_submit_message_type: 'text' | 'flex' | null;
   on_submit_message_content: string | null; // supports template variables: {{name}}, {{auth_url:CHANNEL_ID}}, etc.
+  send_submit_message: number;
   on_submit_webhook_url: string | null;
   on_submit_webhook_headers: string | null;
   on_submit_webhook_fail_message: string | null;
@@ -123,6 +124,7 @@ export interface CreateFormInput {
   onSubmitScenarioId?: string | null;
   onSubmitMessageType?: 'text' | 'flex' | null;
   onSubmitMessageContent?: string | null;
+  sendSubmitMessage?: boolean;
   onSubmitWebhookUrl?: string | null;
   onSubmitWebhookHeaders?: string | null;
   onSubmitWebhookFailMessage?: string | null;
@@ -140,12 +142,12 @@ export async function createForm(db: D1Database, input: CreateFormInput): Promis
     .prepare(
       `INSERT INTO forms
          (id, name, description, fields, on_submit_tag_id, on_submit_scenario_id,
-          on_submit_message_type, on_submit_message_content,
+          on_submit_message_type, on_submit_message_content, send_submit_message,
           on_submit_webhook_url, on_submit_webhook_headers, on_submit_webhook_fail_message,
           save_to_metadata, is_active, submit_count,
           og_title, og_description, og_image_url,
           created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?, ?, ?, ?)`,
     )
     .bind(
       id,
@@ -156,6 +158,7 @@ export async function createForm(db: D1Database, input: CreateFormInput): Promis
       input.onSubmitScenarioId ?? null,
       input.onSubmitMessageType ?? null,
       input.onSubmitMessageContent ?? null,
+      input.sendSubmitMessage !== false ? 1 : 0,
       input.onSubmitWebhookUrl ?? null,
       input.onSubmitWebhookHeaders ?? null,
       input.onSubmitWebhookFailMessage ?? null,
@@ -179,6 +182,7 @@ export interface UpdateFormInput {
   onSubmitScenarioId?: string | null;
   onSubmitMessageType?: 'text' | 'flex' | null;
   onSubmitMessageContent?: string | null;
+  sendSubmitMessage?: boolean;
   onSubmitWebhookUrl?: string | null;
   onSubmitWebhookHeaders?: string | null;
   onSubmitWebhookFailMessage?: string | null;
@@ -209,6 +213,7 @@ export async function updateForm(
            on_submit_scenario_id = ?,
            on_submit_message_type = ?,
            on_submit_message_content = ?,
+           send_submit_message = ?,
            on_submit_webhook_url = ?,
            on_submit_webhook_headers = ?,
            on_submit_webhook_fail_message = ?,
@@ -234,6 +239,9 @@ export async function updateForm(
       'onSubmitMessageContent' in input
         ? (input.onSubmitMessageContent ?? null)
         : existing.on_submit_message_content,
+      'sendSubmitMessage' in input
+        ? (input.sendSubmitMessage !== false ? 1 : 0)
+        : existing.send_submit_message,
       'onSubmitWebhookUrl' in input
         ? (input.onSubmitWebhookUrl ?? null)
         : existing.on_submit_webhook_url,

--- a/packages/db/test/forms-submit-message-toggle.test.ts
+++ b/packages/db/test/forms-submit-message-toggle.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createForm, updateForm } from '../src/forms.js';
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const benignMigrationError = /duplicate column name|already exists/i;
+
+function setupDb(): Database.Database {
+  const sqlite = new Database(':memory:');
+  const apply = (sql: string): void => {
+    for (const statement of sql.split(/;\s*(?:\r?\n|$)/).map((item) => item.trim()).filter(Boolean)) {
+      try {
+        sqlite.exec(statement);
+      } catch (error) {
+        if (!benignMigrationError.test(error instanceof Error ? error.message : String(error))) throw error;
+      }
+    }
+  };
+  apply(readFileSync(join(packageRoot, 'schema.sql'), 'utf8'));
+  for (const file of readdirSync(join(packageRoot, 'migrations')).filter((name) => name.endsWith('.sql')).sort()) {
+    apply(readFileSync(join(packageRoot, 'migrations', file), 'utf8'));
+  }
+  return sqlite;
+}
+
+function asD1(sqlite: Database.Database): D1Database {
+  return {
+    prepare(query: string) {
+      return {
+        bind(...params: unknown[]) {
+          const statement = sqlite.prepare(query);
+          return {
+            async run() { statement.run(...params); return { results: [], success: true, meta: {} }; },
+            async first<T>() { return (statement.get(...params) as T) ?? null; },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+describe('form submit message toggle', () => {
+  let db: D1Database;
+
+  beforeEach(() => {
+    db = asD1(setupDb());
+  });
+
+  test('persists disabled on create and can re-enable it on update', async () => {
+    const form = await createForm(db, {
+      name: '見積もり依頼',
+      fields: '[]',
+      sendSubmitMessage: false,
+    });
+    expect(form.send_submit_message).toBe(0);
+
+    const updated = await updateForm(db, form.id, { sendSubmitMessage: true });
+    expect(updated?.send_submit_message).toBe(1);
+  });
+
+  test('keeps existing form behavior enabled by default', async () => {
+    const form = await createForm(db, { name: '既存フォーム', fields: '[]' });
+    expect(form.send_submit_message).toBe(1);
+  });
+});

--- a/packages/mcp-server/src/tools/create-form.ts
+++ b/packages/mcp-server/src/tools/create-form.ts
@@ -33,6 +33,10 @@ export function registerCreateForm(server: McpServer): void {
         .string()
         .optional()
         .describe("Custom message content to send after submission. If set, replaces the default confirmation Flex."),
+      sendSubmitMessage: z.boolean().default(true).describe("Whether to send a LINE confirmation after submission."),
+      onSubmitWebhookUrl: z.string().url().optional().describe("Webhook URL called once when the form is submitted."),
+      onSubmitWebhookHeaders: z.string().optional().describe("JSON object of headers for the submit webhook."),
+      onSubmitWebhookFailMessage: z.string().optional().describe("LINE message sent only when the webhook rejects the submission."),
       saveToMetadata: z
         .boolean()
         .default(true)
@@ -53,6 +57,10 @@ export function registerCreateForm(server: McpServer): void {
       onSubmitScenarioId,
       onSubmitMessageType,
       onSubmitMessageContent,
+      sendSubmitMessage,
+      onSubmitWebhookUrl,
+      onSubmitWebhookHeaders,
+      onSubmitWebhookFailMessage,
       saveToMetadata,
       ogTitle,
       ogDescription,
@@ -68,6 +76,10 @@ export function registerCreateForm(server: McpServer): void {
           onSubmitScenarioId,
           onSubmitMessageType,
           onSubmitMessageContent,
+          sendSubmitMessage,
+          onSubmitWebhookUrl,
+          onSubmitWebhookHeaders,
+          onSubmitWebhookFailMessage,
           saveToMetadata,
           ogTitle,
           ogDescription,

--- a/packages/mcp-server/src/tools/manage-forms.ts
+++ b/packages/mcp-server/src/tools/manage-forms.ts
@@ -16,13 +16,17 @@ export function registerManageForms(server: McpServer): void {
       onSubmitScenarioId: z.string().nullable().optional().describe("Scenario to enroll on submit (for update)"),
       onSubmitMessageType: z.enum(["text", "flex"]).nullable().optional().describe("Custom message type to send after form submission (for update). Supports template variables: {{name}}, {{auth_url:CHANNEL_ID}}"),
       onSubmitMessageContent: z.string().nullable().optional().describe("Custom message content to send after form submission (for update). If set, replaces the default confirmation Flex."),
+      sendSubmitMessage: z.boolean().optional().describe("Whether to send a LINE confirmation after submission. Set false to save/tag/webhook without sending a LINE message."),
+      onSubmitWebhookUrl: z.string().url().nullable().optional().describe("Webhook URL called once when the form is submitted, or null to clear."),
+      onSubmitWebhookHeaders: z.string().nullable().optional().describe("JSON object of headers for the submit webhook, or null to clear."),
+      onSubmitWebhookFailMessage: z.string().nullable().optional().describe("LINE message sent only when the webhook rejects the submission, or null to disable."),
       saveToMetadata: z.boolean().optional().describe("Save responses to friend metadata (for update)"),
       isActive: z.boolean().optional().describe("Active status (for update)"),
       ogTitle: z.string().nullable().optional().describe("OGP title override for the form's LIFF page preview, or null to clear (for update)"),
       ogDescription: z.string().nullable().optional().describe("OGP description override for the form's LIFF page preview, or null to clear (for update)"),
       ogImageUrl: z.string().nullable().optional().describe("OGP image URL override for the form's LIFF page preview, or null to clear (for update)"),
     },
-    async ({ action, formId, name, description, fields, onSubmitTagId, onSubmitScenarioId, onSubmitMessageType, onSubmitMessageContent, saveToMetadata, isActive, ogTitle, ogDescription, ogImageUrl }) => {
+    async ({ action, formId, name, description, fields, onSubmitTagId, onSubmitScenarioId, onSubmitMessageType, onSubmitMessageContent, sendSubmitMessage, onSubmitWebhookUrl, onSubmitWebhookHeaders, onSubmitWebhookFailMessage, saveToMetadata, isActive, ogTitle, ogDescription, ogImageUrl }) => {
       try {
         const client = getClient();
         if (action === "list") {
@@ -43,6 +47,10 @@ export function registerManageForms(server: McpServer): void {
           if (onSubmitScenarioId !== undefined) input.onSubmitScenarioId = onSubmitScenarioId;
           if (onSubmitMessageType !== undefined) input.onSubmitMessageType = onSubmitMessageType;
           if (onSubmitMessageContent !== undefined) input.onSubmitMessageContent = onSubmitMessageContent;
+          if (sendSubmitMessage !== undefined) input.sendSubmitMessage = sendSubmitMessage;
+          if (onSubmitWebhookUrl !== undefined) input.onSubmitWebhookUrl = onSubmitWebhookUrl;
+          if (onSubmitWebhookHeaders !== undefined) input.onSubmitWebhookHeaders = onSubmitWebhookHeaders;
+          if (onSubmitWebhookFailMessage !== undefined) input.onSubmitWebhookFailMessage = onSubmitWebhookFailMessage;
           if (saveToMetadata !== undefined) input.saveToMetadata = saveToMetadata;
           if (isActive !== undefined) input.isActive = isActive;
           if (ogTitle !== undefined) input.ogTitle = ogTitle;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -401,6 +401,10 @@ export interface Form {
   onSubmitScenarioId: string | null
   onSubmitMessageType: 'text' | 'flex' | null
   onSubmitMessageContent: string | null
+  sendSubmitMessage: boolean
+  onSubmitWebhookUrl: string | null
+  onSubmitWebhookHeaders: string | null
+  onSubmitWebhookFailMessage: string | null
   saveToMetadata: boolean
   isActive: boolean
   submitCount: number
@@ -419,6 +423,10 @@ export interface CreateFormInput {
   onSubmitScenarioId?: string | null
   onSubmitMessageType?: 'text' | 'flex' | null
   onSubmitMessageContent?: string | null
+  sendSubmitMessage?: boolean
+  onSubmitWebhookUrl?: string | null
+  onSubmitWebhookHeaders?: string | null
+  onSubmitWebhookFailMessage?: string | null
   saveToMetadata?: boolean
   ogTitle?: string | null
   ogDescription?: string | null
@@ -433,6 +441,10 @@ export interface UpdateFormInput {
   onSubmitScenarioId?: string | null
   onSubmitMessageType?: 'text' | 'flex' | null
   onSubmitMessageContent?: string | null
+  sendSubmitMessage?: boolean
+  onSubmitWebhookUrl?: string | null
+  onSubmitWebhookHeaders?: string | null
+  onSubmitWebhookFailMessage?: string | null
   saveToMetadata?: boolean
   isActive?: boolean
   ogTitle?: string | null


### PR DESCRIPTION
## Summary

- Problem: operational forms always send the default diagnostic Flex message after submission, consuming one LINE message and duplicating submitted details in chat.
- Solution: add a backward-compatible `sendSubmitMessage` option (default: `true`) so standard LINE replies can be disabled while save, tagging, scenario start, and submit webhooks continue.
- What changed: generic submit webhooks are no longer treated as X engagement gates unless both a sanitized `webhookGateId` and `x_username` field are present; SDK/MCP types and tools expose the new controls.
- What did NOT change: existing forms keep their current reply behavior unless explicitly configured with `sendSubmitMessage: false`.

## Related Issue

N/A

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Security hardening
- [ ] Documentation
- [ ] Tests only
- [ ] Chore / infra
- [ ] Private sync

## Scope

- [ ] Admin web UI
- [x] Worker API
- [x] LINE webhook / postback / reply token
- [ ] Broadcast / multicast / step delivery / reminders
- [ ] Auth / API keys / cookies / CORS / staff permissions
- [x] D1 schema / migrations / account scoping
- [x] SDK / MCP / create-line-harness CLI
- [ ] Cloudflare deploy / release / update workflow
- [ ] Docs only

## Verification

- Commands: targeted Vitest suites (6 tests), DB/Worker/MCP typechecks, LINE SDK and update-engine builds, Worker production build
- Manual checks: verified the migration is additive and defaults existing forms to enabled replies
- Screenshots/logs: N/A
- Not tested: managed cloud deployment (maintainer action required)

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Message sending behavior changed? (Yes — only when a form is explicitly configured to suppress the standard reply)
- Customer/friend data access changed? (No)
- D1 migration or data deletion changed? (Yes — additive nullable-safe boolean column; no deletion)

Risk is limited by preserving the existing default. The new behavior is opt-in per form.

## Safety Checklist

- [x] This PR is focused on one problem and contains no unrelated commits.
- [x] I searched for existing issues/PRs to avoid duplicates.
- [x] No secrets, tokens, customer data, friend IDs, private URLs, or private configuration are included.
- [x] No generated build output, `.tsbuildinfo`, local env files, or formatting-only churn is included.
- [x] Docs or tests were updated when useful.
- [x] Deployment impact is understood.
- [x] For high-risk areas, I included a clear rollback or recovery note.
- [x] I personally verified the behavior described above.

## Rollback / Recovery

Revert this commit. Existing forms remain compatible because the new database column defaults to enabled replies.