### PR TITLE
feat(booking): 予約不可時間 (休憩・外出) を空き枠から除外する

### DIFF
--- a/apps/worker/src/routes/booking.ts
+++ b/apps/worker/src/routes/booking.ts
@@ -1512,6 +1512,121 @@ booking.delete('/api/booking/admin/staff/:id/shifts/:shiftId', async (c) => {
   return c.json({ ok: true });
 });
 
+// ---------------------------------------------------------------------------
+// 予約不可時間 (休憩 / 外出 / 会議)
+// shifts と違い 1 日に複数行を許す (休憩 + 外出 の重ね掛け) ため、
+// upsert ではなく追加 / 削除で扱う。
+// ---------------------------------------------------------------------------
+
+booking.get('/api/booking/admin/staff/:id/time-off', async (c) => {
+  const accountId = await resolveAccountIdAdmin(c);
+  if (!accountId) return c.json({ error: 'missing_account_id' }, 400);
+  const staffId = c.req.param('id');
+  if (!(await assertStaffInAccount(c.env.DB, staffId, accountId))) {
+    return c.json({ error: 'staff_not_found_in_account' }, 404);
+  }
+  const from = c.req.query('from');
+  const to = c.req.query('to');
+  const sql = from && to
+    ? `SELECT id, work_date, start_time, end_time, reason
+         FROM staff_time_off
+        WHERE staff_id = ? AND work_date BETWEEN ? AND ?
+        ORDER BY work_date ASC, start_time ASC`
+    : `SELECT id, work_date, start_time, end_time, reason
+         FROM staff_time_off
+        WHERE staff_id = ?
+        ORDER BY work_date ASC, start_time ASC`;
+  const stmt = c.env.DB.prepare(sql);
+  const rows = await (from && to ? stmt.bind(staffId, from, to) : stmt.bind(staffId)).all();
+  const rules = await c.env.DB
+    .prepare(
+      `SELECT id, weekday, start_time, end_time, reason, is_active
+         FROM staff_time_off_rules
+        WHERE staff_id = ?
+        ORDER BY weekday ASC, start_time ASC`,
+    )
+    .bind(staffId)
+    .all();
+  return c.json({ time_off: rows.results, rules: rules.results });
+});
+
+booking.post('/api/booking/admin/staff/:id/time-off', async (c) => {
+  const accountId = await resolveAccountIdAdmin(c);
+  if (!accountId) return c.json({ error: 'missing_account_id' }, 400);
+  const staffId = c.req.param('id');
+  if (!(await assertStaffInAccount(c.env.DB, staffId, accountId))) {
+    return c.json({ error: 'staff_not_found_in_account' }, 404);
+  }
+  const b = await c.req.json<{
+    work_date: string;
+    start_time: string;
+    end_time: string;
+    reason?: string;
+  }>();
+  if (!b.work_date || !b.start_time || !b.end_time) {
+    return c.json({ error: 'missing_fields' }, 400);
+  }
+  if (b.start_time >= b.end_time) return c.json({ error: 'invalid_range' }, 422);
+  const id = crypto.randomUUID();
+  await c.env.DB
+    .prepare(
+      `INSERT INTO staff_time_off (id, staff_id, work_date, start_time, end_time, reason)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(id, staffId, b.work_date, b.start_time, b.end_time, b.reason ?? null)
+    .run();
+  return c.json({ ok: true, id });
+});
+
+booking.delete('/api/booking/admin/staff/:id/time-off/:timeOffId', async (c) => {
+  const accountId = await resolveAccountIdAdmin(c);
+  if (!accountId) return c.json({ error: 'missing_account_id' }, 400);
+  const staffId = c.req.param('id');
+  if (!(await assertStaffInAccount(c.env.DB, staffId, accountId))) {
+    return c.json({ error: 'staff_not_found_in_account' }, 404);
+  }
+  await c.env.DB
+    .prepare(`DELETE FROM staff_time_off WHERE id = ? AND staff_id = ?`)
+    .bind(c.req.param('timeOffId'), staffId)
+    .run();
+  return c.json({ ok: true });
+});
+
+// 定例の予約不可時間 (毎週の休憩)。availability-rules と同じく全置換で扱う。
+booking.put('/api/booking/admin/staff/:id/time-off-rules', async (c) => {
+  const accountId = await resolveAccountIdAdmin(c);
+  if (!accountId) return c.json({ error: 'missing_account_id' }, 400);
+  const staffId = c.req.param('id');
+  if (!(await assertStaffInAccount(c.env.DB, staffId, accountId))) {
+    return c.json({ error: 'staff_not_found_in_account' }, 404);
+  }
+  const b = await c.req.json<{
+    rules: Array<{ weekday: number; start_time: string; end_time: string; reason?: string }>;
+  }>();
+  if (!Array.isArray(b.rules)) return c.json({ error: 'missing_fields' }, 400);
+  for (const r of b.rules) {
+    if (!Number.isInteger(r.weekday) || r.weekday < 0 || r.weekday > 6) {
+      return c.json({ error: 'invalid_weekday' }, 422);
+    }
+    if (!r.start_time || !r.end_time || r.start_time >= r.end_time) {
+      return c.json({ error: 'invalid_range' }, 422);
+    }
+  }
+  const stmts = [
+    c.env.DB.prepare(`DELETE FROM staff_time_off_rules WHERE staff_id = ?`).bind(staffId),
+    ...b.rules.map((r) =>
+      c.env.DB
+        .prepare(
+          `INSERT INTO staff_time_off_rules (id, staff_id, weekday, start_time, end_time, reason, is_active)
+           VALUES (?, ?, ?, ?, ?, ?, 1)`,
+        )
+        .bind(crypto.randomUUID(), staffId, r.weekday, r.start_time, r.end_time, r.reason ?? null),
+    ),
+  ];
+  await c.env.DB.batch(stmts);
+  return c.json({ ok: true, count: b.rules.length });
+});
+
 booking.post('/api/booking/admin/staff/:id/shifts/generate', async (c) => {
   const accountId = await resolveAccountIdAdmin(c);
   if (!accountId) return c.json({ error: 'missing_account_id' }, 400);

--- a/apps/worker/src/routes/openapi.ts
+++ b/apps/worker/src/routes/openapi.ts
@@ -177,6 +177,99 @@ const spec = {
     },
   },
   paths: {
+    // ── Booking (予約不可時間) ───────────────────────────────────────────────
+    '/api/booking/admin/staff/{id}/time-off': {
+      get: {
+        tags: ['Booking'],
+        summary: 'スタッフの予約不可時間を取得（臨時 + 定例）',
+        description:
+          '臨時（日付指定）と定例（曜日指定）を同時に返す。両者は排他ではなく重なる。',
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+          { name: 'from', in: 'query', schema: { type: 'string', format: 'date' } },
+          { name: 'to', in: 'query', schema: { type: 'string', format: 'date' } },
+        ],
+        responses: {
+          '200': { description: '{ time_off: [...], rules: [...] }' },
+          '404': { description: 'staff_not_found_in_account' },
+        },
+      },
+      post: {
+        tags: ['Booking'],
+        summary: '臨時の予約不可時間を追加（外出・会議など）',
+        description: '1 日に複数登録できる。既存の定例（休憩）に上書きせず追加される。',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  work_date: { type: 'string', format: 'date', description: 'YYYY-MM-DD (JST)' },
+                  start_time: { type: 'string', description: 'HH:MM (JST)' },
+                  end_time: { type: 'string', description: 'HH:MM (JST)' },
+                  reason: { type: 'string' },
+                },
+                required: ['work_date', 'start_time', 'end_time'],
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: '{ ok: true, id }' },
+          '400': { description: 'missing_fields' },
+          '422': { description: 'invalid_range' },
+        },
+      },
+    },
+    '/api/booking/admin/staff/{id}/time-off/{timeOffId}': {
+      delete: {
+        tags: ['Booking'],
+        summary: '臨時の予約不可時間を削除',
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+          { name: 'timeOffId', in: 'path', required: true, schema: { type: 'string' } },
+        ],
+        responses: { '200': { description: '{ ok: true }' } },
+      },
+    },
+    '/api/booking/admin/staff/{id}/time-off-rules': {
+      put: {
+        tags: ['Booking'],
+        summary: '定例の予約不可時間を全置換（毎週の休憩など）',
+        description: 'availability-rules と同じく送られた配列で全置換する。',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  rules: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        weekday: { type: 'integer', minimum: 0, maximum: 6, description: '0=日曜' },
+                        start_time: { type: 'string', description: 'HH:MM (JST)' },
+                        end_time: { type: 'string', description: 'HH:MM (JST)' },
+                        reason: { type: 'string' },
+                      },
+                      required: ['weekday', 'start_time', 'end_time'],
+                    },
+                  },
+                },
+                required: ['rules'],
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: '{ ok: true, count }' },
+          '422': { description: 'invalid_weekday / invalid_range' },
+        },
+      },
+    },
     // ── Friends ─────────────────────────────────────────────────────────────
     '/api/friends': {
       get: {

--- a/apps/worker/src/services/availability.test.ts
+++ b/apps/worker/src/services/availability.test.ts
@@ -137,6 +137,8 @@ interface StubData {
   shifts?: Array<{ staff_id: string; work_date: string; start_time: string; end_time: string }>;
   rules?: Array<{ staff_id: string; weekday: number; start_time: string; end_time: string }>;
   bookings?: Array<{ staff_id: string; starts_at: string; block_ends_at: string }>;
+  timeOff?: Array<{ staff_id: string; work_date: string; start_time: string; end_time: string }>;
+  timeOffRules?: Array<{ staff_id: string; weekday: number; start_time: string; end_time: string }>;
   calendarConnection?: {
     id: string;
     calendar_id: string;
@@ -158,6 +160,12 @@ function stubDB(data: StubData): D1Database {
         async all() {
           if (sql.includes('FROM staff') && sql.includes('staff_menus')) {
             return { results: data.staff ?? [] };
+          }
+          if (sql.includes('FROM staff_time_off_rules')) {
+            return { results: data.timeOffRules ?? [] };
+          }
+          if (sql.includes('FROM staff_time_off')) {
+            return { results: data.timeOff ?? [] };
           }
           if (sql.includes('FROM staff_shifts')) {
             return { results: data.shifts ?? [] };
@@ -385,5 +393,107 @@ describe('getAvailability', () => {
       minLeadTimeMinutes: 60,
     });
     expect(result.by_staff).toEqual([]);
+  });
+});
+
+describe('getAvailability — 予約不可時間', () => {
+  const MENU = {
+    duration_minutes: 60,
+    buffer_after_minutes: 0,
+    override_duration: null,
+    override_price: null,
+  };
+  const STAFF = [{ id: 'S1', display_name: '山田', is_designation_optional: 0 }];
+  // 2026-05-09 は土曜 (weekday = 6)
+  const SHIFT = [
+    { staff_id: 'S1', work_date: '2026-05-09', start_time: '09:00', end_time: '13:00' },
+  ];
+  const params = {
+    lineAccountId: 'A1',
+    menuId: 'M1',
+    from: '2026-05-09',
+    to: '2026-05-09',
+    now: new Date('2026-05-08T00:00:00Z'),
+    minLeadTimeMinutes: 60,
+  };
+
+  test('定例の休憩が枠を分割する (2 部制)', async () => {
+    const db = stubDB({
+      menu: MENU,
+      staff: STAFF,
+      shifts: SHIFT,
+      bookings: [],
+      timeOffRules: [
+        { staff_id: 'S1', weekday: 6, start_time: '11:00', end_time: '12:00' },
+      ],
+    });
+    const result = await getAvailability(db, params);
+    // 勤務 09:00-13:00 から休憩 11:00-12:00 を抜くと [09:00-11:00, 12:00-13:00]。
+    // 60 分メニューが収まる開始時刻は 09:00 / 09:30 / 10:00 と 12:00。
+    expect(result.by_staff[0].slots.map((s) => s.start)).toEqual([
+      '09:00', '09:30', '10:00', '12:00',
+    ]);
+  });
+
+  test('曜日が違う定例は影響しない', async () => {
+    const db = stubDB({
+      menu: MENU,
+      staff: STAFF,
+      shifts: SHIFT,
+      bookings: [],
+      timeOffRules: [
+        { staff_id: 'S1', weekday: 1, start_time: '11:00', end_time: '12:00' },
+      ],
+    });
+    const result = await getAvailability(db, params);
+    expect(result.by_staff[0].slots.map((s) => s.start)).toEqual([
+      '09:00', '09:30', '10:00', '10:30', '11:00', '11:30', '12:00',
+    ]);
+  });
+
+  test('当日の臨時 (外出) が除外される', async () => {
+    const db = stubDB({
+      menu: MENU,
+      staff: STAFF,
+      shifts: SHIFT,
+      bookings: [],
+      timeOff: [
+        { staff_id: 'S1', work_date: '2026-05-09', start_time: '09:30', end_time: '10:30' },
+      ],
+    });
+    const result = await getAvailability(db, params);
+    expect(result.by_staff[0].slots.map((s) => s.start)).toEqual(['10:30', '11:00', '11:30', '12:00']);
+  });
+
+  test('定例と臨時は排他ではなく重なる', async () => {
+    const db = stubDB({
+      menu: MENU,
+      staff: STAFF,
+      shifts: SHIFT,
+      bookings: [],
+      timeOffRules: [
+        { staff_id: 'S1', weekday: 6, start_time: '11:00', end_time: '12:00' },
+      ],
+      timeOff: [
+        { staff_id: 'S1', work_date: '2026-05-09', start_time: '09:30', end_time: '10:00' },
+      ],
+    });
+    const result = await getAvailability(db, params);
+    // 休憩 11:00-12:00 と外出 09:30-10:00 の両方が効く
+    expect(result.by_staff[0].slots.map((s) => s.start)).toEqual(['10:00', '12:00']);
+  });
+
+  test('他スタッフの予約不可時間は影響しない', async () => {
+    const db = stubDB({
+      menu: MENU,
+      staff: STAFF,
+      shifts: SHIFT,
+      bookings: [],
+      timeOffRules: [
+        { staff_id: 'S2', weekday: 6, start_time: '11:00', end_time: '12:00' },
+      ],
+    });
+    const result = await getAvailability(db, params);
+    expect(result.by_staff[0].slots).toHaveLength(7);
   });
 });

--- a/apps/worker/src/services/availability.ts
+++ b/apps/worker/src/services/availability.ts
@@ -210,6 +210,29 @@ export async function getAvailability(
     .bind(...staffIds)
     .all<{ staff_id: string; weekday: number; start_time: string; end_time: string }>();
 
+  // 予約不可時間 (休憩 / 外出 / 会議)。勤務区間を分割せず busy として差し引く。
+  // 曜日ルールと日付指定は排他ではなく重ねる — 定例の休憩に加えて臨時の外出が
+  // 入る、という積み方をするため (staff_shifts が曜日ルールを置き換えるのとは
+  // セマンティクスが異なる)。
+  const timeOff = await db
+    .prepare(
+      `SELECT staff_id, work_date, start_time, end_time
+         FROM staff_time_off
+        WHERE staff_id IN (${placeholders})
+          AND work_date BETWEEN ? AND ?`,
+    )
+    .bind(...staffIds, params.from, params.to)
+    .all<{ staff_id: string; work_date: string; start_time: string; end_time: string }>();
+
+  const timeOffRules = await db
+    .prepare(
+      `SELECT staff_id, weekday, start_time, end_time
+         FROM staff_time_off_rules
+        WHERE staff_id IN (${placeholders}) AND is_active = 1`,
+    )
+    .bind(...staffIds)
+    .all<{ staff_id: string; weekday: number; start_time: string; end_time: string }>();
+
   // Coarse range filter: from の前日 00:00 UTC 〜 to の翌日 00:00 UTC で十分な余裕
   const rangeStart = new Date(`${params.from}T00:00:00Z`);
   rangeStart.setUTCDate(rangeStart.getUTCDate() - 1);
@@ -280,6 +303,16 @@ export async function getAvailability(
           start: jstHHMM(new Date(b.starts_at)),
           end: jstHHMM(new Date(b.block_ends_at)),
         }));
+      for (const r of timeOffRules.results) {
+        if (r.staff_id === s.id && r.weekday === weekdayForDate(date)) {
+          dayBookings.push({ start: r.start_time, end: r.end_time });
+        }
+      }
+      for (const t of timeOff.results) {
+        if (t.staff_id === s.id && t.work_date === date) {
+          dayBookings.push({ start: t.start_time, end: t.end_time });
+        }
+      }
       const googleBusy = googleBusyByStaff.get(s.id);
       if (googleBusy) dayBookings.push(...googleBusyForJstDate(googleBusy, date));
       const daySlots = computeSlots({

--- a/packages/db/bootstrap-meta.json
+++ b/packages/db/bootstrap-meta.json
@@ -77,7 +77,8 @@
     "070_admin_sso_jti.sql",
     "071_quota_alerts.sql",
     "072_broadcast_last_error.sql",
-    "072_health_logs_composite_index.sql"
+    "072_health_logs_composite_index.sql",
+    "NNN_staff_time_off.sql"
   ],
-  "migrationCount": 78
+  "migrationCount": 79
 }

--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -937,6 +937,31 @@ CREATE TABLE IF NOT EXISTS staff_shifts (
   FOREIGN KEY (staff_id) REFERENCES staff(id)
 );
 
+CREATE TABLE IF NOT EXISTS staff_time_off (
+  id          TEXT PRIMARY KEY,
+  staff_id    TEXT NOT NULL,
+  work_date   TEXT NOT NULL,    -- YYYY-MM-DD (JST)
+  start_time  TEXT NOT NULL,    -- HH:MM (JST)
+  end_time    TEXT NOT NULL,    -- HH:MM (JST)
+  reason      TEXT,
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  FOREIGN KEY (staff_id) REFERENCES staff(id)
+);
+
+CREATE TABLE IF NOT EXISTS staff_time_off_rules (
+  id          TEXT PRIMARY KEY,
+  staff_id    TEXT NOT NULL,
+  weekday     INTEGER NOT NULL CHECK (weekday BETWEEN 0 AND 6),
+  start_time  TEXT NOT NULL,
+  end_time    TEXT NOT NULL,
+  reason      TEXT,
+  is_active   INTEGER NOT NULL DEFAULT 1,
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  FOREIGN KEY (staff_id) REFERENCES staff(id)
+);
+
 CREATE TABLE IF NOT EXISTS stripe_events (
   id               TEXT PRIMARY KEY,
   stripe_event_id  TEXT NOT NULL UNIQUE,
@@ -1371,6 +1396,12 @@ CREATE INDEX IF NOT EXISTS idx_staff_availability_rules_staff
 CREATE UNIQUE INDEX IF NOT EXISTS idx_staff_members_api_key ON staff_members(api_key);
 
 CREATE INDEX IF NOT EXISTS idx_staff_members_role ON staff_members(role);
+
+CREATE INDEX IF NOT EXISTS idx_staff_time_off_rules_staff
+  ON staff_time_off_rules (staff_id, weekday, is_active);
+
+CREATE INDEX IF NOT EXISTS idx_staff_time_off_staff_date
+  ON staff_time_off (staff_id, work_date);
 
 CREATE INDEX IF NOT EXISTS idx_stripe_events_friend ON stripe_events (friend_id);
 

--- a/packages/db/migrations/NNN_staff_time_off.sql
+++ b/packages/db/migrations/NNN_staff_time_off.sql
@@ -1,0 +1,50 @@
+-- Migration NNN: 予約不可時間 (staff_time_off / staff_time_off_rules)
+--
+-- 既存の勤務時間モデルは staff_shifts (日付指定) と staff_availability_rules
+-- (曜日指定) の 2 段構えだが、どちらも「勤務している区間」を 1 本しか持てない
+-- (staff_shifts は UNIQUE(staff_id, work_date))。そのため
+--   - 昼休憩を挟む 2 部制 (09:00-12:00 / 13:00-18:00)
+--   - 当日の外出・会議・急用といった一時的な離席
+-- を空き枠から除外できない。
+--
+-- ここでは勤務区間を分割する方向ではなく、通し勤務から「穴」を空ける方向で解決する。
+-- availability.ts の computeSlots は busy 区間を任意個数差し引ける (subtract) ため、
+-- 既存予約と同じように busy へ積むだけでよく、空き枠計算そのものは変更しない。
+--
+-- テーブルを 2 つに分けるのは staff_shifts / staff_availability_rules と同じ理由で、
+-- 定例 (毎週の休憩) を日付で有限生成すると期限切れになるため。
+--
+-- ⚠️ 勤務時間側とセマンティクスが異なる点に注意:
+--    staff_shifts は同日の曜日ルールを「置き換える」が、
+--    staff_time_off は同日の曜日ルールに「追加」される。
+--    休憩 (定例) に加えて外出 (臨時) が入る、という重ね方をするのが自然なため。
+--    したがって 1 スタッフ 1 日に複数行を許し、UNIQUE 制約は張らない。
+
+CREATE TABLE IF NOT EXISTS staff_time_off (
+  id          TEXT PRIMARY KEY,
+  staff_id    TEXT NOT NULL,
+  work_date   TEXT NOT NULL,    -- YYYY-MM-DD (JST)
+  start_time  TEXT NOT NULL,    -- HH:MM (JST)
+  end_time    TEXT NOT NULL,    -- HH:MM (JST)
+  reason      TEXT,             -- 外出 / 会議 / 私用 など。運用メモで、判定には使わない
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  FOREIGN KEY (staff_id) REFERENCES staff(id)
+);
+CREATE INDEX IF NOT EXISTS idx_staff_time_off_staff_date
+  ON staff_time_off (staff_id, work_date);
+
+CREATE TABLE IF NOT EXISTS staff_time_off_rules (
+  id          TEXT PRIMARY KEY,
+  staff_id    TEXT NOT NULL,
+  weekday     INTEGER NOT NULL CHECK (weekday BETWEEN 0 AND 6),
+  start_time  TEXT NOT NULL,    -- HH:MM (JST)
+  end_time    TEXT NOT NULL,    -- HH:MM (JST)
+  reason      TEXT,             -- 休憩 など
+  is_active   INTEGER NOT NULL DEFAULT 1,
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  FOREIGN KEY (staff_id) REFERENCES staff(id)
+);
+CREATE INDEX IF NOT EXISTS idx_staff_time_off_rules_staff
+  ON staff_time_off_rules (staff_id, weekday, is_active);

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -1029,6 +1029,41 @@ CREATE INDEX IF NOT EXISTS idx_staff_availability_rules_staff
   ON staff_availability_rules (staff_id, weekday, is_active);
 
 -- ============================================================
+-- staff_time_off / staff_time_off_rules: 予約不可時間
+-- 勤務区間 (staff_shifts / staff_availability_rules) を分割するのではなく、
+-- 通し勤務から穴を空ける。休憩を挟む 2 部制と臨時の外出を同じ仕組みで表現する。
+-- 勤務時間側と違い、日付指定は曜日ルールを置き換えず「追加」される。
+-- ============================================================
+CREATE TABLE IF NOT EXISTS staff_time_off (
+  id          TEXT PRIMARY KEY,
+  staff_id    TEXT NOT NULL,
+  work_date   TEXT NOT NULL,    -- YYYY-MM-DD (JST)
+  start_time  TEXT NOT NULL,    -- HH:MM (JST)
+  end_time    TEXT NOT NULL,    -- HH:MM (JST)
+  reason      TEXT,
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  FOREIGN KEY (staff_id) REFERENCES staff(id)
+);
+CREATE INDEX IF NOT EXISTS idx_staff_time_off_staff_date
+  ON staff_time_off (staff_id, work_date);
+
+CREATE TABLE IF NOT EXISTS staff_time_off_rules (
+  id          TEXT PRIMARY KEY,
+  staff_id    TEXT NOT NULL,
+  weekday     INTEGER NOT NULL CHECK (weekday BETWEEN 0 AND 6),
+  start_time  TEXT NOT NULL,
+  end_time    TEXT NOT NULL,
+  reason      TEXT,
+  is_active   INTEGER NOT NULL DEFAULT 1,
+  created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  FOREIGN KEY (staff_id) REFERENCES staff(id)
+);
+CREATE INDEX IF NOT EXISTS idx_staff_time_off_rules_staff
+  ON staff_time_off_rules (staff_id, weekday, is_active);
+
+-- ============================================================
 -- bookings: 予約本体
 -- ============================================================
 CREATE TABLE IF NOT EXISTS bookings (


### PR DESCRIPTION
## 問題

勤務時間モデルは `staff_shifts` (日付指定) と `staff_availability_rules` (曜日指定) の 2 段構えですが、どちらも「勤務している区間」を 1 本しか持てません (`staff_shifts` は `UNIQUE(staff_id, work_date)`)。そのため

- 昼休憩を挟む 2 部制 (09:00-12:00 / 13:00-18:00)
- 当日の外出・会議といった一時的な離席

を空き枠から除外できません。現状 busy として差し引けるのは既存予約と Google Calendar の予定だけなので、**外部カレンダーを使わない運用では休憩中にも予約が入ってしまいます**。

美容室・サロン系の案件で必ず出てくる要件のため、汎用機能として提案します。

Issue は立てていません。再現条件がコードから明らかで、変更範囲も小さいためです。方向性が合わなければ遠慮なくクローズしてください。

## 変更

勤務区間を分割するのではなく、通し勤務から「穴」を空ける方向で解決しています。`computeSlots` は busy 区間を任意個数差し引ける実装なので、**空き枠計算そのものは変更していません**。

- `staff_time_off` (日付指定) / `staff_time_off_rules` (曜日指定) を追加
- `getAvailability` が両者を busy に積む
- 管理 API: `GET`/`POST`/`DELETE .../time-off`, `PUT .../time-off-rules`
- OpenAPI に 4 ルートを記載

### セマンティクスの非対称について

`staff_shifts` は同日の曜日ルールを**置き換え**ますが、`staff_time_off` は**追加**されます。「毎週の休憩に加えて今日は外出」という重ね方が自然なためです。1 スタッフ 1 日に複数行を許し、UNIQUE 制約は張っていません。分かりにくい点なので migration とスキーマ両方にコメントを入れました。意図と違えばご指摘ください。

### OpenAPI について

`openapi-coverage.test.ts` が新規ルートの未記載を検出したため、spec に追記しました。既存の予約管理 API は `KNOWN_GAPS` に入っていますが、そこは「返すべき負債」と書かれていたので増やさない方針にしています。

## テスト

`apps/worker` で vitest / `tsc --noEmit` を実行。

- `availability.test.ts` に 5 ケース追加、26 件すべて通過
  - 定例休憩による枠の分割 (2 部制)
  - 曜日が違う定例は影響しない
  - 当日の臨時 (外出) が除外される
  - 定例と臨時は排他ではなく重なる
  - 他スタッフの予約不可時間は影響しない
- ワーカー全体: **1188 passed / 0 failed**
- `scripts/check-migrations.ts` (additive-only ポリシー) 通過

## 検証していないこと

- **実 D1 / デプロイ環境での動作確認は未実施**です (ユニットテストのみ)
- **管理画面 (`apps/web`) の UI は未実装**で、API のみです
- migration 番号は CONTRIBUTING に従いプレースホルダ `NNN_` です。採番時に `pnpm --dir packages/db generate:bootstrap` での `bootstrap.sql` / `bootstrap-meta.json` 再生成が必要です
- 収集に失敗するテストファイルが 17 件ありますが、**変更前のベースラインと同一**で本 PR とは無関係です (`@line-harness/update-engine` 未ビルド等)。同様に `tsc --noEmit` の `admin-update.ts` 3 件も既存エラーです
