### PR TITLE
feat(booking): 予約リクエストをスタッフの LINE へ通知する

### DIFF
--- a/apps/worker/src/routes/booking.ts
+++ b/apps/worker/src/routes/booking.ts
@@ -11,7 +11,8 @@
 // scheduled_at / decided_at / expires_at) are written from the Worker.
 
 import { Hono, type Context } from 'hono';
-import { getLineAccounts } from '@line-crm/db';
+import { getLineAccounts, getAccountSetting, setAccountSetting } from '@line-crm/db';
+import { LineClient } from '@line-crm/line-sdk';
 import type { Env } from '../index.js';
 import { resolveCorsOrigin } from '../middleware/admin-auth-config.js';
 import { canTransition, nextStatus, type BookingAction } from '../services/booking-state.js';
@@ -25,7 +26,12 @@ import {
   findIdempotencyResponse,
   saveIdempotencyResponse,
 } from '../services/booking-idempotency.js';
-import { sendBookingNotification } from '../services/booking-notifier.js';
+import {
+  sendBookingNotification,
+  BOOKING_NOTIFY_RECIPIENTS_KEY,
+  renderStaffNotificationText,
+  resolveStaffRecipients,
+} from '../services/booking-notifier.js';
 import { insertConfirmationReminders } from '../services/booking-confirm.js';
 import { attachTagAndFireSideEffects } from '../services/friend-tag-attach.js';
 import {
@@ -290,6 +296,75 @@ async function notifyForBooking(
   });
 }
 
+/**
+ * 予約リクエストをスタッフの LINE へ通知する。
+ *
+ * 顧客通知 (notifyForBooking) と分けてあるのは宛先と文面が別物のため。
+ * 宛先が 1 件も設定されていなければ何もしない (既定は無効)。
+ *
+ * fire-and-forget で呼ぶこと。通知の失敗で予約自体を巻き戻さない。
+ */
+async function notifyStaffForBooking(db: D1Database, bookingId: string): Promise<void> {
+  const row = await db
+    .prepare(
+      `SELECT b.starts_at,
+              m.name          AS menu_name,
+              s.display_name  AS staff_name,
+              s.notify_friend_id,
+              la.id           AS line_account_id,
+              la.channel_access_token,
+              f.display_name  AS customer_name
+         FROM bookings b
+         INNER JOIN menus m ON m.id = b.menu_id
+         INNER JOIN staff s ON s.id = b.staff_id
+         INNER JOIN line_accounts la ON la.id = b.line_account_id
+         INNER JOIN friends f ON f.id = b.friend_id
+        WHERE b.id = ?`,
+    )
+    .bind(bookingId)
+    .first<{
+      starts_at: string;
+      menu_name: string;
+      staff_name: string;
+      notify_friend_id: string | null;
+      line_account_id: string;
+      channel_access_token: string;
+      customer_name: string | null;
+    }>();
+  if (!row) return;
+
+  const accountRecipients = await getAccountSetting(
+    db,
+    row.line_account_id,
+    BOOKING_NOTIFY_RECIPIENTS_KEY,
+  );
+  const friendIds = resolveStaffRecipients(row.notify_friend_id, accountRecipients);
+  if (friendIds.length === 0) return;
+
+  const placeholders = friendIds.map(() => '?').join(',');
+  const friends = await db
+    .prepare(
+      `SELECT line_user_id FROM friends
+        WHERE id IN (${placeholders}) AND is_following = 1`,
+    )
+    .bind(...friendIds)
+    .all<{ line_user_id: string }>();
+  if (!friends.results.length) return;
+
+  const text = renderStaffNotificationText({
+    menuName: row.menu_name,
+    staffName: row.staff_name,
+    startsAtJst: startsAtJst(row.starts_at),
+    hoursBefore: 0,
+    customerName: row.customer_name ?? '（表示名なし）',
+  });
+  const client = new LineClient(row.channel_access_token);
+  // 1 人失敗しても残りへ送る。通知は best-effort。
+  await Promise.allSettled(
+    friends.results.map((f) => client.pushMessage(f.line_user_id, [{ type: 'text', text }])),
+  );
+}
+
 // ================================================================
 // LIFF endpoints (/api/liff/booking/*)
 // ================================================================
@@ -519,6 +594,13 @@ booking.post('/api/liff/booking/requests', async (c) => {
   c.executionCtx.waitUntil(
     notifyForBooking(c.env.DB, bookingId, 'requested').catch((err) =>
       console.error('booking notify (requested) failed:', err),
+    ),
+  );
+
+  // スタッフへの通知。宛先未設定なら no-op なので既存インストールの挙動は変わらない。
+  c.executionCtx.waitUntil(
+    notifyStaffForBooking(c.env.DB, bookingId).catch((err) =>
+      console.error('[booking] staff notification failed', err),
     ),
   );
 
@@ -1028,12 +1110,15 @@ booking.put('/api/booking/admin/staff/:id', async (c) => {
     sort_order?: number;
     is_designation_optional?: boolean;
     is_active?: boolean;
+    /** 予約リクエストの通知先 friends.id。null で通知を止める。省略時は変更しない。 */
+    notify_friend_id?: string | null;
   }>();
   await c.env.DB
     .prepare(
       `UPDATE staff
           SET name = ?, display_name = ?, role = ?, profile_image_url = ?, bio = ?,
               sort_order = ?, is_designation_optional = ?, is_active = ?,
+              notify_friend_id = COALESCE(?, notify_friend_id),
               updated_at = strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')
         WHERE id = ? AND line_account_id = ?`,
     )
@@ -1046,10 +1131,19 @@ booking.put('/api/booking/admin/staff/:id', async (c) => {
       b.sort_order ?? 0,
       b.is_designation_optional ? 1 : 0,
       b.is_active === false ? 0 : 1,
+      // undefined = 変更しない (COALESCE で既存値を残す)、null = 明示的にクリア
+      b.notify_friend_id === undefined ? null : b.notify_friend_id,
       id,
       accountId,
     )
     .run();
+  // COALESCE では「明示的な null でクリア」が表現できないので別文で処理する
+  if (b.notify_friend_id === null) {
+    await c.env.DB
+      .prepare(`UPDATE staff SET notify_friend_id = NULL WHERE id = ? AND line_account_id = ?`)
+      .bind(id, accountId)
+      .run();
+  }
   return c.json({ ok: true });
 });
 
@@ -1510,6 +1604,29 @@ booking.delete('/api/booking/admin/staff/:id/shifts/:shiftId', async (c) => {
     .bind(shiftId, staffId)
     .run();
   return c.json({ ok: true });
+});
+
+booking.get('/api/booking/admin/notify-recipients', async (c) => {
+  const accountId = await resolveAccountIdAdmin(c);
+  if (!accountId) return c.json({ error: 'missing_account_id' }, 400);
+  const raw = await getAccountSetting(c.env.DB, accountId, BOOKING_NOTIFY_RECIPIENTS_KEY);
+  return c.json({ friend_ids: resolveStaffRecipients(null, raw) });
+});
+
+booking.put('/api/booking/admin/notify-recipients', async (c) => {
+  const accountId = await resolveAccountIdAdmin(c);
+  if (!accountId) return c.json({ error: 'missing_account_id' }, 400);
+  const b = await c.req.json<{ friend_ids: string[] }>();
+  if (!Array.isArray(b.friend_ids) || b.friend_ids.some((v) => typeof v !== 'string')) {
+    return c.json({ error: 'invalid_friend_ids' }, 422);
+  }
+  await setAccountSetting(
+    c.env.DB,
+    accountId,
+    BOOKING_NOTIFY_RECIPIENTS_KEY,
+    JSON.stringify(b.friend_ids),
+  );
+  return c.json({ ok: true, count: b.friend_ids.length });
 });
 
 booking.post('/api/booking/admin/staff/:id/shifts/generate', async (c) => {

--- a/apps/worker/src/routes/openapi.ts
+++ b/apps/worker/src/routes/openapi.ts
@@ -177,6 +177,36 @@ const spec = {
     },
   },
   paths: {
+    // ── Booking (スタッフ通知先) ─────────────────────────────────────────────
+    '/api/booking/admin/notify-recipients': {
+      get: {
+        tags: ['Booking'],
+        summary: '予約リクエストの通知先を取得（アカウント共通）',
+        responses: { '200': { description: '{ friend_ids: string[] }' } },
+      },
+      put: {
+        tags: ['Booking'],
+        summary: '予約リクエストの通知先を設定（アカウント共通）',
+        description:
+          '店長など全予約を受け取る人の friends.id。スタッフ個別の通知先は staff.notify_friend_id。'
+          + ' push は配信通数を消費する点に注意。',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { friend_ids: { type: 'array', items: { type: 'string' } } },
+                required: ['friend_ids'],
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: '{ ok: true, count }' },
+          '422': { description: 'invalid_friend_ids' },
+        },
+      },
+    },
     // ── Friends ─────────────────────────────────────────────────────────────
     '/api/friends': {
       get: {

--- a/apps/worker/src/services/booking-notifier.test.ts
+++ b/apps/worker/src/services/booking-notifier.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest';
-import { renderNotificationText } from './booking-notifier.js';
+import {
+  renderNotificationText,
+  renderStaffNotificationText,
+  resolveStaffRecipients,
+} from './booking-notifier.js';
 
 const ctx = {
   menuName: 'カット',
@@ -34,5 +38,55 @@ describe('renderNotificationText', () => {
   test('当日 N 時間前', () => {
     const t = renderNotificationText('hours_before', ctx);
     expect(t).toContain('本日のご予約まであと 2 時間');
+  });
+});
+
+describe('renderStaffNotificationText', () => {
+  const ctx = {
+    menuName: 'カット',
+    staffName: '山田',
+    startsAtJst: '2026-05-10 14:00',
+    hoursBefore: 0,
+    customerName: '佐藤 花子',
+  };
+
+  test('顧客名・メニュー・担当・日時が入る', () => {
+    const text = renderStaffNotificationText(ctx);
+    expect(text).toContain('新しい予約リクエスト');
+    expect(text).toContain('佐藤 花子');
+    expect(text).toContain('カット');
+    expect(text).toContain('山田');
+    expect(text).toContain('2026-05-10 14:00');
+  });
+
+  test('24 時間で期限切れになることを明示する', () => {
+    // 承認制の放置事故を防ぐのが主目的なので、この一文は落とさない
+    expect(renderStaffNotificationText(ctx)).toContain('24 時間');
+  });
+
+  test('adminUrl を渡すと導線が付く', () => {
+    const text = renderStaffNotificationText({ ...ctx, adminUrl: 'https://admin.example.com' });
+    expect(text).toContain('https://admin.example.com');
+  });
+});
+
+describe('resolveStaffRecipients', () => {
+  test('指名スタッフ + アカウント共通を結合する', () => {
+    expect(resolveStaffRecipients('f1', '["f2","f3"]')).toEqual(['f1', 'f2', 'f3']);
+  });
+
+  test('重複を除き、指名スタッフを先頭に保つ', () => {
+    expect(resolveStaffRecipients('f1', '["f2","f1"]')).toEqual(['f1', 'f2']);
+  });
+
+  test('宛先未設定なら空 — 既定で通知しない', () => {
+    expect(resolveStaffRecipients(null, null)).toEqual([]);
+    expect(resolveStaffRecipients(undefined, '[]')).toEqual([]);
+  });
+
+  test('設定が壊れていても例外にしない（予約自体は成功させる）', () => {
+    expect(resolveStaffRecipients('f1', 'not json')).toEqual(['f1']);
+    expect(resolveStaffRecipients(null, '{"a":1}')).toEqual([]);
+    expect(resolveStaffRecipients(null, '["ok", 42, null]')).toEqual(['ok']);
   });
 });

--- a/apps/worker/src/services/booking-notifier.ts
+++ b/apps/worker/src/services/booking-notifier.ts
@@ -50,3 +50,64 @@ export async function sendBookingNotification(params: SendNotificationParams): P
 }
 
 export type BookingNotificationSender = (params: SendNotificationParams) => Promise<void>;
+
+// ---------------------------------------------------------------------------
+// スタッフ通知
+//
+// 顧客向け通知 (上) と分けている理由は宛先と文面が別物のため。顧客には
+// 「お店からの返信をお待ちください」、スタッフには承認を促す内容を送る。
+//
+// 宛先はスタッフ本人が公式アカウントを友だち追加した friends 行
+// (staff.notify_friend_id)、および account_settings の
+// 'booking_notify_friend_ids' に列挙された friends.id (店長など全件受け取る人)。
+//
+// ⚠️ push はアカウントの配信通数を消費する。
+// ---------------------------------------------------------------------------
+
+export const BOOKING_NOTIFY_RECIPIENTS_KEY = 'booking_notify_friend_ids';
+
+export interface StaffNotificationContext extends NotificationContext {
+  customerName: string;
+  adminUrl?: string;
+}
+
+export function renderStaffNotificationText(ctx: StaffNotificationContext): string {
+  const lines = [
+    '新しい予約リクエストが入りました。',
+    '',
+    `お客様: ${ctx.customerName}`,
+    `メニュー: ${ctx.menuName}`,
+    `担当: ${ctx.staffName}`,
+    `日時: ${ctx.startsAtJst}`,
+    '',
+    // 24 時間で expired になるため、放置されないよう期限を明示する
+    '24 時間以内に承認されないと自動でキャンセル扱いになります。',
+  ];
+  if (ctx.adminUrl) lines.push('', `管理画面: ${ctx.adminUrl}`);
+  return lines.join('\n');
+}
+
+/**
+ * 通知先の friends.id を集める。指名スタッフの通知先と、アカウント共通の
+ * 通知先を結合し重複を除く。順序は「指名スタッフ → 共通」で安定させる。
+ */
+export function resolveStaffRecipients(
+  staffNotifyFriendId: string | null | undefined,
+  accountRecipientsJson: string | null | undefined,
+): string[] {
+  const out: string[] = [];
+  if (staffNotifyFriendId) out.push(staffNotifyFriendId);
+  if (accountRecipientsJson) {
+    try {
+      const parsed: unknown = JSON.parse(accountRecipientsJson);
+      if (Array.isArray(parsed)) {
+        for (const v of parsed) {
+          if (typeof v === 'string' && v && !out.includes(v)) out.push(v);
+        }
+      }
+    } catch {
+      // 設定が壊れていても予約自体は成功させる。通知だけ諦める。
+    }
+  }
+  return out;
+}

--- a/packages/db/bootstrap-meta.json
+++ b/packages/db/bootstrap-meta.json
@@ -77,7 +77,8 @@
     "070_admin_sso_jti.sql",
     "071_quota_alerts.sql",
     "072_broadcast_last_error.sql",
-    "072_health_logs_composite_index.sql"
+    "072_health_logs_composite_index.sql",
+    "NNN_staff_notify_friend.sql"
   ],
-  "migrationCount": 78
+  "migrationCount": 79
 }

--- a/packages/db/bootstrap.sql
+++ b/packages/db/bootstrap.sql
@@ -884,6 +884,9 @@ CREATE TABLE IF NOT EXISTS staff (
   sort_order               INTEGER NOT NULL DEFAULT 0,
   is_designation_optional  INTEGER NOT NULL DEFAULT 0,
   is_active                INTEGER NOT NULL DEFAULT 1,
+  -- 予約リクエストの通知先。スタッフ本人が公式アカウントを友だち追加した
+  -- friends.id。NULL = 通知しない。
+  notify_friend_id         TEXT,
   deleted_at               TEXT,
   created_at               TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   updated_at               TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),

--- a/packages/db/migrations/NNN_staff_notify_friend.sql
+++ b/packages/db/migrations/NNN_staff_notify_friend.sql
@@ -1,0 +1,23 @@
+-- Migration NNN: staff.notify_friend_id — 予約リクエストをスタッフの LINE へ通知する
+
+-- 予約リクエストが入っても、スタッフ側には何の通知も飛ばない。booking.ts は
+-- fireEvent を呼ばないため outgoing webhook にも automation にも乗らず、
+-- 管理画面の pending-count を目視するプル型しか無い。
+--
+-- 承認制 (requested → confirmed) と組み合わさると実害が出る。予約リクエストは
+-- 24 時間承認されないと expired になる (REQUEST_TTL_HOURS) ため、誰も管理画面を
+-- 見ていないと、顧客には「お店からの返信をお待ちください」と伝えたまま静かに
+-- 期限切れになる。
+--
+-- 送信先はスタッフ本人が公式アカウントを友だち追加した friends 行とする。
+-- staff は line_user_id を持たないので、friends.id への参照を 1 列足す。
+-- NULL = 通知しない (既存行はすべて NULL なので挙動は変わらない)。
+--
+-- 全件を受け取る店長などは account_settings の
+-- 'booking_notify_friend_ids' (friends.id の JSON 配列) で指定する。
+-- 汎用 KV なので追加のテーブルは要らない。
+--
+-- ⚠️ push はアカウントの配信通数を消費する。スタッフ通知を有効にすると
+-- 1 予約あたり (指名スタッフ + 全件通知先) の通数が顧客配信と同じ枠から減る。
+
+ALTER TABLE staff ADD COLUMN notify_friend_id TEXT;

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -974,6 +974,9 @@ CREATE TABLE IF NOT EXISTS staff (
   sort_order               INTEGER NOT NULL DEFAULT 0,
   is_designation_optional  INTEGER NOT NULL DEFAULT 0,
   is_active                INTEGER NOT NULL DEFAULT 1,
+  -- 予約リクエストの通知先。スタッフ本人が公式アカウントを友だち追加した
+  -- friends.id。NULL = 通知しない。
+  notify_friend_id         TEXT,
   deleted_at               TEXT,
   created_at               TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
   updated_at               TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),


### PR DESCRIPTION
## 問題

予約リクエストが入っても、**スタッフ側には何の通知も飛びません**。`booking.ts` は `fireEvent` を呼ばないため outgoing webhook にも automation にも乗らず (automation のトリガーにサロン予約のイベントが無い)、管理画面の `pending-count` を目視するプル型しかありません。

承認制と組み合わさると実害が出ます。予約リクエストは 24 時間承認されないと `expired` になる (`REQUEST_TTL_HOURS`) ため、誰も管理画面を見ていないと、顧客には「お店からの返信をお待ちください」と伝えたまま**静かに期限切れ**になります。土日に管理画面を開かない店舗では現実に起こり得ます。

Issue は立てていません。挙動がコードから明らかで変更も小さいためです。方向性が違えば遠慮なくクローズしてください。

## 変更

スタッフ本人が公式アカウントを友だち追加している前提で、その `friends` 行へ push します。

- `staff.notify_friend_id` を追加 (`friends.id` / NULL = 通知しない)
- 全予約を受け取る店長などは `account_settings` の `booking_notify_friend_ids` (JSON 配列) で指定。汎用 KV なので新テーブルは作っていません
- 予約リクエスト作成時に fire-and-forget で通知。**宛先が 1 件も無ければ no-op** なので、既存インストールの挙動は変わりません
- 管理 API: `GET`/`PUT /api/booking/admin/notify-recipients`、`PUT staff` が `notify_friend_id` を受け付ける (`undefined` = 変更しない / `null` = クリア)

通知は best-effort に倒しています。`Promise.allSettled` で 1 人失敗しても残りへ送り、設定 JSON が壊れていても例外にせず予約自体は成功させます。

### 配信通数について

push は**アカウントの配信通数を消費します**。スタッフ通知を有効にすると 1 予約あたり (指名スタッフ + 全件通知先) の通数が顧客配信と同じ枠から減ります。既定は無効 (宛先未設定) なので、有効化は運用側の明示的な判断になります。

通数を使わない選択肢として outgoing webhook 経由 (Slack 等) も考えられますが、そちらは「予約イベントを event-bus に流す」別の変更が必要になるため、この PR では扱っていません。どちらの方向がお好みか、ご意見いただけると助かります。

## テスト

`apps/worker` で vitest / `tsc --noEmit` を実行。

- `booking-notifier.test.ts` に 7 ケース追加、13 件すべて通過
  - 文面に顧客名・メニュー・担当・日時が入る
  - 24 時間で期限切れになる旨を明示する (放置事故の防止が主目的のため)
  - 指名スタッフ + アカウント共通の結合と重複除去、順序の安定
  - 宛先未設定なら空 (既定で通知しない)
  - 設定 JSON が壊れていても例外にしない
- 全体: **118 files / 1331 passed / 0 failed**

## 検証していないこと

- **実 D1 / デプロイ環境での動作確認は未実施**です
- **エンドポイント単位のテストは未追加**で、純関数と型のみです
- **管理画面 (`apps/web`) の UI は未実装**で、API のみです
- migration 番号は CONTRIBUTING に従いプレースホルダ `NNN_` です。採番時に `pnpm --dir packages/db generate:bootstrap` での再生成が必要です
