### PR TITLE
feat(booking): 指名なし予約を空いている実スタッフへ自動割当する

### DIFF
--- a/apps/worker/src/routes/booking.ts
+++ b/apps/worker/src/routes/booking.ts
@@ -17,6 +17,10 @@ import { resolveCorsOrigin } from '../middleware/admin-auth-config.js';
 import { canTransition, nextStatus, type BookingAction } from '../services/booking-state.js';
 import { getAvailability } from '../services/availability.js';
 import {
+  countBookingsByStaffForDate,
+  orderAssignmentCandidates,
+} from '../services/staff-assignment.js';
+import {
   removeBookingFromGoogle,
   syncConfirmedBookingToGoogle,
   verifyStaffCalendarConnection,
@@ -436,29 +440,69 @@ booking.post('/api/liff/booking/requests', async (c) => {
   // リードタイム / 既存予約を、確定直前にもう一度突合する。
   const startJstDate = new Date(startsAt.getTime() + 9 * 3600_000).toISOString().slice(0, 10);
   const startJstHHMM = new Date(startsAt.getTime() + 9 * 3600_000).toISOString().slice(11, 16);
+  // 指名なし枠かどうかで扱いが変わる。指名なしの場合は実スタッフ全員の空きを見て、
+  // 確定時にその中の 1 名へ割り当てる (仮想スタッフに予約を入れると同時 1 件しか
+  // 受けられなくなるため)。
+  const requestedStaff = await c.env.DB
+    .prepare(
+      `SELECT is_designation_optional FROM staff
+        WHERE id = ? AND line_account_id = ? AND is_active = 1 AND deleted_at IS NULL`,
+    )
+    .bind(body.staff_id, accountId)
+    .first<{ is_designation_optional: number }>();
+  if (!requestedStaff) return c.json({ error: 'staff_not_found' }, 404);
+  const noDesignation = requestedStaff.is_designation_optional === 1;
+
   const latestAvailability = await getAvailability(c.env.DB, {
     lineAccountId: accountId,
     menuId: body.menu_id,
-    staffId: body.staff_id,
+    // 指名なしのときは全スタッフ分を受け取り、空いている実スタッフを候補にする
+    staffId: noDesignation ? undefined : body.staff_id,
     from: startJstDate,
     to: startJstDate,
     now: new Date(),
     minLeadTimeMinutes: DEFAULT_ACCOUNT_SETTINGS.min_lead_time_minutes,
     googleCredentials: googleCredentials(c.env),
   });
-  const slotMatched = latestAvailability.by_staff[0]?.slots.some(
-    (slot) => slot.date === startJstDate && slot.start === startJstHHMM,
-  );
-  if (!slotMatched) return c.json({ error: 'slot_not_available' }, 422);
+  const hasSlot = (entry: { staff_id: string; slots: Array<{ date: string; start: string }> }) =>
+    entry.slots.some((slot) => slot.date === startJstDate && slot.start === startJstHHMM);
 
-  const bookingId = crypto.randomUUID();
+  let candidateStaffIds: string[];
+  if (noDesignation) {
+    const free = latestAvailability.by_staff.filter(
+      (entry) => entry.staff_id !== body.staff_id && hasSlot(entry),
+    );
+    if (free.length === 0) return c.json({ error: 'slot_not_available' }, 422);
+    const counts = await countBookingsByStaffForDate(
+      c.env.DB,
+      free.map((e) => e.staff_id),
+      startJstDate,
+    );
+    candidateStaffIds = orderAssignmentCandidates(
+      free.map((e) => ({ staffId: e.staff_id, dayBookingCount: counts.get(e.staff_id) ?? 0 })),
+    );
+  } else {
+    if (!latestAvailability.by_staff[0] || !hasSlot(latestAvailability.by_staff[0])) {
+      return c.json({ error: 'slot_not_available' }, 422);
+    }
+    candidateStaffIds = [body.staff_id];
+  }
+
   const nowIso = new Date().toISOString();
   // 競合チェックと INSERT を 1 ステートメントで原子化する。
   // INSERT ... SELECT WHERE NOT EXISTS パターンで、同一スタッフの overlap 行がある場合は
-  // 0 行 INSERT に落とす。changes=0 を 409 として扱う。
-  const insertResult = await c.env.DB
-    .prepare(
-      `INSERT INTO bookings
+  // 0 行 INSERT に落とす。changes=0 は競合。
+  //
+  // 指名なしのときは候補を順に試す。表示時に空いていても確定までの間に他の予約が
+  // 入り得るため、1 人目が競合したら次の候補へ進む。全滅した場合のみ 409。
+  let bookingId = '';
+  let assignedStaffId = '';
+  let inserted = false;
+  for (const candidateStaffId of candidateStaffIds) {
+    const id = crypto.randomUUID();
+    const insertResult = await c.env.DB
+      .prepare(
+        `INSERT INTO bookings
         (id, line_account_id, friend_id, staff_id, menu_id,
          starts_at, ends_at, block_ends_at, status,
          customer_note, price_at_booking, requested_at)
@@ -470,27 +514,37 @@ booking.post('/api/liff/booking/requests', async (c) => {
              AND starts_at < ?
              AND block_ends_at > ?
         )`,
-    )
-    .bind(
-      bookingId,
-      accountId,
-      friendId,
-      body.staff_id,
-      body.menu_id,
-      startsAt.toISOString(),
-      endsAt.toISOString(),
-      blockEndsAt.toISOString(),
-      'requested' satisfies BookingStatus,
-      body.customer_note ?? null,
-      menuRow.price,
-      nowIso,
-      // NOT EXISTS subquery params
-      body.staff_id,
-      blockEndsAt.toISOString(),
-      startsAt.toISOString(),
-    )
-    .run();
-  if ((insertResult.meta?.changes ?? 0) === 0) {
+      )
+      .bind(
+        id,
+        accountId,
+        friendId,
+        candidateStaffId,
+        body.menu_id,
+        startsAt.toISOString(),
+        endsAt.toISOString(),
+        blockEndsAt.toISOString(),
+        'requested' satisfies BookingStatus,
+        body.customer_note ?? null,
+        // 顧客に提示した価格・所要時間を採用する。指名なしで別スタッフへ割り当てて
+        // も、表示と請求がずれないようにするため。
+        menuRow.price,
+        nowIso,
+        // NOT EXISTS subquery params
+        candidateStaffId,
+        blockEndsAt.toISOString(),
+        startsAt.toISOString(),
+      )
+      .run();
+    if ((insertResult.meta?.changes ?? 0) > 0) {
+      bookingId = id;
+      assignedStaffId = candidateStaffId;
+      inserted = true;
+      break;
+    }
+  }
+  if (!inserted) {
+
     const err = { error: 'slot_conflict' };
     await saveIdempotencyResponse(c.env.DB, {
       key: idemKey,
@@ -510,7 +564,7 @@ booking.post('/api/liff/booking/requests', async (c) => {
       source: 'booking',
       sourceEventId: bookingId,
       friendId,
-      metadata: { bookingType: 'salon', menuId: body.menu_id, staffId: body.staff_id },
+      metadata: { bookingType: 'salon', menuId: body.menu_id, staffId: assignedStaffId },
       occurredAt: nowIso,
     }),
   );

--- a/apps/worker/src/services/availability.test.ts
+++ b/apps/worker/src/services/availability.test.ts
@@ -387,3 +387,100 @@ describe('getAvailability', () => {
     expect(result.by_staff).toEqual([]);
   });
 });
+
+describe('getAvailability — 指名なし枠', () => {
+  const MENU = {
+    duration_minutes: 60,
+    buffer_after_minutes: 0,
+    override_duration: null,
+    override_price: null,
+  };
+  const params = {
+    lineAccountId: 'A1',
+    menuId: 'M1',
+    from: '2026-05-09',
+    to: '2026-05-09',
+    now: new Date('2026-05-08T00:00:00Z'),
+    minLeadTimeMinutes: 60,
+  };
+
+  test('実スタッフの空きの和集合になる（重複は除く）', async () => {
+    const db = stubDB({
+      menu: MENU,
+      staff: [
+        { id: 'ANY', display_name: '指名なし', is_designation_optional: 1 },
+        { id: 'S1', display_name: '山田', is_designation_optional: 0 },
+        { id: 'S2', display_name: '田中', is_designation_optional: 0 },
+      ],
+      shifts: [
+        { staff_id: 'S1', work_date: '2026-05-09', start_time: '09:00', end_time: '11:00' },
+        { staff_id: 'S2', work_date: '2026-05-09', start_time: '10:00', end_time: '12:00' },
+      ],
+      bookings: [],
+    });
+    const result = await getAvailability(db, { ...params, staffId: 'ANY' });
+    expect(result.by_staff).toHaveLength(1);
+    expect(result.by_staff[0].staff_id).toBe('ANY');
+    // S1 (09:00-11:00): 09:00 09:30 10:00 / S2 (10:00-12:00): 10:00 10:30 11:00
+    // → 和集合を時刻順に、10:00 の重複は 1 つに畳む
+    expect(result.by_staff[0].slots.map((s) => s.start)).toEqual([
+      '09:00', '09:30', '10:00', '10:30', '11:00',
+    ]);
+  });
+
+  test('1 人が埋まっていてももう 1 人が空いていれば枠は残る', async () => {
+    const db = stubDB({
+      menu: MENU,
+      staff: [
+        { id: 'ANY', display_name: '指名なし', is_designation_optional: 1 },
+        { id: 'S1', display_name: '山田', is_designation_optional: 0 },
+        { id: 'S2', display_name: '田中', is_designation_optional: 0 },
+      ],
+      shifts: [
+        { staff_id: 'S1', work_date: '2026-05-09', start_time: '09:00', end_time: '11:00' },
+        { staff_id: 'S2', work_date: '2026-05-09', start_time: '09:00', end_time: '11:00' },
+      ],
+      bookings: [
+        // S1 の 09:00-10:00 が埋まっている
+        { staff_id: 'S1', starts_at: '2026-05-09T00:00:00.000Z', block_ends_at: '2026-05-09T01:00:00.000Z' },
+      ],
+    });
+    const result = await getAvailability(db, { ...params, staffId: 'ANY' });
+    expect(result.by_staff[0].slots.map((s) => s.start)).toEqual(['09:00', '09:30', '10:00']);
+  });
+
+  test('指名なし枠は自分のシフトを持たなくてよい', async () => {
+    const db = stubDB({
+      menu: MENU,
+      staff: [
+        { id: 'ANY', display_name: '指名なし', is_designation_optional: 1 },
+        { id: 'S1', display_name: '山田', is_designation_optional: 0 },
+      ],
+      shifts: [{ staff_id: 'S1', work_date: '2026-05-09', start_time: '10:00', end_time: '12:00' }],
+      bookings: [],
+    });
+    const result = await getAvailability(db, { ...params, staffId: 'ANY' });
+    expect(result.by_staff[0].has_working_hours).toBe(true);
+    expect(result.by_staff[0].slots.length).toBe(3);
+  });
+
+  test('実スタッフを指名したときは自分の枠だけ返る', async () => {
+    const db = stubDB({
+      menu: MENU,
+      staff: [
+        { id: 'ANY', display_name: '指名なし', is_designation_optional: 1 },
+        { id: 'S1', display_name: '山田', is_designation_optional: 0 },
+        { id: 'S2', display_name: '田中', is_designation_optional: 0 },
+      ],
+      shifts: [
+        { staff_id: 'S1', work_date: '2026-05-09', start_time: '09:00', end_time: '10:00' },
+        { staff_id: 'S2', work_date: '2026-05-09', start_time: '14:00', end_time: '16:00' },
+      ],
+      bookings: [],
+    });
+    const result = await getAvailability(db, { ...params, staffId: 'S2' });
+    expect(result.by_staff).toHaveLength(1);
+    expect(result.by_staff[0].staff_id).toBe('S2');
+    expect(result.by_staff[0].slots.map((s) => s.start)).toEqual(['14:00', '14:30', '15:00']);
+  });
+});

--- a/apps/worker/src/services/availability.ts
+++ b/apps/worker/src/services/availability.ts
@@ -162,24 +162,18 @@ export async function getAvailability(
   // SQL とパラメータ数を一致させる。staffId 未指定時の no-WHERE バリアントは
   // ?1 と ?2 だけを参照するので bind() も 2 引数に留める。多いと D1 が
   // "Wrong number of parameter bindings" で 500 を返す（本番再現確認済）。
-  const staffStmt = params.staffId
-    ? db
-        .prepare(
-          `SELECT s.id, s.display_name, s.is_designation_optional
-             FROM staff s
-             INNER JOIN staff_menus sm ON sm.staff_id = s.id AND sm.menu_id = ?2 AND sm.is_offered = 1
-            WHERE s.line_account_id = ?1 AND s.is_active = 1 AND s.deleted_at IS NULL AND s.id = ?3`,
-        )
-        .bind(params.lineAccountId, params.menuId, params.staffId)
-    : db
-        .prepare(
-          `SELECT s.id, s.display_name, s.is_designation_optional
-             FROM staff s
-             INNER JOIN staff_menus sm ON sm.staff_id = s.id AND sm.menu_id = ?2 AND sm.is_offered = 1
-            WHERE s.line_account_id = ?1 AND s.is_active = 1 AND s.deleted_at IS NULL
-            ORDER BY s.is_designation_optional DESC, s.sort_order ASC`,
-        )
-        .bind(params.lineAccountId, params.menuId);
+  // staffId が指定されていても全スタッフを取得する。指名なし枠 (is_designation_optional)
+  // の空き枠は「対応可能な実スタッフの誰かが空いている時刻」の和集合として出すため、
+  // 実スタッフの行が必要になる。絞り込みは算出後に行う。
+  const staffStmt = db
+    .prepare(
+      `SELECT s.id, s.display_name, s.is_designation_optional
+         FROM staff s
+         INNER JOIN staff_menus sm ON sm.staff_id = s.id AND sm.menu_id = ?2 AND sm.is_offered = 1
+        WHERE s.line_account_id = ?1 AND s.is_active = 1 AND s.deleted_at IS NULL
+        ORDER BY s.is_designation_optional DESC, s.sort_order ASC`,
+    )
+    .bind(params.lineAccountId, params.menuId);
   const staffRows = await staffStmt.all<{
     id: string;
     display_name: string;
@@ -256,7 +250,11 @@ export async function getAvailability(
   }
 
   const by_staff: AvailabilityByStaff[] = [];
-  for (const s of staffRows.results) {
+  // 指名なし枠は自前のシフトを持たない前提で、実スタッフの和集合から作る。
+  // 先に実スタッフだけ回し、あとで和集合を組み立てる。
+  const realStaff = staffRows.results.filter((s) => !s.is_designation_optional);
+  const optionalStaff = staffRows.results.filter((s) => s.is_designation_optional);
+  for (const s of realStaff) {
     const slots: AvailabilityByStaff['slots'] = [];
     const hasWorkingHours =
       shifts.results.some((r) => r.staff_id === s.id) ||
@@ -296,5 +294,33 @@ export async function getAvailability(
     }
     by_staff.push({ staff_id: s.id, display_name: s.display_name, slots, has_working_hours: hasWorkingHours });
   }
-  return { by_staff, calendar_sync: calendarSync };
+
+  // 指名なし枠: 実スタッフのスロットを和集合にする (date+start で重複除去)。
+  // 「誰か 1 人でも空いていれば予約できる」という表示にするため。実際の担当は
+  // 予約確定時に割り当てる (routes/booking.ts の pickAssignableStaff)。
+  for (const opt of optionalStaff) {
+    const seen = new Set<string>();
+    const merged: AvailabilityByStaff['slots'] = [];
+    for (const entry of by_staff) {
+      for (const slot of entry.slots) {
+        const key = `${slot.date} ${slot.start}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        merged.push(slot);
+      }
+    }
+    merged.sort((a, b) => (a.date === b.date ? a.start.localeCompare(b.start) : a.date.localeCompare(b.date)));
+    by_staff.push({
+      staff_id: opt.id,
+      display_name: opt.display_name,
+      slots: merged,
+      has_working_hours: by_staff.some((e) => e.has_working_hours),
+    });
+  }
+
+  // staffId 指定時はここで絞る (指名なし枠の和集合を組み終えたあと)
+  const filtered = params.staffId
+    ? by_staff.filter((e) => e.staff_id === params.staffId)
+    : by_staff;
+  return { by_staff: filtered, calendar_sync: calendarSync };
 }

--- a/apps/worker/src/services/staff-assignment.test.ts
+++ b/apps/worker/src/services/staff-assignment.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+import { orderAssignmentCandidates, countBookingsByStaffForDate } from './staff-assignment.js';
+
+describe('orderAssignmentCandidates', () => {
+  test('当日の予約件数が少ないスタッフを優先する', () => {
+    expect(
+      orderAssignmentCandidates([
+        { staffId: 'b', dayBookingCount: 3 },
+        { staffId: 'a', dayBookingCount: 1 },
+        { staffId: 'c', dayBookingCount: 2 },
+      ]),
+    ).toEqual(['a', 'c', 'b']);
+  });
+
+  test('同数ならスタッフ ID 順（決定性のため）', () => {
+    expect(
+      orderAssignmentCandidates([
+        { staffId: 'c', dayBookingCount: 0 },
+        { staffId: 'a', dayBookingCount: 0 },
+        { staffId: 'b', dayBookingCount: 0 },
+      ]),
+    ).toEqual(['a', 'b', 'c']);
+  });
+
+  test('入力を破壊しない', () => {
+    const input = [
+      { staffId: 'b', dayBookingCount: 1 },
+      { staffId: 'a', dayBookingCount: 0 },
+    ];
+    orderAssignmentCandidates(input);
+    expect(input[0].staffId).toBe('b');
+  });
+
+  test('候補なしなら空', () => {
+    expect(orderAssignmentCandidates([])).toEqual([]);
+  });
+});
+
+describe('countBookingsByStaffForDate', () => {
+  function stubDB(rows: Array<{ staff_id: string; n: number }>, capture?: (sql: string) => void) {
+    return {
+      prepare(sql: string) {
+        capture?.(sql);
+        return { bind() { return this; }, async all() { return { results: rows }; } };
+      },
+    } as unknown as D1Database;
+  }
+
+  test('返らなかったスタッフは 0 で埋める', async () => {
+    const counts = await countBookingsByStaffForDate(stubDB([{ staff_id: 's1', n: 2 }]), ['s1', 's2'], '2026-05-09');
+    expect(counts.get('s1')).toBe(2);
+    expect(counts.get('s2')).toBe(0);
+  });
+
+  test('スタッフ 0 件ならクエリを投げない', async () => {
+    let called = false;
+    const counts = await countBookingsByStaffForDate(stubDB([], () => { called = true; }), [], '2026-05-09');
+    expect(counts.size).toBe(0);
+    expect(called).toBe(false);
+  });
+
+  test('枠を占有しないステータスは数えない', async () => {
+    let sql = '';
+    await countBookingsByStaffForDate(stubDB([], (s) => { sql = s; }), ['s1'], '2026-05-09');
+    expect(sql).toContain("status IN ('requested','confirmed')");
+    // JST 日付で比較していること（starts_at は UTC 保存）
+    expect(sql).toContain("+9 hours");
+  });
+});

--- a/apps/worker/src/services/staff-assignment.ts
+++ b/apps/worker/src/services/staff-assignment.ts
@@ -1,0 +1,60 @@
+// 指名なし予約の担当スタッフ割当。
+//
+// 「指名なし枠」は is_designation_optional を立てた仮想スタッフ行として表現されて
+// いる。この行に予約を入れてしまうと仮想スタッフが 1 件しか同時に受けられないため、
+// 実スタッフが 3 名空いていても指名なしでは 1 件しか取れない。
+//
+// そこで予約確定時に実スタッフへ割り当てる。候補の並びは仕様どおり
+//   1. その時刻に対応可能なスタッフを抽出
+//   2. 当日の予約件数が少ないスタッフを優先
+//   3. 同数ならスタッフ ID 順 (決定性のため)
+// とする。呼び出し側は先頭から順に INSERT を試し、競合したら次の候補へ進む。
+
+export interface AssignmentCandidate {
+  staffId: string;
+  /** 当日 (JST) の requested/confirmed 件数。少ない順に優先する。 */
+  dayBookingCount: number;
+}
+
+/**
+ * 候補を仕様の優先順位で並べる。純関数なので単体テストしやすい。
+ */
+export function orderAssignmentCandidates(
+  candidates: AssignmentCandidate[],
+): string[] {
+  return [...candidates]
+    .sort((a, b) =>
+      a.dayBookingCount !== b.dayBookingCount
+        ? a.dayBookingCount - b.dayBookingCount
+        : a.staffId.localeCompare(b.staffId),
+    )
+    .map((c) => c.staffId);
+}
+
+/**
+ * 指定日 (JST) の予約件数をスタッフ別に数える。
+ * cancelled / rejected / expired は枠を占有しないので除外する。
+ */
+export async function countBookingsByStaffForDate(
+  db: D1Database,
+  staffIds: string[],
+  jstDate: string,
+): Promise<Map<string, number>> {
+  const out = new Map<string, number>(staffIds.map((id) => [id, 0]));
+  if (staffIds.length === 0) return out;
+  const placeholders = staffIds.map(() => '?').join(',');
+  // starts_at は UTC 保存なので JST 日付へ寄せて比較する
+  const rows = await db
+    .prepare(
+      `SELECT staff_id, COUNT(*) AS n
+         FROM bookings
+        WHERE staff_id IN (${placeholders})
+          AND status IN ('requested','confirmed')
+          AND date(datetime(starts_at, '+9 hours')) = ?
+        GROUP BY staff_id`,
+    )
+    .bind(...staffIds, jstDate)
+    .all<{ staff_id: string; n: number }>();
+  for (const r of rows.results) out.set(r.staff_id, r.n);
+  return out;
+}


### PR DESCRIPTION
## 問題

「指名なし枠」は `is_designation_optional` を立てた仮想スタッフ行として表現されていますが、予約はその仮想スタッフ行に入ります。仮想スタッフも 1 スタッフ 1 予約の制約を受けるため、**実スタッフが 3 名空いていても指名なしでは同時 1 件しか取れません**。

また空き枠は仮想スタッフ自身のシフトから計算されるので、実スタッフの稼働と無関係な枠が表示されます。全員埋まっている時刻でも「指名なし」なら予約できてしまい、逆に仮想スタッフのシフトを入れ忘れると 1 枠も出ません。

Issue は立てていません。挙動がコードから追えて変更も局所的なためです。方向性が違えば遠慮なくクローズしてください。

## 変更

- **空き枠**: 指名なし枠のスロットを、対応可能な実スタッフのスロットの和集合とする (date+start で重複除去)。仮想スタッフ自身のシフトは参照しない
- **予約確定**: 指名なしの予約は実スタッフへ割り当てる。候補の並びは
  1. その時刻に対応可能なスタッフ
  2. 当日の予約件数が少ない順
  3. 同数ならスタッフ ID 順 (決定性のため)

  で、先頭から INSERT を試し、競合したら次の候補へ進みます。全滅した場合のみ 409。
- 価格と所要時間は**顧客に提示した値**(仮想スタッフの `staff_menus`) を採用します。割当先が変わっても表示と請求がずれないようにするためです
- マイレージの `metadata.staffId` に実際の割当先を記録します

同時に 2 件の指名なし予約が来ても、原子的 INSERT が 1 人目で競合したら 2 人目の候補へ進むため、別スタッフへ割り当てて両方成立します。

## 互換性について（要ご判断）

**指名なし枠を「独立した 1 リソース」として使っている既存インストールでは、表示される枠と同時受付可能数が変わります。** 仮想スタッフのシフト設定は不要になります。

現状の挙動をバグと見るか仕様と見るかで判断が分かれると思います。設定で切り替えられるようにする形が良ければ、そのように直します。

## テスト

- `staff-assignment.test.ts` を新規追加 (7 ケース): 件数の少ない順 / 同数は ID 順 / 入力非破壊 / 候補なし / 未返却スタッフの 0 埋め / 空入力でクエリを投げない / 枠を占有しないステータスの除外と JST 日付での比較
- `availability.test.ts` に 4 ケース追加: 和集合と重複除去 / 1 人埋まっていても枠が残る / 仮想スタッフのシフト不要 / 実スタッフ指名時は自分の枠だけ
- 全体: **119 files / 1335 passed / 0 failed**

## 検証していないこと

- **実 D1 / デプロイ環境での動作確認は未実施**です
- **同時実行の競合はコード上の経路のみ**で、実環境での並行リクエスト試験は行っていません
- エンドポイント単位のテストは未追加です
