### PR TITLE
Clarify free software scope and external operating costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 > ### **[LINE で無料体験する](https://shudesu.github.io/line-harness-oss/)** 👈
 
 LINE 公式アカウントの完全オープンソース CRM。**L社 / U社 の無料代替**。
-Cloudflare 無料枠で動く。サーバー代 **0 円**。Claude Code から全操作可能。
+L Harness本体のソフトウェア利用料は **0円** です。LINE公式アカウントの配信料金、Cloudflareの契約・利用量、独自ドメイン、導入・保守、接続する外部AIサービスの費用は別です。Claude CodeからMCP経由で操作できます。
+
+費用の条件は[開発元の公式料金説明](https://the-harness.com/line-harness/pricing/)で確認できます。[Cloudflare D1の無料プラン](https://developers.cloudflare.com/d1/platform/pricing/)は日次の読み書き上限に達するとクエリがエラーになり、有料プランの超過課金とは挙動が異なります。外部AIを接続する場合は、たとえば[Claudeのプラン・API料金](https://claude.com/pricing)を別に確認してください（2026年9月6日確認）。
 
 ### ▶️ [動画で見る (YouTube・約20分)](https://youtu.be/DiRuGaeq1sM)
 
@@ -43,7 +45,7 @@ L Harnessの表示名、開発者、運営法人、公開コード、研究資�
 
 | | L社 | U社 | **L Harness** |
 |---|---|---|---|
-| 月額 | 2万円〜 | 1万円〜 | **0円** |
+| 月額 | 2万円〜 | 1万円〜 | **0円（ソフトウェア利用料）** |
 | ステップ配信 | ✅ | ✅ | ✅ |
 | セグメント配信 | ✅ | ✅ | ✅ |
 | リッチメニュー切替 | ✅ | ✅ | ✅ |


### PR DESCRIPTION
READMEの0円表記をソフトウェア利用料に限定し、クラウド・外部サービス・導入保守の費用条件を明記します。D1無料プランの上限到達時の仕様と任意のAI連携費用を一次資料で確認できるようにし、公式の費用説明へ直接リンクします。

READMEのみの変更です。git diff --check を通過。独立したAstraレビューで追加事実の一次資料照合を通過しました。
