### PR TITLE
Validate rich menu tap-area actionData and surface real API errors

### DIFF
--- a/apps/web/src/components/rich-menus/area-properties.tsx
+++ b/apps/web/src/components/rich-menus/area-properties.tsx
@@ -103,9 +103,13 @@ export function AreaProperties({ area, pages, onUpdate, onDelete }: Props) {
             placeholder="https://..."
             className="mt-0.5 block w-full border border-gray-300 rounded px-2 py-1 text-sm"
           />
-          <p className="mt-1 text-[11px] text-gray-500">
-            LINE 配信用 URL は tracked link (短縮 URL) 経由を推奨。
-          </p>
+          {!(data.uri as string)?.trim() ? (
+            <p className="mt-1 text-[11px] text-red-600">URL は必須です（未入力のままだと登録時にエラーになります）</p>
+          ) : (
+            <p className="mt-1 text-[11px] text-gray-500">
+              LINE 配信用 URL は tracked link (短縮 URL) 経由を推奨。
+            </p>
+          )}
         </label>
       )}
 
@@ -117,6 +121,9 @@ export function AreaProperties({ area, pages, onUpdate, onDelete }: Props) {
             onChange={(e) => onUpdate({ actionData: { ...data, text: e.target.value } })}
             className="mt-0.5 block w-full border border-gray-300 rounded px-2 py-1 text-sm"
           />
+          {!(data.text as string)?.trim() && (
+            <p className="mt-1 text-[11px] text-red-600">送信テキストは必須です（未入力のままだと登録時にエラーになります）</p>
+          )}
         </label>
       )}
 
@@ -129,6 +136,9 @@ export function AreaProperties({ area, pages, onUpdate, onDelete }: Props) {
               onChange={(e) => onUpdate({ actionData: { ...data, data: e.target.value } })}
               className="mt-0.5 block w-full border border-gray-300 rounded px-2 py-1 text-sm"
             />
+            {!(data.data as string)?.trim() && (
+              <p className="mt-1 text-[11px] text-red-600">postback data は必須です（未入力のままだと登録時にエラーになります）</p>
+            )}
           </label>
           <label className="block">
             <span className="text-xs text-gray-500">displayText (任意)</span>

--- a/apps/web/src/lib/api-fetch-error.test.ts
+++ b/apps/web/src/lib/api-fetch-error.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// fetchApi() previously discarded the response body on a non-2xx status and
+// threw a bare `API error: <status>`, hiding the server's own
+// `{ success: false, error: "..." }` message (e.g. a LINE API rejection
+// surfaced by the rich-menu publish route). These tests pin the fix: the
+// server's `error` string should reach the caller when present, and the
+// generic message should remain the fallback when it isn't.
+
+async function loadApi() {
+  vi.resetModules()
+  vi.stubEnv('NEXT_PUBLIC_API_URL', 'https://worker.example.workers.dev')
+  return import('./api')
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+describe('fetchApi error handling', () => {
+  it('surfaces the server-provided error message from a JSON error body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ success: false, error: 'LINE createRichMenu failed: 400 ...' }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    )
+
+    const { fetchApi, ApiError } = await loadApi()
+
+    await expect(fetchApi('/api/rich-menu-groups/g1/publish', { method: 'POST' })).rejects.toMatchObject({
+      message: 'LINE createRichMenu failed: 400 ...',
+      status: 500,
+    })
+    await expect(fetchApi('/api/rich-menu-groups/g1/publish', { method: 'POST' })).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('falls back to the generic status message when the body is not JSON', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('Internal Server Error', { status: 500 })),
+    )
+
+    const { fetchApi } = await loadApi()
+
+    await expect(fetchApi('/api/rich-menu-groups/g1/publish', { method: 'POST' })).rejects.toMatchObject({
+      message: 'API error: 500',
+      status: 500,
+    })
+  })
+
+  it('falls back to the generic status message when the JSON body has no error field', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ success: false }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    )
+
+    const { fetchApi } = await loadApi()
+
+    await expect(fetchApi('/api/rich-menu-groups/g1/publish', { method: 'POST' })).rejects.toMatchObject({
+      message: 'API error: 404',
+      status: 404,
+    })
+  })
+})

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -151,16 +151,22 @@ const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
 /**
  * Non-2xx API responses. message keeps the legacy `API error: <status>` shape
- * (existing catch blocks render e.message), while `status` lets callers
- * branch on the code without parsing the string.
+ * as a fallback (existing catch blocks render e.message), but prefers the
+ * server's own `{ success: false, error: "..." }` body when present, so the
+ * real cause (e.g. a LINE API rejection) reaches the UI instead of being
+ * discarded. `status` lets callers branch on the code without parsing the
+ * string.
  */
 export class ApiError extends Error {
   readonly status: number
+  /** Raw `error` string from the server's JSON body, when it had one. */
+  readonly serverMessage: string | null
 
-  constructor(status: number) {
-    super(`API error: ${status}`)
+  constructor(status: number, serverMessage: string | null = null) {
+    super(serverMessage || `API error: ${status}`)
     this.name = 'ApiError'
     this.status = status
+    this.serverMessage = serverMessage
   }
 }
 
@@ -181,7 +187,21 @@ export async function fetchApi<T>(path: string, options?: RequestInit): Promise<
       ...options?.headers,
     },
   })
-  if (!res.ok) throw new ApiError(res.status)
+  if (!res.ok) {
+    // Best-effort: most routes return `{ success: false, error: "..." }`.
+    // Body may be missing/non-JSON (e.g. an uncaught exception hitting
+    // Hono's default handler) — fall back to the generic status message.
+    let serverMessage: string | null = null
+    try {
+      const body = await res.clone().json()
+      if (body && typeof body === 'object' && typeof (body as { error?: unknown }).error === 'string') {
+        serverMessage = (body as { error: string }).error
+      }
+    } catch {
+      // non-JSON body — ignore, fall back to generic message
+    }
+    throw new ApiError(res.status, serverMessage)
+  }
   if (res.status === 204) return undefined as T
   return res.json() as Promise<T>
 }

--- a/apps/worker/src/routes/rich-menu-groups.test.ts
+++ b/apps/worker/src/routes/rich-menu-groups.test.ts
@@ -255,6 +255,60 @@ describe('POST /api/rich-menu-groups', () => {
     expect(res.status).toBe(400);
   });
 
+  test('rejects message action with empty text', async () => {
+    const app = setupApp();
+    const res = await app.request('/api/rich-menu-groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        accountId: 'a', name: 'x', chatBarText: 'x', size: 'large',
+        pages: [{ name: 'p1', orderIndex: 0, areas: [
+          { boundsX: 0, boundsY: 0, boundsWidth: 1, boundsHeight: 1,
+            actionType: 'message', actionData: { text: '' } },
+        ] }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/text/i);
+  });
+
+  test('rejects uri action with invalid url', async () => {
+    const app = setupApp();
+    const res = await app.request('/api/rich-menu-groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        accountId: 'a', name: 'x', chatBarText: 'x', size: 'large',
+        pages: [{ name: 'p1', orderIndex: 0, areas: [
+          { boundsX: 0, boundsY: 0, boundsWidth: 1, boundsHeight: 1,
+            actionType: 'uri', actionData: { uri: 'not-a-url' } },
+        ] }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/uri/i);
+  });
+
+  test('rejects postback action with empty data', async () => {
+    const app = setupApp();
+    const res = await app.request('/api/rich-menu-groups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        accountId: 'a', name: 'x', chatBarText: 'x', size: 'large',
+        pages: [{ name: 'p1', orderIndex: 0, areas: [
+          { boundsX: 0, boundsY: 0, boundsWidth: 1, boundsHeight: 1,
+            actionType: 'postback', actionData: { data: '' } },
+        ] }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/data/i);
+  });
+
   test('forwards parsed input to createRichMenuGroup', async () => {
     dbMocks.createRichMenuGroup.mockResolvedValue({
       id: 'new-1', account_id: 'a', name: 'x', chat_bar_text: 'x', size: 'large',

--- a/apps/worker/src/routes/rich-menu-groups.ts
+++ b/apps/worker/src/routes/rich-menu-groups.ts
@@ -104,6 +104,10 @@ function parseAreaInput(raw: unknown): Parsed<RichMenuAreaInput> {
   if (!r.actionData || typeof r.actionData !== 'object') {
     return { ok: false, error: 'area.actionData must be object' };
   }
+  const actionType = r.actionType as RichMenuAreaInput['actionType'];
+  const actionData = r.actionData as Record<string, unknown>;
+  const actionDataError = validateActionData(actionType, actionData);
+  if (actionDataError) return { ok: false, error: actionDataError };
   return {
     ok: true,
     value: {
@@ -111,10 +115,61 @@ function parseAreaInput(raw: unknown): Parsed<RichMenuAreaInput> {
       boundsY: r.boundsY as number,
       boundsWidth: r.boundsWidth as number,
       boundsHeight: r.boundsHeight as number,
-      actionType: r.actionType as RichMenuAreaInput['actionType'],
-      actionData: r.actionData as Record<string, unknown>,
+      actionType,
+      actionData,
     },
   };
+}
+
+// area.actionData の中身をアクション種別ごとに検証する。
+// これを怠ると空文字等が LINE API にそのまま渡り、publish 時に LINE 側の
+// 400 として初めて失敗が判明する (原因が publish 失敗のログに紛れて追いにくい)。
+// ここで弾いておけば保存時点でユーザーにわかりやすいエラーを返せる。
+function validateActionData(
+  actionType: RichMenuAreaInput['actionType'],
+  data: Record<string, unknown>,
+): string | null {
+  switch (actionType) {
+    case 'message': {
+      const text = data.text;
+      if (typeof text !== 'string' || text.trim().length === 0) {
+        return 'action.text (送信テキスト) は必須です';
+      }
+      if (text.length > 300) {
+        return 'action.text (送信テキスト) は300文字以内で入力してください';
+      }
+      return null;
+    }
+    case 'uri': {
+      const uri = data.uri;
+      if (typeof uri !== 'string' || uri.trim().length === 0) {
+        return 'action.uri (URL) は必須です';
+      }
+      try {
+        const parsed = new URL(uri);
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          return 'action.uri (URL) は http(s):// 形式で入力してください';
+        }
+      } catch {
+        return 'action.uri (URL) の形式が正しくありません';
+      }
+      return null;
+    }
+    case 'postback': {
+      const postbackData = data.data;
+      if (typeof postbackData !== 'string' || postbackData.trim().length === 0) {
+        return 'action.data (postback data) は必須です';
+      }
+      return null;
+    }
+    case 'richmenuswitch': {
+      const targetPageId = data.targetPageId;
+      if (typeof targetPageId !== 'string' || targetPageId.trim().length === 0) {
+        return 'action.targetPageId (遷移先ページ) を選択してください';
+      }
+      return null;
+    }
+  }
 }
 
 function parsePageInput(raw: unknown): Parsed<RichMenuPageInput> {


### PR DESCRIPTION
## 問題

リッチメニューの「LINEに登録」で `API error: 500` としか表示されず、原因が追えなかった。

### 根本原因
- タップ領域を `message` アクションにした際、送信テキストが空文字のまま保存できてしまう（`uri`/`postback` も同様に空でも保存可能）。LINEの `richmenu` API はこれを publish 時に `400` で拒否する。
- 管理画面の `fetchApi()` が非2xxレスポンスのボディを読まずに `API error: <status>` という定型文だけを投げていたため、サーバー側が返していた `{ success: false, error: "..." }` の詳細メッセージが握りつぶされていた。

## 変更内容
- `apps/worker/src/routes/rich-menu-groups.ts`: `actionType` ごとに `actionData` の中身を検証する `validateActionData()` を追加（`message.text` / `uri.uri` / `postback.data` / `richmenuswitch.targetPageId` が必須）。グループ作成・更新時点で `400` + 具体的なエラーメッセージを返す。
- `apps/web/src/lib/api.ts`: `ApiError` がレスポンスの `error` フィールドを読み取り、サーバーの実際のエラーメッセージを保持するように変更（非JSON/フィールド無しの場合は従来通りのフォールバック）。
- `apps/web/src/components/rich-menus/area-properties.tsx`: 送信テキスト等が空のままだと保存前にインラインで警告を表示。
- テスト: サーバー側3件、フロント`fetchApi`用に新規3件を追加。

## 動作確認
- `apps/worker`: 全1327件のvitestがpass、`tsc --noEmit` エラーなし
- `apps/web`: 全42件のvitestがpass、`tsc --noEmit` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)