### PR TITLE
fix(auth): 顧客情報APIをOwner・Adminに制限する

### DIFF
--- a/apps/worker/src/routes/users-grouped.ts
+++ b/apps/worker/src/routes/users-grouped.ts
@@ -1,10 +1,11 @@
 import { Hono } from 'hono';
 import type { Env } from '../index.js';
+import { requireRole } from '../middleware/role-guard.js';
 import { computeUsersGrouped, type UsersGroupedOptions } from '../services/users-grouped.js';
 
 export const usersGrouped = new Hono<Env>();
 
-usersGrouped.get('/api/users-grouped', async (c) => {
+usersGrouped.get('/api/users-grouped', requireRole('owner', 'admin'), async (c) => {
   try {
     const q = c.req.query('q');
     const onlyDups = c.req.query('onlyDups') === '1';

--- a/apps/worker/src/routes/users-grouped.ts
+++ b/apps/worker/src/routes/users-grouped.ts
@@ -26,7 +26,9 @@ usersGrouped.get('/api/users-grouped', requireRole('owner', 'admin'), async (c) 
     const result = await computeUsersGrouped(c.env.DB, opts);
     return c.json({ success: true, data: result });
   } catch (err) {
-    console.error('GET /api/users-grouped error:', err);
+    console.error('GET /api/users-grouped failed', {
+      errorType: err instanceof Error ? 'Error' : typeof err,
+    });
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });

--- a/apps/worker/src/routes/users.test.ts
+++ b/apps/worker/src/routes/users.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { Hono } from 'hono';
+import type { Env } from '../index.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { users } from './users.js';
+import { usersGrouped } from './users-grouped.js';
+
+const dbMocks = vi.hoisted(() => ({
+  getStaffByApiKey: vi.fn(),
+  getUsers: vi.fn(),
+  getUserById: vi.fn(),
+  createUser: vi.fn(),
+  updateUser: vi.fn(),
+  deleteUser: vi.fn(),
+  linkFriendToUser: vi.fn(),
+  getUserFriends: vi.fn(),
+  getUserByEmail: vi.fn(),
+  getUserByPhone: vi.fn(),
+}));
+const groupedMocks = vi.hoisted(() => ({ computeUsersGrouped: vi.fn() }));
+vi.mock('@line-crm/db', () => dbMocks);
+vi.mock('../services/users-grouped.js', () => groupedMocks);
+
+const userRow = {
+  id: 'user-1', email: 'user@example.test', phone: '09012345678',
+  external_id: 'external-1', display_name: 'Test User',
+  created_at: '2026-09-01T00:00:00+09:00', updated_at: '2026-09-10T00:00:00+09:00',
+};
+const userData = {
+  id: userRow.id, email: userRow.email, phone: userRow.phone,
+  externalId: userRow.external_id, displayName: userRow.display_name,
+  createdAt: userRow.created_at, updatedAt: userRow.updated_at,
+};
+const userInput = {
+  email: userRow.email, phone: userRow.phone,
+  externalId: userRow.external_id, displayName: userRow.display_name,
+};
+const groupedData = { rows: [], total: 0, page: 2, pageSize: 10, computedAt: userRow.updated_at };
+const env = { DB: {} as D1Database, API_KEY: 'env-owner-key' } as Env['Bindings'];
+
+const routes: Array<{
+  method: string;
+  path: string;
+  body?: Record<string, unknown>;
+  operation: ReturnType<typeof vi.fn>;
+  args: unknown[];
+  data: unknown;
+  status?: number;
+}> = [
+  { method: 'GET', path: '/api/users', operation: dbMocks.getUsers, args: [], data: [userData] },
+  { method: 'GET', path: '/api/users/user-1', operation: dbMocks.getUserById, args: ['user-1'], data: userData },
+  {
+    method: 'POST', path: '/api/users', body: userInput,
+    operation: dbMocks.createUser, args: [userInput], data: userData, status: 201,
+  },
+  {
+    method: 'PUT', path: '/api/users/user-1', body: userInput,
+    operation: dbMocks.updateUser,
+    args: ['user-1', {
+      email: userRow.email, phone: userRow.phone,
+      external_id: userRow.external_id, display_name: userRow.display_name,
+    }],
+    data: userData,
+  },
+  { method: 'DELETE', path: '/api/users/user-1', operation: dbMocks.deleteUser, args: ['user-1'], data: null },
+  {
+    method: 'POST', path: '/api/users/user-1/link', body: { friendId: 'friend-1' },
+    operation: dbMocks.linkFriendToUser, args: ['friend-1', 'user-1'], data: null,
+  },
+  {
+    method: 'GET', path: '/api/users/user-1/accounts', operation: dbMocks.getUserFriends,
+    args: ['user-1'], data: [{ id: 'friend-1', lineUserId: 'U1', displayName: 'Friend', isFollowing: true }],
+  },
+  {
+    method: 'POST', path: '/api/users/match', body: { email: userRow.email },
+    operation: dbMocks.getUserByEmail, args: [userRow.email], data: userData,
+  },
+  {
+    method: 'GET', path: '/api/users-grouped?q=Test&onlyDups=1&account=account-1&page=2&pageSize=10&refresh=1',
+    operation: groupedMocks.computeUsersGrouped,
+    args: [{ q: 'Test', onlyDups: true, account: 'account-1', page: 2, pageSize: 10, forceRefresh: true }],
+    data: groupedData,
+  },
+];
+
+function app() {
+  const instance = new Hono<Env>();
+  // Exercise the same authentication -> route role guard order as index.ts.
+  instance.use('*', authMiddleware);
+  instance.route('/', users);
+  instance.route('/', usersGrouped);
+  return instance;
+}
+
+function request(route: typeof routes[number], headers: Record<string, string>) {
+  return app().request(route.path, {
+    method: route.method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: route.body ? JSON.stringify(route.body) : undefined,
+  }, env);
+}
+
+function expectNoUserDataAccess() {
+  // Authentication may look up a staff key; user reads, writes and grouped
+  // aggregation must all remain untouched when access is denied.
+  for (const [name, mock] of Object.entries(dbMocks)) {
+    if (name !== 'getStaffByApiKey') expect(mock).not.toHaveBeenCalled();
+  }
+  expect(groupedMocks.computeUsersGrouped).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  dbMocks.getStaffByApiKey.mockImplementation(async (_db, token) => {
+    for (const role of ['owner', 'admin', 'staff'] as const) {
+      if (token === `${role}-key`) return { id: `${role}-1`, name: role, role };
+    }
+    return null;
+  });
+  dbMocks.getUsers.mockResolvedValue([userRow]);
+  dbMocks.getUserById.mockResolvedValue(userRow);
+  dbMocks.createUser.mockResolvedValue(userRow);
+  dbMocks.updateUser.mockResolvedValue(userRow);
+  dbMocks.getUserByEmail.mockResolvedValue(userRow);
+  dbMocks.getUserFriends.mockResolvedValue([
+    { id: 'friend-1', line_user_id: 'U1', display_name: 'Friend', is_following: 1 },
+  ]);
+  groupedMocks.computeUsersGrouped.mockResolvedValue(groupedData);
+});
+
+const allowedCredentials: Array<[string, Record<string, string>]> = [
+  ['owner API key', { Authorization: 'Bearer owner-key' }],
+  ['admin API key', { Authorization: 'Bearer admin-key' }],
+  ['environment owner API key', { Authorization: 'Bearer env-owner-key' }],
+  ['admin session cookie', { Cookie: 'lh_admin_session=admin-key; lh_csrf=csrf-1', 'X-CSRF-Token': 'csrf-1' }],
+];
+const deniedCredentials: Array<[string, Record<string, string>, number]> = [
+  ['staff API key', { Authorization: 'Bearer staff-key' }, 403],
+  ['staff session cookie', { Cookie: 'lh_admin_session=staff-key; lh_csrf=csrf-1', 'X-CSRF-Token': 'csrf-1' }, 403],
+  ['no credentials', {}, 401],
+];
+
+describe.each(routes)('$method $path permissions', (route) => {
+  test.each(allowedCredentials)('allows %s', async (_name, headers) => {
+    const response = await request(route, headers);
+
+    expect(response.status).toBe(route.status ?? 200);
+    expect(await response.json()).toEqual({ success: true, data: route.data });
+    expect(route.operation).toHaveBeenCalledTimes(1);
+    expect(route.operation).toHaveBeenCalledWith(env.DB, ...route.args);
+  });
+
+  test.each(deniedCredentials)('rejects %s before accessing user data', async (_name, headers, status) => {
+    const response = await request(route, headers);
+
+    expect(response.status).toBe(status);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: status === 401 ? 'Unauthorized' : 'この操作にはowner権限が必要です',
+    });
+    expectNoUserDataAccess();
+  });
+});

--- a/apps/worker/src/routes/users.test.ts
+++ b/apps/worker/src/routes/users.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { Hono } from 'hono';
 import type { Env } from '../index.js';
 import { authMiddleware } from '../middleware/auth.js';
@@ -140,6 +140,10 @@ const deniedCredentials: Array<[string, Record<string, string>, number]> = [
   ['no credentials', {}, 401],
 ];
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe.each(routes)('$method $path permissions', (route) => {
   test.each(allowedCredentials)('allows %s', async (_name, headers) => {
     const response = await request(route, headers);
@@ -160,4 +164,36 @@ describe.each(routes)('$method $path permissions', (route) => {
     });
     expectNoUserDataAccess();
   });
+
+  test('keeps database exception details out of responses and console output', async () => {
+    const secret = 'synthetic-db-secret:user-private@example.test';
+    const error = new Error(`Database query failed: ${secret}`);
+    // Error names, like messages and stacks, may contain untrusted data.
+    error.name = secret;
+    route.operation.mockRejectedValueOnce(error);
+    const consoleSpies = (['error', 'warn', 'log', 'info', 'debug'] as const)
+      .map((method) => vi.spyOn(console, method).mockImplementation(() => {}));
+
+    const response = await request(route, { Authorization: 'Bearer admin-key' });
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ success: false, error: 'Internal server error' });
+    const routeTemplate = route.path.split('?')[0]!.replace('/user-1', '/:id');
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(`${route.method} ${routeTemplate} failed`, {
+      errorType: 'Error',
+    });
+    expect(JSON.stringify(consoleSpies.flatMap((spy) => spy.mock.calls))).not.toContain(secret);
+  });
 });
+
+test.each(routes.filter((route) => route.method !== 'GET'))(
+  '$method $path rejects cookie authentication without CSRF before accessing user data',
+  async (route) => {
+    const response = await request(route, { Cookie: 'lh_admin_session=admin-key' });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ success: false, error: 'CSRF token mismatch' });
+    expectNoUserDataAccess();
+  },
+);

--- a/apps/worker/src/routes/users.ts
+++ b/apps/worker/src/routes/users.ts
@@ -12,6 +12,7 @@ import {
 } from '@line-crm/db';
 import type { User as DbUser } from '@line-crm/db';
 import type { Env } from '../index.js';
+import { requireRole } from '../middleware/role-guard.js';
 
 const users = new Hono<Env>();
 
@@ -28,7 +29,7 @@ function serializeUser(row: DbUser) {
 }
 
 // GET /api/users - list all
-users.get('/api/users', async (c) => {
+users.get('/api/users', requireRole('owner', 'admin'), async (c) => {
   try {
     const items = await getUsers(c.env.DB);
     return c.json({ success: true, data: items.map(serializeUser) });
@@ -39,9 +40,9 @@ users.get('/api/users', async (c) => {
 });
 
 // GET /api/users/:id - get single
-users.get('/api/users/:id', async (c) => {
+users.get('/api/users/:id', requireRole('owner', 'admin'), async (c) => {
   try {
-    const id = c.req.param('id');
+    const id = c.req.param('id')!;
     const user = await getUserById(c.env.DB, id);
     if (!user) {
       return c.json({ success: false, error: 'User not found' }, 404);
@@ -54,7 +55,7 @@ users.get('/api/users/:id', async (c) => {
 });
 
 // POST /api/users - create
-users.post('/api/users', async (c) => {
+users.post('/api/users', requireRole('owner', 'admin'), async (c) => {
   try {
     const body = await c.req.json<{
       email?: string | null;
@@ -72,9 +73,9 @@ users.post('/api/users', async (c) => {
 });
 
 // PUT /api/users/:id - update
-users.put('/api/users/:id', async (c) => {
+users.put('/api/users/:id', requireRole('owner', 'admin'), async (c) => {
   try {
-    const id = c.req.param('id');
+    const id = c.req.param('id')!;
     const body = await c.req.json<{
       email?: string | null;
       phone?: string | null;
@@ -100,9 +101,9 @@ users.put('/api/users/:id', async (c) => {
 });
 
 // DELETE /api/users/:id - delete
-users.delete('/api/users/:id', async (c) => {
+users.delete('/api/users/:id', requireRole('owner', 'admin'), async (c) => {
   try {
-    await deleteUser(c.env.DB, c.req.param('id'));
+    await deleteUser(c.env.DB, c.req.param('id')!);
     return c.json({ success: true, data: null });
   } catch (err) {
     console.error('DELETE /api/users/:id error:', err);
@@ -111,9 +112,9 @@ users.delete('/api/users/:id', async (c) => {
 });
 
 // POST /api/users/:id/link - link friend to user UUID
-users.post('/api/users/:id/link', async (c) => {
+users.post('/api/users/:id/link', requireRole('owner', 'admin'), async (c) => {
   try {
-    const userId = c.req.param('id');
+    const userId = c.req.param('id')!;
     const body = await c.req.json<{ friendId: string }>();
 
     if (!body.friendId) {
@@ -129,9 +130,9 @@ users.post('/api/users/:id/link', async (c) => {
 });
 
 // GET /api/users/:id/accounts - get all linked friends/accounts
-users.get('/api/users/:id/accounts', async (c) => {
+users.get('/api/users/:id/accounts', requireRole('owner', 'admin'), async (c) => {
   try {
-    const userId = c.req.param('id');
+    const userId = c.req.param('id')!;
     const friends = await getUserFriends(c.env.DB, userId);
     return c.json({
       success: true,
@@ -149,7 +150,7 @@ users.get('/api/users/:id/accounts', async (c) => {
 });
 
 // POST /api/users/match - find user by email or phone
-users.post('/api/users/match', async (c) => {
+users.post('/api/users/match', requireRole('owner', 'admin'), async (c) => {
   try {
     const body = await c.req.json<{ email?: string; phone?: string }>();
     let user = null;

--- a/apps/worker/src/routes/users.ts
+++ b/apps/worker/src/routes/users.ts
@@ -16,6 +16,12 @@ import { requireRole } from '../middleware/role-guard.js';
 
 const users = new Hono<Env>();
 
+function logUsersRouteError(route: string, error: unknown): void {
+  console.error(`${route} failed`, {
+    errorType: error instanceof Error ? 'Error' : typeof error,
+  });
+}
+
 function serializeUser(row: DbUser) {
   return {
     id: row.id,
@@ -34,7 +40,7 @@ users.get('/api/users', requireRole('owner', 'admin'), async (c) => {
     const items = await getUsers(c.env.DB);
     return c.json({ success: true, data: items.map(serializeUser) });
   } catch (err) {
-    console.error('GET /api/users error:', err);
+    logUsersRouteError('GET /api/users', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });
@@ -49,7 +55,7 @@ users.get('/api/users/:id', requireRole('owner', 'admin'), async (c) => {
     }
     return c.json({ success: true, data: serializeUser(user) });
   } catch (err) {
-    console.error('GET /api/users/:id error:', err);
+    logUsersRouteError('GET /api/users/:id', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });
@@ -67,7 +73,7 @@ users.post('/api/users', requireRole('owner', 'admin'), async (c) => {
     const user = await createUser(c.env.DB, body);
     return c.json({ success: true, data: serializeUser(user) }, 201);
   } catch (err) {
-    console.error('POST /api/users error:', err);
+    logUsersRouteError('POST /api/users', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });
@@ -95,7 +101,7 @@ users.put('/api/users/:id', requireRole('owner', 'admin'), async (c) => {
     }
     return c.json({ success: true, data: serializeUser(updated) });
   } catch (err) {
-    console.error('PUT /api/users/:id error:', err);
+    logUsersRouteError('PUT /api/users/:id', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });
@@ -106,7 +112,7 @@ users.delete('/api/users/:id', requireRole('owner', 'admin'), async (c) => {
     await deleteUser(c.env.DB, c.req.param('id')!);
     return c.json({ success: true, data: null });
   } catch (err) {
-    console.error('DELETE /api/users/:id error:', err);
+    logUsersRouteError('DELETE /api/users/:id', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });
@@ -124,7 +130,7 @@ users.post('/api/users/:id/link', requireRole('owner', 'admin'), async (c) => {
     await linkFriendToUser(c.env.DB, body.friendId, userId);
     return c.json({ success: true, data: null });
   } catch (err) {
-    console.error('POST /api/users/:id/link error:', err);
+    logUsersRouteError('POST /api/users/:id/link', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });
@@ -144,7 +150,7 @@ users.get('/api/users/:id/accounts', requireRole('owner', 'admin'), async (c) =>
       })),
     });
   } catch (err) {
-    console.error('GET /api/users/:id/accounts error:', err);
+    logUsersRouteError('GET /api/users/:id/accounts', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });
@@ -167,7 +173,7 @@ users.post('/api/users/match', requireRole('owner', 'admin'), async (c) => {
     }
     return c.json({ success: true, data: serializeUser(user) });
   } catch (err) {
-    console.error('POST /api/users/match error:', err);
+    logUsersRouteError('POST /api/users/match', err);
     return c.json({ success: false, error: 'Internal server error' }, 500);
   }
 });


### PR DESCRIPTION
## Summary

Staff credentials could access customer identity lists, contact fields, deletion and friend links. Restrict the eight users routes and grouped-users route to owner/admin through the existing role guard. Keep owner API keys and admin session cookies working.

## Related work

Implements the focused runtime scope discussed in #242; no audit snapshots are included.

## Change type / scope

Security hardening; Worker API and staff permissions. No schema changes.

## Verification

- 77 request cases (including redacted error logs and missing-CSRF denial) cover all nine routes: owner/admin/environment owner key and admin cookie success; staff key/cookie and unauthenticated denial before customer-data access.
- Related auth/grouped tests: 107 passed.
- Combined focused OSS candidate: Worker 1,442 tests, Worker typecheck/build, DB 161 tests, update-engine 209 tests, CLI 92 tests passed.
- Focused upstream-to-OSS diff and known private-value scan passed.

## Security impact

Staff access to these customer identity APIs now returns 403. Owner/admin access and existing authentication remain unchanged. No LINE sends or remote database operations were performed.

## Rollback / remaining gate

Isolated Worker/D1 authorization smoke verification is complete. No production deployment was performed. Reverting restores prior Staff access, so prefer correcting any affected authorized workflow instead of silently reopening these endpoints.

## GitHub CI result

Current PR head checks succeeded: [CI run](https://github.com/Shudesu/line-harness-oss/actions/runs/34459070115).

## Merge completion

Merged after 31 isolated Worker/D1 HTTP checks with synthetic fixtures. Temporary resources were deleted. Final OSS main passed Worker CI and Core Safety CI; 1,442 Worker tests passed locally. This operation did not deploy production or publish npm packages.
