### PR TITLE
fix(links): 追跡リンクのXSSと不正URL転送を防ぐ

### DIFF
--- a/apps/worker/src/routes/tracked-links.test.ts
+++ b/apps/worker/src/routes/tracked-links.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, beforeEach, vi } from 'vitest';
+import { runInNewContext } from 'node:vm';
 
 // Mock the DB package — /t/:linkId route reads the link via getTrackedLinkById
 // and records clicks via recordLinkClick (fire-and-forget in waitUntil).
@@ -108,6 +109,87 @@ beforeEach(() => {
   vi.clearAllMocks();
   dbMocks.recordLinkClick.mockResolvedValue({});
   dbMocks.getTrackedLinkBaseUrl.mockResolvedValue(null);
+});
+
+describe('tracked-link destination validation', () => {
+  const invalidDestinations = [
+    'javascript://instagram.com/%0ainjected=true',
+    'JaVaScRiPt://instagram.com/\ninjected=true',
+    'data:text/html,<script>injected=true</script>',
+    'ftp://instagram.com/profile',
+    '//instagram.com/profile',
+    'not a URL',
+    'https://',
+    'https://[invalid]/',
+    'https://bad host/path',
+    'https://example.com:invalid/',
+  ];
+
+  function createRequest(body: unknown) {
+    return trackedLinks.request('https://worker.example.com/api/tracked-links', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }, { DB: makeDb({}) }, executionCtx);
+  }
+
+  test.each(invalidDestinations)('POST rejects an invalid destination before writing: %s', async (originalUrl) => {
+    const res = await createRequest({ name: 'link', originalUrl });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ success: false });
+    expect(dbMocks.createTrackedLink).not.toHaveBeenCalled();
+  });
+
+  test.each([null, true, 123, [], {}])('POST rejects a non-string destination: %j', async (originalUrl) => {
+    const res = await createRequest({ name: 'link', originalUrl });
+    expect(res.status).toBe(400);
+    expect(dbMocks.createTrackedLink).not.toHaveBeenCalled();
+  });
+
+  test('POST rejects a null request body without throwing a server error', async () => {
+    const res = await createRequest(null);
+    expect(res.status).toBe(400);
+    expect(dbMocks.createTrackedLink).not.toHaveBeenCalled();
+  });
+
+  test.each(['http', 'https', 'HTTPS'])('POST preserves a valid %s URL exactly', async (scheme) => {
+    const originalUrl = `${scheme}://example.com/page?q=日本語&quote="'"&encoded=%26&literal=&quot;#section`;
+    dbMocks.createTrackedLink.mockResolvedValue(makeLink({ original_url: originalUrl }));
+    const res = await createRequest({ name: 'link', originalUrl });
+    expect(res.status).toBe(201);
+    expect(dbMocks.createTrackedLink).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ originalUrl }));
+    expect(await res.json()).toMatchObject({ success: true, data: { originalUrl } });
+  });
+
+  test.each(invalidDestinations)('/t rejects invalid legacy destinations before redirect or tracking: %s', async (originalUrl) => {
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(makeLink({ original_url: originalUrl }));
+    const waitUntil = vi.fn();
+    const prepare = vi.fn();
+    const res = await trackedLinks.request('https://worker.example.com/t/link-1?lu=line-user', {}, {
+      DB: { prepare },
+    }, { ...executionCtx, waitUntil });
+    expect(res.status).toBe(400);
+    expect(res.headers.get('location')).toBeNull();
+    expect(await res.json()).toEqual({ success: false, error: 'Invalid link destination' });
+    expect(waitUntil).not.toHaveBeenCalled();
+    expect(prepare).not.toHaveBeenCalled();
+    expect(dbMocks.getFriendByLineUserId).not.toHaveBeenCalled();
+    expect(dbMocks.recordLinkClick).not.toHaveBeenCalled();
+  });
+
+  test.each([LINE_UA, 'Twitterbot/1.0'])('/t rejects unsafe legacy URLs before LIFF or OG handling for %s', async (ua) => {
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(makeLink({
+      original_url: 'javascript://instagram.com/%0ainjected=true',
+      line_account_id: 'acc-1',
+    }));
+    const prepare = vi.fn();
+    const res = await request({ DB: { prepare }, LIFF_URL: 'https://liff.line.me/123' }, ua);
+    expect(res.status).toBe(400);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    expect(res.headers.get('location')).toBeNull();
+    expect(prepare).not.toHaveBeenCalled();
+    expect(dbMocks.recordLinkClick).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /t/:linkId — per-account LIFF resolution', () => {
@@ -220,5 +302,81 @@ describe('GET /t/:linkId — short codes', () => {
     expect(res.headers.get('location')).toContain(
       encodeURIComponent('https://worker.example.com/t/Ab3xY9k'),
     );
+  });
+});
+
+describe('GET /t/:linkId — app redirect output escaping', () => {
+  const safariUa = 'Mozilla/5.0 (iPhone) Safari/605.1.15';
+  const androidUa = 'Mozilla/5.0 (Linux; Android 14) Chrome/120.0.0.0';
+
+  async function redirectHtml(destination: string) {
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(makeLink({ original_url: destination }));
+    const res = await request({ DB: makeDb({}) }, safariUa);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    return res.text();
+  }
+
+  function executeRedirect(html: string, userAgent: string): string {
+    // Check HTML delimiters before executing: JS parsing alone would miss a
+    // literal </script> terminating the element inside a quoted JS string.
+    expect(html.match(/<script\b/gi)).toHaveLength(1);
+    expect(html.match(/<\/script\s*>/gi)).toHaveLength(1);
+    const script = html.match(/<script>([\s\S]*?)<\/script>/i)?.[1];
+    expect(script).toBeDefined();
+    expect(script).not.toContain('<');
+    const sandbox = { navigator: { userAgent }, window: { location: { href: '' } }, injected: false };
+    runInNewContext(script!, sandbox, { timeout: 1000 });
+    expect(sandbox.injected).toBe(false);
+    return sandbox.window.location.href;
+  }
+
+  test.each([safariUa, androidUa])('keeps script-closing payloads inside URL strings for %s', async (ua) => {
+    const destination = 'https://x.com/search?q=</ScRiPt><img src=x onerror="injected=true"><script>injected=true;//';
+    const html = await redirectHtml(destination);
+    expect(html).not.toMatch(/<img\b/i);
+    const redirect = executeRedirect(html, ua);
+    if (ua === androidUa) {
+      expect(redirect).toBe(`intent://x.com/search?q=</ScRiPt><img src=x onerror="injected=true"><script>injected=true;//#Intent;scheme=https;package=com.twitter.android;S.browser_fallback_url=${encodeURIComponent(destination)};end`);
+    } else {
+      expect(redirect).toBe(destination);
+    }
+  });
+
+  test.each([safariUa, androidUa])('preserves quotes, ampersands, backslashes and Unicode for %s', async (ua) => {
+    const destination = 'https://www.youtube.com/watch?v=abc&label="日本語"&quote=\'single\'&slash=\\path&encoded=%26&literal=&quot;&line=\u2028\u2029';
+    const html = await redirectHtml(destination);
+    const redirect = executeRedirect(html, ua);
+    if (ua === androidUa) {
+      expect(redirect).toBe(`intent://www.youtube.com/watch?v=abc&label="日本語"&quote='single'&slash=\\path&encoded=%26&literal=&quot;&line=\u2028\u2029#Intent;scheme=https;package=com.google.android.youtube;S.browser_fallback_url=${encodeURIComponent(destination)};end`);
+      const fallback = redirect.match(/;S\.browser_fallback_url=(.*);end$/)?.[1];
+      expect(decodeURIComponent(fallback!)).toBe(destination);
+    } else {
+      expect(redirect).toBe(destination);
+    }
+  });
+
+  test('encodes the noscript refresh URL as one HTML attribute without changing its value', async () => {
+    const destination = 'https://x.com/search?q="/><img src=x onerror=alert(1)>&tag=\'日本語\'&literal=&quot;';
+    const html = await redirectHtml(destination);
+    const noscript = html.match(/<noscript>([\s\S]*?)<\/noscript>/)?.[1];
+    expect(noscript).toBe('<meta http-equiv="refresh" content="0;url=https://x.com/search?q=&quot;/&gt;&lt;img src=x onerror=alert(1)&gt;&amp;tag=&#39;日本語&#39;&amp;literal=&amp;quot;">');
+    expect(html).not.toMatch(/<img\b/i);
+    expect(executeRedirect(html, safariUa)).toBe(destination);
+  });
+
+  test.each(['http', 'https'])('keeps normal %s non-app links as redirects with query parameters intact', async (scheme) => {
+    const destination = `${scheme}://example.com/page?first=one&second=two%20words#section`;
+    dbMocks.getTrackedLinkByIdOrShortCode.mockResolvedValue(makeLink({ original_url: destination }));
+    const res = await request({ DB: makeDb({}) }, safariUa);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe(destination);
+  });
+
+  test.each(['http', 'https', 'HTTPS'])('preserves a %s app URL and its Android fallback', async (scheme) => {
+    const destination = `${scheme}://instagram.com/profile?first=one&second=two%20words`;
+    const html = await redirectHtml(destination);
+    expect(executeRedirect(html, safariUa)).toBe(destination);
+    expect(executeRedirect(html, androidUa)).toBe(`intent://instagram.com/profile?first=one&second=two%20words#Intent;scheme=https;package=com.instagram.android;S.browser_fallback_url=${encodeURIComponent(destination)};end`);
   });
 });

--- a/apps/worker/src/routes/tracked-links.ts
+++ b/apps/worker/src/routes/tracked-links.ts
@@ -22,6 +22,16 @@ import { awardActivityMileage } from '../services/activity-mileage.js';
 
 const trackedLinks = new Hono<Env>();
 
+function isHttpDestination(value: unknown): value is string {
+  if (typeof value !== 'string' || !/^https?:\/\//i.test(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 function serializeTrackedLink(row: TrackedLink, baseUrl: string) {
   // Prefer the short code (baseUrl may be a branded short domain).
   const trackingUrl = `${baseUrl}/t/${row.short_code ?? row.id}`;
@@ -136,8 +146,11 @@ trackedLinks.post('/api/tracked-links', async (c) => {
       ogImageUrl?: string | null;
     }>();
 
-    if (!body.name || !body.originalUrl) {
+    if (!body || typeof body.name !== 'string' || !body.name.trim() || !body.originalUrl) {
       return c.json({ success: false, error: 'name and originalUrl are required' }, 400);
+    }
+    if (!isHttpDestination(body.originalUrl)) {
+      return c.json({ success: false, error: 'originalUrl must be a valid http or https URL' }, 400);
     }
 
     const link = await createTrackedLink(c.env.DB, {
@@ -248,14 +261,29 @@ function getAndroidPackage(url: string): string | null {
   }
 }
 
+function serializeInlineScriptString(value: string): string {
+  // JSON escapes JS string delimiters, but HTML still recognizes </script>
+  // inside a string. Escape '<' before embedding JSON in a script element.
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
 function buildAppRedirectHtml(destinationUrl: string): string {
-  const escaped = destinationUrl.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  const destinationJson = serializeInlineScriptString(destinationUrl);
+  const destinationAttribute = destinationUrl
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
   const androidPackage = getAndroidPackage(destinationUrl);
   // intent://path#Intent;scheme=https;package=com.xxx;S.browser_fallback_url=https://...;end
   const intentUrl = androidPackage
-    ? `intent://${destinationUrl.replace(/^https?:\/\//, '')}#Intent;scheme=https;package=${androidPackage};S.browser_fallback_url=${encodeURIComponent(destinationUrl)};end`
+    ? `intent://${destinationUrl.replace(/^https?:\/\//i, '')}#Intent;scheme=https;package=${androidPackage};S.browser_fallback_url=${encodeURIComponent(destinationUrl)};end`
     : null;
-  const intentEscaped = intentUrl ? intentUrl.replace(/&/g, '&amp;').replace(/"/g, '&quot;') : '';
+  const intentJson = serializeInlineScriptString(intentUrl ?? '');
 
   return `<!DOCTYPE html>
 <html><head>
@@ -268,14 +296,14 @@ function buildAppRedirectHtml(destinationUrl: string): string {
 <script>
 (function(){
   var isAndroid = /Android/i.test(navigator.userAgent);
-  if(isAndroid && "${intentEscaped}"){
-    window.location.href="${intentEscaped}";
+  if(isAndroid && ${intentJson}){
+    window.location.href=${intentJson};
   } else {
-    window.location.href="${escaped}";
+    window.location.href=${destinationJson};
   }
 })();
 </script>
-<noscript><meta http-equiv="refresh" content="0;url=${escaped}"></noscript>
+<noscript><meta http-equiv="refresh" content="0;url=${destinationAttribute}"></noscript>
 </body></html>`;
 }
 
@@ -291,6 +319,11 @@ trackedLinks.get('/t/:linkId', async (c) => {
 
   if (!link || !link.is_active) {
     return c.json({ success: false, error: 'Link not found' }, 404);
+  }
+  // Also protect legacy and automatically created records. An allowed app
+  // hostname does not make a javascript: (or other non-web) URL safe to open.
+  if (!isHttpDestination(link.original_url)) {
+    return c.json({ success: false, error: 'Invalid link destination' }, 400);
   }
 
   // Bot UA (LINE/X/Facebook 等のリンクプレビュー) → OGP HTML を返して終了。


### PR DESCRIPTION
## Summary

Tracked app redirects embedded destination URLs into inline JavaScript using HTML escaping. This allowed script-element termination and changed normal query separators into literal HTML entities. Serialize JavaScript strings safely and escape HTML attributes separately. Reject malformed or non-HTTP(S) destinations before creating a link and before serving existing redirect records.

## Related work

Extracts the redirect security issue discussed in #239. Operator search and a new push endpoint are outside this change.

## Change type / scope

Security hardening; tracked-link Worker routes. No schema or sending changes.

## Verification

- 48 tracked-link request tests passed, including unsafe schemes, legacy records, mixed-case delimiters, original query/unicode preservation, Android intent fallback and normal 302 behavior.
- Generated redirect JavaScript was executed with node:vm against stubbed navigator/location; no browser automation or external navigation.
- Combined focused OSS candidate: Worker 1,442 tests, typecheck and build passed.
- Focused upstream-to-OSS diff and known private-value scan passed.

## Security impact

Invalid existing destinations return 400 before OG/LIFF or tracking side effects. Valid HTTP(S) destinations retain their original value. No new endpoint or capability is introduced.

## Rollback / remaining gate

Isolated Worker/D1 HTTP smoke verification is complete. No production deployment was performed. A revert would restore the redirect vulnerability; correct any legitimate URL compatibility issue with a focused patch.

## GitHub CI result

Current PR head checks succeeded: [CI run](https://github.com/Shudesu/line-harness-oss/actions/runs/34459076252).

## Merge completion

Merged after 31 isolated Worker/D1 HTTP checks with synthetic fixtures. Temporary resources were deleted. Final OSS main passed Worker CI and Core Safety CI; 1,442 Worker tests passed locally. This operation did not deploy production or publish npm packages.
