### PR TITLE
fix(update): 旧環境の更新でマイルを二重付与せず、履歴を安全に引き継ぐ

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,7 @@ jobs:
           cat > release-entry.json <<JSON
           {
             "version": "${{ steps.version.outputs.version }}",
+            "legacy_mileage_projection_version": 1,
             "released_at": "${{ steps.hashes.outputs.released_at }}",
             "worker_hash": "${{ steps.hashes.outputs.worker_hash }}",
             "worker_bundle_hash": "${{ steps.bundlehash.outputs.worker_bundle_hash }}",

--- a/docs/UPDATE-MILEAGE-REPLAY.md
+++ b/docs/UPDATE-MILEAGE-REPLAY.md
@@ -32,12 +32,25 @@ and includes linked historic actor grants in daily limits.
   verified release build. This document does not authorize publication.
 - Do not publish the engine/CLI with a schema-1 handoff release. A new engine
   also rejects unrecorded 062/063 against a target without the capability.
-  Matching-checksum migrations remain no-ops when selecting an older target.
+  Matching-checksum migrations remain no-ops when selecting an older target
+  only if no unfinished historical claims remain. Otherwise a compatible target
+  is required so held work cannot be silently stranded.
 - A failed Worker deployment leaves historical claims safely held. Retry the
   compatible deployment; do not remove the hold or migration checksum to force
   old code to process it. After successful deployment, normal scheduled mileage
   processing projects the held rows. SQL completion does not mean projection
   has already finished.
+
+## Setup and resume
+
+The setup command routes 062/063 through the same checked engine, including
+existing-database resume. Its D1 executor uses the authenticated, account-pinned
+Wrangler session. Bundle installs use the selected release capability; source
+installs read an exact leading version declaration in the runtime source without
+executing that source. Even when a saved setup has completed the database step,
+it checks unfinished claims before any Worker deployment or configuration sync
+if the selected target lacks the capability. Fresh bootstrap retains its existing
+fast path.
 
 ## Conditions requiring review
 

--- a/docs/UPDATE-MILEAGE-REPLAY.md
+++ b/docs/UPDATE-MILEAGE-REPLAY.md
@@ -1,0 +1,71 @@
+# Historical mileage updates
+
+Updates must preserve the released bytes and checksums of migrations 062/063
+and all existing `mileage_ledger` rows. Re-running their original INSERTs can
+award live activity a second time because their old history keys differ from
+runtime keys. Do not clear migration ledgers or manually replay those SQL files
+to recover a failed update.
+
+The update engine recognizes only the exact released 062/063 files. It prepares
+additive structure, then uses one atomic D1 request to register historical
+activity and the migration checksum. It does not insert monetary ledger rows.
+Native activity, including events still waiting to enqueue, retains its owner.
+Previously rewarded history gets processed queue entries; genuinely unprocessed
+history is held for the compatible runtime. Existing ledger rows are not edited.
+
+The hold uses `_line_harness_legacy_mileage_claims` and an unavailable queue date.
+Only the compatible processor claims these rows, applies the recorded builtin
+actor rule, and checks its policy snapshot. The sentinel remains on failures
+and abandoned claims, so an older processor cannot accidentally pick them up.
+Normal processing uses immutable legacy grants for source/subject/day dedupe
+and includes linked historic actor grants in daily limits.
+
+## Release contract
+
+- A compatible Worker release advertises `legacy_mileage_projection_version: 1`.
+- Such a release requires manifest `schema_version: 2`. Schema-1 engines reject
+  schema 2 before migrations, instead of ignoring the capability and replaying
+  the unsafe original SQL. The new reader accepts both schema versions.
+- Publish the compatible update engine and CLI before publishing a schema-2
+  manifest. The source versions prepared for this change are engine 0.0.13 and
+  CLI 0.2.12. The Worker bundle and its capability must come from the same
+  verified release build. This document does not authorize publication.
+- Do not publish the engine/CLI with a schema-1 handoff release. A new engine
+  also rejects unrecorded 062/063 against a target without the capability.
+  Matching-checksum migrations remain no-ops when selecting an older target.
+- A failed Worker deployment leaves historical claims safely held. Retry the
+  compatible deployment; do not remove the hold or migration checksum to force
+  old code to process it. After successful deployment, normal scheduled mileage
+  processing projects the held rows. SQL completion does not mean projection
+  has already finished.
+
+## Conditions requiring review
+
+Automatic replay stops atomically when it cannot establish ownership or reward
+policy: changed/renamed historical SQL, a queue-less synchronous baseline with
+existing rules, orphan/repurposed historic events, incompatible custom rules or
+multipliers, a changed held-claim policy, or live activity in flight overlapping
+an old grant. Raw CTA timestamps do not identify which CTA was clicked; without
+native or recoverable historical identity, replay stops rather than inventing
+`primary`. An in-flight enqueue may make a later retry unambiguous.
+
+Preserve data and inspect the indicated ownership/policy discrepancy before
+retrying. In particular, do not drain an old processor's known overlapping
+legacy rewards merely to silence the guard: that old processor can already
+re-award them. Reconcile with the compatible processor in a planned maintenance
+step, preserving any legitimate custom rewards.
+
+The adapter does not repair already-duplicated balances, reverse existing
+entries, or guarantee the behavior of an arbitrary older/forked writer. Its
+atomic guard covers the replay boundary, not new independent actions arriving
+later while old code remains deployed. Plan compatible deployment promptly;
+old-runtime subject-dedupe defects require the runtime fix as well.
+
+## Verification
+
+Regression fixtures cover existing live grants, genuine ungranted history,
+processed/pending/event-before-enqueue states, retries, transaction rollback,
+CTA identity, rule changes, and linked identity/cap behavior. They preserve
+all existing monetary rows. The multi-statement transaction and trigger support
+must also be verified against an isolated real D1 before release. Production
+migration and Worker deployment remain separate from source merges.

--- a/packages/create-line-harness/package.json
+++ b/packages/create-line-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-line-harness",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Set up L Harness — AI-operated LINE CRM — with one command",
   "type": "module",
   "bin": {
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@line-harness/update-engine": "workspace:^0.0.12",
+    "@line-harness/update-engine": "workspace:^0.0.13",
     "execa": "^9.5.2",
     "picocolors": "^1.1.1"
   },

--- a/packages/create-line-harness/src/commands/setup.ts
+++ b/packages/create-line-harness/src/commands/setup.ts
@@ -10,7 +10,7 @@ import { randomUUID } from "node:crypto";
 import { checkDeps } from "../steps/check-deps.js";
 import { ensureAuth, getAccountId } from "../steps/auth.js";
 import { promptLineCredentials } from "../steps/prompt.js";
-import { createDatabase } from "../steps/database.js";
+import { assertSetupMileageHandoffCompatible, createDatabase, readSourceLegacyMileageProjectionVersion } from "../steps/database.js";
 import { deployWorker, syncInstalledWorkerConfig } from "../steps/deploy-worker.js";
 import { ensureWorkersDevSubdomain } from "../steps/ensure-subdomain.js";
 import { deployAdmin } from "../steps/deploy-admin.js";
@@ -564,8 +564,14 @@ async function runSetupInner(
   }
 
   // Step 7: Create D1 database + run migrations
+  const legacyMileageProjectionVersion = release
+    ? release.release.legacy_mileage_projection_version
+    : readSourceLegacyMileageProjectionVersion(repoDir);
   if (!isDone(state, "database")) {
-    const { databaseId, databaseName } = await createDatabase(repoDir, state.projectName!);
+    const { databaseId, databaseName } = await createDatabase(repoDir, state.projectName!, {
+      accountId: state.accountId,
+      legacyMileageProjectionVersion,
+    });
     state.d1DatabaseId = databaseId;
     state.d1DatabaseName = databaseName;
     // Now that the real D1 ID is known, finish patching wrangler.toml so
@@ -582,6 +588,16 @@ async function runSetupInner(
     }
     p.log.success(`D1 データベース: 作成済み（${state.d1DatabaseId}）`);
   }
+
+  // Completion flags can come from a compatible source install while this run
+  // selects an older bundle. Read the remaining handoff even when DB is done,
+  // before either initial Worker deployment or later Worker config syncing.
+  await assertSetupMileageHandoffCompatible({
+    databaseId: state.d1DatabaseId!,
+    databaseName: state.d1DatabaseName!,
+    accountId: state.accountId,
+    legacyMileageProjectionVersion,
+  });
 
   // Step 8: Create R2 bucket for image uploads
   const r2BucketName = `${state.projectName}-images`;

--- a/packages/create-line-harness/src/commands/update.ts
+++ b/packages/create-line-harness/src/commands/update.ts
@@ -694,6 +694,7 @@ export async function runUpdate(
     creds,
     d1DatabaseId: cfg.d1DatabaseId,
     names: upgrade.migrations,
+    legacyMileageProjectionVersion: upgrade.legacy_mileage_projection_version,
     bundle,
     s,
   });
@@ -854,12 +855,14 @@ async function applyMigrations(opts: {
   s: Spinner;
   /** adoption 専用: 破壊的な旧世代 migration を probe + 記録のみで通す (エンジン側 doc 参照)。 */
   adoptGrandfathered?: boolean;
+  legacyMileageProjectionVersion?: 1;
 }): Promise<void> {
   const { creds, d1DatabaseId, names, bundle, s } = opts;
   try {
     await applyD1Migrations({
       creds,
       adoptGrandfathered: opts.adoptGrandfathered,
+      legacyMileageProjectionVersion: opts.legacyMileageProjectionVersion,
       databaseId: d1DatabaseId,
       names,
       migrations: bundle.migrations,
@@ -1240,6 +1243,7 @@ async function runAdoption(opts: {
     bundle,
     s,
     adoptGrandfathered: true,
+    legacyMileageProjectionVersion: target.legacy_mileage_projection_version,
   });
 
   await deployWorkerFromBundle(creds, cfg, bundle, s);

--- a/packages/create-line-harness/src/steps/database.ts
+++ b/packages/create-line-harness/src/steps/database.ts
@@ -1,6 +1,7 @@
 import * as p from "@clack/prompts";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { applyD1Migrations, type ApplyD1MigrationsOptions } from "@line-harness/update-engine";
 import { wrangler, WranglerError } from "../lib/wrangler.js";
 
 interface DatabaseResult {
@@ -11,6 +12,141 @@ interface DatabaseResult {
 interface BootstrapMeta {
   includedMigrations: string[];
   migrationCount: number;
+}
+
+interface DatabaseOptions {
+  accountId?: string;
+  /** Capability of the Worker that setup is actually about to deploy. */
+  legacyMileageProjectionVersion?: 1;
+}
+
+/**
+ * Source builds declare their capability in the first non-comment statement.
+ * Do not import/evaluate the checkout, or mistake a comment/string elsewhere
+ * in an old Worker for evidence that it can consume held historical activity.
+ */
+export function readSourceLegacyMileageProjectionVersion(repoDir: string): 1 | undefined {
+  const file = join(repoDir, "packages/db/src/mileage.ts");
+  if (!existsSync(file)) return undefined;
+  const source = readFileSync(file, "utf8").replace(/^(?:\s|\/\/[^\r\n]*(?:\r?\n|$)|\/\*[\s\S]*?\*\/)+/, "");
+  return /^export\s+const\s+LEGACY_MILEAGE_PROJECTION_VERSION\s*=\s*1\s*;/.test(source)
+    ? 1 : undefined;
+}
+
+/** Wrangler has no bind flag. Encode values, then replace only SQL tokens. */
+function bindMigrationParameters(sql: string, params: unknown[]): string {
+  let index = 0;
+  const bound = sql.replace(
+    /'(?:[^']|'')*'|"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[[^\]]*\]|--[^\r\n]*|\/\*[\s\S]*?\*\/|\?\d*/g,
+    (token) => {
+      if (!token.startsWith("?")) return token;
+      if (token !== "?" || index >= params.length) {
+        throw new Error("Unsupported or missing D1 migration parameter");
+      }
+      const value = params[index++];
+      if (value === null) return "NULL";
+      if (typeof value === "number" && Number.isFinite(value)) return String(value);
+      if (typeof value === "string") {
+        // Hex also preserves embedded NULs without passing them in argv.
+        return `CAST(X'${Buffer.from(value, "utf8").toString("hex")}' AS TEXT)`;
+      }
+      throw new Error("Unsupported D1 migration parameter type");
+    },
+  );
+  if (index !== params.length) throw new Error("Unexpected D1 migration parameters");
+  return bound;
+}
+
+/**
+ * Reuse setup's authenticated, account-pinned Wrangler session. --command
+ * sends the adapter's whole atomic unit to D1 /query in one request; do not
+ * split it into individually committed commands or send it via --file.
+ * wrangler() uses an execa argument array, never shell interpolation.
+ */
+export function createSetupD1Executor(databaseName: string): NonNullable<ApplyD1MigrationsOptions["execute"]> {
+  return async ({ sql, params = [] }) => {
+    const output = await runD1WithRetry(
+      ["d1", "execute", databaseName, "--remote", "--json", "--command", bindMigrationParameters(sql, params)],
+      "マイレージ migration 適用",
+    );
+    let result: unknown;
+    try { result = JSON.parse(output); } catch {
+      throw new Error("D1 migration query did not return valid JSON results");
+    }
+    if (!Array.isArray(result) || result.length === 0 || result.some(
+      (item) => item?.success !== true || !Array.isArray(item.results),
+    )) {
+      throw new Error("D1 migration query returned an unsuccessful SQL result");
+    }
+    return { success: true, result };
+  };
+}
+
+/**
+ * A resumed setup may skip migrations after changing its source/release target.
+ * Check the actual DB handoff before any Worker deployment or config sync;
+ * migration checksums alone do not prove that the new target can finish it.
+ */
+export async function assertSetupMileageHandoffCompatible(
+  options: DatabaseOptions & DatabaseResult,
+): Promise<void> {
+  if (options.legacyMileageProjectionVersion === 1) return;
+  if (!options.databaseName || !options.databaseId) {
+    throw new Error("Cannot verify historical mileage handoff: saved D1 database information is missing.");
+  }
+  const execute = createSetupD1Executor(options.databaseName);
+  const base = {
+    creds: { accountId: options.accountId ?? "", apiToken: "" },
+    databaseId: options.databaseId,
+  };
+  const tables = await execute({ ...base, sql: `SELECT
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '_line_harness_legacy_mileage_claims') AS claims_table,
+    (SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'mileage_event_queue') AS queue_table` });
+  const schema = tables.result[0].results[0];
+  if (![0, 1].includes(schema?.claims_table) || ![0, 1].includes(schema?.queue_table)) {
+    throw new Error("Cannot verify historical mileage handoff state; Worker deployment was stopped.");
+  }
+  if (schema.claims_table === 0) return;
+  const pending = await execute({ ...base, sql: schema.queue_table === 1
+    ? `SELECT EXISTS(SELECT 1 FROM _line_harness_legacy_mileage_claims claim
+        LEFT JOIN mileage_event_queue queue ON queue.engagement_event_id = claim.engagement_event_id
+        WHERE queue.status IS NOT 'processed') AS unresolved`
+    : "SELECT EXISTS(SELECT 1 FROM _line_harness_legacy_mileage_claims) AS unresolved" });
+  const unresolved = pending.result[0].results[0]?.unresolved;
+  if (unresolved !== 0 && unresolved !== 1) {
+    throw new Error("Cannot verify whether historical mileage handoff is complete; Worker deployment was stopped.");
+  }
+  if (unresolved === 1) {
+    throw new Error(
+      "Historical mileage is still awaiting a compatible Worker (legacy_mileage_projection_version=1). " +
+      "Resume setup with a compatible release or source checkout; Worker deployment was stopped and held claims were preserved.",
+    );
+  }
+}
+
+async function applySetupMigration(
+  databaseName: string,
+  databaseId: string,
+  migrationsDir: string,
+  file: string,
+  options: DatabaseOptions,
+): Promise<void> {
+  const filePath = join(migrationsDir, file);
+  if (/^(?:062|063)_/.test(file)) {
+    // Never pass the immutable historical financial INSERTs to applySqlFile,
+    // including its file-level first attempt or statement-level retry path.
+    await applyD1Migrations({
+      // The supplied executor owns authentication; no API token is required.
+      creds: { accountId: options.accountId ?? "", apiToken: "" },
+      databaseId,
+      names: [file],
+      migrations: new Map([[file, readFileSync(filePath)]]),
+      legacyMileageProjectionVersion: options.legacyMileageProjectionVersion,
+      execute: createSetupD1Executor(databaseName),
+    });
+    return;
+  }
+  await applySqlFile(databaseName, filePath, `migration 適用: ${file}`);
 }
 
 const TRANSIENT_D1_ERROR = /code[:\s]*10043|cloudflarestatus|temporarily unavailable|internal error|timed out|timeout|fetch failed|network|connection reset/i;
@@ -210,6 +346,7 @@ function loadBootstrapMeta(repoDir: string): BootstrapMeta | null {
 export async function createDatabase(
   repoDir: string,
   databaseName: string,
+  options: DatabaseOptions = {},
 ): Promise<DatabaseResult> {
   const s = p.spinner();
 
@@ -296,10 +433,12 @@ export async function createDatabase(
 
     for (const file of pendingMigrations) {
       try {
-        await applySqlFile(
+        await applySetupMigration(
           databaseName,
-          join(migrationsDir, file),
-          `bootstrap 後 migration 適用: ${file}`,
+          databaseId,
+          migrationsDir,
+          file,
+          options,
         );
       } catch (err) {
         s.stop(`migration 失敗: ${file}`);
@@ -323,10 +462,12 @@ export async function createDatabase(
 
     for (const file of migrationFiles) {
       try {
-        await applySqlFile(
+        await applySetupMigration(
           databaseName,
-          join(migrationsDir, file),
-          `migration 適用: ${file}`,
+          databaseId,
+          migrationsDir,
+          file,
+          options,
         );
       } catch (err) {
         s.stop(`migration 失敗: ${file}`);

--- a/packages/create-line-harness/test/database-mileage.test.ts
+++ b/packages/create-line-harness/test/database-mileage.test.ts
@@ -1,0 +1,252 @@
+import { createHash } from "node:crypto";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { assertSetupMileageHandoffCompatible, createDatabase, createSetupD1Executor, readSourceLegacyMileageProjectionVersion } from "../src/steps/database.js";
+import { wrangler, WranglerError } from "../src/lib/wrangler.js";
+import { applyMileageRulesForEvent, processPendingMileageEvents } from "../../db/src/mileage.js";
+
+// Reuse the update engine's SQLite test dependency; no remote D1 is involved.
+const Database = createRequire(new URL("../../update-engine/package.json", import.meta.url))("better-sqlite3") as typeof import("../../update-engine/node_modules/better-sqlite3");
+const DB_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../db");
+const NAMES = ["062_mileage_admin_and_activity_rules.sql", "063_webinar_instagram_mileage.sql"];
+const SOURCES = new Map(NAMES.map((name) => [name, readFileSync(join(DB_ROOT, "migrations", name))]));
+const ID = "00000000-0000-4000-8000-000000000001";
+const DAY = "2026-09-09T10:00:00.000+09:00";
+const NOW = "2026-09-10T20:00:00.000+09:00";
+
+vi.mock("@clack/prompts", () => ({
+  spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+  log: { warn: vi.fn() },
+}));
+vi.mock("../src/lib/wrangler.js", async (original) => ({
+  ...await original<typeof import("../src/lib/wrangler.js")>(), wrangler: vi.fn(),
+}));
+vi.mock("@line-harness/update-engine", async () => import("../../update-engine/src/migrations.js"));
+
+function d1(sqlite: InstanceType<typeof Database>): D1Database {
+  return { prepare(sql: string) {
+    const bound = (params: unknown[]) => ({
+      async run() { return { success: true, results: [], meta: sqlite.prepare(sql).run(...params) }; },
+      async first<T>() { return (sqlite.prepare(sql).get(...params) as T) ?? null; },
+      async all<T>() { return { success: true, results: sqlite.prepare(sql).all(...params) as T[], meta: {} }; },
+    });
+    return { ...bound([]), bind: (...params: unknown[]) => bound(params) };
+  }} as unknown as D1Database;
+}
+
+describe("setup mileage migration transport", () => {
+  let repo: string;
+  let sqlite: InstanceType<typeof Database>;
+  let createdNow: boolean;
+  let failAtomic: boolean;
+  let commands: string[];
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(NOW));
+    vi.clearAllMocks();
+    repo = mkdtempSync(join(tmpdir(), "clh-database-mileage-"));
+    mkdirSync(join(repo, "packages/db/migrations"), { recursive: true });
+    mkdirSync(join(repo, "packages/db/src"), { recursive: true });
+    cpSync(join(DB_ROOT, "bootstrap.sql"), join(repo, "packages/db/schema.sql"));
+    for (const name of NAMES) writeFileSync(join(repo, "packages/db/migrations", name), SOURCES.get(name)!);
+    sqlite = new Database(":memory:");
+    createdNow = false;
+    failAtomic = false;
+    commands = [];
+    vi.mocked(wrangler).mockImplementation(async (args) => {
+      if (args[1] === "create") {
+        if (!createdNow) throw new WranglerError("already exists", "already exists");
+        return JSON.stringify({ database_id: ID });
+      }
+      if (args[1] === "list") return JSON.stringify([{ name: "offline", uuid: ID }]);
+      expect(args.slice(0, 4)).toEqual(["d1", "execute", "offline", "--remote"]);
+      const fileIndex = args.indexOf("--file");
+      const sql = fileIndex >= 0 ? readFileSync(args[fileIndex + 1], "utf8") : args[args.indexOf("--command") + 1];
+      commands.push(sql);
+      try {
+        let rows: unknown[] = [];
+        // Wrangler --remote --command sends ONE /query request, which is atomic.
+        sqlite.transaction(() => {
+          if (/^\s*SELECT\b/i.test(sql)) rows = sqlite.prepare(sql).all();
+          else sqlite.exec(failAtomic && sql.includes("CREATE TABLE _line_harness_legacy_mileage_candidates")
+            ? sql.replace("INSERT OR IGNORE INTO _line_harness_migrations", "INSERT OR IGNORE INTO missing_test_table")
+            : sql);
+        })();
+        return JSON.stringify([{ success: true, results: rows }]);
+      } catch (error) {
+        throw new WranglerError((error as Error).message, (error as Error).message);
+      }
+    });
+  });
+  afterEach(() => { sqlite.close(); rmSync(repo, { recursive: true, force: true }); vi.useRealTimers(); });
+
+  const setup = (repo: string, version?: 1) => createDatabase(repo, "offline", { accountId: "account-selected-in-setup", legacyMileageProjectionVersion: version });
+  const ledger = () => sqlite.prepare("SELECT * FROM mileage_ledger ORDER BY id").all();
+
+  function seedActivity() {
+    sqlite.exec(readFileSync(join(DB_ROOT, "bootstrap.sql"), "utf8"));
+    sqlite.exec(`INSERT INTO mileage_programs VALUES ('default','default','Harnessマイル','active','2026-01-01','2026-01-01');
+      INSERT INTO users(id,display_name) VALUES('u','offline');
+      INSERT INTO line_accounts(id,channel_id,name,channel_access_token,channel_secret) VALUES('a','channel','offline','offline','offline');
+      INSERT INTO friends(id,line_user_id,user_id,line_account_id) VALUES('f','Uf','u','a');
+      INSERT INTO messages_log(id,friend_id,direction,message_type,content,created_at) VALUES('m','f','incoming','text','offline','${DAY}');
+      INSERT INTO webinars(id,account_id,title,slug,duration_seconds,created_at,updated_at) VALUES('w','a','offline','offline',1000,'2026-01-01','2026-01-01');
+      INSERT INTO webinar_viewers(id,webinar_id,friend_id,session_start_at,joined_at,last_position_seconds) VALUES('v','w','f',1234,'${DAY}',300);`);
+    for (const source of SOURCES.values()) {
+      const sql = source.toString("utf8");
+      const start = sql.indexOf("INSERT OR IGNORE INTO mileage_rules");
+      sqlite.exec(sql.slice(start, sql.indexOf(";", start) + 1));
+    }
+  }
+
+  it("keeps existing settled message + webinar mileage at 6 across setup and checksum retries", async () => {
+    seedActivity();
+    await applyMileageRulesForEvent(d1(sqlite), { eventType: "message_received", source: "line", sourceEventId: "m", friendId: "f", occurredAt: DAY });
+    await applyMileageRulesForEvent(d1(sqlite), { eventType: "webinar_watch_5m", source: "webinar", sourceEventId: "w:f:5m", friendId: "f", subjectKey: "w", occurredAt: DAY });
+    await processPendingMileageEvents(d1(sqlite), { now: NOW });
+    const before = ledger();
+    expect(sqlite.prepare("SELECT SUM(amount) AS amount FROM mileage_ledger").get()).toEqual({ amount: 6 });
+    expect(await setup(repo, 1)).toEqual({ databaseId: ID, databaseName: "offline" });
+    expect(ledger()).toEqual(before);
+    expect(sqlite.prepare("SELECT name,checksum FROM _line_harness_migrations ORDER BY name").all()).toEqual(
+      NAMES.map((name) => ({ name, checksum: `sha256:${createHash("sha256").update(SOURCES.get(name)!).digest("hex")}` })),
+    );
+    expect(commands.some((sql) => /INSERT\s+OR\s+IGNORE\s+INTO\s+mileage_ledger/i.test(sql))).toBe(false);
+    expect(vi.mocked(wrangler).mock.calls.some(([args]) => args.includes("--file") && /06[23]_/.test(args.at(-1)!))).toBe(false);
+    commands = [];
+    await setup(repo); // Exact ledger matches are valid even for an old target.
+    expect(ledger()).toEqual(before);
+    expect(commands.some((sql) => sql.includes("CREATE TABLE _line_harness_legacy_mileage_candidates"))).toBe(false);
+  });
+
+  it("refuses unrecorded history for an unknown target without changing financial rows", async () => {
+    seedActivity();
+    const before = ledger();
+    await expect(setup(repo)).rejects.toThrow("Select a compatible Worker release");
+    expect(ledger()).toEqual(before);
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM _line_harness_migrations").get()).toEqual({ n: 0 });
+    expect(commands.some((sql) => /INSERT\s+OR\s+IGNORE\s+INTO\s+mileage_ledger/i.test(sql))).toBe(false);
+  });
+
+  it("retries an initially empty existing database using the actual pre-062 setup SQL", async () => {
+    cpSync(join(DB_ROOT, "schema.sql"), join(repo, "packages/db/schema.sql"));
+    for (const name of readdirSync(join(DB_ROOT, "migrations")).filter((name) => name.endsWith(".sql") && name < "062")) {
+      cpSync(join(DB_ROOT, "migrations", name), join(repo, "packages/db/migrations", name));
+    }
+    await setup(repo, 1);
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM _line_harness_migrations").get()).toEqual({ n: 2 });
+    expect(ledger()).toEqual([]);
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM mileage_rules").get()).toEqual({ n: 12 });
+    await setup(repo, 1);
+    expect(ledger()).toEqual([]);
+  });
+
+  it("rolls back a failed atomic claim, then succeeds without duplicating grants", async () => {
+    seedActivity();
+    failAtomic = true;
+    await expect(setup(repo, 1)).rejects.toThrow("atomically");
+    expect(ledger()).toEqual([]);
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM engagement_events").get()).toEqual({ n: 0 });
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM _line_harness_migrations").get()).toEqual({ n: 0 });
+    failAtomic = false;
+    await setup(repo, 1);
+    expect(ledger()).toEqual([]);
+    await processPendingMileageEvents(d1(sqlite), { now: NOW });
+    expect(sqlite.prepare("SELECT SUM(amount) AS amount FROM mileage_ledger").get()).toEqual({ amount: 6 });
+  });
+
+  it("keeps fresh bootstrap to one schema request with covered migrations skipped", async () => {
+    createdNow = true;
+    cpSync(join(DB_ROOT, "bootstrap.sql"), join(repo, "packages/db/bootstrap.sql"));
+    writeFileSync(join(repo, "packages/db/bootstrap-meta.json"), JSON.stringify({ includedMigrations: NAMES, migrationCount: 2 }));
+    await setup(repo);
+    expect(commands).toHaveLength(2); // bootstrap + final schema verification
+    expect(sqlite.prepare("SELECT name FROM sqlite_master WHERE name='_line_harness_migrations'").get()).toBeUndefined();
+  });
+
+  it("binds hostile values as data, preserving question marks in SQL literals and comments", async () => {
+    sqlite.exec("CREATE TABLE protected_table(value TEXT)");
+    const hostile = "a'); DROP TABLE protected_table; -- ? `touch should-never-run` $(echo unsafe)\u0000日本語";
+    const execute = createSetupD1Executor("offline");
+    const response = await execute({ creds: { accountId: "", apiToken: "" }, databaseId: ID,
+      sql: "SELECT ? AS value, '?' AS question /* ? */ -- ?\n", params: [hostile] });
+    expect(response.result[0].results).toEqual([{ value: hostile, question: "?" }]);
+    expect(sqlite.prepare("SELECT * FROM protected_table").all()).toEqual([]);
+    expect(vi.mocked(wrangler).mock.lastCall![0].at(-1)).not.toContain(hostile);
+    await expect(execute({ creds: { accountId: "", apiToken: "" }, databaseId: ID, sql: "SELECT ?", params: [] })).rejects.toThrow("missing");
+    await expect(execute({ creds: { accountId: "", apiToken: "" }, databaseId: ID, sql: "SELECT 1", params: [hostile] })).rejects.toThrow("Unexpected");
+  });
+
+  it.each(["not JSON", "[]", '[{"success":false,"results":[]}]', '{"success":true,"result":[]}'])
+    ("rejects invalid or unsuccessful Wrangler results: %s", async (output) => {
+      vi.mocked(wrangler).mockResolvedValueOnce(output);
+      await expect(createSetupD1Executor("offline")({ creds: { accountId: "", apiToken: "" }, databaseId: ID, sql: "SELECT 1" })).rejects.toThrow("D1 migration query");
+    });
+
+  it("only recognizes the non-executed source capability header", () => {
+    const file = join(repo, "packages/db/src/mileage.ts");
+    expect(readSourceLegacyMileageProjectionVersion(repo)).toBeUndefined();
+    for (const source of [
+      "export const LEGACY_MILEAGE_PROJECTION_VERSION = 0;",
+      "/* export const LEGACY_MILEAGE_PROJECTION_VERSION = 1; */\nexport const unrelated = 1;",
+      "const text = `\nexport const LEGACY_MILEAGE_PROJECTION_VERSION = 1;\n`;",
+      "export const LEGACY_MILEAGE_PROJECTION_VERSION = 10;",
+    ]) {
+      writeFileSync(file, source);
+      expect(readSourceLegacyMileageProjectionVersion(repo)).toBeUndefined();
+    }
+    writeFileSync(file, "/* header */\n// header\nexport const LEGACY_MILEAGE_PROJECTION_VERSION = 1;\nthrow new Error('must not execute');");
+    expect(readSourceLegacyMileageProjectionVersion(repo)).toBe(1);
+  });
+
+  it.each(["pending", "processing", "failed", undefined])("blocks an incompatible Worker when a retained claim has queue status %s", async (status) => {
+    seedActivity();
+    sqlite.exec("CREATE TABLE _line_harness_legacy_mileage_claims(engagement_event_id TEXT PRIMARY KEY); INSERT INTO _line_harness_legacy_mileage_claims VALUES('claim')");
+    // The production queue has a foreign key, so create the event via runtime.
+    const event = await applyMileageRulesForEvent(d1(sqlite), { eventType: "message_received", source: "line", sourceEventId: "m", friendId: "f", occurredAt: DAY });
+    sqlite.prepare("UPDATE _line_harness_legacy_mileage_claims SET engagement_event_id=?").run(event.event.id);
+    if (status) sqlite.prepare("UPDATE mileage_event_queue SET status=?").run(status);
+    else sqlite.exec("DELETE FROM mileage_event_queue");
+    const before = sqlite.prepare("SELECT * FROM mileage_event_queue").all();
+    await expect(assertSetupMileageHandoffCompatible({ databaseId: ID, databaseName: "offline" })).rejects.toThrow("awaiting a compatible Worker");
+    expect(sqlite.prepare("SELECT * FROM mileage_event_queue").all()).toEqual(before);
+    expect(ledger()).toEqual([]);
+    expect(commands.every((sql) => /^SELECT\b/.test(sql))).toBe(true);
+  });
+
+  it("allows an old target only when handoff is absent or all claims are processed", async () => {
+    await assertSetupMileageHandoffCompatible({ databaseId: ID, databaseName: "offline" });
+    expect(commands).toHaveLength(1);
+    sqlite.exec(`CREATE TABLE _line_harness_legacy_mileage_claims(engagement_event_id TEXT PRIMARY KEY);
+      INSERT INTO _line_harness_legacy_mileage_claims VALUES('claim');
+      CREATE TABLE mileage_event_queue(engagement_event_id TEXT PRIMARY KEY, status TEXT);
+      INSERT INTO mileage_event_queue VALUES('claim','processed');`);
+    await assertSetupMileageHandoffCompatible({ databaseId: ID, databaseName: "offline" });
+    expect(commands).toHaveLength(3);
+    expect(commands.every((sql) => /^SELECT\b/.test(sql))).toBe(true);
+  });
+
+  it("blocks unresolved claims even when their entire queue table is missing", async () => {
+    sqlite.exec("CREATE TABLE _line_harness_legacy_mileage_claims(engagement_event_id TEXT PRIMARY KEY); INSERT INTO _line_harness_legacy_mileage_claims VALUES('claim')");
+    await expect(assertSetupMileageHandoffCompatible({ databaseId: ID, databaseName: "offline" })).rejects.toThrow("awaiting a compatible Worker");
+    expect(commands.every((sql) => /^SELECT\b/.test(sql))).toBe(true);
+  });
+
+  it("refuses unavailable handoff probes instead of interpreting them as no claims", async () => {
+    vi.mocked(wrangler).mockResolvedValueOnce('[{"success":true,"results":[]}]');
+    await expect(assertSetupMileageHandoffCompatible({ databaseId: ID, databaseName: "offline" })).rejects.toThrow("Cannot verify");
+    vi.mocked(wrangler).mockResolvedValueOnce('[{"success":true,"results":[{"claims_table":1,"queue_table":1}]}]')
+      .mockResolvedValueOnce('[{"success":true,"results":[]}]');
+    await expect(assertSetupMileageHandoffCompatible({ databaseId: ID, databaseName: "offline" })).rejects.toThrow("Cannot verify");
+  });
+
+  it("does not need additional DB queries when the target can finish held claims", async () => {
+    await assertSetupMileageHandoffCompatible({ databaseId: ID, databaseName: "offline", legacyMileageProjectionVersion: 1 });
+    expect(wrangler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/create-line-harness/test/setup-mileage-capability.test.ts
+++ b/packages/create-line-harness/test/setup-mileage-capability.test.ts
@@ -1,0 +1,153 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadState, runSetup, saveState } from "../src/commands/setup.js";
+import { createDatabase, readSourceLegacyMileageProjectionVersion } from "../src/steps/database.js";
+import { fetchLatestRelease, type FetchedRelease } from "../src/steps/release-bundle.js";
+import { setAccountId, wrangler } from "../src/lib/wrangler.js";
+import { deployWorker } from "../src/steps/deploy-worker.js";
+
+vi.mock("@clack/prompts", () => ({
+  intro: vi.fn(),
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn() },
+}));
+vi.mock("../src/steps/check-deps.js", () => ({ checkDeps: vi.fn() }));
+vi.mock("../src/steps/auth.js", () => ({ ensureAuth: vi.fn(), getAccountId: vi.fn() }));
+vi.mock("../src/steps/clone-repo.js", () => ({ pinRepoToTag: vi.fn() }));
+vi.mock("../src/steps/release-bundle.js", () => ({ fetchLatestRelease: vi.fn() }));
+vi.mock("../src/steps/ensure-subdomain.js", () => ({ ensureWorkersDevSubdomain: vi.fn() }));
+vi.mock("../src/steps/deploy-worker.js", () => ({
+  deployWorker: vi.fn(async () => { throw new Error("stop-before-worker-deploy"); }),
+  syncInstalledWorkerConfig: vi.fn(),
+}));
+vi.mock("../src/lib/wrangler.js", async (original) => ({
+  ...await original<typeof import("../src/lib/wrangler.js")>(),
+  getAccountIds: vi.fn(async () => [{ id: "selected-account", name: "offline" }]),
+  setAccountId: vi.fn(),
+  wrangler: vi.fn(() => { throw new Error("Unexpected remote command"); }),
+}));
+vi.mock("../src/steps/database.js", async (original) => {
+  const actual = await original<typeof import("../src/steps/database.js")>();
+  return { ...actual,
+    createDatabase: vi.fn(async () => { throw new Error("stop-before-D1"); }),
+    readSourceLegacyMileageProjectionVersion: vi.fn(actual.readSourceLegacyMileageProjectionVersion),
+  };
+});
+
+describe("setup target mileage capability", () => {
+  let repo: string;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(wrangler).mockImplementation(async () => { throw new Error("Unexpected remote command"); });
+    repo = mkdtempSync(join(tmpdir(), "clh-setup-mileage-"));
+    mkdirSync(join(repo, "packages/db/src"), { recursive: true });
+    saveState(repo, {
+      completedSteps: ["r2billing", "credentials", "liffId"],
+      projectName: "offline", accountId: "selected-account", apiKey: "offline",
+      lineChannelId: "offline", lineChannelAccessToken: "offline", lineChannelSecret: "offline",
+      liffId: "offline-liff",
+    });
+    vi.stubGlobal("fetch", vi.fn(() => { throw new Error("Unexpected network request"); }));
+  });
+  afterEach(() => { rmSync(repo, { recursive: true, force: true }); vi.unstubAllGlobals(); });
+
+  it.each([1, undefined] as const)("passes only the verified release capability (%s) in bundle mode", async (capability) => {
+    // A newer local source marker must never upgrade an older bundle's capability.
+    writeFileSync(join(repo, "packages/db/src/mileage.ts"), "export const LEGACY_MILEAGE_PROJECTION_VERSION = 1;");
+    vi.mocked(fetchLatestRelease).mockResolvedValue({
+      release: { version: "0.24.0", legacy_mileage_projection_version: capability },
+      bundle: {}, manifest: {},
+    } as FetchedRelease);
+    await expect(runSetup(repo)).rejects.toThrow("stop-before-D1");
+    expect(setAccountId).toHaveBeenCalledWith("selected-account");
+    expect(createDatabase).toHaveBeenCalledWith(repo, "offline", {
+      accountId: "selected-account", legacyMileageProjectionVersion: capability,
+    });
+    expect(readSourceLegacyMileageProjectionVersion).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([1, 0, undefined] as const)("reads the source capability (%s) without executing the checkout", async (capability) => {
+    if (capability !== undefined) writeFileSync(join(repo, "packages/db/src/mileage.ts"),
+      `// source capability\nexport const LEGACY_MILEAGE_PROJECTION_VERSION = ${capability};\nthrow new Error('must not execute');`);
+    await expect(runSetup(repo, { fromSource: true })).rejects.toThrow("stop-before-D1");
+    expect(createDatabase).toHaveBeenCalledWith(repo, "offline", {
+      accountId: "selected-account", legacyMileageProjectionVersion: capability === 1 ? 1 : undefined,
+    });
+    expect(fetchLatestRelease).not.toHaveBeenCalled();
+    expect(readSourceLegacyMileageProjectionVersion).toHaveBeenCalledWith(repo);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  function completedDatabase() {
+    const state = loadState(repo);
+    saveState(repo, { ...state,
+      completedSteps: [...state.completedSteps, "database", "r2"],
+      d1DatabaseId: "saved-database-id", d1DatabaseName: "offline",
+      r2BucketName: "offline-images", botBasicId: "@offline",
+    });
+  }
+
+  function mockHandoff(unresolved: 0 | 1) {
+    vi.mocked(wrangler).mockImplementation(async (args) => {
+      expect(args.slice(0, 6)).toEqual(["d1", "execute", "offline", "--remote", "--json", "--command"]);
+      const sql = args[6];
+      expect(sql).toMatch(/^SELECT\b/);
+      const row = sql.includes("sqlite_master")
+        ? { claims_table: 1, queue_table: 1 } : { unresolved };
+      return JSON.stringify([{ success: true, results: [row] }]);
+    });
+  }
+
+  it("blocks source-to-old-bundle resume with completed DB and unfinished held claims", async () => {
+    completedDatabase(); // Source setups have no persisted releaseVersion.
+    writeFileSync(join(repo, "packages/db/src/mileage.ts"), "export const LEGACY_MILEAGE_PROJECTION_VERSION = 1;");
+    vi.mocked(fetchLatestRelease).mockResolvedValue({
+      release: { version: "0.23.0" }, bundle: {}, manifest: {},
+    } as FetchedRelease);
+    mockHandoff(1);
+    await expect(runSetup(repo)).rejects.toThrow("awaiting a compatible Worker");
+    expect(createDatabase).not.toHaveBeenCalled();
+    expect(deployWorker).not.toHaveBeenCalled();
+    expect(readSourceLegacyMileageProjectionVersion).not.toHaveBeenCalled();
+    expect(wrangler).toHaveBeenCalledTimes(2);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([0, undefined] as const)("blocks completed-DB source resume after marker changed to %s", async (capability) => {
+    completedDatabase();
+    if (capability !== undefined) writeFileSync(join(repo, "packages/db/src/mileage.ts"),
+      `export const LEGACY_MILEAGE_PROJECTION_VERSION = ${capability};`);
+    mockHandoff(1);
+    await expect(runSetup(repo, { fromSource: true })).rejects.toThrow("awaiting a compatible Worker");
+    expect(createDatabase).not.toHaveBeenCalled();
+    expect(deployWorker).not.toHaveBeenCalled();
+    expect(fetchLatestRelease).not.toHaveBeenCalled();
+    expect(wrangler).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([false, true])("allows completed-DB resume with a compatible target (source=%s)", async (fromSource) => {
+    completedDatabase();
+    writeFileSync(join(repo, "packages/db/src/mileage.ts"), "export const LEGACY_MILEAGE_PROJECTION_VERSION = 1;");
+    vi.mocked(fetchLatestRelease).mockResolvedValue({
+      release: { version: "0.24.0", legacy_mileage_projection_version: 1 }, bundle: {}, manifest: {},
+    } as FetchedRelease);
+    await expect(runSetup(repo, { fromSource })).rejects.toThrow("stop-before-worker-deploy");
+    expect(createDatabase).not.toHaveBeenCalled();
+    expect(deployWorker).toHaveBeenCalledOnce();
+    expect(wrangler).not.toHaveBeenCalled();
+  });
+
+  it("allows an old bundle on resume when every held claim has completed", async () => {
+    completedDatabase();
+    vi.mocked(fetchLatestRelease).mockResolvedValue({
+      release: { version: "0.23.0" }, bundle: {}, manifest: {},
+    } as FetchedRelease);
+    mockHandoff(0);
+    await expect(runSetup(repo)).rejects.toThrow("stop-before-worker-deploy");
+    expect(createDatabase).not.toHaveBeenCalled();
+    expect(deployWorker).toHaveBeenCalledOnce();
+    expect(wrangler).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/db/src/mileage.ts
+++ b/packages/db/src/mileage.ts
@@ -212,10 +212,98 @@ export interface PostMileageEntryInput {
   occurredAt?: string;
 }
 
+const HISTORICAL_MILEAGE_RULES = new Map<string, { eventType: string; sources: string[]; prefix: string; subject?: string }>(Object.entries({
+  'builtin-message-received': { eventType: 'message_received', sources: ['line'], prefix: 'message' },
+  'builtin-link-clicked': { eventType: 'link_clicked', sources: ['tracked_link'], prefix: 'link', subject: 'trackedLinkId' },
+  'builtin-form-submitted': { eventType: 'form_submitted', sources: ['form'], prefix: 'form', subject: 'formId' },
+  'builtin-booking-created': { eventType: 'booking_created', sources: ['booking', 'event_booking'], prefix: 'booking' },
+  'builtin-webinar-watch-5m': { eventType: 'webinar_watch_5m', sources: ['webinar'], prefix: 'webinar:5m', subject: 'webinarId' },
+  'builtin-webinar-watch-15m': { eventType: 'webinar_watch_15m', sources: ['webinar'], prefix: 'webinar:15m', subject: 'webinarId' },
+  'builtin-webinar-completed': { eventType: 'webinar_completed', sources: ['webinar'], prefix: 'webinar:complete', subject: 'webinarId' },
+  'builtin-webinar-cta-clicked': { eventType: 'webinar_cta_clicked', sources: ['webinar'], prefix: 'webinar:cta', subject: 'webinarId' },
+  'builtin-instagram-line-returned': { eventType: 'instagram_line_returned', sources: ['instagram'], prefix: 'instagram:return', subject: 'igsid' },
+}));
+
+/** Match only actor grants emitted by the runtime that also existed in 062/063. */
+function legacyMileageCounterpart(
+  input: PostMileageEntryInput,
+  programId: string,
+  occurredAt: string,
+): { sql: string; values: (string | null)[] } | null {
+  const rule = input.mileageRuleId ? HISTORICAL_MILEAGE_RULES.get(input.mileageRuleId) : undefined;
+  if (programId !== DEFAULT_MILEAGE_PROGRAM_ID || !rule || input.entryType !== 'grant'
+      || input.amount <= 0 || input.reversesEntryId || !input.engagementEventId
+      || !rule.sources.includes(input.source) || input.metadata?.beneficiaryType !== 'actor'
+      || input.metadata.ruleId !== input.mileageRuleId || input.metadata.eventType !== rule.eventType) {
+    return null;
+  }
+
+  // Use the actual runtime key, not the original seeded conditions: operators can
+  // change uniqueness or route a rule to a referrer. Other/manual keys are untouched.
+  const identity = input.beneficiaryUserId
+    ? `user:${input.beneficiaryUserId}` : `friend:${input.beneficiaryFriendId}`;
+  const subject = typeof input.metadata.subjectKey === 'string' && input.metadata.subjectKey
+    ? input.metadata.subjectKey : null;
+  const prefix = `rule:${input.mileageRuleId}`;
+  const subjectPrefix = `${prefix}:identity:${identity}`;
+  const uniqueSubject = subject !== null && input.idempotencyKey === `${subjectPrefix}:subject:${subject}`;
+  const uniqueDay = subject !== null
+    && input.idempotencyKey === `${subjectPrefix}:day:${occurredAt.slice(0, 10)}:subject:${subject}`;
+  if (!uniqueSubject && !uniqueDay && input.idempotencyKey !== `${prefix}:event:${input.engagementEventId}`) {
+    return null;
+  }
+
+  // The immutable legacy ledger sometimes carries the subject only on its event.
+  const metadataValue = (key: string) => `COALESCE(
+    json_extract(CASE WHEN json_valid(legacy.metadata) THEN legacy.metadata END, '$.${key}'),
+    json_extract(CASE WHEN json_valid(event.metadata) THEN event.metadata END, '$.${key}'))`;
+  let historicalSubject = rule.subject ? metadataValue(rule.subject) : 'NULL';
+  if (rule.eventType === 'webinar_cta_clicked') {
+    historicalSubject = `(${historicalSubject} || ':' || COALESCE(${metadataValue('ctaId')}, 'primary'))`;
+  } else if (rule.eventType === 'instagram_line_returned') {
+    historicalSubject = `COALESCE(${historicalSubject}, CASE WHEN event.identity_provider = 'instagram' THEN event.identity_subject END)`;
+  }
+  historicalSubject = `COALESCE(${metadataValue('subjectKey')}, ${historicalSubject})`;
+  const historicalPrefix = input.source === 'event_booking' ? 'event-booking' : rule.prefix;
+  const values: (string | null)[] = [
+    input.beneficiaryFriendId ?? null, input.beneficiaryFriendId ?? null, input.beneficiaryUserId ?? null,
+    programId, input.mileageRuleId!, input.source, `history-mile:${historicalPrefix}:%`,
+    input.sourceEventId ?? null,
+  ];
+  let actionMatch = 'legacy.source_event_id = ?';
+  if (uniqueSubject || uniqueDay) {
+    actionMatch += ` OR (${historicalSubject} = ?${uniqueDay ? ' AND substr(legacy.occurred_at, 1, 10) = ?' : ''})`;
+    values.push(subject);
+    if (uniqueDay) values.push(occurredAt.slice(0, 10));
+  }
+  return {
+    sql: `FROM mileage_ledger legacy
+      LEFT JOIN engagement_events event ON event.id = legacy.engagement_event_id AND event.program_id = legacy.program_id
+      LEFT JOIN friends legacy_friend ON legacy_friend.id = legacy.beneficiary_friend_id
+      CROSS JOIN (SELECT ? AS friend_id, COALESCE((SELECT user_id FROM friends WHERE id = ?), ?) AS user_id) beneficiary
+      WHERE legacy.program_id = ? AND legacy.mileage_rule_id = ? AND legacy.source = ?
+        AND legacy.entry_type = 'grant' AND legacy.idempotency_key LIKE ?
+        AND (legacy.beneficiary_friend_id = beneficiary.friend_id
+             OR (beneficiary.user_id IS NOT NULL
+                 AND (legacy.beneficiary_user_id = beneficiary.user_id OR legacy_friend.user_id = beneficiary.user_id)))
+        AND (${actionMatch})`,
+    values,
+  };
+}
+
+interface MileageDailyCap {
+  sql: string;
+  values: (string | number | null)[];
+  limit: number;
+}
+
+class MileageDailyCapReached extends Error {}
+
 /** Add one immutable ledger entry exactly once. Existing entries are returned. */
 export async function postMileageEntry(
   db: D1Database,
   input: PostMileageEntryInput,
+  dailyCap?: MileageDailyCap,
 ): Promise<MileageLedgerEntry> {
   if (!Number.isInteger(input.amount) || input.amount === 0) {
     throw new Error('Mileage amount must be a non-zero integer');
@@ -228,6 +316,12 @@ export async function postMileageEntry(
   const now = jstNow();
   const programId = input.programId ?? DEFAULT_MILEAGE_PROGRAM_ID;
   await ensureBuiltInProgram(db, programId);
+  const occurredAt = input.occurredAt ?? now;
+  const legacy = legacyMileageCounterpart(input, programId, occurredAt);
+  const insertPredicates = [
+    ...(legacy ? [`NOT EXISTS (SELECT 1 ${legacy.sql})`] : []),
+    ...(dailyCap ? [`(${dailyCap.sql}) < ?`] : []),
+  ];
   await db
     .prepare(
       `INSERT OR IGNORE INTO mileage_ledger
@@ -235,7 +329,8 @@ export async function postMileageEntry(
           engagement_event_id, mileage_rule_id, entry_type, status, amount, reason, source,
           source_event_id, idempotency_key, reverses_entry_id, metadata,
           occurred_at, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+       ${insertPredicates.length ? `WHERE ${insertPredicates.join(' AND ')}` : ''}`,
     )
     .bind(
       id,
@@ -253,18 +348,28 @@ export async function postMileageEntry(
       input.idempotencyKey,
       input.reversesEntryId ?? null,
       input.metadata ? JSON.stringify(input.metadata) : null,
-      input.occurredAt ?? now,
+      occurredAt,
       now,
+      ...(legacy?.values ?? []),
+      ...(dailyCap ? [...dailyCap.values, dailyCap.limit] : []),
     )
     .run();
 
-  const entry = await db
+  let entry = await db
     .prepare(
       `SELECT * FROM mileage_ledger
         WHERE program_id = ? AND idempotency_key = ?`,
     )
     .bind(programId, input.idempotencyKey)
     .first<MileageLedgerEntry>();
+  if (!entry && legacy) {
+    entry = await db.prepare(`SELECT legacy.* ${legacy.sql} ORDER BY legacy.created_at, legacy.id LIMIT 1`)
+      .bind(...legacy.values).first<MileageLedgerEntry>();
+  }
+  if (!entry && dailyCap) {
+    const count = await db.prepare(dailyCap.sql).bind(...dailyCap.values).first<{ action_count: number }>();
+    if (count && count.action_count >= dailyCap.limit) throw new MileageDailyCapReached('Mileage daily cap reached');
+  }
   if (!entry) throw new Error('Failed to post mileage entry');
   return entry;
 }
@@ -771,6 +876,8 @@ export interface MileageRuleRow {
   is_active: number;
   created_at: string;
   updated_at: string;
+  valid_from: string | null;
+  valid_until: string | null;
 }
 
 export interface MileageRuleConditions {
@@ -1005,6 +1112,7 @@ async function resolveMileageMultiplier(
 async function applyMileageRulesImmediately(
   db: D1Database,
   input: ApplyMileageRulesInput,
+  historicalClaim?: LegacyMileageClaim | null,
 ): Promise<{ event: EngagementEvent; granted: MileageLedgerEntry[] }> {
   const friend = await db
     .prepare(`SELECT id, user_id FROM friends WHERE id = ?`)
@@ -1013,6 +1121,7 @@ async function applyMileageRulesImmediately(
   if (!friend) throw new Error(`Mileage friend not found: ${input.friendId}`);
 
   const occurredAt = input.occurredAt ?? jstNow();
+  if (historicalClaim) await verifyLegacyMileageClaim(db, historicalClaim, input, occurredAt);
   const metadata = {
     ...(input.metadata ?? {}),
     ...(input.subjectKey ? { subjectKey: input.subjectKey } : {}),
@@ -1037,9 +1146,10 @@ async function applyMileageRulesImmediately(
           AND is_active = 1
           AND (valid_from IS NULL OR valid_from <= ?)
           AND (valid_until IS NULL OR valid_until >= ?)
+          AND (? IS NULL OR id = ?)
         ORDER BY created_at ASC, id ASC`,
     )
-    .bind(input.eventType, input.source, occurredAt, occurredAt)
+    .bind(input.eventType, input.source, occurredAt, occurredAt, historicalClaim?.mileage_rule_id ?? null, historicalClaim?.mileage_rule_id ?? null)
     .all<MileageRuleRow>();
 
   const identityKey = friend.user_id ? `user:${friend.user_id}` : `friend:${friend.id}`;
@@ -1132,10 +1242,19 @@ async function applyMileageRulesImmediately(
       ? await resolveMileageMultiplier(db, beneficiaryFriendId, occurredAt)
       : actorMultiplier;
 
+    if (historicalClaim && !conditions.ignoreMultiplier && multiplier.bps !== 10000) {
+      throw new Error('Historical mileage multiplier changed since migration; review the held claim before retrying');
+    }
+
+    let atomicDailyCap: MileageDailyCap | undefined;
     if (conditions.dailyCapActions && conditions.dailyCapActions > 0) {
-      const capRow = await db
-        .prepare(
-          `SELECT COUNT(*) AS action_count
+      const historicalRule = HISTORICAL_MILEAGE_RULES.get(rule.id);
+      const includeLinkedHistory = rule.program_id === DEFAULT_MILEAGE_PROGRAM_ID
+        && conditions.beneficiary !== 'referrer'
+        && historicalRule?.eventType === input.eventType
+        && historicalRule.sources.includes(input.source);
+      const cap: MileageDailyCap = {
+        sql: `SELECT COUNT(*) AS action_count
              FROM mileage_ledger ml
             WHERE ml.program_id = ?
               AND ml.mileage_rule_id = ?
@@ -1143,9 +1262,12 @@ async function applyMileageRulesImmediately(
               AND ml.status != 'void'
               AND substr(ml.occurred_at, 1, 10) = substr(?, 1, 10)
               AND ((? IS NOT NULL AND ml.beneficiary_user_id = ?)
-                   OR (? IS NULL AND ml.beneficiary_friend_id = ?))`,
-        )
-        .bind(
+                   OR (? IS NULL AND ml.beneficiary_friend_id = ?)
+                   OR (? = 1 AND ml.idempotency_key LIKE 'history-mile:%' AND EXISTS (
+                     SELECT 1 FROM friends historical_friend
+                      WHERE historical_friend.id = ml.beneficiary_friend_id AND historical_friend.user_id = ?
+                   )))`,
+        values: [
           rule.program_id,
           rule.id,
           occurredAt,
@@ -1153,8 +1275,16 @@ async function applyMileageRulesImmediately(
           beneficiaryUserId,
           beneficiaryUserId,
           beneficiaryFriendId,
-        )
-        .first<{ action_count: number }>();
+          includeLinkedHistory ? 1 : 0,
+          beneficiaryUserId,
+        ],
+        // Preserve the numeric comparison used by the precheck; binding a
+        // legacy JSON string as TEXT would use SQLite's storage-class order.
+        limit: Number(conditions.dailyCapActions),
+      };
+      const capRow = await db.prepare(cap.sql).bind(...cap.values).first<{ action_count: number }>();
+      if (rule.program_id === DEFAULT_MILEAGE_PROGRAM_ID && rule.id.startsWith('builtin-')
+          && conditions.beneficiary !== 'referrer') atomicDailyCap = cap;
       if ((capRow?.action_count ?? 0) >= conditions.dailyCapActions) continue;
     }
 
@@ -1167,40 +1297,44 @@ async function applyMileageRulesImmediately(
           : conditions.uniquePerSubjectPerDay && input.subjectKey
             ? `rule:${rule.id}:identity:${beneficiaryIdentityKey}:day:${occurredAt.slice(0, 10)}:subject:${input.subjectKey}`
             : `rule:${rule.id}:event:${event.id}`;
-    const entry = await postMileageEntry(db, {
-      programId: rule.program_id,
-      beneficiaryUserId,
-      beneficiaryFriendId,
-      engagementEventId: event.id,
-      mileageRuleId: rule.id,
-      entryType: 'grant',
-      status: rule.initial_status,
-      amount: conditions.ignoreMultiplier
-        ? rule.amount
-        : Math.max(1, Math.round((rule.amount * multiplier.bps) / 10000)),
-      reason: rule.name,
-      source: input.source,
-      sourceEventId: input.sourceEventId,
-      idempotencyKey,
-      metadata: {
-        ...metadata,
-        ruleId: rule.id,
-        eventType: input.eventType,
-        baseAmount: rule.amount,
-        multiplierBps: multiplier.bps,
-        multiplierTagId: multiplier.tagId,
-        multiplierTagName: multiplier.tagName,
-        beneficiaryType: conditions.beneficiary ?? 'actor',
-        ...(referrer ? {
-          affiliateId: referrer.affiliateId,
-          refCode: referrer.refCode,
-          referredFriendId: friend.id,
-          referredUserId: friend.user_id,
-        } : {}),
-      },
-      occurredAt,
-    });
-    granted.push(entry);
+    try {
+      const entry = await postMileageEntry(db, {
+        programId: rule.program_id,
+        beneficiaryUserId,
+        beneficiaryFriendId,
+        engagementEventId: event.id,
+        mileageRuleId: rule.id,
+        entryType: 'grant',
+        status: rule.initial_status,
+        amount: conditions.ignoreMultiplier
+          ? rule.amount
+          : Math.max(1, Math.round((rule.amount * multiplier.bps) / 10000)),
+        reason: rule.name,
+        source: input.source,
+        sourceEventId: input.sourceEventId,
+        idempotencyKey,
+        metadata: {
+          ...metadata,
+          ruleId: rule.id,
+          eventType: input.eventType,
+          baseAmount: rule.amount,
+          multiplierBps: multiplier.bps,
+          multiplierTagId: multiplier.tagId,
+          multiplierTagName: multiplier.tagName,
+          beneficiaryType: conditions.beneficiary ?? 'actor',
+          ...(referrer ? {
+            affiliateId: referrer.affiliateId,
+            refCode: referrer.refCode,
+            referredFriendId: friend.id,
+            referredUserId: friend.user_id,
+          } : {}),
+        },
+        occurredAt,
+      }, atomicDailyCap);
+      granted.push(entry);
+    } catch (error) {
+      if (!(error instanceof MileageDailyCapReached)) throw error;
+    }
   }
   return { event, granted };
 }
@@ -1224,6 +1358,49 @@ export interface MileageQueueResult {
   granted: number;
 }
 
+// Adapter-owned claims stay invisible to older workers, even after a failed
+// projection. Only this processor recognizes the held rows as eligible work.
+const LEGACY_MILEAGE_HOLD = '9999-12-31T23:59:59';
+interface LegacyMileageClaim {
+  migration_name: string;
+  mileage_rule_id: string;
+  rule_snapshot: string;
+}
+
+async function verifyLegacyMileageClaim(
+  db: D1Database,
+  claim: LegacyMileageClaim,
+  input: ApplyMileageRulesInput,
+  occurredAt: string,
+): Promise<void> {
+  const migrationRules: Record<string, string[]> = {
+    '062_mileage_admin_and_activity_rules.sql': [
+      'builtin-message-received', 'builtin-link-clicked', 'builtin-form-submitted', 'builtin-booking-created',
+    ],
+    '063_webinar_instagram_mileage.sql': [
+      'builtin-webinar-watch-5m', 'builtin-webinar-watch-15m', 'builtin-webinar-completed',
+      'builtin-webinar-cta-clicked', 'builtin-instagram-line-returned',
+    ],
+  };
+  if (!migrationRules[claim.migration_name]?.includes(claim.mileage_rule_id)) {
+    throw new Error('Historical mileage claim has an unsupported migration or rule');
+  }
+  const rule = await getMileageRuleById(db, claim.mileage_rule_id);
+  let snapshot: Record<string, unknown> | null = null;
+  try { snapshot = JSON.parse(claim.rule_snapshot) as Record<string, unknown>; } catch { /* Reject below. */ }
+  const keys = ['amount', 'initial_status', 'conditions', 'source', 'event_type', 'is_active', 'valid_from', 'valid_until'] as const;
+  if (!rule || rule.program_id !== DEFAULT_MILEAGE_PROGRAM_ID || !snapshot || typeof snapshot !== 'object'
+      || keys.some((key) => !Object.prototype.hasOwnProperty.call(snapshot, key) || snapshot[key] !== rule[key])) {
+    throw new Error('Historical mileage policy changed since migration; review the held claim before retrying');
+  }
+  if (rule.is_active !== 1 || rule.event_type !== input.eventType
+      || (rule.source !== null && rule.source !== input.source)
+      || (rule.valid_from !== null && rule.valid_from > occurredAt)
+      || (rule.valid_until !== null && rule.valid_until < occurredAt)) {
+    throw new Error('Historical mileage claim does not match an eligible rule');
+  }
+}
+
 /** Drain a bounded batch. Safe for retries and overlapping cron invocations. */
 export async function processPendingMileageEvents(
   db: D1Database,
@@ -1231,6 +1408,9 @@ export async function processPendingMileageEvents(
 ): Promise<MileageQueueResult> {
   const limit = Math.min(250, Math.max(1, options.limit ?? 100));
   const now = options.now ?? jstNow();
+  const hasLegacyClaims = !!await db.prepare(
+    `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+  ).bind('_line_harness_legacy_mileage_claims').first<{ name: string }>();
   await db
     .prepare(
       `UPDATE mileage_event_queue
@@ -1247,7 +1427,10 @@ export async function processPendingMileageEvents(
          FROM mileage_event_queue q
         WHERE q.status IN ('pending','failed')
           AND q.attempts < 5
-          AND datetime(q.available_at) <= datetime(?)
+          AND (datetime(q.available_at) <= datetime(?)
+               ${hasLegacyClaims ? `OR (q.available_at = '${LEGACY_MILEAGE_HOLD}' AND EXISTS (
+                 SELECT 1 FROM _line_harness_legacy_mileage_claims claim WHERE claim.engagement_event_id = q.engagement_event_id
+               ))` : ''})
         ORDER BY q.created_at ASC, q.engagement_event_id ASC
         LIMIT ?`,
     )
@@ -1280,6 +1463,11 @@ export async function processPendingMileageEvents(
       if (event.metadata) {
         try { metadata = JSON.parse(event.metadata) as Record<string, unknown>; } catch { metadata = {}; }
       }
+      const historicalClaim = hasLegacyClaims
+        ? await db.prepare(`SELECT migration_name, mileage_rule_id, rule_snapshot
+              FROM _line_harness_legacy_mileage_claims WHERE engagement_event_id = ?`)
+          .bind(event.id).first<LegacyMileageClaim>()
+        : null;
       const projection = await applyMileageRulesImmediately(db, {
         eventType: event.event_type,
         source: event.source,
@@ -1288,7 +1476,7 @@ export async function processPendingMileageEvents(
         subjectKey: typeof metadata.subjectKey === 'string' ? metadata.subjectKey : null,
         metadata,
         occurredAt: event.occurred_at,
-      });
+      }, historicalClaim);
       result.granted += projection.granted.length;
       result.processed += 1;
       await db
@@ -1307,7 +1495,8 @@ export async function processPendingMileageEvents(
         .prepare(
           `UPDATE mileage_event_queue
               SET status = 'failed', processing_started_at = NULL,
-                  available_at = datetime(?, '+' || MIN(attempts * 5, 60) || ' minutes'),
+                  available_at = CASE WHEN available_at = '${LEGACY_MILEAGE_HOLD}' THEN available_at
+                    ELSE datetime(?, '+' || MIN(attempts * 5, 60) || ' minutes') END,
                   updated_at = ?, last_error = ?
             WHERE engagement_event_id = ?`,
         )

--- a/packages/db/src/mileage.ts
+++ b/packages/db/src/mileage.ts
@@ -1,3 +1,6 @@
+// Keep this first declaration readable by the source installer without running code.
+export const LEGACY_MILEAGE_PROJECTION_VERSION = 1;
+
 import { jstNow } from './utils.js';
 
 export const DEFAULT_MILEAGE_PROGRAM_ID = 'default';

--- a/packages/db/test/legacy-mileage-compat.test.ts
+++ b/packages/db/test/legacy-mileage-compat.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from 'better-sqlite3';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  applyMileageRulesForEvent, postMileageEntry, processPendingMileageEvents, updateMileageRule,
+  type ApplyMileageRulesInput, type PostMileageEntryInput,
+} from '../src/mileage.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const NOW = '2026-09-10T12:00:00.000+09:00';
+const BEFORE = '2026-09-09T10:00:00.000+09:00';
+const HELD = '9999-12-31T23:59:59';
+const CASES = [
+  ['builtin-message-received', 'message_received', 'line', 'message', null],
+  ['builtin-link-clicked', 'link_clicked', 'tracked_link', 'link', 'trackedLinkId'],
+  ['builtin-form-submitted', 'form_submitted', 'form', 'form', 'formId'],
+  ['builtin-booking-created', 'booking_created', 'booking', 'booking', null],
+  ['builtin-booking-created', 'booking_created', 'event_booking', 'event-booking', null],
+  ['builtin-webinar-watch-5m', 'webinar_watch_5m', 'webinar', 'webinar:5m', 'webinarId'],
+  ['builtin-webinar-watch-15m', 'webinar_watch_15m', 'webinar', 'webinar:15m', 'webinarId'],
+  ['builtin-webinar-completed', 'webinar_completed', 'webinar', 'webinar:complete', 'webinarId'],
+  ['builtin-webinar-cta-clicked', 'webinar_cta_clicked', 'webinar', 'webinar:cta', 'webinarId'],
+  ['builtin-instagram-line-returned', 'instagram_line_returned', 'instagram', 'instagram:return', 'igsid'],
+] as const;
+type LegacyCase = typeof CASES[number];
+
+function asD1(sqlite: Database.Database, afterRead?: (sql: string, result: unknown) => Promise<void>): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          const statement = sqlite.prepare(sql);
+          return {
+            async run() { const result = statement.run(...params); return { success: true, results: [], meta: { changes: result.changes } }; },
+            async first<T>() {
+              const row = (statement.get(...params) as T) ?? null;
+              await afterRead?.(sql, row);
+              return row;
+            },
+            async all<T>() { return { success: true, results: statement.all(...params) as T[], meta: {} }; },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+function execSafe(sqlite: Database.Database, sql: string) {
+  for (const statement of sql.split(/;\s*(?:\r?\n|$)/).map((item) => item.trim()).filter(Boolean)) {
+    try { sqlite.exec(statement); } catch (error) {
+      if (!/duplicate column name|already exists/i.test(String(error))) throw error;
+    }
+  }
+}
+
+describe('immutable historical mileage compatibility', () => {
+  let sqlite: Database.Database;
+  let db: D1Database;
+  let sequence: number;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(NOW));
+    sqlite = new Database(':memory:');
+    execSafe(sqlite, readFileSync(join(ROOT, 'schema.sql'), 'utf8'));
+    for (const file of readdirSync(join(ROOT, 'migrations')).filter((name) => name.endsWith('.sql')).sort()) {
+      execSafe(sqlite, readFileSync(join(ROOT, 'migrations', file), 'utf8'));
+    }
+    sqlite.exec(`INSERT INTO users(id, display_name) VALUES ('user-1', 'One'), ('user-2', 'Two');
+      INSERT INTO line_accounts(id, channel_id, name, channel_access_token, channel_secret)
+        VALUES ('account-1', 'channel-1', 'One', 'private-token', 'private-secret'),
+               ('account-2', 'channel-2', 'Two', 'private-token', 'private-secret');
+      INSERT INTO friends(id, line_user_id, user_id, line_account_id)
+        VALUES ('friend-1', 'U1', 'user-1', 'account-1'), ('friend-2', 'U2', 'user-1', 'account-2'),
+               ('friend-3', 'U3', 'user-2', 'account-1');`);
+    db = asD1(sqlite);
+    sequence = 0;
+  });
+
+  afterEach(() => { sqlite.close(); vi.useRealTimers(); vi.restoreAllMocks(); });
+
+  function legacy(spec: LegacyCase, options: { status?: 'available' | 'pending' | 'void'; userId?: string | null; amount?: number } = {}) {
+    const [ruleId, eventType, source, prefix, subjectField] = spec;
+    const id = `history-${++sequence}`;
+    const sourceId = `action-${sequence}`;
+    const subjectKey = eventType === 'webinar_cta_clicked' ? 'subject-1:primary' : 'subject-1';
+    const metadata = subjectField ? { [subjectField]: 'subject-1', ...(eventType === 'webinar_cta_clicked' ? { ctaId: 'primary' } : {}), backfilled: true } : { backfilled: true };
+    sqlite.prepare(`INSERT INTO engagement_events(id, program_id, idempotency_key, event_type, source, source_event_id,
+      actor_user_id, actor_friend_id, metadata, occurred_at, created_at)
+      VALUES (?, 'default', ?, ?, ?, ?, ?, 'friend-1', ?, ?, ?)`)
+      .run(id, `history:${prefix}:${id}`, eventType, source, sourceId, options.userId === undefined ? 'user-1' : options.userId, JSON.stringify(metadata), BEFORE, BEFORE);
+    // 063 stores the subject only on the linked engagement event; 062 also stores it in the ledger.
+    sqlite.prepare(`INSERT INTO mileage_ledger(id, program_id, beneficiary_user_id, beneficiary_friend_id,
+      engagement_event_id, mileage_rule_id, entry_type, status, amount, reason, source,
+      source_event_id, idempotency_key, metadata, occurred_at, created_at)
+      VALUES (?, 'default', ?, 'friend-1', ?, ?, 'grant', ?, ?, 'Historical', ?, ?, ?, ?, ?, ?)`)
+      .run(`mile-${id}`, options.userId === undefined ? 'user-1' : options.userId, id, ruleId,
+        options.status ?? 'available', options.amount ?? 7, source, sourceId, `history-mile:${prefix}:${id}`,
+        JSON.stringify(source === 'webinar' || source === 'instagram' ? { backfilled: true } : metadata), BEFORE, BEFORE);
+    return { id: `mile-${id}`, ruleId, eventType, source, sourceId, subjectKey };
+  }
+
+  async function project(input: Partial<ApplyMileageRulesInput> & Pick<ApplyMileageRulesInput, 'eventType' | 'source' | 'sourceEventId'>) {
+    await applyMileageRulesForEvent(db, { friendId: 'friend-1', occurredAt: BEFORE, ...input });
+    const result = await processPendingMileageEvents(db, { now: NOW });
+    expect(result.failed).toBe(0);
+    return result;
+  }
+
+  function ledger() { return sqlite.prepare('SELECT * FROM mileage_ledger ORDER BY id').all(); }
+
+  it.each(CASES)('retries the same action without duplicating %s (%s, %s)', async (...spec) => {
+    const old = legacy(spec as unknown as LegacyCase);
+    const original = ledger();
+    await project({ eventType: old.eventType, source: old.source, sourceEventId: old.sourceId, subjectKey: old.subjectKey });
+    expect(ledger()).toEqual(original);
+    expect(sqlite.prepare(`SELECT status FROM mileage_event_queue`).all()).toEqual([{ status: 'processed' }]);
+  });
+
+  it.each(CASES.filter((spec) => spec[4]))('deduplicates distinct actions on the configured subject for %s', async (...spec) => {
+    const old = legacy(spec as unknown as LegacyCase);
+    const original = ledger();
+    await project({ eventType: old.eventType, source: old.source, sourceEventId: 'repeat-action', subjectKey: old.subjectKey, friendId: 'friend-2' });
+    expect(ledger()).toEqual(original);
+    await project({ eventType: old.eventType, source: old.source, sourceEventId: 'new-action', subjectKey: 'new-subject' });
+    expect(ledger()).toHaveLength(2);
+  });
+
+  it('allows another link day and another webinar CTA subject', async () => {
+    const link = legacy(CASES[1]);
+    const cta = legacy(CASES[8]);
+    await project({ eventType: link.eventType, source: link.source, sourceEventId: 'tomorrow-link', subjectKey: link.subjectKey, occurredAt: NOW });
+    await project({ eventType: cta.eventType, source: cta.source, sourceEventId: 'secondary-cta', subjectKey: 'subject-1:secondary' });
+    expect(ledger()).toHaveLength(4);
+  });
+
+  it('recognizes a friend-only historical grant after identities are linked', async () => {
+    const old = legacy(CASES[2], { userId: null });
+    const original = ledger();
+    await project({ eventType: old.eventType, source: old.source, sourceEventId: 'linked-repeat', subjectKey: old.subjectKey, friendId: 'friend-2' });
+    expect(ledger()).toEqual(original);
+    await project({ eventType: old.eventType, source: old.source, sourceEventId: 'unrelated-person', subjectKey: old.subjectKey, friendId: 'friend-3' });
+    expect(ledger()).toHaveLength(2);
+  });
+
+  it('counts linked historical actor grants toward the daily cap and excludes void grants', async () => {
+    for (let index = 0; index < 4; index += 1) legacy(CASES[0], { userId: null, amount: 1 });
+    legacy(CASES[0], { userId: null, amount: 1, status: 'void' });
+    await project({ eventType: 'message_received', source: 'line', sourceEventId: 'last-allowed', friendId: 'friend-2' });
+    await project({ eventType: 'message_received', source: 'line', sourceEventId: 'over-cap', friendId: 'friend-2' });
+    expect(ledger()).toHaveLength(6);
+    expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM mileage_ledger WHERE source_event_id = 'over-cap'`).get()).toEqual({ count: 0 });
+  });
+
+  it.each([false, true])('atomically enforces the cap when two processors both see four grants (held: %s)', async (held) => {
+    for (let index = 0; index < 4; index += 1) legacy(CASES[0], { userId: null, amount: 1 });
+    legacy(CASES[0], { userId: null, amount: 1, status: 'void' });
+    const original = ledger();
+    for (const sourceEventId of ['race-first', 'race-second']) {
+      await applyMileageRulesForEvent(db, {
+        eventType: 'message_received', source: 'line', sourceEventId,
+        friendId: 'friend-2', occurredAt: BEFORE,
+      });
+    }
+    if (held) {
+      sqlite.exec(`CREATE TABLE _line_harness_legacy_mileage_claims (
+        engagement_event_id TEXT PRIMARY KEY REFERENCES engagement_events(id), migration_name TEXT NOT NULL,
+        mileage_rule_id TEXT NOT NULL, rule_snapshot TEXT NOT NULL);
+        INSERT INTO _line_harness_legacy_mileage_claims
+        SELECT q.engagement_event_id, '062_mileage_admin_and_activity_rules.sql', r.id,
+          json_object('amount', r.amount, 'initial_status', r.initial_status, 'conditions', r.conditions,
+            'source', r.source, 'event_type', r.event_type, 'is_active', r.is_active,
+            'valid_from', r.valid_from, 'valid_until', r.valid_until)
+        FROM mileage_event_queue q CROSS JOIN mileage_rules r WHERE r.id = 'builtin-message-received';`);
+      sqlite.prepare('UPDATE mileage_event_queue SET available_at = ?').run(HELD);
+    }
+    let firstRead!: () => void;
+    let release!: () => void;
+    const firstReached = new Promise<void>((resolve) => { firstRead = resolve; });
+    const bothRead = new Promise<void>((resolve) => { release = resolve; });
+    const observedCounts: number[] = [];
+    const concurrentDb = asD1(sqlite, async (sql, row) => {
+      if (!/^\s*SELECT COUNT\(\*\) AS action_count/.test(sql) || observedCounts.length >= 2) return;
+      observedCounts.push((row as { action_count: number }).action_count);
+      if (observedCounts.length === 1) firstRead();
+      else release();
+      await bothRead;
+    });
+    // Start processor two only after processor one owns its queue row. Both
+    // database reads then complete before either ledger INSERT can execute.
+    const first = processPendingMileageEvents(concurrentDb, { now: NOW, limit: 1 });
+    await firstReached;
+    const second = processPendingMileageEvents(concurrentDb, { now: NOW, limit: 1 });
+    const results = await Promise.all([first, second]);
+    expect(observedCounts).toEqual([4, 4]);
+    expect(results.map((result) => result.failed)).toEqual([0, 0]);
+    expect(results.map((result) => result.processed)).toEqual([1, 1]);
+    expect(results.reduce((sum, result) => sum + result.granted, 0)).toBe(1);
+    expect(ledger()).toHaveLength(6);
+    expect(ledger()).toEqual(expect.arrayContaining(original));
+    expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM mileage_ledger WHERE status != 'void'`).get()).toEqual({ count: 5 });
+    if (held) expect(sqlite.prepare('SELECT DISTINCT available_at FROM mileage_event_queue').all()).toEqual([{ available_at: HELD }]);
+  });
+
+  it('reports a real SQL failure instead of treating it as a reached cap', async () => {
+    for (let index = 0; index < 4; index += 1) legacy(CASES[0], { amount: 1 });
+    sqlite.exec(`CREATE TRIGGER fail_mileage_insert BEFORE INSERT ON mileage_ledger
+      WHEN NEW.source_event_id = 'failing-message'
+      BEGIN SELECT RAISE(ABORT, 'Simulated mileage insert failure'); END;`);
+    await applyMileageRulesForEvent(db, {
+      eventType: 'message_received', source: 'line', sourceEventId: 'failing-message',
+      friendId: 'friend-1', occurredAt: BEFORE,
+    });
+    expect(await processPendingMileageEvents(db, { now: NOW })).toMatchObject({ processed: 0, failed: 1, granted: 0 });
+    expect(ledger()).toHaveLength(4);
+    expect(sqlite.prepare('SELECT last_error FROM mileage_event_queue').get())
+      .toEqual({ last_error: 'Simulated mileage insert failure' });
+  });
+
+  it('honors changed uniqueness while never granting the identical action again', async () => {
+    const old = legacy(CASES[2]);
+    await updateMileageRule(db, old.ruleId, { amount: 90, conditions: null });
+    await project({ eventType: old.eventType, source: old.source, sourceEventId: old.sourceId, subjectKey: old.subjectKey });
+    expect(ledger()).toHaveLength(1);
+    await project({ eventType: old.eventType, source: old.source, sourceEventId: 'new-submission', subjectKey: old.subjectKey });
+    expect(ledger()).toHaveLength(2);
+    expect(sqlite.prepare(`SELECT amount FROM mileage_ledger WHERE source_event_id = 'new-submission'`).get()).toEqual({ amount: 90 });
+  });
+
+  async function currentGrant(old: ReturnType<typeof legacy>): Promise<PostMileageEntryInput> {
+    const { event } = await applyMileageRulesForEvent(db, {
+      eventType: old.eventType, source: old.source, sourceEventId: old.sourceId, friendId: 'friend-1', occurredAt: BEFORE,
+    });
+    return {
+      beneficiaryUserId: 'user-1', beneficiaryFriendId: 'friend-1', engagementEventId: event.id,
+      mileageRuleId: old.ruleId, entryType: 'grant', amount: 999, reason: 'Current',
+      source: old.source, sourceEventId: old.sourceId, idempotencyKey: `rule:${old.ruleId}:event:${event.id}`,
+      metadata: { ruleId: old.ruleId, eventType: old.eventType, beneficiaryType: 'actor' }, occurredAt: BEFORE,
+    };
+  }
+
+  it.each(['available', 'pending', 'void'] as const)('returns the unchanged legacy %s entry, like canonical idempotency', async (status) => {
+    const old = legacy(CASES[2], { status, amount: 13 });
+    const original = ledger()[0];
+    const input = await currentGrant(old);
+    expect(await postMileageEntry(db, input)).toEqual(original);
+    expect(await postMileageEntry(db, input)).toEqual(original);
+    expect(ledger()).toEqual([original]);
+  });
+
+  it('returns existing legacy and canonical entries even when the final cap has been exhausted', async () => {
+    const old = legacy(CASES[0], { amount: 1 });
+    const input = await currentGrant(old);
+    const cap = { sql: `SELECT COUNT(*) AS action_count FROM mileage_ledger WHERE status != 'void'`, values: [], limit: 1 };
+    expect((await postMileageEntry(db, input, cap)).id).toBe(old.id);
+    const canonicalInput = { ...input, sourceEventId: 'canonical-action', idempotencyKey: 'canonical-grant' };
+    const canonical = await postMileageEntry(db, canonicalInput);
+    expect(await postMileageEntry(db, canonicalInput, cap)).toEqual(canonical);
+    expect(ledger()).toHaveLength(2);
+  });
+
+  it('scopes equal source IDs by program, rule, source and beneficiary; manual and referrer grants remain independent', async () => {
+    const old = legacy(CASES[3]);
+    const input = await currentGrant(old);
+    sqlite.exec(`INSERT INTO mileage_programs(id, code, name, created_at, updated_at) VALUES ('other', 'other', 'Other', '2026-09-09', '2026-09-09');
+      INSERT INTO mileage_rules(id, program_id, name, event_type, amount, created_at, updated_at) VALUES ('custom', 'default', 'Custom', 'booking_created', 77, '2026-09-09', '2026-09-09');`);
+    const variations: Partial<PostMileageEntryInput>[] = [
+      { programId: 'other' },
+      { mileageRuleId: 'custom', idempotencyKey: `rule:custom:event:${input.engagementEventId}` },
+      { source: 'event_booking' },
+      { beneficiaryUserId: 'user-2', beneficiaryFriendId: 'friend-3' },
+      { idempotencyKey: 'manual-grant' },
+      { idempotencyKey: 'referral-grant', metadata: { ...input.metadata, beneficiaryType: 'referrer' } },
+    ];
+    for (const variation of variations) {
+      const result = await postMileageEntry(db, { ...input, ...variation });
+      expect(result.id).not.toBe(old.id);
+      expect(ledger()).toHaveLength(2);
+      sqlite.prepare('DELETE FROM mileage_ledger WHERE id != ?').run(old.id);
+    }
+  });
+
+  it('still projects additional live custom rules for an action that had a historical builtin grant', async () => {
+    const old = legacy(CASES[2]);
+    sqlite.exec(`INSERT INTO mileage_rules(id, program_id, name, event_type, amount, created_at, updated_at)
+      VALUES ('custom', 'default', 'Custom', 'form_submitted', 77, '2026-09-09', '2026-09-09');`);
+    await project({ eventType: old.eventType, source: old.source, sourceEventId: old.sourceId, subjectKey: old.subjectKey });
+    expect(ledger()).toHaveLength(2);
+    expect(sqlite.prepare(`SELECT amount FROM mileage_ledger WHERE mileage_rule_id = 'custom'`).get()).toEqual({ amount: 77 });
+  });
+
+  async function heldClaim(options: { register?: boolean; sourceId?: string } = {}) {
+    sqlite.exec(`CREATE TABLE IF NOT EXISTS _line_harness_legacy_mileage_claims (
+      engagement_event_id TEXT PRIMARY KEY REFERENCES engagement_events(id), migration_name TEXT NOT NULL,
+      mileage_rule_id TEXT NOT NULL, rule_snapshot TEXT NOT NULL);`);
+    const { event } = await applyMileageRulesForEvent(db, {
+      eventType: 'form_submitted', source: 'form', sourceEventId: options.sourceId ?? 'held-form',
+      friendId: 'friend-1', subjectKey: 'held-subject', occurredAt: BEFORE,
+    });
+    sqlite.prepare('UPDATE mileage_event_queue SET available_at = ? WHERE engagement_event_id = ?').run(HELD, event.id);
+    if (options.register !== false) {
+      sqlite.prepare(`INSERT INTO _line_harness_legacy_mileage_claims
+        SELECT ?, '062_mileage_admin_and_activity_rules.sql', id,
+          json_object('amount', amount, 'initial_status', initial_status, 'conditions', conditions,
+            'source', source, 'event_type', event_type, 'is_active', is_active, 'valid_from', valid_from, 'valid_until', valid_until)
+        FROM mileage_rules WHERE id = 'builtin-form-submitted'`).run(event.id);
+    }
+    return event;
+  }
+
+  it('projects only the claimed builtin and leaves unregistered held rows invisible', async () => {
+    const event = await heldClaim();
+    await heldClaim({ register: false, sourceId: 'unregistered' });
+    sqlite.exec(`INSERT INTO mileage_rules(id, program_id, name, event_type, amount, created_at, updated_at)
+      VALUES ('late-rule', 'default', 'Later custom', 'form_submitted', 123, '2026-09-09', '2026-09-09');`);
+    const result = await processPendingMileageEvents(db, { now: NOW });
+    expect(result).toMatchObject({ claimed: 1, processed: 1, granted: 1, failed: 0 });
+    expect(ledger()).toHaveLength(1);
+    expect(sqlite.prepare(`SELECT mileage_rule_id FROM mileage_ledger`).get()).toEqual({ mileage_rule_id: 'builtin-form-submitted' });
+    expect(sqlite.prepare(`SELECT status, available_at FROM mileage_event_queue WHERE engagement_event_id = ?`).get(event.id)).toEqual({ status: 'processed', available_at: HELD });
+  });
+
+  it('fails changed held policy without grants or exposing retry rows to old workers', async () => {
+    const event = await heldClaim();
+    await updateMileageRule(db, 'builtin-form-submitted', { amount: 50 });
+    expect(await processPendingMileageEvents(db, { now: NOW })).toMatchObject({ claimed: 1, failed: 1, processed: 0 });
+    expect(ledger()).toHaveLength(0);
+    expect(sqlite.prepare(`SELECT status, available_at, last_error FROM mileage_event_queue WHERE engagement_event_id = ?`).get(event.id))
+      .toEqual({ status: 'failed', available_at: HELD, last_error: expect.stringContaining('policy changed') });
+    expect(sqlite.prepare(`SELECT COUNT(*) AS count FROM mileage_event_queue WHERE status IN ('pending','failed') AND datetime(available_at) <= datetime(?)`).get(NOW)).toEqual({ count: 0 });
+    await updateMileageRule(db, 'builtin-form-submitted', { amount: 10 });
+    expect(await processPendingMileageEvents(db, { now: NOW })).toMatchObject({ processed: 1, granted: 1, failed: 0 });
+  });
+
+  it('recovers a stale held processing claim without making it eligible for old runtime', async () => {
+    const event = await heldClaim();
+    sqlite.prepare(`UPDATE mileage_event_queue SET status = 'processing', attempts = 1, processing_started_at = ? WHERE engagement_event_id = ?`).run(BEFORE, event.id);
+    expect(await processPendingMileageEvents(db, { now: NOW })).toMatchObject({ processed: 1, granted: 1, failed: 0 });
+    expect(sqlite.prepare(`SELECT available_at FROM mileage_event_queue WHERE engagement_event_id = ?`).get(event.id)).toEqual({ available_at: HELD });
+  });
+
+  it('rejects a retroactive tier multiplier introduced while a claim was held', async () => {
+    await heldClaim();
+    sqlite.exec(`INSERT INTO tags(id, name, mileage_multiplier_bps) VALUES ('new-tier', 'New tier', 15000);
+      INSERT INTO friend_tags(friend_id, tag_id, assigned_at) VALUES ('friend-1', 'new-tier', '2026-09-01');`);
+    expect(await processPendingMileageEvents(db, { now: NOW })).toMatchObject({ failed: 1, granted: 0 });
+    expect(ledger()).toHaveLength(0);
+    expect(sqlite.prepare('SELECT available_at, last_error FROM mileage_event_queue').get())
+      .toEqual({ available_at: HELD, last_error: expect.stringContaining('multiplier changed') });
+  });
+
+  it('fails a claim attached to a different action instead of silently processing it', async () => {
+    const event = await heldClaim();
+    sqlite.prepare(`UPDATE engagement_events SET event_type = 'booking_created' WHERE id = ?`).run(event.id);
+    expect(await processPendingMileageEvents(db, { now: NOW })).toMatchObject({ failed: 1, processed: 0, granted: 0 });
+    expect(ledger()).toHaveLength(0);
+  });
+
+  it('rejects malformed snapshots without leaking sensitive content to logs or queue errors', async () => {
+    const event = await heldClaim();
+    const log = vi.spyOn(console, 'log');
+    const error = vi.spyOn(console, 'error');
+    sqlite.prepare(`UPDATE _line_harness_legacy_mileage_claims SET rule_snapshot = ? WHERE engagement_event_id = ?`)
+      .run('private-token private-secret', event.id);
+    expect(await processPendingMileageEvents(db, { now: NOW })).toMatchObject({ failed: 1, granted: 0 });
+    expect(log).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+    expect(JSON.stringify(sqlite.prepare(`SELECT last_error FROM mileage_event_queue`).all())).not.toMatch(/private-token|private-secret/);
+  });
+});

--- a/packages/update-engine/package.json
+++ b/packages/update-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/update-engine",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Self-update engine for L Harness — shared between Worker (cloud-side self-update) and CLI (npx create-line-harness update)",
   "repository": {
     "type": "git",

--- a/packages/update-engine/src/cf-api/d1.ts
+++ b/packages/update-engine/src/cf-api/d1.ts
@@ -9,13 +9,13 @@ import { authHeader, d1QueryApiUrl, readBodyExcerpt } from './_shared.js';
  * against a customer's D1 instance using only their CF API token + account
  * id + database id — no `wrangler` binary required at runtime.
  *
- * Batch / transaction support is intentionally out of scope for v1; migrations
- * are applied one statement at a time so a failure surfaces against the exact
- * SQL that broke.
+ * Ordinary migrations use single statements. The legacy mileage adapter uses
+ * one deliberate atomic multi-statement request so claims and its ledger stamp
+ * either commit together or roll back together.
  */
 
 /**
- * Execute a single SQL statement against a D1 database.
+ * Execute SQL against a D1 database (including one deliberate atomic unit).
  *
  * Returns the raw Cloudflare API envelope (`{ success, result, ... }`) so
  * callers can inspect `result[0].results` for SELECT rows or `meta` for
@@ -50,5 +50,12 @@ export async function executeD1Query(opts: {
     throw new Error(`D1 query failed HTTP ${res.status}: ${excerpt}`);
   }
 
-  return (await res.json()) as { success: boolean; result: any[] };
+  const body = (await res.json()) as { success: boolean; result: any[] };
+  if (body.success !== true || !Array.isArray(body.result) ||
+      body.result.some((result) => result?.success === false)) {
+    // An HTTP 200 alone is not proof that the SQL committed. Do not expose
+    // provider error payloads here, which may include SQL or customer data.
+    throw new Error('D1 query returned an unsuccessful SQL result');
+  }
+  return body;
 }

--- a/packages/update-engine/src/legacy-mileage.ts
+++ b/packages/update-engine/src/legacy-mileage.ts
@@ -1,0 +1,404 @@
+import { createHash } from 'node:crypto';
+import type { CfApiCreds } from './types.js';
+import { executeD1Query } from './cf-api/d1.js';
+
+/** The released migration bytes are immutable; only these exact files have an adapter. */
+export const LEGACY_MILEAGE_MIGRATIONS = {
+  '062_mileage_admin_and_activity_rules.sql': 'e735bf39298a8dedf593a267226670b282513210d76e2f8ddc6c9119b01b4a31',
+  '063_webinar_instagram_mileage.sql': 'd0687dc2fc607e8fdfe0c199583eac134afb2603f181c8a2a2d7e97c1dced5f7',
+} as const;
+
+export const LEGACY_MILEAGE_HOLD = '9999-12-31T23:59:59';
+export const LEGACY_MILEAGE_CLAIMS_TABLE = '_line_harness_legacy_mileage_claims';
+const CANDIDATES = '_line_harness_legacy_mileage_candidates';
+const GUARD = '_line_harness_legacy_mileage_guard';
+const NOW = "strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')";
+const q = (value: string): string => `'${value.replace(/'/g, "''")}'`;
+
+type LegacyName = keyof typeof LEGACY_MILEAGE_MIGRATIONS;
+type Executor = typeof executeD1Query;
+
+export function isLegacyMileageMigration(name: string): boolean {
+  // A renamed fork in either reserved slot must also reach the allowlist
+  // check, rather than falling back to the original unsafe DML runner.
+  return /^(?:062|063)_/.test(name);
+}
+
+export function assertLegacyMileageSource(name: string, source: Buffer): void {
+  if (!Object.hasOwn(LEGACY_MILEAGE_MIGRATIONS, name)) throw new Error(`Unsupported legacy mileage migration: ${name}`);
+  const hash = createHash('sha256').update(source).digest('hex');
+  if (hash !== LEGACY_MILEAGE_MIGRATIONS[name as LegacyName]) {
+    throw new Error(`Migration ${name} has unknown historical mileage SQL. Restore the released migration bytes or reconcile this fork manually; unsafe mileage backfill was not executed.`);
+  }
+}
+
+interface CandidateSpec {
+  id: string;
+  eventType: string;
+  source: string;
+  sourceId: string;
+  ruleId: string;
+  amount: number;
+  conditions?: string;
+  ruleSource?: string | null;
+  friend: string;
+  user: string;
+  occurred: string;
+  from: string;
+  where?: string;
+  metadata?: string;
+  subject?: string;
+  identitySubject?: string;
+}
+
+function insertCandidates(s: CandidateSpec): string {
+  const metadata = s.metadata ?? "'{}'";
+  const subject = s.subject ?? 'NULL';
+  return `INSERT OR IGNORE INTO ${CANDIDATES}
+    (legacy_id, canonical_key, event_type, source, source_event_id, mileage_rule_id,
+     expected_amount, expected_conditions, expected_source, friend_id, user_id,
+     occurred_at, metadata, subject_key, identity_subject)
+    SELECT ${s.id}, ${q(s.source + ':' + s.eventType + ':')} || (${s.sourceId}),
+           ${q(s.eventType)}, ${q(s.source)}, ${s.sourceId}, ${q(s.ruleId)},
+           ${s.amount}, ${s.conditions ? q(s.conditions) : 'NULL'},
+           ${s.ruleSource === null ? 'NULL' : q(s.ruleSource ?? s.source)},
+           ${s.friend}, ${s.user}, ${s.occurred},
+           json_set(${metadata}, '$.backfilled', json('true'), '$.subjectKey', ${subject}),
+           ${subject}, ${s.identitySubject ?? 'NULL'}
+      FROM ${s.from}
+     ${s.where ? `WHERE ${s.where}` : ''}
+     ORDER BY ${s.occurred}, ${s.id};`;
+}
+
+function activityCandidates(): string[] {
+  return [
+    insertCandidates({ id: "'history-message-' || ml.id", eventType: 'message_received', source: 'line', sourceId: 'ml.id',
+      ruleId: 'builtin-message-received', amount: 1, conditions: '{"dailyCapActions":5}', friend: 'ml.friend_id', user: 'f.user_id',
+      occurred: 'ml.created_at', from: 'messages_log ml JOIN friends f ON f.id = ml.friend_id', where: "ml.direction = 'incoming'",
+      metadata: "json_object('messageType', ml.message_type)" }),
+    insertCandidates({ id: "'history-link-' || lc.id", eventType: 'link_clicked', source: 'tracked_link', sourceId: 'lc.id',
+      ruleId: 'builtin-link-clicked', amount: 2, conditions: '{"dailyCapActions":5,"uniquePerSubjectPerDay":true}',
+      friend: 'lc.friend_id', user: 'f.user_id', occurred: 'lc.clicked_at', from: 'link_clicks lc LEFT JOIN friends f ON f.id = lc.friend_id',
+      metadata: "json_object('trackedLinkId', lc.tracked_link_id)", subject: 'lc.tracked_link_id' }),
+    insertCandidates({ id: "'history-form-' || fs.id", eventType: 'form_submitted', source: 'form', sourceId: 'fs.id',
+      ruleId: 'builtin-form-submitted', amount: 10, conditions: '{"uniquePerSubject":true}', friend: 'fs.friend_id', user: 'f.user_id',
+      occurred: 'fs.created_at', from: 'form_submissions fs LEFT JOIN friends f ON f.id = fs.friend_id',
+      metadata: "json_object('formId', fs.form_id)", subject: 'fs.form_id' }),
+    insertCandidates({ id: "'history-booking-' || b.id", eventType: 'booking_created', source: 'booking', sourceId: 'b.id',
+      ruleId: 'builtin-booking-created', amount: 20, ruleSource: null, friend: 'b.friend_id', user: 'f.user_id', occurred: 'b.created_at',
+      from: 'bookings b JOIN friends f ON f.id = b.friend_id', where: "b.status IN ('requested', 'confirmed', 'completed')",
+      metadata: "json_object('bookingType', 'salon')" }),
+    insertCandidates({ id: "'history-event-booking-' || b.id", eventType: 'booking_created', source: 'event_booking', sourceId: 'b.id',
+      ruleId: 'builtin-booking-created', amount: 20, ruleSource: null, friend: 'b.friend_id', user: 'f.user_id', occurred: 'b.created_at',
+      from: 'event_bookings b JOIN friends f ON f.id = b.friend_id', where: "b.status IN ('requested', 'confirmed', 'attended')",
+      metadata: "json_object('bookingType', 'event', 'eventId', b.event_id)" }),
+  ];
+}
+
+function webinarCandidates(): string[] {
+  const milestones = [
+    { suffix: '5m', type: 'webinar_watch_5m', rule: 'builtin-webinar-watch-5m', amount: 5, threshold: '300' },
+    { suffix: '15m', type: 'webinar_watch_15m', rule: 'builtin-webinar-watch-15m', amount: 10, threshold: '900' },
+    { suffix: 'complete', type: 'webinar_completed', rule: 'builtin-webinar-completed', amount: 30, threshold: 'CAST(w.duration_seconds * 0.9 AS INTEGER)' },
+  ];
+  return [
+    ...milestones.map(m => insertCandidates({
+      id: `${q('history-webinar-' + m.suffix + '-')} || v.id`, eventType: m.type, source: 'webinar',
+      sourceId: `v.webinar_id || ':' || v.friend_id || ${q(':' + m.suffix)}`, ruleId: m.rule, amount: m.amount,
+      conditions: '{"uniquePerSubject":true}', friend: 'v.friend_id', user: 'f.user_id',
+      occurred: `datetime(v.joined_at, '+' || ${m.threshold} || ' seconds')`,
+      from: 'webinar_viewers v JOIN friends f ON f.id = v.friend_id JOIN webinars w ON w.id = v.webinar_id',
+      where: `v.last_position_seconds >= ${m.threshold}${m.suffix === 'complete' ? ' AND w.duration_seconds > 0' : ''}`,
+      metadata: "json_object('webinarId', v.webinar_id, 'sessionStartAt', v.session_start_at, 'positionSeconds', v.last_position_seconds, 'durationSeconds', w.duration_seconds)",
+      subject: 'v.webinar_id',
+    })),
+    insertCandidates({ id: "'history-webinar-cta-' || v.id", eventType: 'webinar_cta_clicked', source: 'webinar',
+      sourceId: "v.webinar_id || ':' || v.friend_id || ':' || v.session_start_at || ':primary'",
+      ruleId: 'builtin-webinar-cta-clicked', amount: 10, conditions: '{"uniquePerSubject":true}', friend: 'v.friend_id', user: 'f.user_id',
+      occurred: 'v.cta_clicked_at', from: 'webinar_viewers v JOIN friends f ON f.id = v.friend_id', where: 'v.cta_clicked_at IS NOT NULL',
+      metadata: "json_object('webinarId', v.webinar_id, 'sessionStartAt', v.session_start_at, 'ctaId', 'primary')",
+      subject: "v.webinar_id || ':primary'" }),
+    insertCandidates({ id: "'history-instagram-return-' || f.id", eventType: 'instagram_line_returned', source: 'instagram',
+      sourceId: "f.id || ':' || f.ig_igsid", ruleId: 'builtin-instagram-line-returned', amount: 15, conditions: '{"uniquePerSubject":true}',
+      friend: 'f.id', user: 'f.user_id', occurred: 'f.created_at', from: 'friends f', where: "f.ig_igsid IS NOT NULL AND f.ig_igsid <> ''",
+      metadata: "json_object('igsid', f.ig_igsid)", subject: 'f.ig_igsid', identitySubject: 'f.ig_igsid' }),
+  ];
+}
+
+/** Same person through either the immutable friend ID or its current user link. */
+const SAME_BENEFICIARY = `(ml.beneficiary_friend_id = c.friend_id OR
+  (c.user_id IS NOT NULL AND (ml.beneficiary_user_id = c.user_id OR bf.user_id = c.user_id)))`;
+const LEGACY_SUBJECT = `COALESCE(json_extract(ml.metadata, '$.subjectKey'), json_extract(ge.metadata, '$.subjectKey'),
+  CASE c.event_type
+    WHEN 'form_submitted' THEN COALESCE(json_extract(ml.metadata, '$.formId'), json_extract(ge.metadata, '$.formId'))
+    WHEN 'link_clicked' THEN COALESCE(json_extract(ml.metadata, '$.trackedLinkId'), json_extract(ge.metadata, '$.trackedLinkId'))
+    WHEN 'webinar_cta_clicked' THEN COALESCE(json_extract(ml.metadata, '$.webinarId'), json_extract(ge.metadata, '$.webinarId')) || ':' || COALESCE(json_extract(ml.metadata, '$.ctaId'), json_extract(ge.metadata, '$.ctaId'), 'primary')
+    WHEN 'instagram_line_returned' THEN COALESCE(json_extract(ml.metadata, '$.igsid'), json_extract(ge.metadata, '$.igsid'), ge.identity_subject)
+    ELSE COALESCE(json_extract(ml.metadata, '$.webinarId'), json_extract(ge.metadata, '$.webinarId'))
+  END)`;
+
+export interface ApplyLegacyMileageOptions {
+  name: string;
+  source: Buffer;
+  checksum: string;
+  creds: CfApiCreds;
+  databaseId: string;
+  execute?: Executor;
+}
+
+/**
+ * Run after additive 062 DDL preparation, instead of its historical DML.
+ * This adapter never writes mileage_ledger. It transfers genuinely unowned
+ * actions to the existing projection, held until a compatible Worker runs.
+ * Multi-statement execution MUST be atomic (D1 query API contract).
+ */
+export async function applyLegacyMileageMigration(opts: ApplyLegacyMileageOptions): Promise<{
+  executedStatements: number; skippedStatements: number;
+}> {
+  assertLegacyMileageSource(opts.name, opts.source);
+  const expectedChecksum = `sha256:${LEGACY_MILEAGE_MIGRATIONS[opts.name as LegacyName]}`;
+  if (opts.checksum !== expectedChecksum) throw new Error(`Invalid checksum for ${opts.name}`);
+  const execute = opts.execute ?? executeD1Query;
+  const base = { creds: opts.creds, databaseId: opts.databaseId };
+  const schema = await execute({ ...base, sql: `SELECT
+    EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'mileage_event_queue') AS async_queue,
+    EXISTS(SELECT 1 FROM pragma_table_info('tags') WHERE name = 'mileage_multiplier_bps') AS multipliers,
+    EXISTS(SELECT 1 FROM mileage_rules) AS existing_rules` });
+  const row = schema.result?.[0]?.results?.[0];
+  if (!row || !('async_queue' in row) || !('multipliers' in row) || !('existing_rules' in row)) {
+    throw new Error(`Cannot verify the mileage runtime baseline for ${opts.name}; no history was claimed.`);
+  }
+  // A queue-less DB with mileage rules might still have the synchronous
+  // mileage Worker. Installing queue tombstones cannot protect that writer.
+  if (!Number(row.async_queue) && Number(row.existing_rules)) {
+    throw new Error(`Migration ${opts.name} requires the supported asynchronous mileage baseline. Existing mileage rules without its queue need manual reconciliation; no history was claimed.`);
+  }
+  const original = opts.source.toString('utf8');
+  const seedStart = original.indexOf('INSERT OR IGNORE INTO mileage_rules');
+  const seed = original.slice(seedStart, original.indexOf(';', seedStart) + 1);
+  const candidates = opts.name.startsWith('062_') ? activityCandidates() : webinarCandidates();
+  const protectedRules = opts.name.startsWith('062_')
+    ? ['builtin-message-received', 'builtin-link-clicked', 'builtin-form-submitted', 'builtin-booking-created']
+    : ['builtin-webinar-watch-5m', 'builtin-webinar-watch-15m', 'builtin-webinar-completed', 'builtin-webinar-cta-clicked', 'builtin-instagram-line-returned'];
+  const familyPrefixes = opts.name.startsWith('062_')
+    ? ['history-message-', 'history-link-', 'history-form-', 'history-booking-', 'history-event-booking-']
+    : ['history-webinar-5m-', 'history-webinar-15m-', 'history-webinar-complete-', 'history-webinar-cta-', 'history-instagram-return-'];
+  const statements = [
+    `CREATE TABLE IF NOT EXISTS mileage_event_queue (
+      engagement_event_id TEXT PRIMARY KEY REFERENCES engagement_events(id) ON DELETE CASCADE,
+      status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','processing','processed','failed')),
+      attempts INTEGER NOT NULL DEFAULT 0, available_at TEXT NOT NULL, processing_started_at TEXT,
+      processed_at TEXT, last_error TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);`,
+    `CREATE INDEX IF NOT EXISTS idx_mileage_event_queue_due ON mileage_event_queue(status, available_at, created_at);`,
+    `CREATE TABLE IF NOT EXISTS ${LEGACY_MILEAGE_CLAIMS_TABLE} (
+      engagement_event_id TEXT PRIMARY KEY REFERENCES engagement_events(id),
+      migration_name TEXT NOT NULL, mileage_rule_id TEXT NOT NULL, rule_snapshot TEXT NOT NULL);`,
+    `CREATE TABLE ${CANDIDATES} (
+      canonical_key TEXT PRIMARY KEY, legacy_id TEXT NOT NULL UNIQUE,
+      event_type TEXT NOT NULL, source TEXT NOT NULL, source_event_id TEXT NOT NULL,
+      mileage_rule_id TEXT NOT NULL, expected_amount INTEGER NOT NULL, expected_conditions TEXT,
+      expected_source TEXT, friend_id TEXT, user_id TEXT, occurred_at TEXT NOT NULL,
+      metadata TEXT NOT NULL, subject_key TEXT, identity_subject TEXT,
+      event_id TEXT, settled INTEGER NOT NULL DEFAULT 0);`,
+    `CREATE TABLE ${GUARD}(
+      valid INTEGER CONSTRAINT legacy_mileage_requires_manual_reconciliation CHECK(valid = 1),
+      cta_identity INTEGER CONSTRAINT legacy_mileage_ambiguous_cta CHECK(cta_identity = 1),
+      native_overlap INTEGER CONSTRAINT legacy_mileage_native_queue_overlap CHECK(native_overlap = 1));`,
+    seed,
+    ...candidates,
+    // A pre-existing live queue can already overlap old history before this
+    // adapter runs. The old Worker lacks the new counterpart check, so leaving
+    // that queue runnable during deployment is unsafe. Do not claim it under
+    // one builtin rule (that would drop legitimate custom rewards); stop for a
+    // reviewed reconciliation. Include the event-before-queue gap and events
+    // whose raw source row has already been removed.
+    `WITH native_pending AS MATERIALIZED (
+      SELECT e.event_type, e.source, e.source_event_id, r.id AS mileage_rule_id,
+        e.actor_friend_id AS friend_id, f.user_id AS user_id, e.occurred_at,
+        COALESCE(json_extract(e.metadata, '$.subjectKey'), CASE e.event_type
+          WHEN 'form_submitted' THEN json_extract(e.metadata, '$.formId')
+          WHEN 'link_clicked' THEN json_extract(e.metadata, '$.trackedLinkId')
+          WHEN 'instagram_line_returned' THEN COALESCE(json_extract(e.metadata, '$.igsid'), e.identity_subject)
+          WHEN 'webinar_cta_clicked' THEN json_extract(e.metadata, '$.webinarId') || ':' || COALESCE(json_extract(e.metadata, '$.ctaId'), 'primary')
+          ELSE json_extract(e.metadata, '$.webinarId') END) AS subject_key
+      FROM engagement_events e JOIN friends f ON f.id = e.actor_friend_id
+      JOIN mileage_rules r ON r.program_id = e.program_id AND r.event_type = e.event_type
+        AND (r.source IS NULL OR r.source = e.source)
+      LEFT JOIN mileage_event_queue mq ON mq.engagement_event_id = e.id
+      WHERE e.program_id = 'default' AND r.id IN (${protectedRules.map(q).join(', ')})
+        AND e.idempotency_key = e.source || ':' || e.event_type || ':' || e.source_event_id
+        AND (mq.engagement_event_id IS NULL OR mq.status = 'processing'
+          OR (mq.status IN ('pending', 'failed') AND mq.attempts < 5))
+        AND NOT EXISTS (SELECT 1 FROM ${LEGACY_MILEAGE_CLAIMS_TABLE} cl WHERE cl.engagement_event_id = e.id)
+    ) INSERT INTO ${GUARD}(native_overlap) SELECT 0 WHERE EXISTS (
+      SELECT 1 FROM native_pending c WHERE EXISTS (
+        SELECT 1 FROM mileage_ledger ml
+        LEFT JOIN engagement_events ge ON ge.id = ml.engagement_event_id
+        LEFT JOIN friends bf ON bf.id = ml.beneficiary_friend_id
+        WHERE ml.program_id = 'default' AND ml.mileage_rule_id = c.mileage_rule_id
+          AND ml.entry_type = 'grant' AND ml.source = c.source
+          AND (ml.idempotency_key LIKE 'history-mile:%' OR ml.id LIKE 'history-mile-%')
+          AND ${SAME_BENEFICIARY}
+          AND (ml.source_event_id = c.source_event_id OR
+            (c.subject_key IS NOT NULL AND ${LEGACY_SUBJECT} = c.subject_key
+              AND (c.event_type <> 'link_clicked' OR substr(ml.occurred_at, 1, 10) = substr(c.occurred_at, 1, 10))))));`,
+    // Native events, including an event whose enqueue has not happened yet,
+    // belong to runtime. CTA's raw storage omits ctaId; any live CTA for that
+    // viewer/session owns it, rather than manufacturing a primary CTA.
+    `DELETE FROM ${CANDIDATES} AS c WHERE EXISTS (
+      SELECT 1 FROM engagement_events e WHERE e.program_id = 'default'
+        AND (e.idempotency_key = c.canonical_key OR
+          (c.event_type = 'webinar_cta_clicked' AND e.event_type = c.event_type AND e.source = c.source
+           AND e.actor_friend_id = c.friend_id
+           AND json_extract(e.metadata, '$.webinarId') = json_extract(c.metadata, '$.webinarId')
+           AND json_extract(e.metadata, '$.sessionStartAt') = json_extract(c.metadata, '$.sessionStartAt')
+           AND e.id NOT LIKE 'history-%'
+           AND NOT EXISTS (SELECT 1 FROM engagement_events historical
+             WHERE historical.id = c.legacy_id AND historical.idempotency_key LIKE 'history:%'))));`,
+    // The raw viewer stores only the first CTA timestamp, not which CTA was
+    // clicked. A request can be between that write and its live enqueue, so
+    // manufacturing a primary action here can pay both primary and secondary.
+    // Only the exact old migration event proves a recoverable primary action:
+    // its deterministic ID binds the viewer/session, and its retained metadata
+    // and timestamp must agree with that viewer. Otherwise abort the whole unit.
+    `INSERT INTO ${GUARD}(cta_identity) SELECT 0 WHERE EXISTS (
+      SELECT 1 FROM ${CANDIDATES} c WHERE c.event_type = 'webinar_cta_clicked'
+        AND NOT EXISTS (
+          SELECT 1 FROM engagement_events e WHERE e.id = c.legacy_id
+            AND e.program_id = 'default' AND e.event_type = c.event_type AND e.source = c.source
+            AND e.idempotency_key = 'history:webinar:cta:' || substr(c.legacy_id, length('history-webinar-cta-') + 1)
+            AND e.actor_friend_id = c.friend_id
+            AND e.source_event_id = json_extract(c.metadata, '$.webinarId') || ':' || c.friend_id || ':primary'
+            AND json_extract(e.metadata, '$.webinarId') = json_extract(c.metadata, '$.webinarId')
+            AND json_extract(e.metadata, '$.ctaId') = 'primary'
+            AND (json_type(e.metadata, '$.sessionStartAt') IS NULL
+              OR json_extract(e.metadata, '$.sessionStartAt') = json_extract(c.metadata, '$.sessionStartAt'))
+            AND e.occurred_at = c.occurred_at));`,
+    // An old history ID with a different canonical owner or unusual queue is
+    // ambiguous, not permission to overwrite an event/queue already in use.
+    `INSERT INTO ${GUARD}(valid) SELECT 0 WHERE EXISTS (
+      SELECT 1 FROM ${CANDIDATES} c JOIN engagement_events e ON e.id = c.legacy_id
+      LEFT JOIN mileage_event_queue mq ON mq.engagement_event_id = e.id
+      WHERE e.program_id <> 'default' OR e.idempotency_key NOT LIKE 'history:%'
+         OR mq.engagement_event_id IS NOT NULL OR e.source <> c.source OR e.event_type <> c.event_type
+         OR e.actor_friend_id IS NOT c.friend_id
+         OR (e.source_event_id IS NOT c.source_event_id AND NOT (
+           c.event_type = 'webinar_cta_clicked' AND e.source_event_id =
+             json_extract(c.metadata, '$.webinarId') || ':' || c.friend_id || ':primary'))
+         OR (c.subject_key IS NOT NULL AND c.subject_key IS NOT
+           COALESCE(json_extract(e.metadata, '$.subjectKey'), CASE c.event_type
+             WHEN 'form_submitted' THEN json_extract(e.metadata, '$.formId')
+             WHEN 'link_clicked' THEN json_extract(e.metadata, '$.trackedLinkId')
+             WHEN 'instagram_line_returned' THEN COALESCE(json_extract(e.metadata, '$.igsid'), e.identity_subject)
+             WHEN 'webinar_cta_clicked' THEN json_extract(e.metadata, '$.webinarId') || ':' || COALESCE(json_extract(e.metadata, '$.ctaId'), 'primary')
+             ELSE json_extract(e.metadata, '$.webinarId') END)));`,
+    `INSERT INTO ${GUARD}(valid) SELECT 0 WHERE EXISTS (
+      SELECT 1 FROM engagement_events e
+      WHERE (${familyPrefixes.map(p => `e.id LIKE ${q(p + '%')}`).join(' OR ')})
+        AND NOT EXISTS (SELECT 1 FROM ${CANDIDATES} c WHERE c.legacy_id = e.id)
+        AND NOT EXISTS (SELECT 1 FROM mileage_ledger ml WHERE ml.engagement_event_id = e.id)
+        AND NOT EXISTS (SELECT 1 FROM ${LEGACY_MILEAGE_CLAIMS_TABLE} cl WHERE cl.engagement_event_id = e.id)
+        AND e.idempotency_key LIKE 'history:%'
+        AND NOT EXISTS (SELECT 1 FROM engagement_events live WHERE live.program_id = e.program_id
+          AND live.source = e.source AND live.event_type = e.event_type
+          AND (live.source_event_id = e.source_event_id OR
+            (e.event_type = 'webinar_cta_clicked' AND live.actor_friend_id = e.actor_friend_id
+             AND json_extract(live.metadata, '$.webinarId') = json_extract(e.metadata, '$.webinarId')))
+          AND live.id NOT LIKE 'history-%'));`,
+    // Claiming an in-flight raw action would bypass live custom rewards. Stop
+    // rather than guessing which absent ledger entries were intentional.
+    `INSERT INTO ${GUARD}(valid) SELECT 0 WHERE EXISTS (
+      SELECT 1 FROM ${CANDIDATES} c JOIN mileage_rules r ON r.id = c.mileage_rule_id
+      WHERE c.friend_id IS NOT NULL AND (
+        r.program_id <> 'default' OR r.event_type <> c.event_type OR r.source IS NOT c.expected_source
+        OR r.amount <> c.expected_amount OR r.initial_status <> 'available' OR r.is_active <> 1
+        OR r.valid_from IS NOT NULL OR r.valid_until IS NOT NULL
+        OR (r.conditions IS NOT NULL AND json_type(r.conditions) <> 'object')
+        OR EXISTS (SELECT key, type, atom FROM json_each(r.conditions)
+          EXCEPT SELECT key, type, atom FROM json_each(c.expected_conditions))
+        OR EXISTS (SELECT key, type, atom FROM json_each(c.expected_conditions)
+          EXCEPT SELECT key, type, atom FROM json_each(r.conditions))
+        OR EXISTS (SELECT 1 FROM mileage_rules extra WHERE extra.program_id = 'default'
+          AND extra.event_type = c.event_type AND (extra.source IS NULL OR extra.source = c.source)
+          AND extra.is_active = 1 AND extra.id <> r.id)));`,
+    ...(Number(row.multipliers) ? [`INSERT INTO ${GUARD}(valid) SELECT 0 WHERE EXISTS (
+      SELECT 1 FROM ${CANDIDATES} c JOIN friends tf ON tf.id = c.friend_id OR (c.user_id IS NOT NULL AND tf.user_id = c.user_id)
+      JOIN friend_tags ft ON ft.friend_id = tf.id JOIN tags t ON t.id = ft.tag_id
+      WHERE t.mileage_multiplier_bps IS NOT NULL AND t.mileage_multiplier_bps <> 10000
+        AND ft.assigned_at <= c.occurred_at);`] : []),
+    `UPDATE ${CANDIDATES} AS c SET settled = 1
+      WHERE c.friend_id IS NULL OR EXISTS (
+        SELECT 1 FROM mileage_ledger ml
+        LEFT JOIN engagement_events ge ON ge.id = ml.engagement_event_id
+        LEFT JOIN friends bf ON bf.id = ml.beneficiary_friend_id
+        WHERE ml.program_id = 'default' AND ml.mileage_rule_id = c.mileage_rule_id
+          AND ml.entry_type = 'grant' AND ml.source = c.source AND ${SAME_BENEFICIARY}
+          AND (ml.source_event_id = c.source_event_id OR
+            (c.subject_key IS NOT NULL AND ${LEGACY_SUBJECT} = c.subject_key
+             AND (c.event_type <> 'link_clicked' OR substr(ml.occurred_at, 1, 10) = substr(c.occurred_at, 1, 10)))));`,
+    // Already-completed daily caps are evidence that the historic action
+    // should remain suppressed. Pending/new history otherwise uses one
+    // projection path; the adapter never reproduces grant amounts or ranking.
+    `WITH grants AS MATERIALIZED (
+        SELECT ml.id, ml.mileage_rule_id AS rule_id, substr(ml.occurred_at, 1, 10) AS day,
+          ml.beneficiary_friend_id AS friend_id, ml.beneficiary_user_id AS user_id, bf.user_id AS current_user_id
+        FROM mileage_ledger ml LEFT JOIN friends bf ON bf.id = ml.beneficiary_friend_id
+        WHERE ml.program_id = 'default' AND ml.entry_type = 'grant' AND ml.status <> 'void'
+          AND ml.mileage_rule_id IN ('builtin-message-received', 'builtin-link-clicked')
+      ), identities AS (
+        SELECT id, rule_id, day, 'friend:' || friend_id AS identity_key FROM grants WHERE friend_id IS NOT NULL
+        UNION SELECT id, rule_id, day, 'user:' || user_id FROM grants WHERE user_id IS NOT NULL
+        UNION SELECT id, rule_id, day, 'user:' || current_user_id FROM grants WHERE current_user_id IS NOT NULL
+      ), caps AS MATERIALIZED (
+        SELECT rule_id, day, identity_key, COUNT(*) AS actions FROM identities GROUP BY rule_id, day, identity_key
+      ) UPDATE ${CANDIDATES} AS c SET settled = 1
+      WHERE c.event_type IN ('message_received', 'link_clicked') AND EXISTS (
+        SELECT 1 FROM caps WHERE caps.rule_id = c.mileage_rule_id AND caps.day = substr(c.occurred_at, 1, 10)
+          AND caps.identity_key = COALESCE('user:' || c.user_id, 'friend:' || c.friend_id) AND caps.actions >= 5);`,
+    `UPDATE engagement_events AS e SET
+      idempotency_key = (SELECT c.canonical_key FROM ${CANDIDATES} c WHERE c.legacy_id = e.id),
+      source_event_id = (SELECT c.source_event_id FROM ${CANDIDATES} c WHERE c.legacy_id = e.id),
+      metadata = json_patch(COALESCE(e.metadata, '{}'), (SELECT c.metadata FROM ${CANDIDATES} c WHERE c.legacy_id = e.id))
+      WHERE EXISTS (SELECT 1 FROM ${CANDIDATES} c WHERE c.legacy_id = e.id);`,
+    `INSERT OR IGNORE INTO engagement_events
+      (id, program_id, idempotency_key, event_type, source, source_event_id,
+       actor_user_id, actor_friend_id, identity_provider, identity_subject, metadata, occurred_at, created_at)
+      SELECT legacy_id, 'default', canonical_key, event_type, source, source_event_id,
+        user_id, friend_id, CASE WHEN identity_subject IS NOT NULL THEN 'instagram' END,
+        identity_subject, metadata, occurred_at, occurred_at FROM ${CANDIDATES};`,
+    `UPDATE ${CANDIDATES} AS c SET event_id = (
+      SELECT e.id FROM engagement_events e WHERE e.program_id = 'default' AND e.idempotency_key = c.canonical_key);`,
+    `INSERT INTO ${LEGACY_MILEAGE_CLAIMS_TABLE}
+      (engagement_event_id, migration_name, mileage_rule_id, rule_snapshot)
+      SELECT c.event_id, ${q(opts.name)}, c.mileage_rule_id,
+        json_object('amount', r.amount, 'initial_status', r.initial_status, 'conditions', r.conditions,
+          'source', r.source, 'event_type', r.event_type, 'is_active', r.is_active,
+          'valid_from', r.valid_from, 'valid_until', r.valid_until)
+      FROM ${CANDIDATES} c JOIN mileage_rules r ON r.id = c.mileage_rule_id;`,
+    `INSERT INTO mileage_event_queue
+      (engagement_event_id, status, attempts, available_at, processed_at, created_at, updated_at)
+      SELECT event_id, CASE WHEN settled = 1 THEN 'processed' ELSE 'pending' END, 0,
+        CASE WHEN settled = 1 THEN ${NOW} ELSE ${q(LEGACY_MILEAGE_HOLD)} END,
+        CASE WHEN settled = 1 THEN ${NOW} END, occurred_at, ${NOW}
+      FROM ${CANDIDATES};`,
+    `INSERT OR IGNORE INTO _line_harness_migrations(name, checksum, applied_at)
+      VALUES (${q(opts.name)}, ${q(opts.checksum)}, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'));`,
+    `INSERT INTO ${GUARD}(valid) SELECT 0 WHERE EXISTS (SELECT 1 FROM _line_harness_migrations
+      WHERE name = ${q(opts.name)} AND checksum <> ${q(opts.checksum)});`,
+    `DROP TABLE ${CANDIDATES};`,
+    `DROP TABLE ${GUARD};`,
+  ];
+  try {
+    await execute({ ...base, sql: statements.join('\n') });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    if (detail.includes('legacy_mileage_native_queue_overlap')) {
+      throw new Error(`Migration ${opts.name} found pending live mileage events that overlap existing historical grants. Install the compatible mileage runtime or reconcile those live events before retrying; their queue ownership and custom rules were preserved and the atomic history claim was aborted.`, { cause: error });
+    }
+    if (detail.includes('legacy_mileage_ambiguous_cta')) {
+      throw new Error(`Migration ${opts.name} cannot establish historical CTA identity: the raw viewer timestamp does not record ctaId. Retry after in-flight CTA requests have enqueued their engagement events. If this persists, reconcile the historical CTA events before retrying; the atomic history claim was aborted.`, { cause: error });
+    }
+    throw new Error(`Migration ${opts.name} could not reconcile historical mileage atomically. Custom rules, multipliers, orphan history, or existing queue ownership require review; no partial history claim should commit. ${detail}`, { cause: error });
+  }
+  return { executedStatements: statements.length, skippedStatements: 0 };
+}

--- a/packages/update-engine/src/manifest.ts
+++ b/packages/update-engine/src/manifest.ts
@@ -16,10 +16,15 @@ export async function fetchManifest(url: string): Promise<Manifest> {
   }
 
   const body = (await res.json()) as Manifest;
-  if (body.schema_version !== 1) {
+  if (body.schema_version !== 1 && body.schema_version !== 2) {
     throw new Error(
       `unsupported manifest schema_version ${body.schema_version}`,
     );
+  }
+  if (body.schema_version === 1 && body.releases.some(
+    release => release.legacy_mileage_projection_version !== undefined,
+  )) {
+    throw new Error('historical mileage handoff requires manifest schema_version 2');
   }
   return body;
 }

--- a/packages/update-engine/src/migrations.ts
+++ b/packages/update-engine/src/migrations.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { containsDestructiveSchemaChanges, splitSqlStatements, stripSqlComments } from './sql-statements.js';
 export { containsDestructiveSchemaChanges, splitSqlStatements } from './sql-statements.js';
-import { applyLegacyMileageMigration, assertLegacyMileageSource, isLegacyMileageMigration } from './legacy-mileage.js';
+import { applyLegacyMileageMigration, assertLegacyMileageSource, isLegacyMileageMigration, LEGACY_MILEAGE_CLAIMS_TABLE } from './legacy-mileage.js';
 import type { CfApiCreds } from './types.js';
 import { executeD1Query } from './cf-api/d1.js';
 import { isBenignSchemaErrorText } from './materialize.js';
@@ -167,6 +167,9 @@ export async function applyD1Migrations(
           `migration ${name}: recorded checksum differs from bundle (never executed by this engine — continuing)`,
         );
       }
+      if (isLegacyMileageMigration(name) && opts.legacyMileageProjectionVersion !== 1) {
+        await assertNoUnfinishedMileageClaims(execute, base);
+      }
       const result: MigrationApplyResult = {
         name,
         alreadyApplied: true,
@@ -270,6 +273,27 @@ export async function applyD1Migrations(
     await opts.onMigrationDone?.(result);
   }
   return results;
+}
+
+async function assertNoUnfinishedMileageClaims(
+  execute: D1Executor,
+  base: { creds: CfApiCreds; databaseId: string },
+): Promise<void> {
+  const schema = await execute({ ...base, sql:
+    `SELECT COUNT(*) AS claims_table FROM sqlite_master WHERE type='table' AND name='${LEGACY_MILEAGE_CLAIMS_TABLE}'`,
+  });
+  const present = firstResultValue(schema, 'claims_table');
+  if (present === 0) return;
+  if (present !== 1) throw new Error('Cannot verify historical mileage handoff state');
+  const pending = await execute({ ...base, sql:
+    `SELECT COUNT(*) AS unfinished FROM ${LEGACY_MILEAGE_CLAIMS_TABLE} c
+     LEFT JOIN mileage_event_queue q ON q.engagement_event_id=c.engagement_event_id
+     WHERE q.engagement_event_id IS NULL OR q.status <> 'processed'`,
+  });
+  const count = firstResultValue(pending, 'unfinished');
+  if (count !== 0) {
+    throw new Error('Historical mileage handoff is unfinished. A Worker with legacy_mileage_projection_version=1 is required even when migration checksums match.');
+  }
 }
 
 /**

--- a/packages/update-engine/src/migrations.ts
+++ b/packages/update-engine/src/migrations.ts
@@ -1,4 +1,7 @@
 import { createHash } from 'node:crypto';
+import { containsDestructiveSchemaChanges, splitSqlStatements, stripSqlComments } from './sql-statements.js';
+export { containsDestructiveSchemaChanges, splitSqlStatements } from './sql-statements.js';
+import { applyLegacyMileageMigration, assertLegacyMileageSource, isLegacyMileageMigration } from './legacy-mileage.js';
 import type { CfApiCreds } from './types.js';
 import { executeD1Query } from './cf-api/d1.js';
 import { isBenignSchemaErrorText } from './materialize.js';
@@ -31,19 +34,6 @@ export const GRANDFATHERED_CUTOFF_PREFIX = '041';
 export function isGrandfatheredMigration(name: string): boolean {
   const prefix = name.slice(0, 3);
   return /^\d{3}$/.test(prefix) && prefix < GRANDFATHERED_CUTOFF_PREFIX;
-}
-
-/**
- * 破壊的スキーマ変更 (DROP TABLE/COLUMN, RENAME TO/COLUMN) を含むか。
- * splitSqlStatements の拒否条件と同一定義 — adopt-stamp の対象判定と
- * スプリッタのガードがずれないよう、双方がこの関数を使う。
- */
-export function containsDestructiveSchemaChanges(sql: string): boolean {
-  const uncommented = stripSqlComments(sql);
-  return (
-    /\bDROP\s+(?:TABLE|COLUMN)\b/i.test(uncommented) ||
-    /\bRENAME\s+(?:TO|COLUMN)\b/i.test(uncommented)
-  );
 }
 
 export interface MigrationApplyResult {
@@ -79,95 +69,10 @@ export interface ApplyD1MigrationsOptions {
    * 停止する (通常の差分更新に現れるのは異常なので loud に落とす)。
    */
   adoptGrandfathered?: boolean;
+  /** Target Worker explicitly supports projecting adapter-held historical activity. */
+  legacyMileageProjectionVersion?: 1;
   /** Test seam. Production callers use the Cloudflare D1 HTTP API. */
   execute?: D1Executor;
-}
-
-/**
- * Split a SQLite migration into individual statements.
- *
- * D1 executes a multi-statement SQL string atomically. That is unsafe for
- * legacy L Harness installs: one duplicate ALTER TABLE rolls back later
- * statements in the same file. This scanner splits only on semicolons that
- * are outside strings, quoted identifiers, and comments.
- *
- * Current L Harness migrations intentionally do not use CREATE TRIGGER
- * bodies (whose internal BEGIN/END semicolons need a full SQLite parser).
- * Fail loudly if one appears so a future release cannot silently split it
- * incorrectly.
- */
-export function splitSqlStatements(sql: string): string[] {
-  const uncommented = stripSqlComments(sql);
-  if (/\bCREATE\s+(?:TEMP(?:ORARY)?\s+)?TRIGGER\b/i.test(uncommented)) {
-    throw new Error('CREATE TRIGGER migrations are not supported by the safe D1 splitter');
-  }
-  if (containsDestructiveSchemaChanges(sql)) {
-    throw new Error('destructive schema changes are not supported by safe D1 updates');
-  }
-
-  const statements: string[] = [];
-  let start = 0;
-  let quote: "'" | '"' | '`' | ']' | null = null;
-  let lineComment = false;
-  let blockComment = false;
-
-  for (let i = 0; i < sql.length; i += 1) {
-    const ch = sql[i];
-    const next = sql[i + 1];
-
-    if (lineComment) {
-      if (ch === '\n' || ch === '\r') lineComment = false;
-      continue;
-    }
-    if (blockComment) {
-      if (ch === '*' && next === '/') {
-        blockComment = false;
-        i += 1;
-      }
-      continue;
-    }
-    if (quote) {
-      const closing = quote;
-      if (ch === closing) {
-        // SQLite escapes quote characters by doubling them.
-        if (next === closing && closing !== ']') {
-          i += 1;
-        } else {
-          quote = null;
-        }
-      }
-      continue;
-    }
-
-    if (ch === '-' && next === '-') {
-      lineComment = true;
-      i += 1;
-      continue;
-    }
-    if (ch === '/' && next === '*') {
-      blockComment = true;
-      i += 1;
-      continue;
-    }
-    if (ch === "'" || ch === '"' || ch === '`') {
-      quote = ch;
-      continue;
-    }
-    if (ch === '[') {
-      quote = ']';
-      continue;
-    }
-    if (ch === ';') {
-      pushSqlStatement(statements, sql.slice(start, i));
-      start = i + 1;
-    }
-  }
-
-  if (quote || blockComment) {
-    throw new Error('migration contains an unterminated SQL quote or block comment');
-  }
-  pushSqlStatement(statements, sql.slice(start));
-  return statements;
 }
 
 /**
@@ -207,6 +112,9 @@ export async function applyD1Migrations(
       throw new Error(`migration ${name} missing in bundle`);
     }
     const sql = (opts.migrations.get(name) as Buffer).toString('utf8');
+    if (isLegacyMileageMigration(name)) {
+      assertLegacyMileageSource(name, opts.migrations.get(name) as Buffer);
+    }
     if (
       adoptGrandfathered &&
       isGrandfatheredMigration(name) &&
@@ -300,7 +208,20 @@ export async function applyD1Migrations(
       continue;
     }
 
-    const statements = parsedStatements.get(name) as string[];
+    const legacyMileage = isLegacyMileageMigration(name);
+    if (legacyMileage && opts.legacyMileageProjectionVersion !== 1) {
+      throw new Error(
+        `Migration ${name} requires a target release with legacy_mileage_projection_version=1. ` +
+        'Select a compatible Worker release; historical mileage was not replayed.',
+      );
+    }
+    // The released SQL/checksum stays immutable. Prepare only additive structure;
+    // the adapter atomically hands history to the compatible runtime and stamps
+    // the migration, without replaying its direct monetary INSERTs.
+    const statements = legacyMileage
+      ? (parsedStatements.get(name) as string[]).filter(statement =>
+          /^(?:ALTER\s+TABLE|CREATE\s+(?:UNIQUE\s+)?INDEX)\b/i.test(stripSqlComments(statement).trim()))
+      : parsedStatements.get(name) as string[];
     let executedStatements = 0;
     let skippedStatements = 0;
     for (let index = 0; index < statements.length; index += 1) {
@@ -318,6 +239,18 @@ export async function applyD1Migrations(
           { cause: error },
         );
       }
+    }
+
+    if (legacyMileage) {
+      const applied = await applyLegacyMileageMigration({ ...base, execute, name, source, checksum });
+      const result: MigrationApplyResult = {
+        name, alreadyApplied: false,
+        executedStatements: executedStatements + applied.executedStatements,
+        skippedStatements: skippedStatements + applied.skippedStatements,
+      };
+      results.push(result);
+      await opts.onMigrationDone?.(result);
+      continue;
     }
 
     await execute({
@@ -381,15 +314,6 @@ async function assertAdoptableSchemaPresent(
         '手動での更新が必要です: https://github.com/Shudesu/line-harness-oss/blob/main/docs/wiki/26-Manual-Update.md',
     );
   }
-}
-
-function pushSqlStatement(statements: string[], candidate: string): void {
-  const trimmed = candidate.trim();
-  if (trimmed && stripSqlComments(trimmed).trim()) statements.push(trimmed);
-}
-
-function stripSqlComments(sql: string): string {
-  return sql.replace(/--[^\r\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
 function firstResultValue(

--- a/packages/update-engine/src/phases/apply.ts
+++ b/packages/update-engine/src/phases/apply.ts
@@ -64,6 +64,7 @@ export async function runApply(
     databaseId: ctx.d1DatabaseId,
     names: ctx.target.migrations,
     migrations: bundle.migrations,
+    legacyMileageProjectionVersion: ctx.target.legacy_mileage_projection_version,
     onMigrationStart: (name) =>
       ev.emit({ step: 'migration', status: 'running', name }),
     onMigrationDone: (result) =>

--- a/packages/update-engine/src/sql-statements.ts
+++ b/packages/update-engine/src/sql-statements.ts
@@ -1,0 +1,262 @@
+interface SqlToken {
+  kind: 'word' | 'quoted' | 'symbol' | 'comment';
+  value: string;
+  start: number;
+  end: number;
+}
+
+/** Lex once without interpreting keywords inside strings, identifiers or comments. */
+function tokenizeSql(sql: string): SqlToken[] {
+  const tokens: SqlToken[] = [];
+  for (let i = 0; i < sql.length;) {
+    const start = i;
+    const ch = sql[i];
+    if (/\s/.test(ch)) {
+      i += 1;
+      continue;
+    }
+    if (sql.startsWith('--', i)) {
+      i += 2;
+      while (i < sql.length && sql[i] !== '\n' && sql[i] !== '\r') i += 1;
+      tokens.push({ kind: 'comment', value: '', start, end: i });
+      continue;
+    }
+    if (sql.startsWith('/*', i)) {
+      const closing = sql.indexOf('*/', i + 2);
+      if (closing === -1) throw new Error('migration contains an unterminated SQL quote or block comment');
+      i = closing + 2;
+      tokens.push({ kind: 'comment', value: '', start, end: i });
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`' || ch === '[') {
+      const closing = ch === '[' ? ']' : ch;
+      i += 1;
+      let closed = false;
+      while (i < sql.length) {
+        if (sql[i++] !== closing) continue;
+        if (closing !== ']' && sql[i] === closing) {
+          i += 1;
+          continue;
+        }
+        closed = true;
+        break;
+      }
+      if (!closed) throw new Error('migration contains an unterminated SQL quote or block comment');
+      tokens.push({ kind: 'quoted', value: sql.slice(start, i), start, end: i });
+      continue;
+    }
+    if (/[\w$\u0080-\uffff]/.test(ch)) {
+      i += 1;
+      while (i < sql.length && /[\w$\u0080-\uffff]/.test(sql[i])) i += 1;
+      tokens.push({ kind: 'word', value: sql.slice(start, i).toUpperCase(), start, end: i });
+      continue;
+    }
+    i += 1;
+    tokens.push({ kind: 'symbol', value: ch, start, end: i });
+  }
+  return tokens;
+}
+
+/** Preserve quoted text and whitespace; a removed comment must not join two words. */
+export function stripSqlComments(sql: string): string {
+  let result = '';
+  let start = 0;
+  for (const token of tokenizeSql(sql)) {
+    if (token.kind !== 'comment') continue;
+    result += sql.slice(start, token.start) + sql.slice(token.start, token.end).replace(/[^\r\n]/g, ' ');
+    start = token.end;
+  }
+  return result + sql.slice(start);
+}
+
+function hasDestructiveTokens(tokens: SqlToken[]): boolean {
+  return tokens.some((token, index) => {
+    const next = tokens[index + 1];
+    if (token.kind !== 'word' || next?.kind !== 'word') return false;
+    return (token.value === 'DROP' && /^(TABLE|COLUMN)$/.test(next.value)) ||
+      (token.value === 'RENAME' && /^(TO|COLUMN)$/.test(next.value));
+  });
+}
+
+/** Shared DROP/RENAME guard for splitting and grandfathered adoption. */
+export function containsDestructiveSchemaChanges(sql: string): boolean {
+  return hasDestructiveTokens(tokenizeSql(sql).filter((token) => token.kind !== 'comment'));
+}
+
+function keyword(token: SqlToken | undefined, value: string): boolean {
+  return token?.kind === 'word' && token.value === value;
+}
+
+function triggerError(detail: string): never {
+  throw new Error(`malformed CREATE TRIGGER migration: ${detail}`);
+}
+
+function triggerCommand(token: SqlToken | undefined): boolean {
+  return token?.kind === 'word' && /^(INSERT|UPDATE|DELETE|SELECT|REPLACE)$/.test(token.value);
+}
+
+/**
+ * Validate the trigger envelope, not arbitrary SQL expressions. SQLite owns
+ * expression/type/name validation. Body commands must end with a semicolon;
+ * their CASE expressions must close before that delimiter. Only an END at a
+ * command boundary may finish the trigger (https://sqlite.org/lang_createtrigger.html).
+ */
+function triggerEnd(tokens: SqlToken[], triggerIndex: number): number {
+  let i = triggerIndex + 1;
+  const take = (value: string): boolean => {
+    if (!keyword(tokens[i], value)) return false;
+    i += 1;
+    return true;
+  };
+  const requireKeyword = (value: string): void => {
+    if (!take(value)) triggerError(`expected ${value} in trigger header`);
+  };
+  const identifier = (): void => {
+    if (tokens[i]?.kind !== 'word' && tokens[i]?.kind !== 'quoted') {
+      triggerError('expected an identifier in trigger header');
+    }
+    i += 1;
+  };
+  const qualifiedIdentifier = (): void => {
+    identifier();
+    if (tokens[i]?.value === '.') {
+      i += 1;
+      identifier();
+    }
+  };
+
+  if (take('IF')) {
+    requireKeyword('NOT');
+    requireKeyword('EXISTS');
+  }
+  qualifiedIdentifier();
+  if (take('INSTEAD')) requireKeyword('OF');
+  else if (!take('BEFORE')) take('AFTER');
+  if (take('UPDATE')) {
+    if (take('OF')) {
+      identifier();
+      while (tokens[i]?.value === ',') {
+        i += 1;
+        identifier();
+      }
+    }
+  } else if (!take('INSERT') && !take('DELETE')) {
+    triggerError('expected INSERT, UPDATE or DELETE in trigger header');
+  }
+  requireKeyword('ON');
+  qualifiedIdentifier();
+  if (take('FOR')) {
+    requireKeyword('EACH');
+    requireKeyword('ROW');
+  }
+
+  let parentheses = 0;
+  const cases: Array<{
+    parentheses: number;
+    phase: 'base' | 'when' | 'then' | 'else';
+    needsOperand: boolean;
+  }> = [];
+  const expressionToken = (token: SqlToken, previous: SqlToken | undefined): void => {
+    const qualified = previous?.value === '.';
+    if (token.value === '(') parentheses += 1;
+    if (token.value === ')' && --parentheses < 0) triggerError('unbalanced parentheses');
+    if (!qualified && keyword(token, 'CASE')) {
+      cases.push({ parentheses, phase: 'base', needsOperand: true });
+      return;
+    }
+    const current = cases.at(-1);
+    if (!current) return;
+    if (!qualified && parentheses === current.parentheses) {
+      if (keyword(token, 'WHEN') || keyword(token, 'THEN') || keyword(token, 'ELSE')) {
+        current.phase = token.value.toLowerCase() as 'when' | 'then' | 'else';
+        current.needsOperand = true;
+        return;
+      }
+      // END also falls back to an identifier in SQLite. In `THEN end END`
+      // the first END is the result operand, and only the second closes CASE.
+      if (keyword(token, 'END') && !current.needsOperand &&
+          (current.phase === 'then' || current.phase === 'else')) {
+        cases.pop();
+        const parent = cases.at(-1);
+        if (parent) parent.needsOperand = false;
+        return;
+      }
+    }
+    // Only enough expression context to distinguish fallback identifiers
+    // from CASE terminators; SQLite still validates the expression itself.
+    current.needsOperand = token.kind === 'symbol'
+      ? token.value !== ')'
+      : token.kind === 'word' && /^(AND|OR|NOT|IS|IN|LIKE|GLOB|MATCH|REGEXP|BETWEEN|ESCAPE|AS|SELECT|DISTINCT|ALL|FROM|JOIN|ON|WHERE|HAVING|BY|SET|VALUES|RETURNING|COLLATE)$/.test(token.value);
+  };
+  // A WHEN clause can itself contain CASE ... END and parenthesized subqueries.
+  if (take('WHEN')) {
+    const conditionStart = i;
+    for (; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      const qualified = tokens[i - 1]?.value === '.';
+      // BEGIN can be an unquoted column name (`WHEN begin > 0 BEGIN ...`).
+      // The envelope delimiter must introduce a body command (or empty END,
+      // which the body validator rejects), rather than consume that operand.
+      if (keyword(token, 'BEGIN') && !qualified && parentheses === 0 && cases.length === 0 &&
+          (triggerCommand(tokens[i + 1]) || keyword(tokens[i + 1], 'END'))) break;
+      if (token.value === ';') triggerError('missing BEGIN after WHEN clause');
+      expressionToken(token, tokens[i - 1]);
+    }
+    if (conditionStart === i) triggerError('empty WHEN clause');
+  }
+  requireKeyword('BEGIN');
+
+  let commands = 0;
+  let commandStart = i;
+  for (; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (i === commandStart) {
+      if (keyword(token, 'END')) {
+        if (commands === 0) triggerError('empty trigger body');
+        if (tokens[i + 1] && tokens[i + 1].value !== ';') {
+          triggerError('expected semicolon after END');
+        }
+        return i;
+      }
+      if (!triggerCommand(token)) {
+        triggerError('expected a trigger body command or END');
+      }
+    }
+    expressionToken(token, tokens[i - 1]);
+    if (token.value === ';') {
+      if (cases.length || parentheses) triggerError('unclosed CASE or parentheses in trigger body');
+      if (i === commandStart + 1) triggerError('incomplete trigger body command');
+      commands += 1;
+      commandStart = i + 1;
+    }
+  }
+  return triggerError('unterminated trigger body (expected END)');
+}
+
+/**
+ * Split cumulative SQLite migrations for individual D1 requests, preserving
+ * complete trigger programs and their internal semicolons. Validate all input
+ * before execution so an incomplete trigger cannot leave a partial migration.
+ */
+export function splitSqlStatements(sql: string): string[] {
+  const tokens = tokenizeSql(sql).filter((token) => token.kind !== 'comment');
+  if (hasDestructiveTokens(tokens)) {
+    throw new Error('destructive schema changes are not supported by safe D1 updates');
+  }
+  const statements: string[] = [];
+  let start = 0;
+  let firstToken = 0;
+  for (let i = 0; i < tokens.length; i += 1) {
+    if (i === firstToken && keyword(tokens[i], 'CREATE')) {
+      let next = i + 1;
+      if (keyword(tokens[next], 'TEMP') || keyword(tokens[next], 'TEMPORARY')) next += 1;
+      if (keyword(tokens[next], 'TRIGGER')) i = triggerEnd(tokens, next);
+    }
+    if (tokens[i].value !== ';') continue;
+    if (i > firstToken) statements.push(sql.slice(start, tokens[i].start).trim());
+    start = tokens[i].end;
+    firstToken = i + 1;
+  }
+  if (firstToken < tokens.length) statements.push(sql.slice(start).trim());
+  return statements;
+}

--- a/packages/update-engine/src/types.ts
+++ b/packages/update-engine/src/types.ts
@@ -25,12 +25,14 @@ export interface ReleaseEntry {
   required_secrets: string[];
   new_required_secrets: string[];
   migrations: string[];
+  /** Worker can safely claim historical mileage held by the update adapter. */
+  legacy_mileage_projection_version?: 1;
   changelog_url: string;
   min_from_version: string;
 }
 
 export interface Manifest {
-  schema_version: 1;
+  schema_version: 1 | 2;
   latest: string;
   releases: ReleaseEntry[];
 }

--- a/packages/update-engine/test/cf-api/d1.test.ts
+++ b/packages/update-engine/test/cf-api/d1.test.ts
@@ -104,6 +104,18 @@ describe('executeD1Query', () => {
     expect(body.params).toEqual(['one', 2, true]);
   });
 
+  it.each([
+    { success: false, result: [] },
+    { success: true, result: [{ success: false, error: 'sensitive SQL data' }] },
+    { success: true, result: null },
+  ])('rejects an unsuccessful SQL envelope even with HTTP 200', async (body) => {
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true, status: 200, json: async () => body,
+    } as Response);
+    await expect(executeD1Query({ creds, databaseId: 'db', sql: 'SELECT 1' }))
+      .rejects.toThrow('D1 query returned an unsuccessful SQL result');
+  });
+
   it('defaults params to [] when not provided', async () => {
     const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
     fetchMock.mockResolvedValue({

--- a/packages/update-engine/test/legacy-mileage-capability.test.ts
+++ b/packages/update-engine/test/legacy-mileage-capability.test.ts
@@ -22,11 +22,23 @@ describe('legacy mileage target capability', () => {
 
   it('keeps matching-checksum updates to older targets as no-ops', async () => {
     const execute = vi.fn(async ({sql}: {sql: string}) => ({
-      success: true, result: [{ success: true, results: sql.startsWith('SELECT checksum') ? [{checksum}] : [] }],
+      success: true, result: [{ success: true, results: sql.startsWith('SELECT checksum') ? [{checksum}]
+        : sql.includes('claims_table') ? [{claims_table: 0}] : [] }],
     }));
     const result = await applyD1Migrations({ ...options, execute });
     expect(result).toEqual([{name, alreadyApplied: true, executedStatements: 0, skippedStatements: 0}]);
-    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not strand existing held claims behind a matching checksum when selecting an old Worker', async () => {
+    const execute = vi.fn(async ({sql}: {sql: string}) => ({
+      success: true, result: [{ success: true, results:
+        sql.startsWith('SELECT checksum') ? [{checksum}] : sql.includes('claims_table') ? [{claims_table: 1}]
+          : sql.includes('AS unfinished') ? [{unfinished: 1}] : [],
+      }],
+    }));
+    await expect(applyD1Migrations({ ...options, execute })).rejects.toThrow('handoff is unfinished');
+    expect(execute.mock.calls.every(([input]) => !input.sql.startsWith('INSERT'))).toBe(true);
   });
 
   it('rejects changed or renamed historical SQL before contacting D1', async () => {

--- a/packages/update-engine/test/legacy-mileage-capability.test.ts
+++ b/packages/update-engine/test/legacy-mileage-capability.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { applyD1Migrations } from '../src/migrations.js';
+
+const name = '062_mileage_admin_and_activity_rules.sql';
+const source = readFileSync(new URL(`../../db/migrations/${name}`, import.meta.url));
+const checksum = `sha256:${createHash('sha256').update(source).digest('hex')}`;
+const options = {
+  creds: { accountId: 'fixture-account', apiToken: 'fixture-token' }, databaseId: 'fixture-db',
+  names: [name], migrations: new Map([[name, source]]),
+};
+
+describe('legacy mileage target capability', () => {
+  it('does not start historical replay when the target Worker cannot claim held history', async () => {
+    const execute = vi.fn(async (_opts: { sql: string }) => ({ success: true, result: [{ success: true, results: [] }] }));
+    await expect(applyD1Migrations({ ...options, execute })).rejects.toThrow('legacy_mileage_projection_version=1');
+    const sql = execute.mock.calls.map(call => (call[0] as {sql: string}).sql);
+    expect(sql).toHaveLength(2); // Ledger existence and checksum lookup only.
+    expect(sql.join('\n')).not.toMatch(/ALTER TABLE mileage_ledger|INSERT|legacy_mileage_claims/i);
+  });
+
+  it('keeps matching-checksum updates to older targets as no-ops', async () => {
+    const execute = vi.fn(async ({sql}: {sql: string}) => ({
+      success: true, result: [{ success: true, results: sql.startsWith('SELECT checksum') ? [{checksum}] : [] }],
+    }));
+    const result = await applyD1Migrations({ ...options, execute });
+    expect(result).toEqual([{name, alreadyApplied: true, executedStatements: 0, skippedStatements: 0}]);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects changed or renamed historical SQL before contacting D1', async () => {
+    const execute = vi.fn();
+    await expect(applyD1Migrations({ ...options, execute, legacyMileageProjectionVersion: 1,
+      migrations: new Map([[name, Buffer.concat([source, Buffer.from('\n-- changed')])]]),
+    })).rejects.toThrow(/unknown historical mileage SQL/);
+    const renamed = '062_renamed_history.sql';
+    await expect(applyD1Migrations({ ...options, execute, legacyMileageProjectionVersion: 1,
+      names: [renamed], migrations: new Map([[renamed, source]]),
+    })).rejects.toThrow(/unknown historical mileage SQL|Unsupported legacy mileage/);
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/update-engine/test/legacy-mileage.test.ts
+++ b/packages/update-engine/test/legacy-mileage.test.ts
@@ -1,0 +1,387 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyLegacyMileageMigration, assertLegacyMileageSource, LEGACY_MILEAGE_HOLD, LEGACY_MILEAGE_MIGRATIONS } from '../src/legacy-mileage.js';
+import { applyD1Migrations } from '../src/migrations.js';
+import { applyMileageRulesForEvent, processPendingMileageEvents, recordEngagementEvent } from '../../db/src/mileage.js';
+
+const DB_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../db');
+const NAMES = Object.keys(LEGACY_MILEAGE_MIGRATIONS) as Array<keyof typeof LEGACY_MILEAGE_MIGRATIONS>;
+const sources = new Map(NAMES.map(name => [name, readFileSync(join(DB_ROOT, 'migrations', name))]));
+const NOW = '2026-09-10T20:00:00.000+09:00';
+const DAY = '2026-09-09T10:00:00.000+09:00';
+const creds = { accountId: 'offline', apiToken: 'offline' };
+
+function seedSql(name: string) {
+  const sql = sources.get(name as typeof NAMES[number])!.toString('utf8');
+  const start = sql.indexOf('INSERT OR IGNORE INTO mileage_rules');
+  return sql.slice(start, sql.indexOf(';', start) + 1);
+}
+function fixture() {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(readFileSync(join(DB_ROOT, 'bootstrap.sql'), 'utf8'));
+  sqlite.exec(`INSERT INTO mileage_programs VALUES ('default','default','Harnessマイル','active','2026-01-01','2026-01-01');
+    INSERT INTO users(id,display_name) VALUES ('u','test');
+    INSERT INTO line_accounts(id,channel_id,name,channel_access_token,channel_secret) VALUES('a','channel','offline','not-a-token','not-a-secret');
+    INSERT INTO friends(id,line_user_id,user_id,line_account_id) VALUES ('f','Uf','u','a'),('f2','Uf2','u','a');
+    CREATE TABLE _line_harness_migrations(name TEXT PRIMARY KEY, checksum TEXT NOT NULL, applied_at TEXT NOT NULL);`);
+  for (const name of NAMES) sqlite.exec(seedSql(name));
+  return sqlite;
+}
+function d1(sqlite: Database.Database): D1Database {
+  return { prepare(sql: string) {
+    const bound = (params: unknown[]) => ({
+      async run() { const result = sqlite.prepare(sql).run(...params); return {success: true, results: [], meta: {changes: result.changes}}; },
+      async first<T>() { return (sqlite.prepare(sql).get(...params) as T) ?? null; },
+      async all<T>() { return {success: true, results: sqlite.prepare(sql).all(...params) as T[], meta: {}}; },
+    });
+    return {...bound([]), bind: (...params: unknown[]) => bound(params)};
+  }} as unknown as D1Database;
+}
+function transport(sqlite: Database.Database, failBeforeStamp = false) {
+  return async ({sql, params = []}: {sql: string; params?: any[]}) => {
+    if (sql.trim().startsWith('SELECT')) {
+      return {success: true, result: [{success: true, results: sqlite.prepare(sql).all(...params)}]};
+    }
+    // Model the D1 *single-request* transaction, not an application loop of
+    // committed statements. Faults after candidate writes must roll them back.
+    sqlite.transaction(() => sqlite.exec(failBeforeStamp
+      ? sql.replace('INSERT OR IGNORE INTO _line_harness_migrations', 'INSERT OR IGNORE INTO deliberately_missing_table')
+      : sql))();
+    return {success: true, result: [{success: true, results: []}]};
+  };
+}
+async function adapt(sqlite: Database.Database, name = NAMES[0], failBeforeStamp = false) {
+  return applyLegacyMileageMigration({name, source: sources.get(name)!, checksum: `sha256:${LEGACY_MILEAGE_MIGRATIONS[name]}`,
+    creds, databaseId: 'memory', execute: transport(sqlite, failBeforeStamp)});
+}
+function rawMessage(sqlite: Database.Database, id = 'm', friend = 'f', occurred = DAY) {
+  sqlite.prepare("INSERT INTO messages_log(id,friend_id,direction,message_type,content,created_at) VALUES(?,?,'incoming','text','offline',?)").run(id, friend, occurred);
+}
+function rawWebinar(sqlite: Database.Database, position = 300, cta = false) {
+  sqlite.exec(`INSERT INTO webinars(id,account_id,title,slug,duration_seconds,created_at,updated_at) VALUES('w','a','offline','offline',1000,'2026-01-01','2026-01-01');`);
+  sqlite.prepare('INSERT INTO webinar_viewers(id,webinar_id,friend_id,session_start_at,joined_at,last_position_seconds,cta_clicked_at) VALUES(?,?,?,?,?,?,?)')
+    .run('v','w','f',1234,DAY,position,cta ? DAY : null);
+}
+function wallet(sqlite: Database.Database) { return sqlite.prepare('SELECT COALESCE(SUM(amount),0) AS amount FROM mileage_ledger').get() as {amount: number}; }
+function legacyProjection(sqlite: Database.Database, name = NAMES[0]) {
+  const source = sources.get(name)!.toString('utf8');
+  sqlite.exec(source.slice(source.indexOf('INSERT OR IGNORE INTO mileage_rules')));
+}
+function ledger(sqlite: Database.Database) { return sqlite.prepare('SELECT * FROM mileage_ledger ORDER BY id').all(); }
+
+describe('immutable mileage replay adapter', () => {
+  let sqlite: Database.Database;
+  beforeEach(() => { vi.useFakeTimers({toFake: ['Date']}); vi.setSystemTime(new Date(NOW)); sqlite = fixture(); });
+  afterEach(() => { sqlite.close(); vi.useRealTimers(); });
+
+  it('recognizes only the exact released SQL bytes', () => {
+    for (const name of NAMES) expect(() => assertLegacyMileageSource(name, sources.get(name)!)).not.toThrow();
+    expect(() => assertLegacyMileageSource(NAMES[0], Buffer.concat([sources.get(NAMES[0])!, Buffer.from('\n')]))).toThrow('unknown historical mileage SQL');
+  });
+
+  it('keeps settled live message + webinar mileage at 6 and retains every ledger row', async () => {
+    rawMessage(sqlite); rawWebinar(sqlite);
+    await applyMileageRulesForEvent(d1(sqlite), {eventType:'message_received',source:'line',sourceEventId:'m',friendId:'f',occurredAt:DAY});
+    await applyMileageRulesForEvent(d1(sqlite), {eventType:'webinar_watch_5m',source:'webinar',sourceEventId:'w:f:5m',friendId:'f',subjectKey:'w',occurredAt:DAY});
+    await processPendingMileageEvents(d1(sqlite), {now:NOW});
+    const before = ledger(sqlite);
+    expect(wallet(sqlite)).toEqual({amount:6});
+    const apply = () => applyD1Migrations({creds,databaseId:'memory',names:NAMES,migrations:sources,
+      legacyMileageProjectionVersion:1,execute:transport(sqlite)});
+    await apply();
+    expect(ledger(sqlite)).toEqual(before);
+    expect(sqlite.prepare('SELECT COUNT(*) AS count FROM engagement_events').get()).toEqual({count:2});
+    expect(sqlite.prepare('SELECT COUNT(*) AS count FROM _line_harness_legacy_mileage_claims').get()).toEqual({count:0});
+    expect(sqlite.prepare('SELECT COUNT(*) AS count FROM _line_harness_migrations').get()).toEqual({count:2});
+    expect((await apply()).every(result => result.alreadyApplied)).toBe(true);
+    expect(ledger(sqlite)).toEqual(before);
+  });
+
+  it('leaves pending live queue rows and disabled live-owned decisions untouched', async () => {
+    rawMessage(sqlite);
+    await applyMileageRulesForEvent(d1(sqlite), {eventType:'message_received',source:'line',sourceEventId:'m',friendId:'f',occurredAt:DAY});
+    sqlite.exec("UPDATE mileage_rules SET is_active=0 WHERE id='builtin-message-received'");
+    const queue = sqlite.prepare('SELECT * FROM mileage_event_queue').all();
+    await adapt(sqlite);
+    expect(sqlite.prepare('SELECT * FROM mileage_event_queue').all()).toEqual(queue);
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM _line_harness_legacy_mileage_claims').get()).toEqual({n:0});
+    await processPendingMileageEvents(d1(sqlite), {now:NOW});
+    expect(wallet(sqlite)).toEqual({amount:0});
+  });
+
+  it('claims raw-write → migration → old enqueue exactly once and holds it from old cron', async () => {
+    rawMessage(sqlite);
+    await adapt(sqlite);
+    expect(wallet(sqlite)).toEqual({amount:0});
+    const resumed = await applyMileageRulesForEvent(d1(sqlite), {eventType:'message_received',source:'line',sourceEventId:'m',friendId:'f',occurredAt:DAY});
+    expect(resumed.event.id).toBe('history-message-m');
+    expect(sqlite.prepare('SELECT status,available_at FROM mileage_event_queue').get()).toEqual({status:'pending',available_at:LEGACY_MILEAGE_HOLD});
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM mileage_event_queue WHERE status='pending' AND datetime(available_at)<=datetime(?)").get(NOW)).toEqual({n:0});
+    expect(await processPendingMileageEvents(d1(sqlite), {now:NOW})).toMatchObject({processed:1, failed:0});
+    expect(wallet(sqlite)).toEqual({amount:1});
+    await adapt(sqlite);
+    expect(await processPendingMileageEvents(d1(sqlite), {now:NOW})).toMatchObject({processed:0});
+    expect(wallet(sqlite)).toEqual({amount:1});
+  });
+
+  it('does not claim the event-before-queue gap', async () => {
+    rawMessage(sqlite);
+    const event = await recordEngagementEvent(d1(sqlite), {idempotencyKey:'line:message_received:m',eventType:'message_received',source:'line',sourceEventId:'m',actorFriendId:'f',actorUserId:'u',occurredAt:DAY});
+    await adapt(sqlite);
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM mileage_event_queue').get()).toEqual({n:0});
+    const resumed = await applyMileageRulesForEvent(d1(sqlite), {eventType:'message_received',source:'line',sourceEventId:'m',friendId:'f',occurredAt:DAY});
+    expect(resumed.event.id).toBe(event.id);
+    await processPendingMileageEvents(d1(sqlite), {now:NOW});
+    expect(wallet(sqlite)).toEqual({amount:1});
+  });
+
+  it('repairs an old event whose grant is missing without changing another historical grant', async () => {
+    rawMessage(sqlite, 'granted'); rawMessage(sqlite, 'unfinished');
+    legacyProjection(sqlite);
+    sqlite.exec("DELETE FROM mileage_ledger WHERE source_event_id='unfinished'");
+    const before = ledger(sqlite);
+    await adapt(sqlite);
+    expect(ledger(sqlite)).toEqual(before);
+    expect(sqlite.prepare("SELECT id,idempotency_key FROM engagement_events WHERE source_event_id='unfinished'").get())
+      .toEqual({id:'history-message-unfinished',idempotency_key:'line:message_received:unfinished'});
+    expect(sqlite.prepare('SELECT status,COUNT(*) AS n FROM mileage_event_queue GROUP BY status ORDER BY status').all())
+      .toEqual([{status:'pending',n:1},{status:'processed',n:1}]);
+    await processPendingMileageEvents(d1(sqlite), {now:NOW});
+    expect(wallet(sqlite)).toEqual({amount:2});
+    expect(ledger(sqlite)).toEqual(expect.arrayContaining(before));
+  });
+
+  it('preserves historical cap suppression and uses runtime for genuinely ungranted days', async () => {
+    for (let i=0;i<6;i++) rawMessage(sqlite, `m${i}`, i%2 ? 'f2':'f');
+    legacyProjection(sqlite);
+    const before = ledger(sqlite);
+    rawMessage(sqlite, 'next-day', 'f', '2026-09-10T10:00:00.000+09:00');
+    await adapt(sqlite);
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM mileage_event_queue WHERE status='processed'").get()).toEqual({n:6});
+    expect(ledger(sqlite)).toEqual(before);
+    await processPendingMileageEvents(d1(sqlite), {now:NOW});
+    expect(wallet(sqlite)).toEqual({amount:6});
+  });
+
+  it('queues all source families and recovers the CTA session key from a proven legacy event', async () => {
+    rawMessage(sqlite); rawWebinar(sqlite, 1000, true);
+    sqlite.exec(`UPDATE friends SET ig_igsid='ig' WHERE id='f';
+      INSERT INTO tracked_links(id,name,original_url) VALUES('link','link','https://example.test');
+      INSERT INTO link_clicks(id,tracked_link_id,friend_id,clicked_at) VALUES('click','link','f','${DAY}');
+      INSERT INTO forms(id,name) VALUES('form','form');
+      INSERT INTO form_submissions(id,form_id,friend_id,created_at) VALUES('submission','form','f','${DAY}');
+      INSERT INTO staff(id,line_account_id,name,display_name) VALUES('staff','a','staff','staff');
+      INSERT INTO menus(id,line_account_id,name,duration_minutes,base_price) VALUES('menu','a','menu',30,100);
+      INSERT INTO bookings(id,line_account_id,friend_id,staff_id,menu_id,starts_at,ends_at,block_ends_at,status,price_at_booking,requested_at,created_at)
+        VALUES('booking','a','f','staff','menu','${DAY}','${DAY}','${DAY}','confirmed',100,'${DAY}','${DAY}');
+      INSERT INTO events(id,line_account_id,name) VALUES('event','a','event');
+      INSERT INTO event_slots(id,event_id,starts_at,ends_at) VALUES('slot','event','${DAY}','${DAY}');
+      INSERT INTO event_bookings(id,line_account_id,event_id,slot_id,friend_id,status,requested_at,created_at)
+        VALUES('event-booking','a','event','slot','f','confirmed','${DAY}','${DAY}');`);
+    // A partial old projection proves the CTA identity that the raw viewer
+    // alone cannot provide. Keep its events while simulating unfinished grants.
+    legacyProjection(sqlite,NAMES[1]);
+    sqlite.exec('DELETE FROM mileage_ledger');
+    for (const name of NAMES) await adapt(sqlite,name);
+    expect(sqlite.prepare("SELECT idempotency_key,json_extract(metadata,'$.subjectKey') AS subject FROM engagement_events WHERE event_type='webinar_cta_clicked'").get())
+      .toEqual({idempotency_key:'webinar:webinar_cta_clicked:w:f:1234:primary',subject:'w:primary'});
+    expect(wallet(sqlite)).toEqual({amount:0});
+    expect(await processPendingMileageEvents(d1(sqlite),{now:NOW})).toMatchObject({processed:10,failed:0});
+    expect(wallet(sqlite)).toEqual({amount:123});
+  });
+
+  it('keeps previously rewarded form subjects settled across linked friends', async () => {
+    sqlite.exec(`INSERT INTO forms(id,name) VALUES('form','form');
+      INSERT INTO form_submissions(id,form_id,friend_id,created_at) VALUES('old','form','f','${DAY}');`);
+    legacyProjection(sqlite);
+    const before = ledger(sqlite);
+    sqlite.exec(`INSERT INTO form_submissions(id,form_id,friend_id,created_at) VALUES('repeat','form','f2','${DAY}');`);
+    await adapt(sqlite);
+    expect(sqlite.prepare('SELECT DISTINCT status FROM mileage_event_queue').all()).toEqual([{status:'processed'}]);
+    expect(ledger(sqlite)).toEqual(before);
+    await applyMileageRulesForEvent(d1(sqlite),{eventType:'form_submitted',source:'form',sourceEventId:'future',friendId:'f2',subjectKey:'form',occurredAt:DAY});
+    await processPendingMileageEvents(d1(sqlite),{now:NOW});
+    expect(ledger(sqlite)).toEqual(before);
+  });
+
+  it('retains anonymous historical analytics without creating an unprocessable pending action', async () => {
+    sqlite.exec(`INSERT INTO tracked_links(id,name,original_url) VALUES('link','link','https://example.test');
+      INSERT INTO link_clicks(id,tracked_link_id,clicked_at) VALUES('anonymous','link','${DAY}');`);
+    await adapt(sqlite);
+    expect(sqlite.prepare('SELECT actor_friend_id FROM engagement_events').get()).toEqual({actor_friend_id:null});
+    expect(sqlite.prepare('SELECT status FROM mileage_event_queue').get()).toEqual({status:'processed'});
+    expect(await processPendingMileageEvents(d1(sqlite),{now:NOW})).toMatchObject({claimed:0});
+  });
+
+  it('repairs a proven historic primary CTA without taking over a distinct live secondary CTA', async () => {
+    rawWebinar(sqlite, 100, true);
+    legacyProjection(sqlite, NAMES[1]);
+    sqlite.exec("DELETE FROM mileage_ledger WHERE mileage_rule_id='builtin-webinar-cta-clicked'");
+    await applyMileageRulesForEvent(d1(sqlite), {eventType:'webinar_cta_clicked',source:'webinar',sourceEventId:'w:f:1234:secondary',
+      friendId:'f',subjectKey:'w:secondary',metadata:{webinarId:'w',sessionStartAt:1234,ctaId:'secondary'},occurredAt:DAY});
+    const queue = sqlite.prepare('SELECT * FROM mileage_event_queue').all();
+    await adapt(sqlite,NAMES[1]);
+    expect(sqlite.prepare('SELECT * FROM mileage_event_queue').all()).toEqual(expect.arrayContaining(queue));
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM _line_harness_legacy_mileage_claims').get()).toEqual({n:1});
+    await processPendingMileageEvents(d1(sqlite),{now:NOW});
+    expect(wallet(sqlite)).toEqual({amount:20});
+  });
+
+  it('aborts the raw-secondary-CTA → migration gap, then retries safely after live enqueue', async () => {
+    // /cta-click commits this timestamp before it records the request's
+    // secondary CTA identity. The migration must not guess a primary action.
+    rawWebinar(sqlite, 100, true);
+    const viewer = sqlite.prepare('SELECT * FROM webinar_viewers').all();
+    await expect(adapt(sqlite,NAMES[1])).rejects.toThrow('cannot establish historical CTA identity');
+    expect(sqlite.prepare('SELECT * FROM webinar_viewers').all()).toEqual(viewer);
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM engagement_events').get()).toEqual({n:0});
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM mileage_event_queue').get()).toEqual({n:0});
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM _line_harness_migrations').get()).toEqual({n:0});
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM sqlite_master WHERE name LIKE '_line_harness_legacy_mileage_%'").get()).toEqual({n:0});
+
+    // Resume the old async request with its actual CTA, then retry migration.
+    await applyMileageRulesForEvent(d1(sqlite), {eventType:'webinar_cta_clicked',source:'webinar',sourceEventId:'w:f:1234:secondary',
+      friendId:'f',subjectKey:'w:secondary',metadata:{webinarId:'w',sessionStartAt:1234,ctaId:'secondary'},occurredAt:DAY});
+    await adapt(sqlite,NAMES[1]);
+    expect(await processPendingMileageEvents(d1(sqlite),{now:NOW})).toMatchObject({processed:1,failed:0});
+    expect(wallet(sqlite)).toEqual({amount:10});
+    expect(sqlite.prepare("SELECT json_extract(metadata,'$.subjectKey') AS subject FROM engagement_events").all())
+      .toEqual([{subject:'w:secondary'}]);
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM _line_harness_legacy_mileage_claims').get()).toEqual({n:0});
+  });
+
+  it('rejects legacy CTA recovery when its recorded session disagrees with the raw viewer', async () => {
+    rawWebinar(sqlite, 100, true);
+    legacyProjection(sqlite,NAMES[1]);
+    sqlite.exec("UPDATE engagement_events SET metadata=json_set(metadata,'$.sessionStartAt',9999) WHERE event_type='webinar_cta_clicked'");
+    const events = sqlite.prepare('SELECT * FROM engagement_events').all();
+    const grants = ledger(sqlite);
+    await expect(adapt(sqlite,NAMES[1])).rejects.toThrow('cannot establish historical CTA identity');
+    expect(sqlite.prepare('SELECT * FROM engagement_events').all()).toEqual(events);
+    expect(ledger(sqlite)).toEqual(grants);
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM _line_harness_migrations').get()).toEqual({n:0});
+  });
+
+  it.each(['pending','processing','failed'] as const)('blocks an old-runtime %s queue overlapping a historical grant without taking ownership', async status => {
+    rawMessage(sqlite);
+    legacyProjection(sqlite);
+    const grants = ledger(sqlite);
+    await applyMileageRulesForEvent(d1(sqlite),{eventType:'message_received',source:'line',sourceEventId:'m',friendId:'f',occurredAt:DAY});
+    sqlite.prepare('UPDATE mileage_event_queue SET status=?,attempts=1,processing_started_at=?').run(status,NOW);
+    const queue = sqlite.prepare('SELECT * FROM mileage_event_queue').all();
+    const events = sqlite.prepare('SELECT * FROM engagement_events ORDER BY id').all();
+    await expect(adapt(sqlite)).rejects.toThrow('pending live mileage events that overlap existing historical grants');
+    expect(sqlite.prepare('SELECT * FROM mileage_event_queue').all()).toEqual(queue);
+    expect(sqlite.prepare('SELECT * FROM engagement_events ORDER BY id').all()).toEqual(events);
+    expect(ledger(sqlite)).toEqual(grants);
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM _line_harness_migrations').get()).toEqual({n:0});
+  });
+
+  it('detects a historical overlap in the event-before-queue gap', async () => {
+    rawMessage(sqlite);
+    legacyProjection(sqlite);
+    await recordEngagementEvent(d1(sqlite),{idempotencyKey:'line:message_received:m',eventType:'message_received',source:'line',sourceEventId:'m',actorFriendId:'f',actorUserId:'u',occurredAt:DAY});
+    await expect(adapt(sqlite)).rejects.toThrow('pending live mileage events that overlap existing historical grants');
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM mileage_event_queue').get()).toEqual({n:0});
+    expect(wallet(sqlite)).toEqual({amount:1});
+  });
+
+  it('finds pending subject overlaps even without the live source row and succeeds after compatible reconciliation', async () => {
+    sqlite.exec(`INSERT INTO forms(id,name) VALUES('form','form');
+      INSERT INTO form_submissions(id,form_id,friend_id,created_at) VALUES('old','form','f','${DAY}');`);
+    legacyProjection(sqlite);
+    const grants = ledger(sqlite);
+    await applyMileageRulesForEvent(d1(sqlite),{eventType:'form_submitted',source:'form',sourceEventId:'different-source-not-in-raw-table',
+      friendId:'f2',subjectKey:'form',occurredAt:DAY});
+    await expect(adapt(sqlite)).rejects.toThrow('pending live mileage events that overlap existing historical grants');
+    // Reconcile with the actual compatible processor; blindly draining the
+    // old processor would duplicate this grant, which is why replay stopped.
+    expect(await processPendingMileageEvents(d1(sqlite),{now:NOW})).toMatchObject({processed:1,failed:0});
+    expect(ledger(sqlite)).toEqual(grants);
+    await adapt(sqlite);
+    expect(ledger(sqlite)).toEqual(grants);
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM _line_harness_migrations').get()).toEqual({n:1});
+  });
+
+  it('accepts reordered equivalent default condition keys', async () => {
+    sqlite.exec(`UPDATE mileage_rules SET conditions='{"uniquePerSubjectPerDay":true,"dailyCapActions":5}' WHERE id='builtin-link-clicked';
+      INSERT INTO tracked_links(id,name,original_url) VALUES('link','link','https://example.test');
+      INSERT INTO link_clicks(id,tracked_link_id,friend_id,clicked_at) VALUES('click','link','f','${DAY}');`);
+    await adapt(sqlite);
+    expect(await processPendingMileageEvents(d1(sqlite),{now:NOW})).toMatchObject({processed:1,failed:0});
+    expect(wallet(sqlite)).toEqual({amount:2});
+  });
+
+  it('ignores a multiplier assigned after the historical action', async () => {
+    rawMessage(sqlite);
+    sqlite.exec(`INSERT INTO tags(id,name,mileage_multiplier_bps) VALUES('later-tier','later-tier',20000);
+      INSERT INTO friend_tags(friend_id,tag_id,assigned_at) VALUES('f','later-tier','${NOW}');`);
+    await adapt(sqlite);
+    expect(await processPendingMileageEvents(d1(sqlite),{now:NOW})).toMatchObject({processed:1,failed:0});
+    expect(wallet(sqlite)).toEqual({amount:1});
+  });
+
+  it('fails a held projection explicitly if its saved rule policy later changes', async () => {
+    rawMessage(sqlite);
+    await adapt(sqlite);
+    sqlite.exec("UPDATE mileage_rules SET amount=7 WHERE id='builtin-message-received'");
+    expect(await processPendingMileageEvents(d1(sqlite),{now:NOW})).toMatchObject({processed:0,failed:1});
+    expect(wallet(sqlite)).toEqual({amount:0});
+    expect(sqlite.prepare('SELECT status,available_at FROM mileage_event_queue').get())
+      .toEqual({status:'failed',available_at:LEGACY_MILEAGE_HOLD});
+  });
+
+  it('rejects orphan ungranted legacy history rather than stamping it as complete', async () => {
+    rawMessage(sqlite);
+    legacyProjection(sqlite);
+    sqlite.exec("DELETE FROM mileage_ledger; DELETE FROM messages_log WHERE id='m'");
+    await expect(adapt(sqlite)).rejects.toThrow('require review');
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM _line_harness_migrations').get()).toEqual({n:0});
+    expect(sqlite.prepare('SELECT idempotency_key FROM engagement_events').get()).toEqual({idempotency_key:'history:message:m'});
+  });
+
+  it('does not repurpose an old Instagram event if its friend now has a different IGSID', async () => {
+    sqlite.exec("UPDATE friends SET ig_igsid='original' WHERE id='f'");
+    legacyProjection(sqlite,NAMES[1]);
+    const oldEvents = sqlite.prepare('SELECT * FROM engagement_events').all();
+    const oldLedger = ledger(sqlite);
+    sqlite.exec("UPDATE friends SET ig_igsid='changed' WHERE id='f'");
+    await expect(adapt(sqlite,NAMES[1])).rejects.toThrow('require review');
+    expect(sqlite.prepare('SELECT * FROM engagement_events').all()).toEqual(oldEvents);
+    expect(ledger(sqlite)).toEqual(oldLedger);
+  });
+
+  it.each([
+    "UPDATE mileage_rules SET is_active=0 WHERE id='builtin-message-received'",
+    "UPDATE mileage_rules SET amount=7 WHERE id='builtin-message-received'",
+    "INSERT INTO mileage_rules(id,program_id,name,event_type,source,amount,initial_status,is_active,created_at,updated_at) VALUES('custom','default','custom','message_received','line',3,'available',1,'2026-01-01','2026-01-01')",
+    `INSERT INTO tags(id,name,mileage_multiplier_bps) VALUES('tier','tier',20000); INSERT INTO friend_tags(friend_id,tag_id,assigned_at) VALUES('f','tier','${DAY}')`,
+  ])('rolls back a candidate whose entitlement has ambiguous custom policy: %s', async sql => {
+    rawMessage(sqlite); sqlite.exec(sql);
+    await expect(adapt(sqlite)).rejects.toThrow('require review');
+    expect(wallet(sqlite)).toEqual({amount:0});
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM engagement_events').get()).toEqual({n:0});
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM _line_harness_migrations').get()).toEqual({n:0});
+    expect(sqlite.prepare("SELECT COUNT(*) AS n FROM sqlite_master WHERE name LIKE '_line_harness_legacy_mileage_%'").get()).toEqual({n:0});
+  });
+
+  it('rolls back claims/events/queue together when execution fails before the stamp, then retries', async () => {
+    rawMessage(sqlite);
+    await expect(adapt(sqlite,NAMES[0],true)).rejects.toThrow('deliberately_missing_table');
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM engagement_events').get()).toEqual({n:0});
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM mileage_event_queue').get()).toEqual({n:0});
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM _line_harness_migrations').get()).toEqual({n:0});
+    await adapt(sqlite);
+    await processPendingMileageEvents(d1(sqlite),{now:NOW});
+    expect(wallet(sqlite)).toEqual({amount:1});
+  });
+
+  it('refuses a queue-less existing synchronous mileage baseline', async () => {
+    sqlite.exec('DROP TABLE mileage_event_queue'); rawMessage(sqlite);
+    await expect(adapt(sqlite)).rejects.toThrow('asynchronous mileage baseline');
+    expect(sqlite.prepare('SELECT COUNT(*) AS n FROM engagement_events').get()).toEqual({n:0});
+  });
+});

--- a/packages/update-engine/test/manifest.test.ts
+++ b/packages/update-engine/test/manifest.test.ts
@@ -74,15 +74,29 @@ describe('fetchManifest', () => {
     );
   });
 
+  it('accepts schema 2 while keeping schema 1 releases readable', async () => {
+    const manifest: Manifest = { ...sampleManifest(), schema_version: 2 };
+    manifest.releases[2].legacy_mileage_projection_version = 1;
+    vi.mocked(globalThis.fetch).mockResolvedValue({ ok: true, json: async () => manifest } as Response);
+    expect(await fetchManifest('https://example.com/manifest.json')).toEqual(manifest);
+  });
+
+  it('does not allow handoff releases to masquerade as old-engine-compatible schema 1', async () => {
+    const manifest = sampleManifest();
+    manifest.releases[2].legacy_mileage_projection_version = 1;
+    vi.mocked(globalThis.fetch).mockResolvedValue({ ok: true, json: async () => manifest } as Response);
+    await expect(fetchManifest('https://example.com/manifest.json')).rejects.toThrow('requires manifest schema_version 2');
+  });
+
   it('throws on unsupported schema_version', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 200,
-      json: async () => ({ schema_version: 2, latest: '1.0.0', releases: [] }),
+      json: async () => ({ schema_version: 3, latest: '1.0.0', releases: [] }),
     } as Response);
 
     await expect(fetchManifest('https://example.com/manifest.json')).rejects.toThrow(
-      /unsupported manifest schema_version 2/,
+      /unsupported manifest schema_version 3/,
     );
   });
 });

--- a/packages/update-engine/test/migrations.test.ts
+++ b/packages/update-engine/test/migrations.test.ts
@@ -34,12 +34,10 @@ describe('splitSqlStatements', () => {
     expect(splitSqlStatements('-- only a comment;\n; /* another */')).toEqual([]);
   });
 
-  it('rejects trigger bodies instead of splitting them incorrectly', () => {
-    expect(() =>
-      splitSqlStatements(
-        'CREATE TRIGGER t AFTER INSERT ON a BEGIN UPDATE b SET x = 1; END;',
-      ),
-    ).toThrow(/CREATE TRIGGER/);
+  it('preserves complete trigger bodies as one statement', () => {
+    expect(splitSqlStatements(
+      'CREATE TRIGGER t AFTER INSERT ON a BEGIN UPDATE b SET x = 1; END;',
+    )).toEqual(['CREATE TRIGGER t AFTER INSERT ON a BEGIN UPDATE b SET x = 1; END']);
   });
 });
 

--- a/packages/update-engine/test/sql-statements.test.ts
+++ b/packages/update-engine/test/sql-statements.test.ts
@@ -1,0 +1,181 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it, vi } from 'vitest';
+import { applyD1Migrations } from '../src/migrations.js';
+import {
+  containsDestructiveSchemaChanges,
+  splitSqlStatements,
+  stripSqlComments,
+} from '../src/sql-statements.js';
+
+const malformedTriggers = [
+  ['missing BEGIN', 'CREATE TRIGGER t AFTER INSERT ON a SELECT 1; END;'],
+  ['missing END', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 1;'],
+  ['empty body', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN END;'],
+  ['missing body semicolon', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 1 END;'],
+  ['unclosed CASE', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT CASE WHEN 1 THEN 2; END;'],
+  ['unclosed nested CASE', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT CASE WHEN 1 THEN CASE WHEN 2 THEN 3 END; END;'],
+  ['unclosed CASE with END identifier', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT CASE WHEN end > 0 THEN end; END;'],
+  ['unclosed WHEN CASE with END identifier', 'CREATE TRIGGER t AFTER INSERT ON a WHEN CASE WHEN end > 0 THEN end BEGIN SELECT 1; END;'],
+  ['unclosed parentheses', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT (1; END;'],
+  ['unmatched closing parenthesis', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 1); END;'],
+  ['extra END', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 1; END END;'],
+  ['unterminated outer statement', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 1; END CREATE TABLE b (id);'],
+  ['nested BEGIN block', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN BEGIN SELECT 1; END; END;'],
+  ['unfinished WHEN CASE', 'CREATE TRIGGER t AFTER INSERT ON a WHEN CASE WHEN 1 THEN 1 BEGIN SELECT 1; END;'],
+  ['empty WHEN', 'CREATE TRIGGER t AFTER INSERT ON a WHEN BEGIN SELECT 1; END;'],
+  ['unterminated string', "CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 'END;"],
+  ['unterminated comment', 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 1; /* END;'],
+] as const;
+
+describe('safe SQLite statement scanning', () => {
+  it('executes multiple commands, nested CASE, another trigger and following DDL separately', () => {
+    const db = new Database(':memory:');
+    try {
+      const statements = splitSqlStatements(`
+        CREATE TABLE events (id INTEGER PRIMARY KEY, value INTEGER);
+        CREATE TABLE logs (event_id INTEGER, value TEXT);
+        CREATE /* TRIGGER BEGIN END; */ TEMPORARY TRIGGER IF NOT EXISTS audit
+        AFTER INSERT ON main.events FOR EACH ROW
+        WHEN CASE WHEN NEW.value > 0 THEN CASE WHEN NEW.id > 0 THEN 1 ELSE 0 END ELSE 0 END
+        BEGIN
+          INSERT INTO logs VALUES (NEW.id, CASE WHEN NEW.value = 1 THEN
+            CASE WHEN NEW.id = 1 THEN 'it''s CASE; END; -- /*' ELSE 'other' END
+            ELSE 'BEGIN; END' END);
+          -- CASE END; CREATE TRIGGER ignored
+          UPDATE events SET value = value + 1 WHERE id = NEW.id;
+        END;
+        CREATE TRIGGER audit_delete AFTER DELETE ON events BEGIN
+          INSERT INTO logs VALUES (OLD.id, 'deleted;');
+        END;
+        CREATE INDEX logs_event ON logs(event_id);
+        INSERT INTO events VALUES (1, 1);
+        DELETE FROM events WHERE id = 1;
+      `);
+      expect(statements).toHaveLength(7);
+      // prepare().run() rejects accidentally joined statements and incomplete
+      // trigger fragments, unlike exec(), which accepts multi-statement input.
+      for (const statement of statements) db.prepare(statement).run();
+      expect(db.prepare('SELECT value FROM logs ORDER BY rowid').all()).toEqual([
+        { value: "it's CASE; END; -- /*" },
+        { value: 'deleted;' },
+      ]);
+      expect(db.prepare("SELECT name FROM sqlite_master WHERE type = 'index'").all()).toContainEqual({ name: 'logs_event' });
+    } finally {
+      db.close();
+    }
+  });
+
+  it('keeps quoted identifiers and comment markers out of keyword handling', () => {
+    const db = new Database(':memory:');
+    try {
+      const statements = splitSqlStatements(`
+        CREATE TABLE a ("END;" INTEGER, [CASE] INTEGER, \`BEGIN\` INTEGER);
+        CREATE TABLE b (value INTEGER);
+        CREATE TRIGGER "audit;END" UPDATE OF "END;", [CASE] ON a BEGIN
+          INSERT INTO b VALUES (NEW."END;" + NEW.[CASE] + NEW.\`BEGIN\`);
+        END;
+        INSERT INTO a VALUES (1, 2, 3);
+        UPDATE a SET "END;" = 4;
+      `);
+      for (const statement of statements) db.prepare(statement).run();
+      expect(db.prepare('SELECT value FROM b').get()).toEqual({ value: 9 });
+    } finally {
+      db.close();
+    }
+  });
+
+  it('supports omitted timing, INSTEAD OF, TEMP and a complete final END without an outer semicolon', () => {
+    const db = new Database(':memory:');
+    try {
+      for (const statement of splitSqlStatements(`
+        CREATE TABLE items (value INTEGER);
+        CREATE VIEW input AS SELECT value FROM items;
+        CREATE TEMP TRIGGER insert_input INSTEAD OF INSERT ON input BEGIN
+          INSERT INTO items VALUES (NEW.value);
+        END;
+        CREATE TRIGGER validate_input INSERT ON items BEGIN
+          SELECT CASE WHEN NEW.value < 0 THEN RAISE(ABORT, 'negative') END;
+        END
+      `)) db.prepare(statement).run();
+      db.prepare('INSERT INTO input VALUES (4)').run();
+      expect(db.prepare('SELECT value FROM items').get()).toEqual({ value: 4 });
+      expect(() => db.prepare('INSERT INTO input VALUES (-1)').run()).toThrow('negative');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('executes BEGIN and END fallback identifiers without consuming CASE or trigger delimiters', () => {
+    const db = new Database(':memory:');
+    try {
+      db.function('begin', () => 1);
+      const statements = splitSqlStatements(`
+        CREATE TABLE events (begin INTEGER, end INTEGER);
+        CREATE TABLE logs (begin INTEGER, end INTEGER);
+        CREATE TRIGGER audit AFTER INSERT ON events
+        WHEN (SELECT begin FROM events LIMIT 1) > 0 BEGIN
+          INSERT INTO logs(end, begin) VALUES (NEW.end, NEW.begin);
+          UPDATE logs SET end = CASE WHEN end > 0 THEN end ELSE 0 END,
+            begin = CASE end WHEN 4 THEN CASE WHEN begin > 0 THEN end ELSE 0 END ELSE 0 END;
+        END;
+        CREATE TRIGGER audit_update AFTER UPDATE ON events
+        WHEN begin() > 0 BEGIN
+          UPDATE logs SET end = (SELECT CASE WHEN end > 0 THEN end ELSE 0 END FROM events LIMIT 1);
+        END;
+        INSERT INTO events VALUES (2, 4);
+      `);
+      expect(statements).toHaveLength(5);
+      for (const statement of statements) db.prepare(statement).run();
+      expect(db.prepare('SELECT * FROM logs').get()).toEqual({ begin: 4, end: 4 });
+      db.prepare('UPDATE events SET end = 7').run();
+      expect(db.prepare('SELECT * FROM logs').get()).toEqual({ begin: 4, end: 7 });
+      // Name resolution in a WHEN expression belongs to SQLite. Its bare
+      // BEGIN operand must still be preserved by the envelope scanner.
+      const bareWhen = 'CREATE TRIGGER bare_when AFTER INSERT ON events WHEN begin > 0 BEGIN SELECT 1; END';
+      expect(splitSqlStatements(`${bareWhen};`)).toEqual([bareWhen]);
+      db.prepare(bareWhen).run();
+    } finally {
+      db.close();
+    }
+  });
+
+  it.each(malformedTriggers)('rejects %s during scanning', (_name, sql) => {
+    expect(() => splitSqlStatements(sql)).toThrow(/malformed CREATE TRIGGER|unterminated SQL/);
+  });
+
+  it.each(malformedTriggers)('does not contact D1 for a cumulative release with %s', async (_name, sql) => {
+    const execute = vi.fn();
+    const onMigrationStart = vi.fn();
+    await expect(applyD1Migrations({
+      creds: { accountId: 'account', apiToken: 'token' },
+      databaseId: 'db',
+      names: ['041_valid.sql', '076_malformed.sql'],
+      migrations: new Map([
+        ['041_valid.sql', Buffer.from('CREATE TABLE a (id INTEGER);')],
+        ['076_malformed.sql', Buffer.from(sql)],
+      ]),
+      execute,
+      onMigrationStart,
+    })).rejects.toThrow(/malformed CREATE TRIGGER|unterminated SQL/);
+    expect(execute).not.toHaveBeenCalled();
+    expect(onMigrationStart).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'DROP/**/TABLE a;',
+    'ALTER TABLE a DROP -- name\nCOLUMN b;',
+    'ALTER TABLE a RENAME TO b;',
+    'ALTER TABLE a RENAME COLUMN b TO c;',
+    "SELECT '--'; DROP TABLE a;",
+  ])('keeps destructive schema guards for %s', (sql) => {
+    expect(containsDestructiveSchemaChanges(sql)).toBe(true);
+    expect(() => splitSqlStatements(sql)).toThrow(/destructive schema changes/);
+  });
+
+  it('does not treat quoted text or comments as destructive schema operations', () => {
+    const sql = `/* DROP TABLE a; */ SELECT 'DROP TABLE a; CREATE TRIGGER t', "RENAME COLUMN", [DROP TABLE];`;
+    expect(containsDestructiveSchemaChanges(sql)).toBe(false);
+    expect(splitSqlStatements(sql)).toHaveLength(1);
+    expect(stripSqlComments("SELECT '--literal', '/*literal*/'; -- comment").trim()).toBe("SELECT '--literal', '/*literal*/';");
+  });
+});

--- a/packages/update-engine/test/upgrade-matrix.test.ts
+++ b/packages/update-engine/test/upgrade-matrix.test.ts
@@ -29,7 +29,16 @@ type SqliteExecutor = NonNullable<Parameters<typeof applyD1Migrations>[0]['execu
 
 function sqliteExecutor(db: Database.Database): SqliteExecutor {
   return (async (opts: { sql: string; params?: any[] }) => {
-    const statement = db.prepare(opts.sql);
+    let statement: ReturnType<Database.Database['prepare']>;
+    try {
+      statement = db.prepare(opts.sql);
+    } catch (error) {
+      if (!String(error).includes('more than one statement') || opts.params?.length) throw error;
+      // Model the HTTP API's intentionally atomic multi-statement adapter unit.
+      // Ordinary migration statements still use prepare() below.
+      db.transaction(() => db.exec(opts.sql))();
+      return { success: true, result: [{ success: true, results: [] }] };
+    }
     const params = opts.params ?? [];
     if (statement.reader) {
       return {
@@ -91,6 +100,7 @@ async function applyAll(db: Database.Database): Promise<void> {
     databaseId: 'local',
     names: allMigrationNames,
     migrations: allMigrations,
+    legacyMileageProjectionVersion: 1,
     execute: sqliteExecutor(db),
   });
 }
@@ -171,6 +181,7 @@ describe('safe upgrade matrix', () => {
           databaseId: 'local',
           names: allMigrationNames.slice(0, lastIndex + 1),
           migrations: allMigrations,
+          legacyMileageProjectionVersion: 1,
           execute: sqliteExecutor(db),
         });
         // Historical releases did not have the new checksum ledger. Remove

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@line-harness/update-engine':
-        specifier: workspace:^0.0.12
+        specifier: workspace:^0.0.13
         version: link:../update-engine
       execa:
         specifier: ^9.5.2

--- a/scripts/check-migrations.test.ts
+++ b/scripts/check-migrations.test.ts
@@ -6,12 +6,48 @@ import {
 } from './check-migrations';
 
 describe('checkMigration', () => {
-  it('rejects CREATE TRIGGER because its body cannot be split safely', () => {
+  it('allows complete CREATE TRIGGER bodies', () => {
     const result = checkMigration(
       'CREATE TRIGGER audit AFTER INSERT ON friends BEGIN INSERT INTO logs VALUES (NEW.id); END;',
     );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it.each([
+    'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 1;',
+    'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 1 END;',
+    'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT CASE WHEN 1 THEN 2; END;',
+    'CREATE TRIGGER t AFTER INSERT ON a BEGIN END;',
+    'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 1; END CREATE TABLE b (id);',
+  ])('rejects structurally malformed triggers: %s', (sql) => {
+    const result = checkMigration(sql);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.violation).toContain('CREATE TRIGGER');
+  });
+
+  it('still applies additive rules to SQL following a trigger', () => {
+    const trigger = 'CREATE TRIGGER t AFTER INSERT ON a BEGIN SELECT 1; END;';
+    const result = checkMigration(`${trigger} ALTER TABLE a ADD COLUMN required TEXT NOT NULL;`);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.violation).toContain('NOT NULL');
+  });
+
+  it('does not let a comment marker inside a string hide destructive SQL', () => {
+    const result = checkMigration("SELECT '--'; DROP TABLE foo;");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.violation).toContain('DROP TABLE');
+  });
+
+  it('ignores block comments without merging adjacent keywords', () => {
+    expect(checkMigration('/* DROP TABLE foo; */ CREATE TABLE foo (id INTEGER);')).toEqual({ ok: true });
+    const result = checkMigration('DROP/**/TABLE foo;');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.violation).toContain('DROP TABLE');
+  });
+
+  it('reports unterminated quotes and comments through the library result', () => {
+    expect(checkMigration("SELECT 'unfinished;").ok).toBe(false);
+    expect(checkMigration('CREATE TABLE foo (id); /* unfinished').ok).toBe(false);
   });
   it('allows CREATE TABLE', () => {
     const sql = `CREATE TABLE foo (id INTEGER PRIMARY KEY, name TEXT);`;

--- a/scripts/check-migrations.ts
+++ b/scripts/check-migrations.ts
@@ -17,6 +17,7 @@
  *   - CREATE TABLE
  *   - ALTER TABLE ... ADD COLUMN  (NULL or with DEFAULT)
  *   - CREATE [UNIQUE] INDEX
+ *   - CREATE TRIGGER (complete BEGIN ... END body)
  *   - INSERT (seed data)
  *
  * Library API:
@@ -41,6 +42,14 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { argv, exit, stderr, stdout } from 'node:process';
+import {
+  GRANDFATHERED_CUTOFF_PREFIX,
+  isGrandfatheredMigration,
+} from '../packages/update-engine/src/migrations.js';
+import {
+  splitSqlStatements,
+  stripSqlComments,
+} from '../packages/update-engine/src/sql-statements.js';
 
 export type CheckResult = { ok: true } | { ok: false; violation: string };
 
@@ -53,10 +62,6 @@ interface Rule {
 
 // Order matters: more specific rules first so messages are useful.
 const RULES: Rule[] = [
-  {
-    label: 'CREATE TRIGGER is unsupported by the safe statement splitter',
-    pattern: /\bCREATE\s+(?:TEMP(?:ORARY)?\s+)?TRIGGER\b/i,
-  },
   {
     label: 'DROP TABLE is forbidden (additive-only migrations)',
     pattern: /\bDROP\s+TABLE\b/i,
@@ -99,31 +104,22 @@ const RULES: Rule[] = [
   },
 ];
 
-/**
- * Strip `--` line comments. Block comments (`/* ... *\/`) are rare in
- * D1 migrations and ignored for now; if they appear we still get correct
- * results because the rules match real DDL anyway. Keeping the stripper
- * simple avoids accidentally hiding real code inside `/* ... *\/`.
- */
-function stripLineComments(sql: string): string {
-  return sql
-    .split('\n')
-    .map((line) => {
-      const idx = line.indexOf('--');
-      return idx === -1 ? line : line.slice(0, idx);
-    })
-    .join('\n');
-}
-
 export function checkMigration(sql: string): CheckResult {
-  const stripped = stripLineComments(sql);
-  for (const rule of RULES) {
-    const m = stripped.match(rule.pattern);
-    if (m) {
-      return { ok: false, violation: `${rule.label} (matched: "${m[0].trim()}")` };
+  try {
+    const stripped = stripSqlComments(sql);
+    for (const rule of RULES) {
+      const m = stripped.match(rule.pattern);
+      if (m) {
+        return { ok: false, violation: `${rule.label} (matched: "${m[0].trim()}")` };
+      }
     }
+    // Use the update engine's structural validation as well as policy rules:
+    // CI must reject a malformed trigger before the updater can touch D1.
+    splitSqlStatements(sql);
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, violation: error instanceof Error ? error.message : String(error) };
   }
-  return { ok: true };
 }
 
 // ─── CLI ──────────────────────────────────────────────────────────────────────
@@ -136,27 +132,31 @@ const DEFAULT_MIGRATIONS_DIR = 'packages/db/migrations';
  * already been applied to production D1 and cannot be rewritten — they are
  * grandfathered. Bump this only when starting a new policy era.
  *
- * String comparison works here because migration prefixes are numeric and
- * zero-padded (`001`..`041`..), so lexicographic order matches numeric order.
+ * 単一ソースは packages/update-engine/src/migrations.ts の
+ * GRANDFATHERED_CUTOFF_PREFIX (update-engine は「grandfathered かつ破壊的」な
+ * migration を adoption 時に実行せず記録のみで通すため、境界がずれると
+ * CI の合格範囲とエンジンの実行範囲が乖離する)。このスクリプトはリポ専用
+ * (OSS 同期から除外) なので、published パッケージ側を import できる。
  */
-export const POLICY_CUTOFF_PREFIX = '041';
+export const POLICY_CUTOFF_PREFIX = GRANDFATHERED_CUTOFF_PREFIX;
 
 /**
  * Filter the list of migration filenames (basenames, not full paths) to those
  * that fall under the active policy. With `all = true`, returns the input
  * unchanged (escape hatch for ad-hoc full scans).
  *
- * Files whose name starts with a prefix >= POLICY_CUTOFF_PREFIX pass. Files
- * with non-numeric or shorter prefixes pass through too (the comparison is
- * lexicographic and any newer naming scheme is assumed in-policy until we
- * decide otherwise).
+ * 判定はエンジンの isGrandfatheredMigration と同一 (単一ソース):
+ * 3桁数字プレフィックスがカットオフ未満のものだけ免除。非数値・桁違いの
+ * 命名はポリシー対象として必ずスキャンする — エンジン側も同じ判定で
+ * splitSqlStatements の破壊ガードに回すため、「CI は素通りするのに更新は
+ * 全環境で throw する」という非対称を作らない。
  */
 export function filterMigrationsByPolicy(
   names: string[],
   options: { all?: boolean } = {},
 ): string[] {
   if (options.all) return names;
-  return names.filter((name) => name >= POLICY_CUTOFF_PREFIX);
+  return names.filter((name) => !isGrandfatheredMigration(name));
 }
 
 function listDefaultMigrations(options: { all?: boolean } = {}): string[] {

--- a/scripts/release/update-manifest.test.ts
+++ b/scripts/release/update-manifest.test.ts
@@ -84,6 +84,20 @@ describe('updateManifest', () => {
     ).toThrow(/release 0\.8\.0 already exists in manifest/);
   });
 
+  it('gates handoff releases from old engines without discarding existing release history', () => {
+    const oldRelease = makeEntry('0.24.0');
+    updateManifest({ manifestPath, release: oldRelease });
+    const compatible = makeEntry('0.24.1', { legacy_mileage_projection_version: 1 });
+    updateManifest({ manifestPath, release: compatible });
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Manifest;
+    expect(manifest.schema_version).toBe(2);
+    expect(manifest.releases).toEqual([compatible, oldRelease]);
+    // The released schema-1 reader checks this before any migration work.
+    expect(manifest.schema_version === 1).toBe(false);
+    updateManifest({ manifestPath, release: makeEntry('0.24.2') });
+    expect(JSON.parse(readFileSync(manifestPath, 'utf8')).schema_version).toBe(2);
+  });
+
   it('writes pretty-printed, parseable JSON output', () => {
     const release = makeEntry('0.8.0');
     updateManifest({ manifestPath, release });
@@ -121,11 +135,11 @@ describe('updateManifest', () => {
   it('throws on unsupported schema_version', () => {
     writeFileSync(
       manifestPath,
-      JSON.stringify({ schema_version: 2, latest: '0.7.0', releases: [] }, null, 2),
+      JSON.stringify({ schema_version: 3, latest: '0.7.0', releases: [] }, null, 2),
     );
 
     expect(() => updateManifest({ manifestPath, release: makeEntry('0.8.0') })).toThrow(
-      /unsupported manifest schema_version: 2/,
+      /unsupported manifest schema_version: 3/,
     );
   });
 });

--- a/scripts/release/update-manifest.ts
+++ b/scripts/release/update-manifest.ts
@@ -37,12 +37,13 @@ export interface ReleaseEntry {
   required_secrets: string[];
   new_required_secrets: string[];
   migrations: string[];
+  legacy_mileage_projection_version?: 1;
   changelog_url: string;
   min_from_version: string;
 }
 
 export interface Manifest {
-  schema_version: 1;
+  schema_version: 1 | 2;
   latest: string;
   releases: ReleaseEntry[];
 }
@@ -54,13 +55,24 @@ export function updateManifest(opts: { manifestPath: string; release: ReleaseEnt
     ? (JSON.parse(readFileSync(manifestPath, 'utf8')) as Manifest)
     : { schema_version: 1, latest: release.version, releases: [] };
 
-  if (manifest.schema_version !== 1) {
+  if (manifest.schema_version !== 1 && manifest.schema_version !== 2) {
     throw new Error(`unsupported manifest schema_version: ${manifest.schema_version}`);
   }
 
   if (manifest.releases.some((r) => r.version === release.version)) {
     throw new Error(`release ${release.version} already exists in manifest`);
   }
+
+  if (release.legacy_mileage_projection_version !== undefined &&
+      release.legacy_mileage_projection_version !== 1) {
+    throw new Error('unsupported legacy_mileage_projection_version');
+  }
+  // Old schema-1 engines otherwise ignore the new capability and execute
+  // 062/063's unsafe SQL. Schema 2 deliberately makes them stop before D1;
+  // the compatible CLI must be published before this manifest is released.
+  if (release.legacy_mileage_projection_version === 1 || manifest.releases.some(
+    entry => entry.legacy_mileage_projection_version === 1,
+  )) manifest.schema_version = 2;
 
   manifest.releases = [release, ...manifest.releases];
   manifest.latest = release.version;


### PR DESCRIPTION
## Problem and result

Replaying migrations 062/063 on an existing database without the new checksum ledger can award the same live activity twice. The update adapter preserves the released SQL bytes and every existing monetary ledger row. It transfers genuinely unprocessed history into an atomic, owned handoff for the compatible mileage processor instead of replaying the old monetary INSERTs.

Native events keep their ownership. Already-settled history is not rewarded again, and held history remains invisible to older processors, including during failures and retries. The compatible processor applies only the recorded builtin actor rule, validates its policy, deduplicates legacy source/subject/day grants, and enforces builtin actor daily caps atomically at INSERT.

Fixes #279

## Coupled compatibility changes

- Support complete SQLite trigger programs, including nested CASE and valid BEGIN/END identifiers, while retaining whole-manifest structural preflight and destructive-schema guards.
- Require `legacy_mileage_projection_version: 1` for an unrecorded historical handoff. Matching-checksum updates to older targets remain no-ops only after all held history is complete.
- Publish handoff releases in manifest schema 2 so older schema-1 engines stop before unsafe replay. The compatible reader accepts both schemas.
- Prepare engine 0.0.13 and CLI 0.2.12, with dependency/lockfile alignment. Publication is not performed by this PR.
- Route setup/resume 062/063 through the same authenticated, account-pinned engine; verify bundle/source capability again even when the database step was already completed.
- Reject unsuccessful SQL result envelopes even when HTTP status is 200.

These changes must remain one release unit: an engine that prepares held history needs a matching Worker, and an older engine must not be allowed to ignore that contract.

## Validation

- Update engine: 291 tests; DB: 197; CLI: 122; Worker: 1,442; scripts: 73. Typechecks/build and bootstrap/migration checks passed.
- Isolated real D1: replay preserves 6 -> 6; genuine ungranted history waits, then the compatible processor grants it once to 7.
- Real D1: deliberate late failure leaves no partial claim/stamp; retry grants once. Known native/history overlap stops, then compatible reconciliation permits a safe retry.
- Actual isolated Worker with a real D1 binding: one held event projects exactly once and the repeated request is a no-op; test Worker/database and secret removed.
- Real D1 multi-statement rollback and nested-CASE trigger execution verified.
- Deterministic SQLite concurrent native/held tests: both prechecks see four grants, but atomic INSERT permits only one fifth grant.
- Independent reviews found and fixed CTA identity races, active legacy/native overlap and keyword-identifier parsing. Existing SQL migration files remain byte-identical.

## Safety limits and release order

Unknown/renamed SQL, synchronous or unverifiable baselines, ambiguous CTA/orphan identity, incompatible policy/multipliers, and known in-flight legacy overlap stop explicitly rather than inventing rewards. Already-duplicated balances are not rewritten. Arbitrary old writers' later independent actions are not retroactively fixed by an adapter snapshot.

Publish the compatible engine/CLI before a schema-2 Worker release. Do not clear holds or migration checksums after a failed deployment; retry the compatible deployment. See `docs/UPDATE-MILEAGE-REPLAY.md`.

No production database, LINE send, deployment or package publication is part of this source change. Temporary D1 tests use synthetic fixtures.

## Recovery

A failed migration unit rolls back claims and its stamp together. Existing granted amounts remain unchanged. Held rows remain recoverable and invisible to old processors. A source revert cannot undo a published schema-2 contract or already-created holds; restore a compatible Worker instead of forcing old replay.
