### PR TITLE
fix(worker): allow Idempotency-Key header in admin CORS preflight（一斉配信が管理画面から作成できない）

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -187,7 +187,7 @@ app.use('*', cors({
   origin: (origin, c) => resolveCorsOrigin(c.env, origin, c.req.url),
   credentials: true,
   allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-  allowHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token', 'x-admin-api-key'],
+  allowHeaders: ['Content-Type', 'Authorization', 'X-CSRF-Token', 'x-admin-api-key', 'Idempotency-Key'],
   maxAge: 600,
 }));
 


### PR DESCRIPTION
## 概要

Closes #330（同じ症状の報告。タグ＋下書きの組み合わせに限らず、管理画面からの配信作成全般で発生します）


管理画面（`*.pages.dev`）から一斉配信を作成すると、必ず「作成できません 作成に失敗しました」になる問題の修正です。

## 原因

- 管理画面は配信作成時に `Idempotency-Key` ヘッダーを送ります（`apps/web/src/lib/api.ts` の `broadcasts.create`）。
- Worker の CORS 設定（`apps/worker/src/index.ts` の `allowHeaders`）にこのヘッダーが含まれていないため、デフォルトのクロスサイト構成（Pages 管理画面 → Workers API）ではブラウザのプリフライトが失敗し、`POST /api/broadcasts` が Worker に届きません。
- `fetchApi` は例外を「作成に失敗しました」としか表示しないため、原因が分かりにくい状態でした。

再現時のプリフライト応答（v0.24.0、`create-line-harness` での標準インストール）:

```
access-control-allow-headers: Content-Type,Authorization,X-CSRF-Token,x-admin-api-key
```

`Access-Control-Request-Headers: content-type,x-csrf-token,idempotency-key` を含む OPTIONS に対して `Idempotency-Key` が許可されず、Chrome が POST を送信しません。`wrangler tail` でも該当リクエストは記録されませんでした。

## 変更

`allowHeaders` に `Idempotency-Key` を追加（1 行）。

## 確認したこと

- v0.24.0 の本番環境で、同一ペイロードを Bearer / Cookie+CSRF+Idempotency-Key で直接 API に送ると 201 になること（＝サーバー側ロジックは正常で、プリフライトだけが原因）
- `wrangler tail --method POST` で、管理画面からの作成操作時に Worker へリクエストが到達していないこと

## 未確認

- `pnpm --filter worker test` は未実行です（ローカルに依存関係を入れていないため）。CORS 設定の配列に 1 要素追加するのみで、既存テストへの影響は無い想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

