### PR TITLE
fix: integrate calendar and setup reliability contributions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# SQL files must stay LF in the working tree on every platform.
+#
+# packages/db/scripts/generate-bootstrap.mjs embeds SQL text read from
+# schema.sql / migrations into bootstrap.sql and compares the result
+# byte-for-byte. With core.autocrlf=true a Windows checkout rewrites these
+# files to CRLF, which makes `generate-bootstrap.mjs --check` (and the
+# bootstrap.sql sync test) fail even with no real schema drift.
+*.sql text eol=lf

--- a/apps/worker/src/durable-objects/tenant-scheduler.test.ts
+++ b/apps/worker/src/durable-objects/tenant-scheduler.test.ts
@@ -227,21 +227,58 @@ describe('TenantScheduler クラス — DO ランタイムへの配線', () => {
     expect(storage.alarm()).not.toBeNull();
   });
 
+  // alarm() は now を引数に取らず runSchedulerTick の既定値 (new Date()) を使うため、
+  // 実時刻のまま走らせると UTC 0/6/12/18 時ちょうどに CI が回ったときだけ
+  // isSixHourBoundary() が真になり scheduled() が 2 回呼ばれて落ちる。
+  // Date だけを固定して分岐を決め打ちする (タイマーは実物のまま = await を壊さない)。
+  function withFixedNow<T>(iso: string, run: () => Promise<T>): Promise<T> {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(iso));
+    return run().finally(() => {
+      vi.useRealTimers();
+    });
+  }
+
   test('alarm() は次アラームを先にセットしてから既存の scheduled() を呼ぶ', async () => {
-    const storage = fakeStorage(1_700_000_000_000); // コンストラクタの自己修復をスキップさせる
-    const ctx = fakeCtx(storage);
-    const env = { DB: {} } as never;
-    const scheduler = new TenantScheduler(ctx as never, env);
-    await ctx.ready;
+    // 6時間境界ではない時刻に固定する (境界の挙動は次のテストで確認する)。
+    await withFixedNow('2026-08-23T10:30:00Z', async () => {
+      const storage = fakeStorage(1_700_000_000_000); // コンストラクタの自己修復をスキップさせる
+      const ctx = fakeCtx(storage);
+      const env = { DB: {} } as never;
+      const scheduler = new TenantScheduler(ctx as never, env);
+      await ctx.ready;
 
-    const beforeAlarm = storage.alarm();
-    await scheduler.alarm();
+      const beforeAlarm = storage.alarm();
+      await scheduler.alarm();
 
-    expect(storage.alarm()).not.toBe(beforeAlarm); // 再アームされている
-    expect(scheduledMock).toHaveBeenCalledTimes(1);
-    const [eventArg, envArg] = scheduledMock.mock.calls[0] as unknown as [{ cron: string }, unknown];
-    expect(eventArg.cron).toBe('* * * * *');
-    expect(envArg).toBe(env);
+      expect(storage.alarm()).not.toBe(beforeAlarm); // 再アームされている
+      expect(scheduledMock).toHaveBeenCalledTimes(1);
+      const [eventArg, envArg] = scheduledMock.mock.calls[0] as unknown as [
+        { cron: string },
+        unknown,
+      ];
+      expect(eventArg.cron).toBe('* * * * *');
+      expect(envArg).toBe(env);
+    });
+  });
+
+  test('alarm() は6時間境界では分足と6h足の2イベントで scheduled() を呼ぶ', async () => {
+    // Cloudflare Cron Triggers が両パターンにマッチする分の挙動 (トリガーごとに1回) の再現。
+    await withFixedNow('2026-08-23T12:00:00Z', async () => {
+      const storage = fakeStorage(1_700_000_000_000);
+      const ctx = fakeCtx(storage);
+      const env = { DB: {} } as never;
+      const scheduler = new TenantScheduler(ctx as never, env);
+      await ctx.ready;
+
+      await scheduler.alarm();
+
+      expect(scheduledMock).toHaveBeenCalledTimes(2);
+      const crons = scheduledMock.mock.calls.map(
+        (call) => (call as unknown as [{ cron: string }])[0].cron,
+      );
+      expect(crons).toEqual(['* * * * *', '0 */6 * * *']);
+    });
   });
 
   test('ensureArmed() は公開 RPC メソッドとして自己修復ロジックに委譲する', async () => {

--- a/packages/create-line-harness/src/commands/setup.ts
+++ b/packages/create-line-harness/src/commands/setup.ts
@@ -20,6 +20,7 @@ import { setSecrets } from "../steps/secrets.js";
 import { configureAdminAuth } from "../steps/admin-auth.js";
 import { generateMcpConfig } from "../steps/mcp-config.js";
 import { generateApiKey } from "../lib/crypto.js";
+import { buildLineIdentitySql, quoteSqlString } from "../lib/line-account-sql.js";
 import {
   getAccountIds,
   setAccountId,
@@ -702,8 +703,8 @@ async function runSetupInner(
     // Two separate temp files so we can clean each one immediately and never
     // hold both plaintext credentials on disk simultaneously.
     const insertSqlFile = join(tmpdir(), `clh-line-account-${randomUUID()}.sql`);
-    const loginSqlFile = join(tmpdir(), `clh-line-login-${randomUUID()}.sql`);
-    const q = (val: string) => `'${val.replace(/'/g, "''")}'`;
+    const identitySqlFile = join(tmpdir(), `clh-line-identity-${randomUUID()}.sql`);
+    const q = quoteSqlString;
     let insertErr: unknown = null;
 
     try {
@@ -756,12 +757,21 @@ ON CONFLICT(channel_id) DO UPDATE SET
       process.exit(1);
     }
 
-    // Step B (best-effort): set login_channel_id. May fail on older
-    // schemas that don't have the column — that's fine, the dashboard
-    // can set it later.
+    // Step B (best-effort): set the non-secret identifiers — login_channel_id
+    // and liff_id. Both columns arrived in the same later migration
+    // (008_multi_account), so this may fail on an older schema — that's fine,
+    // the dashboard can set them later.
+    //
+    // liff_id has to be written here: the LIFF endpoints resolve the owning
+    // account with `WHERE liff_id = ?`, so leaving it NULL makes the booking
+    // and event screens answer `unknown_liff` (404) on a fresh install.
     try {
-      const loginSql = `UPDATE line_accounts SET login_channel_id = ${q(state.lineLoginChannelId!)} WHERE channel_id = ${q(state.lineChannelId!)};`;
-      writeFileSync(loginSqlFile, loginSql, { mode: 0o600 });
+      const identitySql = buildLineIdentitySql({
+        channelId: state.lineChannelId!,
+        loginChannelId: state.lineLoginChannelId!,
+        liffId: state.liffId!,
+      });
+      writeFileSync(identitySqlFile, identitySql, { mode: 0o600 });
       try {
         await wrangler([
           "d1",
@@ -769,13 +779,13 @@ ON CONFLICT(channel_id) DO UPDATE SET
           state.d1DatabaseName!,
           "--remote",
           "--file",
-          loginSqlFile,
+          identitySqlFile,
         ]);
       } finally {
-        try { rmSync(loginSqlFile, { force: true }); } catch { /* best-effort */ }
+        try { rmSync(identitySqlFile, { force: true }); } catch { /* best-effort */ }
       }
     } catch {
-      // Non-critical — login_channel_id can be set from the dashboard.
+      // Non-critical — both identifiers can be set from the dashboard.
     }
 
     s.stop("LINE アカウント登録完了");

--- a/packages/create-line-harness/src/commands/setup.ts
+++ b/packages/create-line-harness/src/commands/setup.ts
@@ -15,7 +15,7 @@ import { deployWorker, syncInstalledWorkerConfig } from "../steps/deploy-worker.
 import { ensureWorkersDevSubdomain } from "../steps/ensure-subdomain.js";
 import { deployAdmin } from "../steps/deploy-admin.js";
 import { fetchLatestRelease, type FetchedRelease } from "../steps/release-bundle.js";
-import { pinRepoToTag } from "../steps/clone-repo.js";
+import { installRepoDeps, pinRepoToTag } from "../steps/clone-repo.js";
 import { setSecrets } from "../steps/secrets.js";
 import { configureAdminAuth } from "../steps/admin-auth.js";
 import { generateMcpConfig } from "../steps/mcp-config.js";
@@ -432,6 +432,9 @@ async function runSetupInner(
         "(`npx create-line-harness update`) の対象外になります。開発用途向けです。",
       ].join("\n"),
     );
+    // Nothing else installs on this path: pinRepoToTag() is skipped, and
+    // ensureRepo() returns early for a checkout that already exists.
+    await installRepoDeps(repoDir);
   }
 
   // Step 2: Authenticate with Cloudflare

--- a/packages/create-line-harness/src/lib/line-account-sql.ts
+++ b/packages/create-line-harness/src/lib/line-account-sql.ts
@@ -1,0 +1,46 @@
+/**
+ * SQL builders for the `line_accounts` row the setup CLI registers.
+ *
+ * Kept out of `commands/setup.ts` so the statements can be asserted in a unit
+ * test without driving the whole interactive flow.
+ */
+
+/**
+ * Quote a value for inline SQL. The setup CLI writes statements to a file and
+ * runs them through `wrangler d1 execute --file`, which has no parameter
+ * binding, so values are escaped here instead.
+ */
+export function quoteSqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+export interface LineIdentitySqlOptions {
+  /** Messaging API channel ID — identifies the row to update. */
+  channelId: string;
+  /** LINE Login channel ID (a different channel from the Messaging API one). */
+  loginChannelId: string;
+  /** LIFF ID in `<login channel id>-<random>` form. */
+  liffId: string;
+}
+
+/**
+ * Non-secret LINE identifiers stored on the account row.
+ *
+ * `liff_id` is not bookkeeping: the LIFF endpoints resolve the owning account
+ * with `WHERE liff_id = ?` (booking, events), and `{{liff_id}}` in an auto-reply
+ * is expanded from the receiving account's row — deliberately without falling
+ * back to the global `LIFF_URL`, so one account never hands out another
+ * account's LIFF link. Leaving the column NULL therefore breaks those paths on
+ * a stock install even though the CLI already collected the value.
+ *
+ * `login_channel_id` and `liff_id` were both added by migration
+ * `008_multi_account`, so a single statement is either fully applied or fully
+ * skipped on an older schema.
+ */
+export function buildLineIdentitySql(options: LineIdentitySqlOptions): string {
+  return (
+    `UPDATE line_accounts SET login_channel_id = ${quoteSqlString(options.loginChannelId)}, ` +
+    `liff_id = ${quoteSqlString(options.liffId)} ` +
+    `WHERE channel_id = ${quoteSqlString(options.channelId)};`
+  );
+}

--- a/packages/create-line-harness/src/steps/clone-repo.ts
+++ b/packages/create-line-harness/src/steps/clone-repo.ts
@@ -70,12 +70,28 @@ export async function pinRepoToTag(
 
   // The tag may pin different dependency versions than the previously
   // installed main HEAD — reinstall to match its lockfile.
+  await installRepoDeps(repoDir);
+}
+
+/**
+ * Install workspace dependencies into an existing checkout.
+ *
+ * `ensureRepo()` installs only on the fresh-clone path, so a checkout that
+ * already exists locally — cwd, `--repo-dir`, or a previous
+ * `~/.line-harness` clone — arrives at the build steps with no
+ * `node_modules`. `pinRepoToTag()` covers that for release installs;
+ * `--from-source` skips pinning entirely and must install here instead,
+ * or the first build fails with `tsc: command not found`.
+ */
+export async function installRepoDeps(repoDir: string): Promise<void> {
+  const s = p.spinner();
   s.start("依存関係インストール中...");
   try {
     await repoPnpm(repoDir, ["install", "--frozen-lockfile"], {
       cwd: repoDir,
     });
   } catch {
+    // A drifted lockfile must not block setup — retry unfrozen.
     await repoPnpm(repoDir, ["install"], { cwd: repoDir });
   }
   s.stop("依存関係インストール完了");
@@ -167,17 +183,7 @@ export async function ensureRepo(repoDir: string | null): Promise<string> {
   }
   s.stop("ダウンロード完了");
 
-  // Install dependencies
-  s.start("依存関係インストール中...");
-  try {
-    await repoPnpm(homeDir, ["install", "--frozen-lockfile"], {
-      cwd: homeDir,
-    });
-  } catch {
-    // Try without frozen lockfile
-    await repoPnpm(homeDir, ["install"], { cwd: homeDir });
-  }
-  s.stop("依存関係インストール完了");
+  await installRepoDeps(homeDir);
 
   return homeDir;
 }

--- a/packages/create-line-harness/test/install-repo-deps.test.ts
+++ b/packages/create-line-harness/test/install-repo-deps.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const repoPnpm = vi.fn();
+
+vi.mock('../src/lib/pnpm.js', () => ({ repoPnpm }));
+vi.mock('@clack/prompts', () => ({
+  spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+  log: { warn: vi.fn(), info: vi.fn() },
+}));
+
+const { installRepoDeps } = await import('../src/steps/clone-repo.js');
+
+const REPO = '/tmp/repo';
+
+describe('installRepoDeps', () => {
+  beforeEach(() => {
+    repoPnpm.mockReset();
+  });
+
+  it('installs with the lockfile frozen', async () => {
+    repoPnpm.mockResolvedValue(undefined);
+    await installRepoDeps(REPO);
+    expect(repoPnpm).toHaveBeenCalledTimes(1);
+    expect(repoPnpm).toHaveBeenCalledWith(
+      REPO,
+      ['install', '--frozen-lockfile'],
+      { cwd: REPO },
+    );
+  });
+
+  it('retries unfrozen when the lockfile is out of date', async () => {
+    repoPnpm
+      .mockRejectedValueOnce(new Error('ERR_PNPM_OUTDATED_LOCKFILE'))
+      .mockResolvedValueOnce(undefined);
+    await installRepoDeps(REPO);
+    expect(repoPnpm).toHaveBeenCalledTimes(2);
+    expect(repoPnpm).toHaveBeenLastCalledWith(REPO, ['install'], { cwd: REPO });
+  });
+
+  it('propagates the failure when the unfrozen retry also fails', async () => {
+    repoPnpm.mockRejectedValue(new Error('network unreachable'));
+    await expect(installRepoDeps(REPO)).rejects.toThrow('network unreachable');
+  });
+});

--- a/packages/create-line-harness/test/line-account-sql.test.ts
+++ b/packages/create-line-harness/test/line-account-sql.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { buildLineIdentitySql, quoteSqlString } from '../src/lib/line-account-sql.js';
+
+const CHANNEL_ID = '2011000001';
+const LOGIN_CHANNEL_ID = '2011000002';
+const LIFF_ID = '2011000002-ab12CD34';
+
+describe('quoteSqlString', () => {
+  it('wraps the value in single quotes', () => {
+    expect(quoteSqlString('2011000001')).toBe("'2011000001'");
+  });
+
+  it('doubles embedded single quotes', () => {
+    expect(quoteSqlString("O'Brien")).toBe("'O''Brien'");
+  });
+});
+
+describe('buildLineIdentitySql', () => {
+  it('sets both login_channel_id and liff_id', () => {
+    const sql = buildLineIdentitySql({
+      channelId: CHANNEL_ID,
+      loginChannelId: LOGIN_CHANNEL_ID,
+      liffId: LIFF_ID,
+    });
+
+    // liff_id is what the LIFF booking/event endpoints look the account up by
+    // (`WHERE liff_id = ?`), so a setup run that skips it leaves those screens
+    // answering `unknown_liff`.
+    expect(sql).toContain(`login_channel_id = '${LOGIN_CHANNEL_ID}'`);
+    expect(sql).toContain(`liff_id = '${LIFF_ID}'`);
+  });
+
+  it('scopes the update to the Messaging API channel that was just registered', () => {
+    const sql = buildLineIdentitySql({
+      channelId: CHANNEL_ID,
+      loginChannelId: LOGIN_CHANNEL_ID,
+      liffId: LIFF_ID,
+    });
+
+    expect(sql).toContain(`WHERE channel_id = '${CHANNEL_ID}'`);
+    expect(sql.endsWith(';')).toBe(true);
+  });
+
+  it('escapes values instead of interpolating them raw', () => {
+    const sql = buildLineIdentitySql({
+      channelId: CHANNEL_ID,
+      loginChannelId: LOGIN_CHANNEL_ID,
+      liffId: "2011000002-ab'12",
+    });
+
+    expect(sql).toContain("liff_id = '2011000002-ab''12'");
+  });
+});

--- a/packages/create-line-harness/test/setup-mileage-capability.test.ts
+++ b/packages/create-line-harness/test/setup-mileage-capability.test.ts
@@ -14,7 +14,7 @@ vi.mock("@clack/prompts", () => ({
 }));
 vi.mock("../src/steps/check-deps.js", () => ({ checkDeps: vi.fn() }));
 vi.mock("../src/steps/auth.js", () => ({ ensureAuth: vi.fn(), getAccountId: vi.fn() }));
-vi.mock("../src/steps/clone-repo.js", () => ({ pinRepoToTag: vi.fn() }));
+vi.mock("../src/steps/clone-repo.js", () => ({ pinRepoToTag: vi.fn(), installRepoDeps: vi.fn() }));
 vi.mock("../src/steps/release-bundle.js", () => ({ fetchLatestRelease: vi.fn() }));
 vi.mock("../src/steps/ensure-subdomain.js", () => ({ ensureWorkersDevSubdomain: vi.fn() }));
 vi.mock("../src/steps/deploy-worker.js", () => ({

--- a/packages/create-line-harness/test/setup-source-deps.test.ts
+++ b/packages/create-line-harness/test/setup-source-deps.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const mocks = vi.hoisted(() => ({
+  repoPnpm: vi.fn(),
+  pinRepoToTag: vi.fn(),
+  ensureAuth: vi.fn(),
+  fetchLatestRelease: vi.fn(),
+}));
+
+vi.mock('../src/lib/pnpm.js', () => ({ repoPnpm: mocks.repoPnpm }));
+vi.mock('../src/steps/check-deps.js', () => ({ checkDeps: vi.fn() }));
+vi.mock('../src/steps/auth.js', () => ({ ensureAuth: mocks.ensureAuth, getAccountId: vi.fn() }));
+vi.mock('../src/steps/release-bundle.js', () => ({ fetchLatestRelease: mocks.fetchLatestRelease }));
+vi.mock('../src/steps/clone-repo.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../src/steps/clone-repo.js')>(),
+  pinRepoToTag: mocks.pinRepoToTag,
+}));
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  spinner: () => ({ start: vi.fn(), stop: vi.fn() }),
+  log: { warn: vi.fn(), info: vi.fn() },
+}));
+
+import { runSetup } from '../src/commands/setup.js';
+
+describe('setup dependency preparation', () => {
+  let repoDir: string;
+  const stopBeforeAuth = new Error('stop before Cloudflare authentication');
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    repoDir = mkdtempSync(join(tmpdir(), 'clh-source-deps-'));
+    mocks.repoPnpm.mockResolvedValue(undefined);
+    mocks.ensureAuth.mockRejectedValue(stopBeforeAuth);
+    mocks.fetchLatestRelease.mockResolvedValue({ release: { version: '0.24.0' } });
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it('installs source dependencies before authentication even in an existing checkout', async () => {
+    await expect(runSetup(repoDir, { fromSource: true })).rejects.toBe(stopBeforeAuth);
+    expect(mocks.repoPnpm).toHaveBeenCalledWith(repoDir, ['install', '--frozen-lockfile'], { cwd: repoDir });
+    expect(mocks.repoPnpm.mock.invocationCallOrder[0]).toBeLessThan(mocks.ensureAuth.mock.invocationCallOrder[0]);
+    expect(mocks.pinRepoToTag).not.toHaveBeenCalled();
+    expect(mocks.fetchLatestRelease).not.toHaveBeenCalled();
+  });
+
+  it('stops before authentication when source dependency installation fails', async () => {
+    const installError = new Error('dependency installation failed');
+    mocks.repoPnpm.mockRejectedValue(installError);
+    await expect(runSetup(repoDir, { fromSource: true })).rejects.toBe(installError);
+    expect(mocks.ensureAuth).not.toHaveBeenCalled();
+  });
+
+  it('keeps official releases on their existing tag-pinning path', async () => {
+    await expect(runSetup(repoDir)).rejects.toBe(stopBeforeAuth);
+    expect(mocks.pinRepoToTag).toHaveBeenCalledWith(repoDir, '0.24.0');
+    expect(mocks.repoPnpm).not.toHaveBeenCalled();
+    expect(mocks.pinRepoToTag.mock.invocationCallOrder[0]).toBeLessThan(mocks.ensureAuth.mock.invocationCallOrder[0]);
+  });
+});

--- a/packages/db/scripts/generate-bootstrap.mjs
+++ b/packages/db/scripts/generate-bootstrap.mjs
@@ -23,6 +23,15 @@ function isBenignSqliteError(error) {
   return error instanceof Error && BENIGN_SQLITE_ERROR.test(error.message);
 }
 
+/**
+ * Windows の checkout (core.autocrlf) では schema.sql / migrations が CRLF になり、
+ * sqlite_master 経由で CR が bootstrap.sql に混入する。
+ * 生成物も比較対象も LF に揃え、checkout 設定に依存しないようにする。
+ */
+function normalizeEol(text) {
+  return text.replace(/\r\n/g, "\n");
+}
+
 function splitSqlStatements(sql) {
   return sql
     .split(/;\s*(?:\r?\n|$)/)
@@ -145,7 +154,7 @@ function buildBootstrapSql() {
     const builtinSeeds = buildBuiltinAutoReplySeeds(db);
 
     return {
-      sql: `${header}${body}${builtinSeeds ? `\n\n${builtinSeeds}` : ""}\n`,
+      sql: normalizeEol(`${header}${body}${builtinSeeds ? `\n\n${builtinSeeds}` : ""}\n`),
       meta: {
         includedMigrations: migrationFiles,
         migrationCount: migrationFiles.length,
@@ -170,10 +179,10 @@ if (wantsStdout) {
 
 if (wantsCheck) {
   const current = existsSync(BOOTSTRAP_PATH)
-    ? readFileSync(BOOTSTRAP_PATH, "utf8")
+    ? normalizeEol(readFileSync(BOOTSTRAP_PATH, "utf8"))
     : "";
   const currentMeta = existsSync(BOOTSTRAP_META_PATH)
-    ? readFileSync(BOOTSTRAP_META_PATH, "utf8")
+    ? normalizeEol(readFileSync(BOOTSTRAP_META_PATH, "utf8"))
     : "";
   const nextMeta = `${JSON.stringify(generated.meta, null, 2)}\n`;
   if (current !== generated.sql || currentMeta !== nextMeta) {

--- a/packages/db/src/calendar.ts
+++ b/packages/db/src/calendar.ts
@@ -127,8 +127,13 @@ export async function updateCalendarBookingEventId(db: D1Database, id: string, e
 /** 空きスロット計算用: 指定日範囲の予約一覧を取得 */
 export async function getBookingsInRange(db: D1Database, connectionId: string, startAt: string, endAt: string): Promise<CalendarBookingRow[]> {
   const result = await db
-    .prepare(`SELECT * FROM calendar_bookings WHERE connection_id = ? AND start_at >= ? AND end_at <= ? AND status != 'cancelled' ORDER BY start_at ASC`)
-    .bind(connectionId, startAt, endAt)
+    .prepare(`SELECT * FROM calendar_bookings
+              WHERE connection_id = ?
+                AND julianday(start_at) < julianday(?)
+                AND julianday(end_at) > julianday(?)
+                AND status != 'cancelled'
+              ORDER BY julianday(start_at) ASC`)
+    .bind(connectionId, endAt, startAt)
     .all<CalendarBookingRow>();
   return result.results;
 }

--- a/packages/db/test/bootstrap-eol.test.ts
+++ b/packages/db/test/bootstrap-eol.test.ts
@@ -1,0 +1,40 @@
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from 'vitest';
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+it('ignores checkout line endings while still rejecting genuine bootstrap drift', () => {
+  // Keep the fixture under this package so the copied generator resolves its
+  // installed SQLite dependency, without changing the real schema or output.
+  const fixture = mkdtempSync(join(PKG_ROOT, '.bootstrap-eol-test-'));
+  try {
+    cpSync(join(PKG_ROOT, 'scripts'), join(fixture, 'scripts'), { recursive: true });
+    cpSync(join(PKG_ROOT, 'migrations'), join(fixture, 'migrations'), { recursive: true });
+    for (const file of ['schema.sql', 'bootstrap.sql', 'bootstrap-meta.json']) {
+      cpSync(join(PKG_ROOT, file), join(fixture, file));
+    }
+    const paths = [
+      ...['schema.sql', 'bootstrap.sql', 'bootstrap-meta.json'].map((file) => join(fixture, file)),
+      ...readdirSync(join(fixture, 'migrations'))
+        .filter((file) => file.endsWith('.sql'))
+        .map((file) => join(fixture, 'migrations', file)),
+    ];
+    for (const path of paths) {
+      writeFileSync(path, readFileSync(path, 'utf8').replace(/\r\n/g, '\n').replace(/\n/g, '\r\n'));
+    }
+    const check = () => execFileSync(process.execPath, [join(fixture, 'scripts', 'generate-bootstrap.mjs'), '--check'], {
+      cwd: fixture,
+      stdio: 'pipe',
+    });
+    expect(check).not.toThrow();
+
+    const schemaPath = join(fixture, 'schema.sql');
+    writeFileSync(schemaPath, readFileSync(schemaPath, 'utf8') + '\r\nCREATE TABLE eol_drift_probe (id TEXT PRIMARY KEY);\r\n');
+    expect(check).toThrow();
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});

--- a/packages/db/test/calendar-bookings-range.test.ts
+++ b/packages/db/test/calendar-bookings-range.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { getBookingsInRange } from '../src/calendar.js';
+
+function asD1(sqlite: Database.Database): D1Database {
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...params: unknown[]) {
+          const statement = sqlite.prepare(sql);
+          return {
+            async all<T>() {
+              return { success: true, results: statement.all(...params) as T[], meta: {} };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+describe('getBookingsInRange', () => {
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    sqlite = new Database(':memory:');
+    sqlite.exec(`
+      CREATE TABLE calendar_bookings (
+        id TEXT PRIMARY KEY,
+        connection_id TEXT NOT NULL,
+        friend_id TEXT,
+        event_id TEXT,
+        title TEXT NOT NULL,
+        start_at TEXT NOT NULL,
+        end_at TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'confirmed',
+        metadata TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      INSERT INTO calendar_bookings
+        (id, connection_id, title, start_at, end_at, status, created_at, updated_at)
+      VALUES
+        ('crosses-start', 'calendar-1', 'Crosses start',
+         '2026-08-16T23:30:00Z', '2026-08-17T00:30:00Z', 'confirmed', '', ''),
+        ('jst', 'calendar-1', 'JST booking',
+         '2026-08-17T10:00:00+09:00', '2026-08-17T11:00:00+09:00', 'confirmed', '', ''),
+        ('utc', 'calendar-1', 'UTC booking',
+         '2026-08-17T02:00:00Z', '2026-08-17T03:00:00Z', 'confirmed', '', ''),
+        ('at-end', 'calendar-1', 'Starts at range end',
+         '2026-08-17T09:00:00Z', '2026-08-17T10:00:00Z', 'confirmed', '', ''),
+        ('cancelled', 'calendar-1', 'Cancelled',
+         '2026-08-17T04:00:00Z', '2026-08-17T05:00:00Z', 'cancelled', '', ''),
+        ('other-calendar', 'calendar-2', 'Other calendar',
+         '2026-08-17T04:00:00Z', '2026-08-17T05:00:00Z', 'confirmed', '', '');
+    `);
+  });
+
+  afterEach(() => sqlite.close());
+
+  it('normalizes UTC and JST timestamps and returns every overlapping booking', async () => {
+    const bookings = await getBookingsInRange(
+      asD1(sqlite),
+      'calendar-1',
+      '2026-08-17T09:00:00+09:00',
+      '2026-08-17T18:00:00+09:00',
+    );
+
+    expect(bookings.map((booking) => booking.id)).toEqual([
+      'crosses-start',
+      'jst',
+      'utc',
+    ]);
+  });
+
+  it('includes bookings spanning the full range or its end, but excludes touching boundaries', async () => {
+    sqlite.exec(`
+      DELETE FROM calendar_bookings;
+      INSERT INTO calendar_bookings
+        (id, connection_id, title, start_at, end_at, status, created_at, updated_at)
+      VALUES
+        ('spans-range', 'calendar-1', 'Spans range',
+         '2026-08-16T23:00:00Z', '2026-08-17T10:00:00Z', 'confirmed', '', ''),
+        ('crosses-end', 'calendar-1', 'Crosses end',
+         '2026-08-17T17:30:00+09:00', '2026-08-17T18:30:00+09:00', 'confirmed', '', ''),
+        ('ends-at-start', 'calendar-1', 'Ends at start',
+         '2026-08-17T08:00:00+09:00', '2026-08-17T09:00:00+09:00', 'confirmed', '', ''),
+        ('starts-at-end', 'calendar-1', 'Starts at end',
+         '2026-08-17T09:00:00Z', '2026-08-17T10:00:00Z', 'confirmed', '', '');
+    `);
+
+    const bookings = await getBookingsInRange(
+      asD1(sqlite), 'calendar-1', '2026-08-17T00:00:00Z', '2026-08-17T09:00:00Z',
+    );
+    expect(bookings.map((booking) => booking.id)).toEqual(['spans-range', 'crosses-end']);
+  });
+
+  it('preserves millisecond overlaps and chronological ordering within the same second', async () => {
+    sqlite.exec(`
+      DELETE FROM calendar_bookings;
+      INSERT INTO calendar_bookings
+        (id, connection_id, title, start_at, end_at, status, created_at, updated_at)
+      VALUES
+        ('later', 'calendar-1', 'Later',
+         '2026-08-17T09:00:00.700+09:00', '2026-08-17T09:00:00.900+09:00', 'confirmed', '', ''),
+        ('earlier', 'calendar-1', 'Earlier',
+         '2026-08-17T00:00:00.200Z', '2026-08-17T00:00:00.600Z', 'confirmed', '', ''),
+        ('touches-start', 'calendar-1', 'Touches start',
+         '2026-08-17T00:00:00.100Z', '2026-08-17T00:00:00.500Z', 'confirmed', '', '');
+    `);
+
+    const bookings = await getBookingsInRange(
+      asD1(sqlite), 'calendar-1', '2026-08-17T00:00:00.500Z', '2026-08-17T00:00:00.800Z',
+    );
+    expect(bookings.map((booking) => booking.id)).toEqual(['earlier', 'later']);
+  });
+});


### PR DESCRIPTION
Existing calendar bookings were omitted when their timestamps used a different UTC offset or crossed the requested range boundary. Source setup could reach authentication/build without installing dependencies, and a freshly collected LIFF ID was not saved to its LINE account. This integration ports the corresponding focused contributions to the current main and adds regression coverage.

- #277: compare actual instants and include every overlapping booking, preserving milliseconds, calendar isolation, cancellation and ordering.
- #296: save the collected LIFF ID with the account-scoped login identity. This applies to account registration; previously completed installs with missing LIFF IDs still need the value filled in their account settings.
- #307: install dependencies before source setup authentication, fail if installation fails, and reuse the same installer for clone/tag paths.
- #283: normalize checkout line endings for bootstrap verification while still rejecting real schema drift; preserve all historical SQL bytes.
- #302: fix the test clock and cover normal/six-hour alarm boundaries, without changing scheduler runtime behavior.

Original contributor references are retained in the five individual commits: @Shudesu, @hitaraku, @yokozawa0701, @smatsushita-maker and @gamgpomg-rgb. The original proposals were adapted, not blindly applied over newer code.

Validation: DB 201, update engine 291, CLI 133 and Worker 1,448 tests pass; typechecks/build and migration/bootstrap checks pass. Newly added DB/CLI cases fail against the former behavior and pass with these changes. Windows CRLF is simulated; external auth/deployment in CLI tests is mocked. No production database, LINE send, deployment or package publication is included.

Merge with a merge commit to retain individual contribution history.
