### PR TITLE
fix(broadcasts): isolate tag and OR audiences by sending account

### DIFF
--- a/apps/worker/src/routes/broadcasts.ts
+++ b/apps/worker/src/routes/broadcasts.ts
@@ -16,7 +16,6 @@ import {
   estimateSendAudience,
   personalizedAudienceFilter,
   personalizedAudienceCount,
-  queuedTagAudienceCount,
   quotaConfig,
   monthStartJst,
 } from '../services/quota.js';
@@ -209,15 +208,7 @@ broadcasts.get('/api/broadcasts/:id/preview-count', async (c) => {
       count = active;
       perAccount = breakdown;
     } else if (broadcast.target_type === 'tag' && broadcast.target_tag_id) {
-      // 注: ここは inline send パス (broadcast.ts:61 getFriendsByTag) が
-      // line_account_id でフィルタしないので、preview もアカウント横断で数える。
-      // 実際の送信先と modal 表示を一致させるための整合性。
-      const row = await c.env.DB.prepare(
-        `SELECT COUNT(*) AS cnt FROM friends f
-           INNER JOIN friend_tags ft ON ft.friend_id = f.id
-           WHERE ft.tag_id = ? AND f.is_following = 1`,
-      ).bind(broadcast.target_tag_id).first<{ cnt: number }>();
-      count = row?.cnt ?? 0;
+      count = (await estimateSendAudience(c.env.DB, broadcast)) ?? 0;
     } else if (broadcast.target_type === 'all') {
       const accountId = (raw.line_account_id as string | null) || null;
       const sql = accountId
@@ -599,31 +590,11 @@ broadcasts.post('/api/broadcasts/:id/send', async (c) => {
     // Also refuse when the projected total would cross the monthly limit, so
     // one big send just under the limit cannot overshoot it wholesale.
     //
-    // The personalized branch below is exempt from this generic estimate: its
-    // queued per-recipient send filters by the broadcast's account, while the
-    // generic tag estimate is deliberately unfiltered (it mirrors the
-    // non-personalized getFriendsByTag path). Judging a personalized
-    // account-bound tag send by the unfiltered count would over-estimate and
-    // refuse sends that actually fit — the branch applies the same refusal
-    // with its own exact audience count instead.
+    // Personalized delivery additionally validates missing recipient names below.
     const personalizedSend = hasRecipientVariables(existing.message_content)
       && existing.target_type !== 'multi-account-dedup';
     if (!personalizedSend && quota.monthlyMessages.max > 0) {
-      let estimate = await estimateSendAudience(c.env.DB, existing);
-      // A tag send with more than 500 following members — the same threshold
-      // this route uses below to switch to the queued path — is delivered by
-      // the queue executor via a tag marker: NO is_following rule, and the
-      // broadcast's account filter only when one is set. Judge those by that
-      // exact population (queuedTagAudienceCount mirrors both variants);
-      // smaller tag sends stay inline via getFriendsByTag (unfiltered,
-      // following only), which the generic estimate above already mirrors.
-      if (
-        existing.target_type === 'tag'
-        && estimate !== null
-        && estimate > 500
-      ) {
-        estimate = await queuedTagAudienceCount(c.env.DB, existing);
-      }
+      const estimate = await estimateSendAudience(c.env.DB, existing);
       if (wouldExceedMonthlyQuota(quota, estimate)) {
         return c.json({ success: false, error: 'quota_exceeded', quota }, 403);
       }
@@ -780,12 +751,12 @@ broadcasts.post('/api/broadcasts/:id/send', async (c) => {
     // target_type='tag' で対象が多い場合はキュー方式
     if (existing.target_type === 'tag' && existing.target_tag_id) {
       const { getFriendsByTag } = await import('@line-crm/db');
-      const friends = await getFriendsByTag(c.env.DB, existing.target_tag_id);
+      const friends = await getFriendsByTag(c.env.DB, existing.target_tag_id, existing.line_account_id);
       const followingCount = friends.filter(f => f.is_following).length;
 
       if (followingCount > 500) {
         // Atomic lock: status='draft'|'scheduled' のときだけ status='sending' に遷移
-        const tagMarker = JSON.stringify({ operator: 'AND', rules: [{ type: 'tag_exists', value: existing.target_tag_id }] });
+        const tagMarker = JSON.stringify({ operator: 'AND', rules: [{ type: 'is_following', value: true }, { type: 'tag_exists', value: existing.target_tag_id }] });
         const lockResult = await c.env.DB.prepare(
           `UPDATE broadcasts SET status = 'sending', batch_offset = 0, segment_conditions = ? WHERE id = ? AND status IN ('draft','scheduled')`
         ).bind(tagMarker, id).run();

--- a/apps/worker/src/routes/broadcasts.ts
+++ b/apps/worker/src/routes/broadcasts.ts
@@ -1227,7 +1227,7 @@ broadcasts.post('/api/segments/count', async (c) => {
       accountBindings.unshift(body.accountId);
     }
 
-    const countSql = accountSql.replace(/^SELECT .+ FROM/, 'SELECT COUNT(*) as count FROM');
+    const countSql = `SELECT COUNT(*) as count FROM (${accountSql}) audience`;
     const result = await c.env.DB.prepare(countSql).bind(...accountBindings).first<{ count: number }>();
 
     return c.json({ success: true, count: result?.count ?? 0 });

--- a/apps/worker/src/services/broadcast-account-isolation.test.ts
+++ b/apps/worker/src/services/broadcast-account-isolation.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { URL } from 'node:url';
+import { Hono } from 'hono';
+import { LineClient } from '@line-crm/line-sdk';
+import { sqliteD1 } from '../test-support/sqlite-d1.js';
+import { broadcasts } from '../routes/broadcasts.js';
+import { processQueuedBroadcasts, processScheduledBroadcasts } from './broadcast.js';
+import { estimateSendAudience, queuedTagAudienceCount } from './quota.js';
+
+vi.mock('./stealth.js', () => ({
+  sleep: async () => {}, calculateStaggerDelay: () => 0,
+  addMessageVariation: (text: string) => text,
+}));
+const schema = readFileSync(new URL('../../../../packages/db/bootstrap.sql', import.meta.url), 'utf8');
+afterEach(() => {
+  expect(globalThis.fetch).not.toHaveBeenCalled();
+  vi.restoreAllMocks();
+});
+
+function setup() {
+  const { db, sqlite } = sqliteD1();
+  sqlite.exec(schema);
+  db.batch = async <T>(statements: D1PreparedStatement[]) => Promise.all(statements.map(s => s.run<T>()));
+  vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No real network allowed'));
+  vi.spyOn(LineClient.prototype, 'getMessageQuota').mockResolvedValue({ type: 'none' });
+  vi.spyOn(LineClient.prototype, 'getMessageQuotaConsumption').mockResolvedValue({ totalUsage: 0 });
+  const multicast = vi.spyOn(LineClient.prototype, 'multicast').mockResolvedValue({ data: {}, requestId: 'synthetic' });
+  sqlite.exec("INSERT INTO tags(id,name) VALUES('shared','Shared campaign')");
+  for (const id of ['a', 'b', 'c', 'd']) {
+    sqlite.prepare('INSERT INTO line_accounts(id,channel_id,name,channel_access_token,channel_secret) VALUES(?,?,?,?,?)')
+      .run(id, id, id, `synthetic-${id}`, 'synthetic');
+    for (const kind of ['yes', 'blocked', 'untagged']) {
+      const friend = `${id}-${kind}`;
+      sqlite.prepare('INSERT INTO friends(id,line_user_id,display_name,line_account_id,is_following) VALUES(?,?,?,?,?)')
+        .run(friend, `line-${friend}`, friend, id, kind === 'blocked' ? 0 : 1);
+      if (kind !== 'untagged') sqlite.prepare("INSERT INTO friend_tags(friend_id,tag_id) VALUES(?,'shared')").run(friend);
+    }
+  }
+  sqlite.exec("INSERT INTO friends(id,line_user_id) VALUES('legacy','line-legacy'); INSERT INTO friend_tags VALUES('legacy','shared',datetime('now'))");
+  function addBroadcast(id: string, account: string, status: string, marker: string | null = null) {
+    sqlite.prepare(`INSERT INTO broadcasts(id,title,message_type,message_content,target_type,target_tag_id,line_account_id,status,scheduled_at,segment_conditions,track_links)
+      VALUES(?,?,'text','Same announcement','tag','shared',?,?, '2020-01-01T00:00:00Z',?,0)`)
+      .run(id, id, account, status, marker);
+  }
+  const app = new Hono(); app.route('/', broadcasts);
+  return { db, sqlite, multicast, addBroadcast, app };
+}
+
+describe('tag broadcasts keep shared tags isolated by sending account', () => {
+  it('four simultaneous scheduled broadcasts deliver once to each account member, including a second cron tick', async () => {
+    const s = setup();
+    try {
+      for (const account of ['a', 'b', 'c', 'd']) s.addBroadcast(`send-${account}`, account, 'scheduled');
+      await processScheduledBroadcasts(s.db, new LineClient('unused-default'));
+      await processScheduledBroadcasts(s.db, new LineClient('unused-default'));
+      expect(s.multicast).toHaveBeenCalledTimes(4);
+      expect(s.multicast.mock.calls.map(call => call[0]).sort()).toEqual(
+        ['a', 'b', 'c', 'd'].map(id => [`line-${id}-yes`]),
+      );
+      const rows = s.sqlite.prepare(`SELECT friend_id,COUNT(*) n FROM messages_log GROUP BY friend_id ORDER BY friend_id`).all();
+      expect(rows).toEqual(['a','b','c','d'].map(id => ({ friend_id: `${id}-yes`, n: 1 })));
+      expect(s.sqlite.prepare("SELECT COUNT(*) n FROM messages_log m JOIN friends f ON f.id=m.friend_id WHERE m.line_account_id != f.line_account_id").get()).toEqual({ n: 0 });
+    } finally { s.sqlite.close(); }
+  });
+
+  it.each(['', JSON.stringify({ operator: 'AND', rules: [{ type: 'tag_exists', value: 'shared' }] })])(
+    'queued tag delivery is account-scoped and following-only, including legacy markers %s', async marker => {
+      const s = setup();
+      try {
+        s.addBroadcast('queued', 'a', 'sending', marker);
+        await processQueuedBroadcasts(s.db, new LineClient('unused-default'));
+        expect(s.multicast).toHaveBeenCalledTimes(1);
+        expect(s.multicast.mock.calls[0][0]).toEqual(['line-a-yes']);
+        expect(s.sqlite.prepare("SELECT total_count,success_count,status FROM broadcasts WHERE id='queued'").get())
+          .toEqual({ total_count: 1, success_count: 1, status: 'sent' });
+      } finally { s.sqlite.close(); }
+    },
+  );
+
+  it('preview and quota estimates match the exact tagged, following account audience', async () => {
+    const s = setup();
+    try {
+      s.addBroadcast('preview', 'a', 'draft');
+      const response = await s.app.request('/api/broadcasts/preview/preview-count', {}, { DB: s.db });
+      expect(await response.json()).toMatchObject({ success: true, data: { count: 1 } });
+      const row = { target_type: 'tag', target_tag_id: 'shared', line_account_id: 'a' };
+      expect(await estimateSendAudience(s.db, row)).toBe(1);
+      expect(await queuedTagAudienceCount(s.db, row)).toBe(1);
+      expect(s.multicast).not.toHaveBeenCalled();
+    } finally { s.sqlite.close(); }
+  });
+
+  it.each([1, 501])('the /send route and queued batches keep %i recipients in their own account', async count => {
+    const s = setup();
+    try {
+      for (let i = 1; i < count; i++) {
+        s.sqlite.prepare("INSERT INTO friends(id,line_user_id,line_account_id) VALUES(?,?,'a')").run(`extra-${i}`, `line-extra-${i}`);
+        s.sqlite.prepare("INSERT INTO friend_tags(friend_id,tag_id) VALUES(?,'shared')").run(`extra-${i}`);
+      }
+      s.addBroadcast('direct', 'a', 'draft');
+      const response = await s.app.request('/api/broadcasts/direct/send', { method: 'POST' }, { DB: s.db, LINE_CHANNEL_ACCESS_TOKEN: 'synthetic' });
+      expect(response.status).toBe(count > 500 ? 202 : 200);
+      if (count > 500) await processQueuedBroadcasts(s.db, new LineClient('unused-default'));
+      const recipients = s.multicast.mock.calls.flatMap(call => call[0]);
+      expect(recipients).toHaveLength(count);
+      expect(new Set(recipients).size).toBe(count);
+      expect(recipients.every(id => id === 'line-a-yes' || id.startsWith('line-extra-'))).toBe(true);
+      expect(s.sqlite.prepare("SELECT success_count,status FROM broadcasts WHERE id='direct'").get())
+        .toEqual({ success_count: count, status: 'sent' });
+    } finally { s.sqlite.close(); }
+  });
+});

--- a/apps/worker/src/services/broadcast.ts
+++ b/apps/worker/src/services/broadcast.ts
@@ -332,7 +332,7 @@ export async function processBroadcastSend(
         throw new Error('target_tag_id is required for tag-targeted broadcasts');
       }
 
-      const friends = await getFriendsByTag(db, broadcast.target_tag_id);
+      const friends = await getFriendsByTag(db, broadcast.target_tag_id, broadcast.line_account_id);
       const followingFriends = friends.filter((f) => f.is_following);
       totalCount = followingFriends.length;
 
@@ -672,10 +672,12 @@ async function processQueuedBroadcastBatches(
     const condition = JSON.parse(segmentConditionsStr);
     const { sql, bindings } = buildSegmentQuery(condition);
     // アカウントフィルタを追加（line_account_idで絞り込み）
-    let accountSql = sql;
+    let accountSql = broadcast.target_type === 'tag'
+      ? sql.replace('WHERE', 'WHERE f.is_following = 1 AND')
+      : sql;
     const accountBindings = [...bindings];
     if (accountId) {
-      accountSql = sql.replace('WHERE', 'WHERE f.line_account_id = ? AND');
+      accountSql = accountSql.replace('WHERE', 'WHERE f.line_account_id = ? AND');
       accountBindings.unshift(accountId);
     }
     const result = await db.prepare(accountSql).bind(...accountBindings).all<{
@@ -686,7 +688,7 @@ async function processQueuedBroadcastBatches(
     friends = result.results ?? [];
   } else if (broadcast.target_tag_id) {
     const { getFriendsByTag } = await import('@line-crm/db');
-    const tagFriends = await getFriendsByTag(db, broadcast.target_tag_id);
+    const tagFriends = await getFriendsByTag(db, broadcast.target_tag_id, broadcast.line_account_id);
     friends = tagFriends.filter(f => f.is_following).map(f => ({
       id: f.id,
       line_user_id: f.line_user_id,

--- a/apps/worker/src/services/quota-gate.test.ts
+++ b/apps/worker/src/services/quota-gate.test.ts
@@ -555,32 +555,28 @@ describe('send routes projected-audience guard', () => {
       { method: 'POST' },
     );
     expect(res.status).toBe(409);
-    // The queued executor's tag-marker WHERE has no is_following rule —
-    // unfollowed tagged rows are part of the send (and log) population, so
-    // the estimate must include them too.
+    // All tag paths now use the account's following members only.
     const accountCount = executed.find((s) => s.includes('line_account_id = ?') && s.includes('friend_tags'))!;
     expect(accountCount).toBeDefined();
-    expect(accountCount).not.toContain('is_following');
+    expect(accountCount).toContain('is_following');
   });
 
-  test('unscoped tag send above the queue threshold: judged by the tag-marker population (no is_following)', async () => {
+  test('unscoped tag send above the queue threshold: following audience exceeding quota is blocked', async () => {
     dbMocks.getBroadcastById.mockResolvedValue({
       ...draftRow, target_type: 'tag', target_tag_id: 'tag-1', line_account_id: null,
     });
     dbMocks.getFriendsByTag.mockResolvedValue(
       Array.from({ length: 600 }, (_, i) => ({ id: `f${i}`, line_user_id: `U${i}`, is_following: 1 })),
     );
-    // Following count 600 (> 500 → queued path). The tag marker's WHERE has
-    // no is_following rule, so the queued population may differ; the guard
-    // must use it (stubbed to 1 → 4999 + 1 <= 5000 passes; the lock stub then
-    // returns 0 changes → 409, proving that figure decided).
+    // The following count is 600, so 4999 + 600 exceeds the limit.
+    // The former membership-only marker count must no longer override it.
     const { db, executed } = makeTagDb({ monthly: 4999, unfilteredTag: 600, accountTag: 999, queuedUnscopedTag: 1 });
     const res = await setupApp(db, { QUOTA_MONTHLY_MESSAGES_MAX: '5000' }).request(
       `/api/broadcasts/${draftRow.id}/send`,
       { method: 'POST' },
     );
-    expect(res.status).toBe(409);
-    const queuedCount = executed.find((s) => s.includes('friend_tags') && !s.includes('is_following'))!;
+    expect(res.status).toBe(403);
+    const queuedCount = executed.find((s) => s.includes('friend_tags') && s.includes('is_following'))!;
     expect(queuedCount).toBeDefined();
     expect(queuedCount).not.toContain('line_account_id');
   });
@@ -602,7 +598,7 @@ describe('send routes projected-audience guard', () => {
     expect(body.error).toBe('quota_exceeded');
   });
 
-  test("account-bound 'tag': estimate mirrors the unfiltered send path (no account filter)", async () => {
+  test("account-bound 'tag': estimate filters by sending account", async () => {
     dbMocks.getBroadcastById.mockResolvedValue({
       ...draftRow, target_type: 'tag', target_tag_id: 'tag-1', line_account_id: 'acc-1',
     });
@@ -612,12 +608,10 @@ describe('send routes projected-audience guard', () => {
       { method: 'POST' },
     );
     expect(res.status).toBe(403);
-    // The actual tag send (getFriendsByTag) applies no account filter, so the
-    // estimate must not either — filtering would undercount and let a send
-    // slip past the limit.
+    // Preview, quota and delivery must all use the sending account.
     const est = executed.find((s) => s.includes('friend_tags'))!;
     expect(est).toBeDefined();
-    expect(est).not.toContain('line_account_id');
+    expect(est).toContain('line_account_id');
   });
 
   test('/send under the projected limit proceeds past the guard', async () => {

--- a/apps/worker/src/services/quota.ts
+++ b/apps/worker/src/services/quota.ts
@@ -176,20 +176,8 @@ export async function estimateSendAudience(
 ): Promise<number | null> {
   if (broadcast.target_type === 'tag') {
     if (!broadcast.target_tag_id) return null;
-    // Deliberately NO account filter here, even for an account-bound
-    // broadcast: the actual tag send path (getFriendsByTag in broadcast.ts)
-    // messages every following friend with the tag regardless of account.
-    // The estimate must mirror what will really be sent — an account-filtered
-    // count would undercount and let a send slip past the monthly limit.
-    const row = await db
-      .prepare(
-        `SELECT COUNT(*) as count FROM friends
-          WHERE is_following = 1
-            AND EXISTS (SELECT 1 FROM friend_tags ft WHERE ft.friend_id = friends.id AND ft.tag_id = ?)`,
-      )
-      .bind(broadcast.target_tag_id)
-      .first<{ count: number }>();
-    return row?.count ?? 0;
+    // Same account + following + tag conditions as inline and queued delivery.
+    return personalizedAudienceCount(db, broadcast);
   }
   if (broadcast.target_type !== 'all') return null;
   const accountId = (broadcast as unknown as Record<string, unknown>).line_account_id as string | null;
@@ -209,32 +197,13 @@ export async function estimateSendAudience(
   return row?.count ?? 0;
 }
 
-/**
- * Audience COUNT of a queued (tag-marker) tag send: the exact population the
- * queue executor delivers to. The marker carries only a tag_exists rule, so
- * there is deliberately NO is_following filter — unfollowed tagged rows are
- * part of the send (and log) population — and the account filter is the same
- * strict equality the executor injects. Returns null without a tag id.
- */
+/** Exact tag audience, shared by inline estimates and legacy queued markers. */
 export async function queuedTagAudienceCount(
   db: D1Database,
   broadcast: { target_type: string; target_tag_id?: string | null },
 ): Promise<number | null> {
   if (!broadcast.target_tag_id) return null;
-  const accountId = (broadcast as unknown as Record<string, unknown>).line_account_id as string | null;
-  const where: string[] = [
-    'EXISTS (SELECT 1 FROM friend_tags ft WHERE ft.friend_id = f.id AND ft.tag_id = ?)',
-  ];
-  const binds: unknown[] = [broadcast.target_tag_id];
-  if (accountId) {
-    where.unshift('f.line_account_id = ?');
-    binds.unshift(accountId);
-  }
-  const row = await db
-    .prepare(`SELECT COUNT(*) as count FROM friends f WHERE ${where.join(' AND ')}`)
-    .bind(...binds)
-    .first<{ count: number }>();
-  return row?.count ?? 0;
+  return personalizedAudienceCount(db, broadcast);
 }
 
 /**

--- a/apps/worker/src/services/segment-account-isolation.test.ts
+++ b/apps/worker/src/services/segment-account-isolation.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { URL } from 'node:url';
+import { Hono } from 'hono';
+import { LineClient } from '@line-crm/line-sdk';
+import { sqliteD1 } from '../test-support/sqlite-d1.js';
+import { broadcasts } from '../routes/broadcasts.js';
+import { processQueuedBroadcasts } from './broadcast.js';
+import { processSegmentSend } from './segment-send.js';
+import { buildSegmentQuery, type SegmentCondition } from './segment-query.js';
+
+vi.mock('./stealth.js', () => ({
+  sleep: async () => {}, calculateStaggerDelay: () => 0,
+  addMessageVariation: (text: string) => text,
+}));
+
+const schema = readFileSync(new URL('../../../../packages/db/bootstrap.sql', import.meta.url), 'utf8');
+const conditions: SegmentCondition = {
+  operator: 'OR',
+  rules: [
+    { type: 'tag_exists', value: 'first-branch' },
+    { type: 'metadata_equals', value: { key: 'tier', value: 'vip' } },
+  ],
+};
+
+afterEach(() => {
+  expect(globalThis.fetch).not.toHaveBeenCalled();
+  vi.restoreAllMocks();
+});
+
+function setup() {
+  const { db, sqlite } = sqliteD1();
+  sqlite.exec(schema);
+  db.batch = async <T>(statements: D1PreparedStatement[]) => Promise.all(statements.map(statement => statement.run<T>()));
+  vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No real network allowed'));
+  vi.spyOn(LineClient.prototype, 'getMessageQuota').mockResolvedValue({ type: 'none' });
+  vi.spyOn(LineClient.prototype, 'getMessageQuotaConsumption').mockResolvedValue({ totalUsage: 0 });
+  const multicast = vi.spyOn(LineClient.prototype, 'multicast').mockResolvedValue({ data: {}, requestId: 'synthetic' });
+  for (const id of ['a', 'b']) {
+    sqlite.prepare('INSERT INTO line_accounts(id,channel_id,name,channel_access_token,channel_secret) VALUES(?,?,?,?,?)')
+      .run(id, id, id, `synthetic-${id}`, 'synthetic');
+  }
+  const rows: Array<[string, string | null, string | null, string]> = [
+    ['a-left', 'a', 'A left', '{}'],
+    ['a-right', 'a', 'A right', '{"tier":"vip"}'],
+    ['a-neither', 'a', 'A neither', '{}'],
+    // Missing display names must not block a personalized send from account A.
+    ['b-right', 'b', null, '{"tier":"vip"}'],
+    ['legacy-right', null, null, '{"tier":"vip"}'],
+  ];
+  for (const [id, account, displayName, metadata] of rows) {
+    sqlite.prepare('INSERT INTO friends(id,line_user_id,line_account_id,display_name,metadata) VALUES(?,?,?,?,?)')
+      .run(id, `line-${id}`, account, displayName, metadata);
+  }
+  sqlite.exec("INSERT INTO tags(id,name) VALUES('first-branch','First branch'); INSERT INTO friend_tags(friend_id,tag_id) VALUES('a-left','first-branch')");
+  function addBroadcast(id: string, options: { status?: string; tag?: boolean; personalized?: boolean } = {}) {
+    sqlite.prepare(`INSERT INTO broadcasts
+      (id,title,message_type,message_content,target_type,target_tag_id,line_account_id,status,segment_conditions,track_links)
+      VALUES(?,?,'text',?, ?,?,'a',?,?,0)`)
+      .run(id, id, options.personalized ? 'Hello {{name}}' : 'Synthetic announcement',
+        options.tag ? 'tag' : 'all', options.tag ? 'first-branch' : null,
+        options.status ?? 'draft', JSON.stringify(conditions));
+  }
+  const app = new Hono();
+  app.route('/', broadcasts);
+  return { db, sqlite, multicast, addBroadcast, app };
+}
+
+describe('OR segments stay inside the selected sending account', () => {
+  it('groups both OR branches under account scope and keeps parameter order and unscoped semantics', async () => {
+    const s = setup();
+    try {
+      const { sql, bindings } = buildSegmentQuery(conditions);
+      const scoped = sql.replace('WHERE', 'WHERE f.line_account_id = ? AND');
+      const scopedRows = await s.db.prepare(scoped).bind('a', ...bindings).all<{ id: string }>();
+      expect(scopedRows.results.map(row => row.id).sort()).toEqual(['a-left', 'a-right']);
+      const unscopedRows = await s.db.prepare(sql).bind(...bindings).all<{ id: string }>();
+      expect(unscopedRows.results.map(row => row.id).sort())
+        .toEqual(['a-left', 'a-right', 'b-right', 'legacy-right']);
+    } finally { s.sqlite.close(); }
+  });
+
+  it('counts the same OR audience with nested tag subqueries in the segment preview API', async () => {
+    const s = setup();
+    try {
+      const response = await s.app.request('/api/segments/count', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ conditions, accountId: 'a' }),
+      }, { DB: s.db });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ success: true, count: 2 });
+      expect(s.multicast).not.toHaveBeenCalled();
+    } finally { s.sqlite.close(); }
+  });
+
+  it('the direct segment service sends both local branches without sending the other account branch', async () => {
+    const s = setup();
+    try {
+      s.addBroadcast('direct');
+      await processSegmentSend(s.db, new LineClient('synthetic-a'), 'direct', conditions);
+      expect(s.multicast.mock.calls.flatMap(call => call[0]).sort()).toEqual(['line-a-left', 'line-a-right']);
+      expect(s.sqlite.prepare("SELECT total_count,success_count,status FROM broadcasts WHERE id='direct'").get())
+        .toEqual({ total_count: 2, success_count: 2, status: 'sent' });
+    } finally { s.sqlite.close(); }
+  });
+
+  it('projected quota and queued dispatch both use the two local OR matches', async () => {
+    const s = setup();
+    try {
+      s.addBroadcast('queued');
+      const response = await s.app.request('/api/broadcasts/queued/send-segment', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ conditions }),
+      }, { DB: s.db, QUOTA_MONTHLY_MESSAGES_MAX: '2' });
+      expect(response.status).toBe(202);
+      await processQueuedBroadcasts(s.db, new LineClient('synthetic-a'));
+      expect(s.multicast.mock.calls.flatMap(call => call[0]).sort()).toEqual(['line-a-left', 'line-a-right']);
+      expect(s.sqlite.prepare("SELECT total_count,success_count,status FROM broadcasts WHERE id='queued'").get())
+        .toEqual({ total_count: 2, success_count: 2, status: 'sent' });
+    } finally { s.sqlite.close(); }
+  });
+
+  it('queued tag OR markers keep following and account filters outside both branches', async () => {
+    const s = setup();
+    try {
+      s.sqlite.exec(`INSERT INTO friends(id,line_user_id,line_account_id,is_following,metadata)
+        VALUES('a-blocked','line-a-blocked','a',0,'{"tier":"vip"}')`);
+      s.addBroadcast('tag-queued', { status: 'sending', tag: true });
+      await processQueuedBroadcasts(s.db, new LineClient('synthetic-a'));
+      expect(s.multicast.mock.calls.flatMap(call => call[0]).sort()).toEqual(['line-a-left', 'line-a-right']);
+    } finally { s.sqlite.close(); }
+  });
+
+  it('personalized audience validation ignores nameless OR matches belonging to another account', async () => {
+    const s = setup();
+    try {
+      s.addBroadcast('personalized', { personalized: true });
+      const response = await s.app.request('/api/broadcasts/personalized/send-segment', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ conditions }),
+      }, { DB: s.db });
+      expect(response.status).toBe(202);
+      expect(s.multicast).not.toHaveBeenCalled();
+    } finally { s.sqlite.close(); }
+  });
+});

--- a/apps/worker/src/services/segment-query.ts
+++ b/apps/worker/src/services/segment-query.ts
@@ -93,7 +93,9 @@ export function buildSegmentQuery(condition: SegmentCondition): { sql: string; b
 
   const separator = condition.operator === 'AND' ? ' AND ' : ' OR '
   const where = clauses.length > 0 ? clauses.join(separator) : '1=1'
-  const sql = `SELECT f.id, f.line_user_id, f.display_name FROM friends f WHERE ${where} ORDER BY f.created_at ASC, f.id ASC`
+  // Callers prepend account/following constraints. Keep the complete segment
+  // grouped so `account AND (left OR right)` cannot become `(account AND left) OR right`.
+  const sql = `SELECT f.id, f.line_user_id, f.display_name FROM friends f WHERE (${where}) ORDER BY f.created_at ASC, f.id ASC`
 
   return { sql, bindings }
 }

--- a/apps/worker/src/test-support/sqlite-d1.ts
+++ b/apps/worker/src/test-support/sqlite-d1.ts
@@ -1,0 +1,26 @@
+// Local/test adapter only. Production routes use the Cloudflare D1 binding.
+import type { SQLInputValue } from 'node:sqlite';
+const { DatabaseSync } = process.getBuiltinModule('node:sqlite') as typeof import('node:sqlite');
+export function sqliteD1(path = ':memory:') {
+  const sqlite = new DatabaseSync(path);
+  function prepare(sql: string, values: SQLInputValue[] = []): D1PreparedStatement {
+    return {
+      bind(...args: unknown[]) { return prepare(sql, args as SQLInputValue[]); },
+      async first<T>(column?: string) {
+        const row = sqlite.prepare(sql).get(...values);
+        return (column ? row?.[column] ?? null : row ?? null) as T | null;
+      },
+      async all<T>() {
+        const results = sqlite.prepare(sql).all(...values) as T[];
+        return { success: true, results, meta: { changes: 0, duration: 0, last_row_id: 0, changed_db: false, size_after: 0, rows_read: results.length, rows_written: 0 } };
+      },
+      async run<T>() {
+        const info = sqlite.prepare(sql).run(...values);
+        return { success: true, results: [] as T[], meta: { changes: Number(info.changes), duration: 0, last_row_id: Number(info.lastInsertRowid), changed_db: !!info.changes, size_after: 0, rows_read: 0, rows_written: Number(info.changes) } };
+      },
+      async raw<T>() { return sqlite.prepare(sql).all(...values).map(row => Object.values(row)) as T[]; },
+    } as D1PreparedStatement;
+  }
+  const db = { prepare } as D1Database;
+  return { db, sqlite };
+}

--- a/packages/db/src/tags.ts
+++ b/packages/db/src/tags.ts
@@ -242,16 +242,17 @@ import type { Friend } from './friends';
 export async function getFriendsByTag(
   db: D1Database,
   tagId: string,
+  lineAccountId?: string | null,
 ): Promise<Friend[]> {
   const result = await db
     .prepare(
       `SELECT f.*
        FROM friends f
        INNER JOIN friend_tags ft ON ft.friend_id = f.id
-       WHERE ft.tag_id = ?
+       WHERE ft.tag_id = ?${lineAccountId ? ' AND f.line_account_id = ?' : ''}
        ORDER BY f.created_at DESC`,
     )
-    .bind(tagId)
+    .bind(...(lineAccountId ? [tagId, lineAccountId] : [tagId]))
     .all<Friend>();
   return result.results;
 }


### PR DESCRIPTION
Account-bound tag broadcasts could select friends from other LINE accounts, and OR segments could escape a caller's account predicate (`account=A AND left OR right`). This change uses the sending account for tagged recipients and groups the full segment predicate, so direct sends, queued sends, preview counts and quota checks agree on the same audience.

The segment count endpoint now counts the original query as a subquery instead of rewriting SELECT with a regex that also matched nested tag queries. Existing queued tag markers also respect follow status. Account-unspecified legacy behavior is unchanged; missing/deleted account token fallback and general failure tracking remain separate work under #259/#64, which this PR does not close.

Validation: new synthetic SQLite cases fail before the fixes (6 tag and 6 OR cases), then pass. Four account-bound tagged broadcasts select only their own recipients; OR retains both branches inside the chosen account. Immediate/queued paths, old markers, blocked/NULL-account friends, counts and quota are covered. All 1,460 Worker tests, typecheck and build pass. Outbound network is stubbed and asserted unused in new cases; no actual LINE send or production mutation was performed.

Only the focused public files are changed; historical migrations, account data and queued broadcast state are preserved.
