### PR TITLE
test(worker): keep SQLite release checks compatible with Node 20

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -34,6 +34,8 @@
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
     "vitest": "^2.0.0",
-    "wrangler": "^4.0.0"
+    "wrangler": "^4.0.0",
+    "better-sqlite3": "12.11.1",
+    "@types/better-sqlite3": "7.6.13"
   }
 }

--- a/apps/worker/src/test-support/sqlite-d1.ts
+++ b/apps/worker/src/test-support/sqlite-d1.ts
@@ -1,13 +1,13 @@
 // Local/test adapter only. Production routes use the Cloudflare D1 binding.
-import type { SQLInputValue } from 'node:sqlite';
-const { DatabaseSync } = process.getBuiltinModule('node:sqlite') as typeof import('node:sqlite');
-export function sqliteD1(path = ':memory:') {
-  const sqlite = new DatabaseSync(path);
+import Database from 'better-sqlite3';
+type SQLInputValue = string | number | bigint | Buffer | null;
+export function sqliteD1(path = ':memory:'): { db: D1Database; sqlite: Database.Database } {
+  const sqlite = new Database(path);
   function prepare(sql: string, values: SQLInputValue[] = []): D1PreparedStatement {
     return {
       bind(...args: unknown[]) { return prepare(sql, args as SQLInputValue[]); },
       async first<T>(column?: string) {
-        const row = sqlite.prepare(sql).get(...values);
+        const row = sqlite.prepare(sql).get(...values) as Record<string, SQLInputValue> | undefined;
         return (column ? row?.[column] ?? null : row ?? null) as T | null;
       },
       async all<T>() {
@@ -18,7 +18,7 @@ export function sqliteD1(path = ':memory:') {
         const info = sqlite.prepare(sql).run(...values);
         return { success: true, results: [] as T[], meta: { changes: Number(info.changes), duration: 0, last_row_id: Number(info.lastInsertRowid), changed_db: !!info.changes, size_after: 0, rows_read: 0, rows_written: Number(info.changes) } };
       },
-      async raw<T>() { return sqlite.prepare(sql).all(...values).map(row => Object.values(row)) as T[]; },
+      async raw<T>() { return sqlite.prepare(sql).all(...values).map(row => Object.values(row as Record<string, SQLInputValue>)) as T[]; },
     } as D1PreparedStatement;
   }
   const db = { prepare } as D1Database;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.2.4(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.0))
+      '@types/better-sqlite3':
+        specifier: 7.6.13
+        version: 7.6.13
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -176,6 +179,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.23.0))
+      better-sqlite3:
+        specifier: 12.11.1
+        version: 12.11.1
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.2


### PR DESCRIPTION
The stable release workflow runs tests on Node 20, but the new Worker SQLite fixture adapter used Node 22-only `node:sqlite`. PR checks on Node 22 therefore passed while the release job would fail loading the tests.

Use the same better-sqlite3 12.11.1 version already resolved for the DB/update-engine workspaces, declare the Worker test dependencies, and retain the existing D1 adapter operations and assertions. No production route or supported Node policy changes.

Validation: Node 20.20.2 was downloaded from the official Node distribution with its published SHA256 verified, then installed into an isolated test checkout/store. Worker 1,460, DB 201, update engine 291 and CLI 133 tests pass on Node 20; Worker typecheck passes. The public Node 22 Worker suite (1,460 tests) and typecheck also pass. Historical SQL and existing records remain unchanged. No deployment or publication.
