### PR TITLE
fix: align timestamps and improve bounded CORS diagnostics

### DIFF
--- a/apps/worker/src/middleware/admin-auth-config.ts
+++ b/apps/worker/src/middleware/admin-auth-config.ts
@@ -246,7 +246,39 @@ export function resolveCorsOrigin(
     return normalizedOrigin;
   }
 
-  return allowedOrigins.some((allowedOrigin) => isAllowedAdminOrigin(normalizedOrigin, allowedOrigin))
-    ? normalizedOrigin
-    : '';
+  if (allowedOrigins.some((allowedOrigin) => isAllowedAdminOrigin(normalizedOrigin, allowedOrigin))) {
+    return normalizedOrigin;
+  }
+  if (allowedOrigins.length === 0 && /^https?:\/\//.test(normalizedOrigin)) {
+    warnMissingAdminOrigin(env, requestUrl);
+  }
+  return '';
+}
+
+// Advisory diagnostic only: one fixed-size message per loaded Worker module.
+// The latch retains no request data or environment object, and never affects
+// authorization. A first anonymous auth probe can consume this one message.
+let warnedMissingAdminOrigin = false;
+
+function warnMissingAdminOrigin(env: AdminAuthEnv, requestUrl: string): void {
+  if (warnedMissingAdminOrigin) return;
+  let pathname: string;
+  try {
+    pathname = new URL(requestUrl).pathname;
+  } catch {
+    return;
+  }
+  if (!pathname.startsWith('/api/auth/')) return;
+
+  const configured = Boolean(env.ADMIN_ORIGIN?.trim());
+  warnedMissingAdminOrigin = true;
+  // Do not interpolate Origin, pathname, or the configured value: all can
+  // contain misleading text, and a mistaken secret value must not be logged.
+  console.warn(JSON.stringify({
+    component: 'admin-auth',
+    code: configured ? 'admin_origin_invalid' : 'admin_origin_empty',
+    message: configured
+      ? 'ADMIN_ORIGIN is set but contains no parseable origins. Use an absolute admin URL including https://. See docs/ADMIN-AUTH.md.'
+      : 'ADMIN_ORIGIN is empty. Set it to the admin URL; enable ADMIN_ALLOW_CROSS_SITE for the Pages/Workers topology. See docs/ADMIN-AUTH.md.',
+  }));
 }

--- a/apps/worker/src/middleware/admin-auth-diagnostic.test.ts
+++ b/apps/worker/src/middleware/admin-auth-diagnostic.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { AdminAuthEnv, resolveCorsOrigin as CorsResolver } from './admin-auth-config.js';
+
+const ADMIN = 'https://example-admin.pages.dev';
+const WORKER = 'https://example-api.workers.dev';
+let resolveCorsOrigin: typeof CorsResolver;
+
+beforeEach(async () => {
+  vi.resetModules();
+  ({ resolveCorsOrigin } = await import('./admin-auth-config.js'));
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => vi.restoreAllMocks());
+
+function diagnostic() {
+  return JSON.parse(vi.mocked(console.warn).mock.calls[0][0] as string) as {
+    component: string; code: string; message: string;
+  };
+}
+
+describe('missing ADMIN_ORIGIN diagnostic', () => {
+  test.each([
+    [{}, 'admin_origin_empty'],
+    [{ ADMIN_ORIGIN: '   ' }, 'admin_origin_empty'],
+    [{ ADMIN_ORIGIN: 'example-admin.pages.dev' }, 'admin_origin_invalid'],
+  ] as const)('explains a rejected auth request without allowing it (%j)', (env, code) => {
+    expect(resolveCorsOrigin(env, ADMIN, `${WORKER}/api/auth/login`)).toBe('');
+    expect(console.warn).toHaveBeenCalledOnce();
+    expect(diagnostic()).toMatchObject({ component: 'admin-auth', code });
+    expect(diagnostic().message).toContain('ADMIN_ORIGIN');
+  });
+
+  test('warns at most once even when calls use different environment objects', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(resolveCorsOrigin({}, `https://probe-${i}.example`, `${WORKER}/api/auth/login`)).toBe('');
+    }
+    expect(console.warn).toHaveBeenCalledOnce();
+  });
+
+  test('an anonymous first probe consumes the advisory log without authorizing either origin', () => {
+    const env: AdminAuthEnv = {};
+    expect(resolveCorsOrigin(env, 'https://probe.example', `${WORKER}/api/auth/session`)).toBe('');
+    expect(resolveCorsOrigin(env, ADMIN, `${WORKER}/api/auth/login`)).toBe('');
+    expect(console.warn).toHaveBeenCalledOnce();
+    expect(JSON.stringify(vi.mocked(console.warn).mock.calls)).not.toContain('probe.example');
+  });
+
+  test('does not log request text, configured values, controls, or unbounded content', () => {
+    const privateValue = 'not-a-url-' + '\u001b[31m\r\n' + 'secret-value-'.repeat(2000);
+    expect(resolveCorsOrigin(
+      { ADMIN_ORIGIN: privateValue },
+      'https://untrusted.example',
+      `${WORKER}/api/auth/${'long-path-'.repeat(2000)}?token=private-token`,
+    )).toBe('');
+    const logged = vi.mocked(console.warn).mock.calls[0][0] as string;
+    expect(new TextEncoder().encode(logged).byteLength).toBeLessThan(512);
+    expect(logged).not.toMatch(/[\u0000-\u001f\u007f-\u009f\u2028\u2029]/);
+    expect(logged).not.toMatch(/secret-value|private-token|untrusted\.example|long-path/);
+    expect(diagnostic().code).toBe('admin_origin_invalid');
+  });
+
+  test('does not consume the warning on data routes, same-origin, missing Origin, opaque Origin, or loopback', () => {
+    expect(resolveCorsOrigin({}, ADMIN, `${WORKER}/api/friends`)).toBe('');
+    expect(resolveCorsOrigin({}, WORKER, `${WORKER}/api/auth/login`)).toBe(WORKER);
+    expect(resolveCorsOrigin({}, undefined, `${WORKER}/api/auth/session`)).toBe(WORKER);
+    expect(resolveCorsOrigin({}, 'null', `${WORKER}/api/auth/login`)).toBe('');
+    expect(resolveCorsOrigin({}, 'data:text/plain,opaque', `${WORKER}/api/auth/login`)).toBe('');
+    expect(resolveCorsOrigin({}, 'http://localhost:3001', 'http://localhost:8787/api/auth/login')).toBe('http://localhost:3001');
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(resolveCorsOrigin({}, ADMIN, `${WORKER}/api/auth/login`)).toBe('');
+    expect(console.warn).toHaveBeenCalledOnce();
+  });
+
+  test('leaves configured allowlist and Pages preview decisions unchanged without warnings', () => {
+    const env = { ADMIN_ORIGIN: ADMIN };
+    expect(resolveCorsOrigin(env, ADMIN, `${WORKER}/api/auth/login`)).toBe(ADMIN);
+    expect(resolveCorsOrigin(env, 'https://preview.example-admin.pages.dev', `${WORKER}/api/auth/login`)).toBe('https://preview.example-admin.pages.dev');
+    expect(resolveCorsOrigin(env, 'https://other-project.pages.dev', `${WORKER}/api/auth/login`)).toBe('');
+    expect(resolveCorsOrigin(env, 'https://attacker.example', `${WORKER}/api/auth/login`)).toBe('');
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/routes/media-inquiries.test.ts
+++ b/apps/worker/src/routes/media-inquiries.test.ts
@@ -32,7 +32,10 @@ const validBody = {
 };
 
 beforeEach(() => vi.restoreAllMocks());
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
 
 describe('POST /api/public/media-inquiries', () => {
   it('rejects origins outside the media allowlist without persisting', async () => {
@@ -98,5 +101,74 @@ describe('POST /api/public/media-inquiries', () => {
     expect(calls[1].values[0]).toBe('activation_required');
     const body = await res.json() as { data: { notification: string } };
     expect(body.data.notification).toBe('activation_required');
+  });
+
+  // タイムスタンプはプロジェクト共通の JST ISO-8601（+09:00 付き）で保存する。
+  // SQLite 側の now 系関数はオフセットなしの UTC 文字列を返すため、それを
+  // 使うと読み手がローカル時刻として解釈し、JST 00:00〜09:00 の問い合わせが
+  // 前日の日付として扱われる。
+  it('persists offset-bearing JST timestamps instead of offset-less UTC', async () => {
+    const calls: RunCall[] = [];
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ success: true }), { status: 200 })));
+
+    await mediaInquiries.request(
+      '/api/public/media-inquiries',
+      {
+        method: 'POST',
+        headers: { origin: 'https://the-harness.com', 'content-type': 'application/json' },
+        body: JSON.stringify(validBody),
+      },
+      createEnv(calls),
+    );
+
+    const JST_ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}\+09:00$/;
+
+    // INSERT: created_at / updated_at は末尾 2 バインド。
+    const [createdAt, initialUpdatedAt] = calls[0].values.slice(-2) as [string, string];
+    expect(createdAt).toMatch(JST_ISO);
+    expect(initialUpdatedAt).toMatch(JST_ISO);
+    // 同一イベントなので初期値は完全一致させる（無駄な数 ms 差を作らない）。
+    expect(initialUpdatedAt).toBe(createdAt);
+
+    // UPDATE: updated_at は id の 1 つ手前。
+    const notifiedUpdatedAt = calls[1].values.at(-2) as string;
+    expect(notifiedUpdatedAt).toMatch(JST_ISO);
+
+    // タイムスタンプを SQL 側で生成しない（オフセットなし UTC への逆戻り防止）。
+    expect(calls[0].sql).not.toContain('datetime(');
+    expect(calls[1].sql).not.toContain('datetime(');
+  });
+
+  it.each([
+    ['2026-08-19T15:30:00.123Z', '2026-08-20T00:30:00.123+09:00', false],
+    ['2026-08-31T15:10:00.999Z', '2026-09-01T00:10:00.999+09:00', false],
+    ['2026-12-31T15:05:00.456Z', '2027-01-01T00:05:00.456+09:00', true],
+  ] as const)('preserves the instant across JST date boundaries (%s)', async (utc, expectedJst, notificationFails) => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(utc));
+    const calls: RunCall[] = [];
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      vi.setSystemTime(new Date(new Date(utc).getTime() + 2500));
+      if (notificationFails) throw new Error('notification unavailable');
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    }));
+
+    const response = await mediaInquiries.request('/api/public/media-inquiries', {
+      method: 'POST',
+      headers: { origin: 'https://the-harness.com', 'content-type': 'application/json' },
+      body: JSON.stringify(validBody),
+    }, createEnv(calls));
+
+    expect(response.status).toBe(201);
+    expect(calls).toHaveLength(2);
+    const [createdAt, updatedAt] = calls[0].values.slice(-2) as [string, string];
+    expect(createdAt).toBe(expectedJst);
+    expect(updatedAt).toBe(createdAt);
+    expect(new Date(createdAt).toISOString()).toBe(utc);
+    const afterNotification = calls[1].values.at(-2) as string;
+    expect(afterNotification).toMatch(/\+09:00$/);
+    expect(new Date(afterNotification).getTime() - new Date(createdAt).getTime()).toBe(2500);
+    expect(calls[1].values[0]).toBe(notificationFails ? 'failed' : 'accepted');
   });
 });

--- a/apps/worker/src/routes/media-inquiries.ts
+++ b/apps/worker/src/routes/media-inquiries.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { jstNow } from '@line-crm/db';
 import type { Env } from '../index.js';
 
 const mediaInquiries = new Hono<Env>();
@@ -91,6 +92,12 @@ mediaInquiries.post('/api/public/media-inquiries', async (c) => {
     utmCampaign: text(body.utmCampaign, 200),
   };
 
+  // 他テーブルと同じく JST ISO-8601（+09:00 付き）で保存する。SQLite 側の
+  // now 系関数はオフセットなしの UTC 文字列を返すため、読み手がローカル時刻
+  // として解釈してしまう。created_at と初期 updated_at は同一イベントなので
+  // 同じ値を使う。
+  const now = jstNow();
+
   await c.env.DB.prepare(
     `INSERT INTO media_inquiries (
       id, inquiry_type, company_name, contact_name, department, position,
@@ -99,7 +106,7 @@ mediaInquiries.post('/api/public/media-inquiries', async (c) => {
       preferred_contact, source_article, source_url, referrer,
       utm_source, utm_medium, utm_campaign, country, cf_ray,
       mail_status, created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', datetime('now'), datetime('now'))`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`,
   ).bind(
     id, inquiryType, companyName, contactName, values.department, values.position,
     values.decisionRole, email, values.phone, values.companySize, values.currentTools,
@@ -107,6 +114,7 @@ mediaInquiries.post('/api/public/media-inquiries', async (c) => {
     values.preferredContact, values.sourceArticle, values.sourceUrl, values.referrer,
     values.utmSource, values.utmMedium, values.utmCampaign,
     c.req.header('cf-ipcountry') || '', c.req.header('cf-ray') || '',
+    now, now,
   ).run();
 
   let mailStatus = 'pending';
@@ -167,8 +175,8 @@ mediaInquiries.post('/api/public/media-inquiries', async (c) => {
   }
 
   await c.env.DB.prepare(
-    `UPDATE media_inquiries SET mail_status = ?, mail_error = ?, updated_at = datetime('now') WHERE id = ?`,
-  ).bind(mailStatus, mailError || null, id).run();
+    `UPDATE media_inquiries SET mail_status = ?, mail_error = ?, updated_at = ? WHERE id = ?`,
+  ).bind(mailStatus, mailError || null, jstNow(), id).run();
 
   return c.json({
     success: true,

--- a/docs/ADMIN-AUTH.md
+++ b/docs/ADMIN-AUTH.md
@@ -192,3 +192,45 @@ credential.
   `Referrer-Policy: no-referrer` so the token does not leak onward.
 - The resulting session is indistinguishable from an API-key login, including
   CSRF handling and the 7-day cookie lifetime. `POST /api/auth/logout` ends it.
+
+
+## Troubleshooting: admin login fails with CORS
+
+An incomplete setup can leave `ADMIN_ORIGIN` unset, so a browser reports a
+missing `Access-Control-Allow-Origin` header even though the Worker is running.
+A value without an absolute URL scheme, such as `example-admin.pages.dev`, can
+produce the same symptom because no configured origin can be parsed.
+
+For a rejected HTTP(S) origin on an `/api/auth/*` route with an empty parsed
+allowlist, the Worker emits one structured warning:
+
+```json
+{"component":"admin-auth","code":"admin_origin_empty","message":"ADMIN_ORIGIN is empty. Set it to the admin URL; enable ADMIN_ALLOW_CROSS_SITE for the Pages/Workers topology. See docs/ADMIN-AUTH.md."}
+```
+
+`admin_origin_invalid` means the setting has a value but no entry parses as an
+origin; check that the admin URL includes `https://`. The log deliberately omits
+request origins, paths, and configuration values. Its fixed messages remain
+bounded and cannot include request-controlled line breaks or a secret pasted
+into the wrong setting.
+
+The diagnostic is limited to **one warning per loaded Worker module/isolate**,
+even if successive requests use different environment objects. It is advisory:
+an anonymous first auth probe may consume the warning before the operator opens
+logs, and a later request will not emit it again. Missing log output does not
+prove configuration is correct. The warning never changes the allowlist,
+cookie configuration, or the decision to reject a request.
+
+To investigate an existing installation, inspect Worker logs and whether the
+setting exists:
+
+```sh
+npx wrangler tail <worker-name>
+npx wrangler secret list --name <worker-name>
+```
+
+A listed secret name does not verify its value. Confirm the full admin origin
+and follow the topology instructions above. For the usual Pages/Workers setup,
+set `ADMIN_ORIGIN` to the actual admin URL and `ADMIN_ALLOW_CROSS_SITE` to `true`.
+Use secret settings so they survive redeploys; no diagnostic requires an
+immediate production redeploy just to produce a fresh log entry.

--- a/packages/db/schema.sql
+++ b/packages/db/schema.sql
@@ -130,7 +130,20 @@ CREATE TABLE IF NOT EXISTS broadcasts (
   aggregation_unit  TEXT,
   batch_offset    INTEGER NOT NULL DEFAULT 0,
   segment_conditions TEXT,
-  created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')),
+  -- NOTE: この DEFAULT だけ他テーブルの JST ISO-8601 形式ではなく UTC の datetime('now')。
+  -- 029_account_management_v2.sql がテーブルを再構築した際に datetime('now') で
+  -- 宣言しており、029 は schema.sql より後に適用されるため、replay 後の実効値は
+  -- UTC 側になる。
+  -- ここは「意図」ではなく「実際に出来上がる DDL」を書いている（schema.sql と
+  -- bootstrap.sql / migrated schema の乖離を防ぐため）。
+  -- 現時点で実害はない: broadcasts への INSERT は src/broadcasts.ts の 1 箇所のみで、
+  -- created_at を明示列挙して jstNow() をバインドしているため DEFAULT は発火しない。
+  -- created_at を省略する INSERT を新設する場合は、必ず jstNow() を明示バインドすること。
+  -- 揃えるには SQLite の仕様上テーブル再構築が必要で、未使用の DEFAULT のために
+  -- 既存テーブルを作り直すのは割に合わないと判断した。
+  -- 同様に UTC DEFAULT のままの列は test/timestamp-defaults.test.ts の
+  -- KNOWN_UTC_DEFAULTS に列挙してある（新規追加はテストが失敗する）。
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
   account_ids        TEXT CHECK (account_ids IS NULL OR json_valid(account_ids)),
   dedup_priority     TEXT CHECK (dedup_priority IS NULL OR json_valid(dedup_priority)),
   failed_account_ids TEXT CHECK (failed_account_ids IS NULL OR json_valid(failed_account_ids)),

--- a/packages/db/test/timestamp-defaults.test.ts
+++ b/packages/db/test/timestamp-defaults.test.ts
@@ -1,0 +1,182 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+// =============================================================================
+// created_at / updated_at の DEFAULT 式ドリフト検知
+// =============================================================================
+//
+// このリポジトリのタイムスタンプ列は JST ISO-8601（ミリ秒付き）で保存する規約。
+// 一方 SQLite の datetime('now') は「UTC・スペース区切り・ミリ秒なし」を返すため、
+// 両者が混ざると文字列比較の順序・境界判定が壊れる。
+// （実際に一度踏んでいる: src/affiliate-report.ts の "Task 4 boundary-bug lesson"
+//   コメント参照。あちらは julianday() で読み側を防御している。）
+//
+// ドリフトが起きる典型は「テーブル再構築マイグレーション」で、schema.sql 側の
+// 宣言と食い違っても replay 後は後勝ちで気付けない。実例として
+// 029_account_management_v2.sql が broadcasts を datetime('now') で作り直している。
+//
+// そこで replay 後の *実効 DDL* を PRAGMA table_info で読み、DEFAULT 式が
+// 正準形か既知の例外かを検査する。PRAGMA を使うのは、空白や改行の差で
+// 誤検知しない正規化済みの値が得られるため。
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = join(__dirname, '..');
+const MIGRATIONS_DIR = join(PKG_ROOT, 'migrations');
+const BOOTSTRAP_PATH = join(PKG_ROOT, 'bootstrap.sql');
+
+const BENIGN_SQLITE_ERROR = /duplicate column name|already exists/i;
+
+/** 全テーブル共通の正準 DEFAULT 式（JST ISO-8601, ミリ秒付き）。 */
+const CANONICAL_JST_DEFAULT = "strftime('%Y-%m-%dT%H:%M:%f', 'now', '+9 hours')";
+
+/** UTC を返す非正準式。 */
+const UTC_DEFAULT = "datetime('now')";
+
+// 既知の UTC DEFAULT。SQLite は DEFAULT の変更にテーブル再構築を要するため、
+// 「現時点で DEFAULT が発火していない（INSERT が created_at を明示している）」
+// 列については、既存テーブルの作り直しを避けて現状を追認している。
+//
+// このリストは ratchet として機能する:
+//   * 新しく UTC DEFAULT の列が増えたらテストが落ちる（＝ドリフトの新規流入を止める）
+//   * 逆にここの列を正準形へ直したら、リストから消すまでテストが落ちる
+//
+// 追加する場合は「なぜ DEFAULT が発火しないか」を必ず確認すること。
+// DEFAULT に依存する INSERT を書くなら、ここに足すのではなく jstNow() を明示バインドする。
+const KNOWN_UTC_DEFAULTS = new Set([
+  'broadcasts.created_at',
+  'entry_routes.created_at',
+  'entry_routes.updated_at',
+  'form_submissions.created_at',
+  'forms.created_at',
+  'forms.updated_at',
+  'media_inquiries.created_at',
+  'media_inquiries.updated_at',
+  'message_templates.created_at',
+  'message_templates.updated_at',
+  'pool_accounts.created_at',
+  'ref_tracking.created_at',
+  'tracked_links.created_at',
+  'tracked_links.updated_at',
+  'webinar_funnel_events.created_at',
+]);
+
+function splitSqlStatements(sql: string): string[] {
+  return sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+}
+
+function applyMigrationReplay(db: Database.Database): void {
+  db.exec(readFileSync(join(PKG_ROOT, 'schema.sql'), 'utf8'));
+  const migrationFiles = readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+
+  for (const file of migrationFiles) {
+    const sql = readFileSync(join(MIGRATIONS_DIR, file), 'utf8');
+    for (const statement of splitSqlStatements(sql)) {
+      try {
+        db.exec(statement);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!BENIGN_SQLITE_ERROR.test(message)) {
+          throw new Error(`${file}: ${message}`);
+        }
+      }
+    }
+  }
+}
+
+/** `table.column` -> DEFAULT 式（DEFAULT 無しの列は含めない）。 */
+function collectTimestampDefaults(db: Database.Database): Map<string, string> {
+  const found = new Map<string, string>();
+  const tables = db
+    .prepare(
+      `SELECT name FROM sqlite_master
+        WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+        ORDER BY name`,
+    )
+    .all() as Array<{ name: string }>;
+
+  for (const { name } of tables) {
+    const columns = db.prepare(`PRAGMA table_info("${name}")`).all() as Array<{
+      name: string;
+      dflt_value: string | null;
+    }>;
+    for (const column of columns) {
+      if (column.name !== 'created_at' && column.name !== 'updated_at') continue;
+      if (column.dflt_value === null) continue;
+      found.set(`${name}.${column.name}`, column.dflt_value);
+    }
+  }
+  return found;
+}
+
+function replayedDefaults(): Map<string, string> {
+  const db = new Database(':memory:');
+  try {
+    applyMigrationReplay(db);
+    return collectTimestampDefaults(db);
+  } finally {
+    db.close();
+  }
+}
+
+describe('created_at / updated_at DEFAULT expressions', () => {
+  it('schema.sql describes the effective timestamp defaults after migration replay', () => {
+    const schemaDb = new Database(':memory:');
+    try {
+      schemaDb.exec(readFileSync(join(PKG_ROOT, 'schema.sql'), 'utf8'));
+      const declared = collectTimestampDefaults(schemaDb);
+      const effective = replayedDefaults();
+      const differences = [...declared]
+        .filter(([key, expr]) => effective.get(key) !== expr)
+        .map(([key, expr]) => `${key}: schema=${expr}; replay=${effective.get(key)}`);
+      expect(differences).toEqual([]);
+    } finally {
+      schemaDb.close();
+    }
+  });
+
+  it('uses the canonical JST expression except for known UTC columns', () => {
+    const defaults = replayedDefaults();
+    expect(defaults.size).toBeGreaterThan(0);
+
+    const offenders = [...defaults]
+      .filter(([key, expr]) => expr !== CANONICAL_JST_DEFAULT && !KNOWN_UTC_DEFAULTS.has(key))
+      .map(([key, expr]) => `${key} => ${expr}`);
+
+    expect(offenders).toEqual([]);
+  });
+
+  // KNOWN_UTC_DEFAULTS が現実とズレたら落とす。片方向の抑制リストにすると
+  // 直したあともリストが残り、次のドリフトを隠してしまうため。
+  it('keeps KNOWN_UTC_DEFAULTS exactly in sync with reality', () => {
+    const defaults = replayedDefaults();
+    const actualUtc = [...defaults]
+      .filter(([, expr]) => expr === UTC_DEFAULT)
+      .map(([key]) => key)
+      .sort();
+
+    expect(actualUtc).toEqual([...KNOWN_UTC_DEFAULTS].sort());
+  });
+
+  // 新規インストールは bootstrap.sql から作られるので、replay と一致していないと
+  // 「移行済み DB と新規 DB でタイムスタンプ形式が違う」事故になる。
+  it('bootstrap.sql agrees with the migration replay', () => {
+    const bootstrapDb = new Database(':memory:');
+    try {
+      bootstrapDb.exec(readFileSync(BOOTSTRAP_PATH, 'utf8'));
+      const fromBootstrap = collectTimestampDefaults(bootstrapDb);
+      expect(Object.fromEntries([...fromBootstrap].sort())).toEqual(
+        Object.fromEntries([...replayedDefaults()].sort()),
+      );
+    } finally {
+      bootstrapDb.close();
+    }
+  });
+});


### PR DESCRIPTION
Integrate three focused maintenance contributions against the current main:

- #290 (@smatsushita-maker): store inquiry creation and notification-update timestamps with explicit JST offsets, representing the same instant across month/year boundaries. Existing stored timestamps are not rewritten.
- #284 (@smatsushita-maker): align the canonical broadcast `created_at` default with the UTC default already established by historical migration 029. Application inserts explicitly supply timestamps. Preserve all historical migration bytes; formal bootstrap regeneration produces no change. The exact known UTC-default exception set is checked in both directions, so a newly introduced drift cannot be hidden by widening an allowlist.
- #186 (@masa-kaz): emit one bounded, fixed JSON diagnostic per loaded module for missing/unparseable admin origins on auth requests. Do not log request origins, paths or configuration values. Authorization/allowlist/preview/loopback decisions and the current Idempotency-Key preflight remain unchanged. An anonymous first probe can consume the single diagnostic; this limitation is documented.

Regression evidence: 11 new route/diagnostic cases and the schema-vs-replay check fail before the changes; adding an extra UTC-default column also fails the guard. Candidate full Worker tests/typecheck/build pass. On the latest merged base, 36 relevant route/CORS/tag tests and all 205 DB tests pass; migration/bootstrap/diff checks pass. GitHub CI validates the final integrated head.

Original PR links and contributor credits are retained in the individual commits. No production deployment, message send, data migration or package publication is performed by this source PR.
