### PR TITLE
fix(messages): align test-send URLs and tracked chat logs

### DIFF
--- a/apps/worker/src/routes/broadcasts-test-send.test.ts
+++ b/apps/worker/src/routes/broadcasts-test-send.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from 'node:fs';
+import { URL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { LineClient, type Message } from '@line-crm/line-sdk';
+import { sqliteD1 } from '../test-support/sqlite-d1.js';
+import { broadcasts } from './broadcasts.js';
+
+const schema = readFileSync(new URL('../../../../packages/db/bootstrap.sql', import.meta.url), 'utf8');
+
+describe('broadcast test-send tracking origin', () => {
+  let fixture: ReturnType<typeof sqliteD1>;
+  let app: Hono;
+  let requests: Array<{ token: string; to: string; messages: Message[] }>;
+  beforeEach(() => {
+    fixture = sqliteD1();
+    fixture.sqlite.exec(schema);
+    fixture.sqlite.exec(`
+      INSERT INTO line_accounts(id,channel_id,name,channel_access_token,channel_secret)
+        VALUES('account-a','channel-a','Synthetic account','synthetic-token-a','synthetic-secret');
+      INSERT INTO friends(id,line_user_id,line_account_id,display_name)
+        VALUES('friend-a','line-friend-a','account-a','Synthetic friend');
+      INSERT INTO account_settings(id,line_account_id,key,value)
+        VALUES('recipients','account-a','test_recipients','["friend-a"]');
+      INSERT INTO broadcasts(id,title,message_type,message_content,target_type,line_account_id,track_links)
+        VALUES('broadcast-a','Synthetic draft','text','See https://example.test/join','all','account-a',1);
+    `);
+    requests = [];
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Real network is forbidden in this test'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(LineClient.prototype, 'request').mockImplementation(async function (this: LineClient, method, path, body) {
+      expect(method).toBe('POST');
+      expect(path).toBe('/v2/bot/message/push');
+      requests.push({ token: Reflect.get(this, 'channelAccessToken'), ...(body as { to: string; messages: Message[] }) });
+      return { data: {}, headers: new Headers() };
+    });
+    app = new Hono();
+    app.route('/', broadcasts);
+  });
+  afterEach(() => {
+    expect(fetch).not.toHaveBeenCalled();
+    fixture.sqlite.close();
+    vi.restoreAllMocks();
+  });
+
+  function send(workerUrl?: string) {
+    return app.request('https://request-worker.example/api/broadcasts/broadcast-a/test-send', {
+      method: 'POST', headers: { Origin: 'https://untrusted-admin.example' },
+    }, { DB: fixture.db, ...(workerUrl === undefined ? {} : { WORKER_URL: workerUrl }) });
+  }
+
+  async function expectTrackedSend(response: Response, base: string) {
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ success: true, sent: 1, failed: 0 });
+    const link = fixture.sqlite.prepare('SELECT short_code,line_account_id FROM tracked_links').get() as { short_code: string; line_account_id: string };
+    expect(link.line_account_id).toBe('account-a');
+    const text = `【テスト配信】\nSee ${base}/t/${link.short_code}`;
+    expect(requests).toEqual([{ token: 'synthetic-token-a', to: 'line-friend-a', messages: [{ type: 'text', text }], customAggregationUnits: undefined }]);
+    expect(fixture.sqlite.prepare('SELECT message_type,content,delivery_type FROM messages_log').all())
+      .toEqual([{ message_type: 'text', content: text, delivery_type: 'test' }]);
+    expect(text).not.toContain('untrusted-admin');
+  }
+
+  it('falls back to the request URL, never the Origin header, when WORKER_URL is absent', async () => {
+    await expectTrackedSend(await send(), 'https://request-worker.example');
+  });
+
+  it('keeps a configured Worker URL authoritative', async () => {
+    await expectTrackedSend(await send('https://configured-worker.example/'), 'https://configured-worker.example');
+  });
+
+  it('still honors the configured branded tracking domain with no Worker URL binding', async () => {
+    fixture.sqlite.prepare("INSERT INTO account_settings(id,line_account_id,key,value) VALUES('short-domain','__global__','tracked_link_base_url',?)")
+      .run(JSON.stringify('https://go.example'));
+    await expectTrackedSend(await send(), 'https://go.example');
+  });
+
+  it('keeps track_links=0 unchanged without creating tracked links', async () => {
+    fixture.sqlite.exec("UPDATE broadcasts SET track_links=0 WHERE id='broadcast-a'");
+    const response = await send();
+    expect(response.status).toBe(200);
+    expect(requests[0].messages).toEqual([{ type: 'text', text: '【テスト配信】\nSee https://example.test/join' }]);
+    expect(fixture.sqlite.prepare('SELECT COUNT(*) AS count FROM tracked_links').get()).toEqual({ count: 0 });
+  });
+});

--- a/apps/worker/src/routes/broadcasts.ts
+++ b/apps/worker/src/routes/broadcasts.ts
@@ -1154,7 +1154,10 @@ broadcasts.post('/api/broadcasts/:id/test-send', async (c) => {
     let tracked = { messageType: broadcast.message_type as string, content: messageContent };
     if (broadcast.track_links !== 0) {
       const { autoTrackContent } = await import('../services/auto-track.js');
-      tracked = await autoTrackContent(c.env.DB, broadcast.message_type, messageContent, c.env.WORKER_URL, {
+      // Self-hosted installs may omit WORKER_URL. Use the request URL, never
+      // the caller-controlled Origin header, for the Worker's tracking base.
+      const trackWorkerUrl = c.env.WORKER_URL || new URL(c.req.url).origin;
+      tracked = await autoTrackContent(c.env.DB, broadcast.message_type, messageContent, trackWorkerUrl, {
         lineAccountId: accountId,
       });
     }

--- a/apps/worker/src/routes/chats-send-tracking.test.ts
+++ b/apps/worker/src/routes/chats-send-tracking.test.ts
@@ -1,0 +1,181 @@
+import { readFileSync } from 'node:fs';
+import { URL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import { LineClient, type Message } from '@line-crm/line-sdk';
+import { sqliteD1 } from '../test-support/sqlite-d1.js';
+import { chats } from './chats.js';
+
+const schema = readFileSync(new URL('../../../../packages/db/bootstrap.sql', import.meta.url), 'utf8');
+const RAW_URL = 'https://example.test/join';
+const WORKER = 'https://request-worker.example';
+
+describe('chat reply tracking and delivery logs', () => {
+  let fixture: ReturnType<typeof sqliteD1>;
+  let app: Hono;
+  let requests: Array<{ token: string; to: string; messages: Message[] }>;
+  let failDelivery: boolean;
+  beforeEach(() => {
+    fixture = sqliteD1();
+    fixture.sqlite.exec(schema);
+    for (const id of ['a', 'b']) {
+      fixture.sqlite.prepare('INSERT INTO line_accounts(id,channel_id,name,channel_access_token,channel_secret) VALUES(?,?,?,?,?)')
+        .run(`account-${id}`, `channel-${id}`, 'Synthetic account', `synthetic-token-${id}`, 'synthetic-secret');
+      fixture.sqlite.prepare('INSERT INTO friends(id,line_user_id,line_account_id,display_name) VALUES(?,?,?,?)')
+        .run(`friend-${id}`, `line-friend-${id}`, `account-${id}`, 'Synthetic friend');
+      fixture.sqlite.prepare('INSERT INTO chats(id,friend_id,status) VALUES(?,?,?)').run(`chat-${id}`, `friend-${id}`, 'unread');
+    }
+    requests = [];
+    failDelivery = false;
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Real network is forbidden in this test'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(LineClient.prototype, 'request').mockImplementation(async function (this: LineClient, method, path, body) {
+      expect(method).toBe('POST');
+      expect(path).toBe('/v2/bot/message/push');
+      requests.push({ token: Reflect.get(this, 'channelAccessToken'), ...(body as { to: string; messages: Message[] }) });
+      if (failDelivery) throw new Error('Synthetic delivery failure');
+      return { data: {}, headers: new Headers() };
+    });
+    app = new Hono();
+    app.route('/', chats);
+  });
+  afterEach(() => {
+    expect(fetch).not.toHaveBeenCalled();
+    fixture.sqlite.close();
+    vi.restoreAllMocks();
+  });
+
+  function send(body: { content: string; messageType?: string; trackLinks?: boolean }, id = 'chat-a', workerUrl?: string) {
+    return app.request(`${WORKER}/api/chats/${id}/send`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json', Origin: 'https://untrusted-admin.example' }, body: JSON.stringify(body),
+    }, { DB: fixture.db, LINE_CHANNEL_ACCESS_TOKEN: 'synthetic-unrelated-default', ...(workerUrl === undefined ? {} : { WORKER_URL: workerUrl }) });
+  }
+
+  function links() {
+    return fixture.sqlite.prepare('SELECT original_url,line_account_id,short_code FROM tracked_links ORDER BY line_account_id').all() as Array<{
+      original_url: string; line_account_id: string | null; short_code: string;
+    }>;
+  }
+
+  function expectLogMatches(message: Message, friend = 'friend-a', account = 'account-a') {
+    const content = message.type === 'text' ? message.text
+      : message.type === 'flex' ? JSON.stringify(message.contents)
+        : message.type === 'image' ? JSON.stringify({ originalContentUrl: message.originalContentUrl, previewImageUrl: message.previewImageUrl })
+          : JSON.stringify(message);
+    expect(fixture.sqlite.prepare('SELECT message_type,content,source,line_account_id FROM messages_log WHERE friend_id=?').get(friend))
+      .toEqual({ message_type: message.type, content, source: 'manual', line_account_id: account });
+  }
+
+  it('uses each recipient account for both its current token and owned tracked link, with distinct friend attribution', async () => {
+    fixture.sqlite.exec("UPDATE line_accounts SET channel_access_token='synthetic-rotated-b' WHERE id='account-b'");
+    for (const id of ['a', 'b']) expect((await send({ content: `See ${RAW_URL}` }, `chat-${id}`)).status).toBe(200);
+    const rows = links();
+    expect(rows).toHaveLength(2);
+    for (const [index, id] of ['a', 'b'].entries()) {
+      expect(rows[index]).toMatchObject({ original_url: RAW_URL, line_account_id: `account-${id}` });
+      expect(requests[index]).toMatchObject({
+        token: id === 'a' ? 'synthetic-token-a' : 'synthetic-rotated-b', to: `line-friend-${id}`,
+        messages: [{ type: 'text', text: `See ${WORKER}/t/${rows[index].short_code}?f=friend-${id}` }],
+      });
+      expectLogMatches(requests[index].messages[0], `friend-${id}`, `account-${id}`);
+    }
+  });
+
+  it('attributes a lazy-created chat to the friend ID, not the new chat ID', async () => {
+    fixture.sqlite.exec("DELETE FROM chats WHERE id='chat-a'");
+    expect((await send({ content: RAW_URL }, 'friend-a')).status).toBe(200);
+    const chat = fixture.sqlite.prepare("SELECT id,status FROM chats WHERE friend_id='friend-a'").get() as { id: string; status: string };
+    expect(chat.id).not.toBe('friend-a');
+    expect(chat.status).toBe('in_progress');
+    expect(requests[0].messages).toEqual([{ type: 'text', text: `${WORKER}/t/${links()[0].short_code}?f=friend-a` }]);
+    expectLogMatches(requests[0].messages[0]);
+  });
+
+  it('retains the owner ID when an unassigned legacy friend uses the sole active account', async () => {
+    fixture.sqlite.exec("UPDATE friends SET line_account_id=NULL WHERE id='friend-a'; UPDATE line_accounts SET is_active=0 WHERE id='account-b'");
+    expect((await send({ content: RAW_URL })).status).toBe(200);
+    expect(requests[0].token).toBe('synthetic-token-a');
+    expect(links()[0].line_account_id).toBe('account-a');
+    expectLogMatches(requests[0].messages[0]);
+  });
+
+  it('leaves raw links alone when tracking is disabled', async () => {
+    expect((await send({ content: RAW_URL, trackLinks: false })).status).toBe(200);
+    expect(links()).toEqual([]);
+    expect(requests[0].messages).toEqual([{ type: 'text', text: RAW_URL }]);
+    expectLogMatches(requests[0].messages[0]);
+  });
+
+  it('still attributes an existing tracked link when raw-URL tracking is disabled', async () => {
+    const text = `${WORKER}/t/ExistingCode?utm_source=chat`;
+    expect((await send({ content: text, trackLinks: false })).status).toBe(200);
+    expect(links()).toEqual([]);
+    expect(requests[0].messages).toEqual([{ type: 'text', text: `${text}&f=friend-a` }]);
+    expectLogMatches(requests[0].messages[0]);
+  });
+
+  it('tracks Flex URI actions and preserves media URLs while logging the actual sent object', async () => {
+    const contents = { type: 'bubble', hero: { type: 'image', url: 'https://images.example/hero.png' }, body: {
+      type: 'box', layout: 'vertical', contents: [{ type: 'button', action: { type: 'uri', label: 'Join', uri: RAW_URL } }],
+    } };
+    expect((await send({ messageType: 'flex', content: JSON.stringify(contents, null, 2) })).status).toBe(200);
+    const rows = links();
+    expect(rows).toHaveLength(1);
+    const expected = structuredClone(contents);
+    expected.body.contents[0].action.uri = `${WORKER}/t/${rows[0].short_code}?f=friend-a`;
+    expect(requests[0].messages[0]).toMatchObject({ type: 'flex', contents: expected });
+    expectLogMatches(requests[0].messages[0]);
+  });
+
+  it('keeps image URLs untouched and excludes unsent input fields from the log', async () => {
+    const image = { originalContentUrl: `${WORKER}/t/image-original.png`, previewImageUrl: 'https://images.example/preview.png', unsentCaption: 'not sent' };
+    expect((await send({ messageType: 'image', content: JSON.stringify(image, null, 2) })).status).toBe(200);
+    expect(links()).toEqual([]);
+    expect(requests[0].messages).toEqual([{ type: 'image', originalContentUrl: image.originalContentUrl, previewImageUrl: image.previewImageUrl }]);
+    expectLogMatches(requests[0].messages[0]);
+  });
+
+  it('uses the request URL origin when WORKER_URL is missing, never the Origin header', async () => {
+    expect((await send({ content: RAW_URL })).status).toBe(200);
+    expect(requests[0].messages).toEqual([{ type: 'text', text: `${WORKER}/t/${links()[0].short_code}?f=friend-a` }]);
+  });
+
+  it('uses a configured short domain for tracking and friend attribution', async () => {
+    fixture.sqlite.prepare("INSERT INTO account_settings(id,line_account_id,key,value) VALUES('short-domain','__global__','tracked_link_base_url',?)")
+      .run(JSON.stringify('https://go.example'));
+    expect((await send({ content: RAW_URL }, 'chat-a', 'https://configured-worker.example')).status).toBe(200);
+    expect(requests[0].messages).toEqual([{ type: 'text', text: `https://go.example/t/${links()[0].short_code}?f=friend-a` }]);
+    expectLogMatches(requests[0].messages[0]);
+  });
+
+  it('reuses existing app-link behavior instead of introducing another URL rewrite policy', async () => {
+    expect((await send({ content: 'https://youtube.com/watch?v=synthetic' })).status).toBe(200);
+    expect(links()).toEqual([]);
+    expect(requests[0].messages).toEqual([{ type: 'text', text: 'https://youtube.com/watch?v=synthetic&openExternalBrowser=1' }]);
+    expectLogMatches(requests[0].messages[0]);
+  });
+
+  it.each(['inactive', 'empty token'])('does not send or create tracking rows for an assigned account with %s', async state => {
+    fixture.sqlite.exec(state === 'inactive'
+      ? "UPDATE line_accounts SET is_active=0 WHERE id='account-a'"
+      : "UPDATE line_accounts SET channel_access_token='' WHERE id='account-a'");
+    expect((await send({ content: RAW_URL })).status).toBe(500);
+    expect(requests).toEqual([]);
+    expect(links()).toEqual([]);
+    expect(fixture.sqlite.prepare('SELECT COUNT(*) AS count FROM messages_log').get()).toEqual({ count: 0 });
+  });
+
+  it('does not record a sent message or advance chat state when LINE delivery fails', async () => {
+    failDelivery = true;
+    expect((await send({ content: RAW_URL })).status).toBe(500);
+    expect(fixture.sqlite.prepare('SELECT COUNT(*) AS count FROM messages_log').get()).toEqual({ count: 0 });
+    expect(fixture.sqlite.prepare("SELECT status FROM chats WHERE id='chat-a'").get()).toEqual({ status: 'unread' });
+  });
+
+  it('rejects unsupported message types instead of logging an unsent message as successful', async () => {
+    expect((await send({ messageType: 'video', content: RAW_URL })).status).toBe(400);
+    expect(requests).toEqual([]);
+    expect(links()).toEqual([]);
+    expect(fixture.sqlite.prepare('SELECT COUNT(*) AS count FROM messages_log').get()).toEqual({ count: 0 });
+  });
+});

--- a/apps/worker/src/routes/chats.ts
+++ b/apps/worker/src/routes/chats.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono';
 import { extractFlexAltText } from '../utils/flex-alt-text.js';
+import type { Message } from '@line-crm/line-sdk';
+import { messageToLogPayload } from '../services/step-delivery.js';
 import {
   getOperators,
   getOperatorById,
@@ -11,7 +13,7 @@ import {
   createChat,
   getFriendById,
   getLineAccountById,
-  resolveDefaultAccessToken,
+  resolveDefaultLineAccount,
   updateChat,
   jstNow,
 } from '@line-crm/db';
@@ -102,9 +104,10 @@ async function resolveOrCreateChat(db: D1Database, id: string): Promise<ChatLike
 }
 
 /**
- * `envAccessToken` は「最後の砦」であって既定値ではない —
- * `resolveDefaultAccessToken` の doc comment を参照。friend にアカウントが
- * 紐付いていなくても、テナントに有効なアカウントが1本しか無ければそれを使う。
+ * Resolve the sending token and tracking-link owner from the same account.
+ * Unassigned legacy friends can use the sole active account or the existing
+ * environment fallback. An assigned but unavailable account never falls back
+ * to another bot.
  */
 async function resolveFriendAndAccessToken(
   db: D1Database,
@@ -113,19 +116,18 @@ async function resolveFriendAndAccessToken(
 ) {
   const friend = await getFriendById(db, friendId);
   if (!friend) {
-    return { friend: null, accessToken: await resolveDefaultAccessToken(db, envAccessToken) };
+    return { friend: null, accessToken: envAccessToken, lineAccountId: null };
   }
 
-  if (!friend.line_account_id) {
-    return { friend, accessToken: await resolveDefaultAccessToken(db, envAccessToken) };
+  const account = friend.line_account_id
+    ? await getLineAccountById(db, friend.line_account_id)
+    : await resolveDefaultLineAccount(db);
+  if (friend.line_account_id && (!account?.is_active || !account.channel_access_token?.trim())) {
+    throw new Error('LINE account credentials are unavailable');
   }
-
-  const account = await getLineAccountById(db, friend.line_account_id);
-  if (!account) {
-    return { friend, accessToken: await resolveDefaultAccessToken(db, envAccessToken) };
-  }
-
-  return { friend, accessToken: account.channel_access_token };
+  const accessToken = account?.channel_access_token || envAccessToken;
+  if (!accessToken?.trim()) throw new Error('LINE account credentials are unavailable');
+  return { friend, accessToken, lineAccountId: account?.id ?? null };
 }
 
 // ========== オペレーターCRUD ==========
@@ -557,10 +559,14 @@ chats.post('/api/chats/:id/send', async (c) => {
     const chat = await resolveOrCreateChat(c.env.DB, chatId);
     if (!chat) return c.json({ success: false, error: 'Chat not found' }, 404);
 
-    const body = await c.req.json<{ messageType?: string; content: string }>();
-    if (!body.content) return c.json({ success: false, error: 'content is required' }, 400);
+    const body = await c.req.json<{ messageType?: string; content: string; trackLinks?: boolean }>();
+    if (typeof body.content !== 'string' || !body.content) return c.json({ success: false, error: 'content is required' }, 400);
+    const messageType = body.messageType ?? 'text';
+    if (!['text', 'flex', 'image'].includes(messageType)) {
+      return c.json({ success: false, error: 'Unsupported message type' }, 400);
+    }
 
-    const { friend, accessToken } = await resolveFriendAndAccessToken(
+    const { friend, accessToken, lineAccountId } = await resolveFriendAndAccessToken(
       c.env.DB,
       chat.friend_id,
       c.env.LINE_CHANNEL_ACCESS_TOKEN,
@@ -570,30 +576,40 @@ chats.post('/api/chats/:id/send', async (c) => {
     // LINE APIでメッセージ送信
     const { LineClient } = await import('@line-crm/line-sdk');
     const lineClient = new LineClient(accessToken);
-    const messageType = body.messageType ?? 'text';
 
-    if (messageType === 'text') {
-      await lineClient.pushTextMessage(friend.line_user_id, body.content);
-    } else if (messageType === 'flex') {
-      const contents = JSON.parse(body.content);
-      await lineClient.pushFlexMessage(friend.line_user_id, extractFlexAltText(contents), contents);
-    } else if (messageType === 'image') {
-      const parsed = JSON.parse(body.content) as {
+    const sendWorkerUrl = c.env.WORKER_URL || new URL(c.req.url).origin;
+    const { autoTrackContent, appendFriendToTrackedLinks } = await import('../services/auto-track.js');
+    let tracked = { messageType, content: body.content };
+    if (body.trackLinks !== false) {
+      tracked = await autoTrackContent(c.env.DB, messageType, body.content, sendWorkerUrl, { lineAccountId });
+    }
+    // Opt-out disables raw URL wrapping, but existing tracked links still get
+    // this 1:1 recipient. Image URLs are media and must remain untouched.
+    if (tracked.messageType !== 'image') {
+      tracked.content = await appendFriendToTrackedLinks(c.env.DB, tracked.content, sendWorkerUrl, friend.id);
+    }
+
+    let message: Message;
+    if (tracked.messageType === 'text') {
+      message = { type: 'text', text: tracked.content };
+    } else if (tracked.messageType === 'flex') {
+      const contents = JSON.parse(tracked.content);
+      message = { type: 'flex', altText: extractFlexAltText(contents), contents };
+    } else {
+      const parsed = JSON.parse(tracked.content) as {
         originalContentUrl: string;
         previewImageUrl: string;
       };
-      await lineClient.pushImageMessage(
-        friend.line_user_id,
-        parsed.originalContentUrl,
-        parsed.previewImageUrl,
-      );
+      message = { type: 'image', originalContentUrl: parsed.originalContentUrl, previewImageUrl: parsed.previewImageUrl };
     }
+    await lineClient.pushMessage(friend.line_user_id, [message]);
 
-    // メッセージログに記録
+    // Store exactly the payload delivered to LINE, including tracking changes.
+    const log = messageToLogPayload(message);
     const logId = crypto.randomUUID();
     await c.env.DB
-      .prepare(`INSERT INTO messages_log (id, friend_id, direction, message_type, content, source, created_at) VALUES (?, ?, 'outgoing', ?, ?, 'manual', ?)`)
-      .bind(logId, friend.id, messageType, body.content, jstNow())
+      .prepare(`INSERT INTO messages_log (id, friend_id, direction, message_type, content, source, line_account_id, created_at) VALUES (?, ?, 'outgoing', ?, ?, 'manual', ?, ?)`)
+      .bind(logId, friend.id, log.messageType, log.content, lineAccountId, jstNow())
       .run();
 
     // チャットの最終メッセージ日時を更新（chat.id を直接使う — friend_id で呼ばれても resolveOrCreateChat 済み）


### PR DESCRIPTION
Port the focused broadcast-test and chat-tracking contributions onto the current main:

- #247 (@haruddd): when WORKER_URL is absent, derive the tracking base from the request URL origin, preserving configured/branded URL precedence and opt-out. The caller's Origin header is not used as the fallback.
- #297 (@tomomuran): use the existing tracking and recipient-attribution helpers for chat text/Flex replies. Keep image messages intact. Resolve a known sending token and tracked-link owner together; an assigned inactive/empty account never falls back to another bot. Existing unassigned legacy environment fallback remains outside the broader #259 cleanup.
- Build the existing manual message log from the Message that was successfully sent, including rewritten URLs and the resolved account. Invalid message types and failed sends cannot create a successful message log. The loading indicator uses the same safe credential resolution.

There are 18 new HTTP/SQLite/SDK-mock controls: four for test-send and fourteen for chat tracking; failing baseline cases reproduce both original issues and the raw-log mismatch. Candidate full Worker tests and typechecks pass. Latest-base integration also verifies these routes with the existing CORS and tag-automation controls. All LINE transport is mocked and external fetch is rejected during tests; no real send or deployment was performed.

Original contribution credits remain in two individual commits. Tracking helper behavior, historical SQL and unrelated source are preserved; no fixed environment URL is added.
