### PR TITLE
fix(input): normalize text keywords and preserve LIFF query semantics

### DIFF
--- a/apps/worker/src/lib/liff-query.ts
+++ b/apps/worker/src/lib/liff-query.ts
@@ -1,0 +1,20 @@
+type DirectQueryReader = (key: string) => string | undefined;
+
+/**
+ * LIFF puts its additional path/query/fragment in liff.state. Read only the
+ * query part as fallback; never rewrite liff.state or the request URL.
+ * Hono has decoded the outer value already, so do not decode it again.
+ */
+export function createLiffQueryReader(readDirect: DirectQueryReader): (key: string) => string {
+  const state = (readDirect('liff.state') ?? '').split('#', 1)[0];
+  const queryStart = state.indexOf('?');
+  // Additional LIFF information is a path, not an absolute/protocol-relative URL.
+  const hasAuthority = /^\s*(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(state);
+  // URLSearchParams itself removes one leading '?'. Keep the delimiter so a
+  // second '?' stays part of the first key, just as it does in a direct URL.
+  const stateParams = new URLSearchParams(!hasAuthority && queryStart >= 0 ? state.slice(queryStart) : '');
+
+  // A present empty direct value deliberately overrides a value hidden in state.
+  // Both Hono.query and URLSearchParams.get retain first-value duplicate semantics.
+  return (key) => readDirect(key) ?? stateParams.get(key) ?? '';
+}

--- a/apps/worker/src/routes/liff-state-query.test.ts
+++ b/apps/worker/src/routes/liff-state-query.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { URL } from 'node:url';
+import { Buffer } from 'node:buffer';
+import { Hono } from 'hono';
+import { sqliteD1 } from '../test-support/sqlite-d1.js';
+import { liffRoutes } from './liff.js';
+
+const schema = readFileSync(new URL('../../../../packages/db/bootstrap.sql', import.meta.url), 'utf8');
+afterEach(() => { vi.restoreAllMocks(); });
+
+function setup() {
+  const { db, sqlite } = sqliteD1();
+  sqlite.exec(schema);
+  for (const account of ['a', 'b']) {
+    sqlite.prepare(`INSERT INTO line_accounts
+      (id,channel_id,name,channel_access_token,channel_secret,login_channel_id)
+      VALUES(?,?,?,?,?,?)`)
+      .run(account, `channel-${account}`, account, 'synthetic-token', 'synthetic-secret', `login-${account}`);
+  }
+  sqlite.prepare("INSERT INTO traffic_pools(id,slug,name,active_account_id,created_at,updated_at) VALUES(?,?,?,?,'2020-01-01','2020-01-01')")
+    .run('pool-b', 'campaign', 'Synthetic pool', 'b');
+  sqlite.prepare("INSERT INTO pool_accounts(id,pool_id,line_account_id,is_active,created_at) VALUES(?,?,?,1,'2020-01-01')")
+    .run('member-b', 'pool-b', 'b');
+  const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No real network allowed'));
+  const app = new Hono();
+  app.route('/', liffRoutes);
+  async function request(query: URLSearchParams, configured = true) {
+    const response = await app.request(`/auth/oauth?${query.toString()}`, {}, {
+      DB: db, LINE_LOGIN_CHANNEL_ID: configured ? 'login-default' : undefined,
+      LINE_CHANNEL_ACCESS_TOKEN: 'synthetic-default-token',
+    });
+    expect(network).not.toHaveBeenCalled();
+    return response;
+  }
+  async function authorize(query: URLSearchParams) {
+    const response = await request(query);
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get('location')!);
+    expect(location.origin).toBe('https://access.line.me');
+    expect(location.pathname).toBe('/oauth2/v2.1/authorize');
+    expect(location.searchParams.get('redirect_uri')).toBe('http://localhost/auth/callback');
+    expect(location.searchParams.get('response_type')).toBe('code');
+    expect(location.searchParams.get('scope')).toBe('profile openid email');
+    expect(location.searchParams.get('bot_prompt')).toBe('aggressive');
+    const state = JSON.parse(Buffer.from(location.searchParams.get('state')!, 'base64').toString('utf8')) as Record<string, string>;
+    return { location, state };
+  }
+  return { sqlite, request, authorize };
+}
+
+describe('/auth/oauth LIFF query fallback (PR #159)', () => {
+  it.each(['?ref=campaign-a', '/path?ref=campaign-a', 'relative/path?ref=campaign-a'])(
+    'recovers query parameters from %s without changing the OAuth contract', async liffState => {
+      const s = setup();
+      try {
+        const { state, location } = await s.authorize(new URLSearchParams({ 'liff.state': liffState }));
+        expect(state.ref).toBe('campaign-a');
+        expect(location.searchParams.get('client_id')).toBe('login-default');
+      } finally { s.sqlite.close(); }
+    },
+  );
+
+  it('recovers all existing fields, including iga/igan and encoded Japanese values', async () => {
+    const s = setup();
+    try {
+      const fields = {
+        ref: '広告/東京 50% +', redirect: 'https://destination.example/path?a=1#section',
+        form: 'synthetic-form', gate: 'synthetic-gate', xh: 'synthetic-xh',
+        gclid: 'synthetic-g', fbclid: 'synthetic-fb', twclid: 'synthetic-tw', ttclid: 'synthetic-tt',
+        utm_source: '紹介', utm_medium: 'SNS', utm_campaign: '夏の勉強会',
+        account: 'channel-b', uid: 'synthetic-user', ig: 'synthetic-ig',
+        iga: 'synthetic-iga', igan: '日本語アカウント',
+      };
+      const direct = await s.authorize(new URLSearchParams(fields));
+      const wrapped = await s.authorize(new URLSearchParams({
+        'liff.state': '/path?' + new URLSearchParams(fields).toString() + '#ignored-fragment',
+      }));
+      expect(wrapped.state).toEqual(direct.state);
+      expect(wrapped.location.searchParams.get('client_id')).toBe('login-b');
+      expect(wrapped.state.redirect).toBe(fields.redirect);
+    } finally { s.sqlite.close(); }
+  });
+
+  it('recovers pool selection with the same account resolution as a direct pool query', async () => {
+    const s = setup();
+    try {
+      const direct = await s.authorize(new URLSearchParams({ pool: 'campaign', ref: 'pool-ref' }));
+      const wrapped = await s.authorize(new URLSearchParams({ 'liff.state': '/path?pool=campaign&ref=pool-ref' }));
+      expect(wrapped.state).toEqual(direct.state);
+      expect(wrapped.state.account).toBe('channel-b');
+      expect(wrapped.location.searchParams.get('client_id')).toBe('login-b');
+    } finally { s.sqlite.close(); }
+  });
+
+  it.each(['/path??account=channel-b&ref=normal', '??ref=hidden', '/path?%3Fref=hidden&iga=normal'])('keeps standard URL query-key semantics for %s', async liffState => {
+    const s = setup();
+    try {
+      const directQuery = new URL(liffState, 'https://synthetic.example').searchParams;
+      const direct = await s.authorize(directQuery);
+      const wrapped = await s.authorize(new URLSearchParams({ 'liff.state': liffState }));
+      expect(wrapped.state).toEqual(direct.state);
+      expect(wrapped.location.searchParams.get('client_id')).toBe(direct.location.searchParams.get('client_id'));
+    } finally { s.sqlite.close(); }
+  });
+
+  it('direct values, including explicit empty values, override hidden state', async () => {
+    const s = setup();
+    try {
+      const { state, location } = await s.authorize(new URLSearchParams({
+        ref: '', account: 'channel-a', iga: '', pool: '',
+        'liff.state': '?ref=hidden&account=channel-b&iga=hidden&igan=rescued&pool=campaign',
+      }));
+      expect(state.ref).toBe('');
+      expect(state.iga).toBe('');
+      expect(state.igan).toBe('rescued');
+      expect(state.account).toBe('channel-a');
+      expect(location.searchParams.get('client_id')).toBe('login-a');
+    } finally { s.sqlite.close(); }
+  });
+
+  it('an explicit empty account and pool keep the existing default selection', async () => {
+    const s = setup();
+    try {
+      const { state, location } = await s.authorize(new URLSearchParams({
+        account: '', pool: '', 'liff.state': '?account=channel-b&pool=campaign',
+      }));
+      expect(location.searchParams.get('client_id')).toBe('login-default');
+      expect(state.account).toBe('');
+    } finally { s.sqlite.close(); }
+  });
+
+  it('keeps first-value semantics for duplicate direct and state parameters', async () => {
+    const s = setup();
+    try {
+      const direct = new URLSearchParams([
+        ['ref', 'first-direct'], ['ref', 'second-direct'],
+        ['liff.state', '?ref=hidden&iga=first-state&iga=second-state'],
+      ]);
+      const first = await s.authorize(direct);
+      expect(first.state.ref).toBe('first-direct');
+      expect(first.state.iga).toBe('first-state');
+      const duplicateState = await s.authorize(new URLSearchParams([
+        ['liff.state', '?ref=first-state'], ['liff.state', '?ref=second-state'],
+      ]));
+      expect(duplicateState.state.ref).toBe('first-state');
+      const emptyFirst = await s.authorize(new URLSearchParams([
+        ['ref', ''], ['ref', 'second-direct'], ['liff.state', '?ref=hidden'],
+      ]));
+      expect(emptyFirst.state.ref).toBe('');
+    } finally { s.sqlite.close(); }
+  });
+
+  it('does not treat fragments or encoded delimiters as extra parameters', async () => {
+    const s = setup();
+    try {
+      const { state } = await s.authorize(new URLSearchParams({
+        'liff.state': '/path?ref=a%26b%3D1%23part&iga=%2526literal#igan=not-a-query',
+      }));
+      expect(state.ref).toBe('a&b=1#part');
+      expect(state.iga).toBe('%26literal');
+      expect(state.igan).toBe('');
+    } finally { s.sqlite.close(); }
+  });
+
+  it.each([
+    '/path-only', '#?iga=fragment-only', '%3Figa%3Ddouble-encoded',
+    'https://other.example/path?iga=not-a-liff-path', '//other.example/path?iga=not-a-liff-path',
+  ])('ignores unsupported state shape %s and keeps direct values', async liffState => {
+    const s = setup();
+    try {
+      const { state } = await s.authorize(new URLSearchParams({ ref: 'direct', 'liff.state': liffState }));
+      expect(state.ref).toBe('direct');
+      expect(state.iga).toBe('');
+    } finally { s.sqlite.close(); }
+  });
+
+  it('malformed percent escapes do not throw or override an explicit direct value', async () => {
+    const s = setup();
+    try {
+      const { state } = await s.authorize(new URLSearchParams({ ref: '', 'liff.state': '?ref=%ZZ&iga=%E0%A4' }));
+      expect(state.ref).toBe('');
+      expect(typeof state.iga).toBe('string');
+    } finally { s.sqlite.close(); }
+  });
+
+  it('does not bypass the existing unconfigured-login guard', async () => {
+    const s = setup();
+    try {
+      const response = await s.request(new URLSearchParams({ 'liff.state': '?ref=campaign' }), false);
+      expect(response.status).toBe(503);
+      expect(response.headers.has('location')).toBe(false);
+    } finally { s.sqlite.close(); }
+  });
+});

--- a/apps/worker/src/routes/liff.ts
+++ b/apps/worker/src/routes/liff.ts
@@ -1,4 +1,5 @@
 import { Hono, type Context } from 'hono';
+import { createLiffQueryReader } from '../lib/liff-query.js';
 import {
   getFriendByLineUserId,
   getFriendByLineUserIdForAccount,
@@ -569,23 +570,24 @@ liffRoutes.get('/auth/line', async (c) => {
  * Same query params as /auth/line. No HTML rendering, no smart logic.
  */
 liffRoutes.get('/auth/oauth', async (c) => {
-  const ref = c.req.query('ref') || '';
-  const redirect = c.req.query('redirect') || '';
-  const formId = c.req.query('form') || '';
-  const gateParam = c.req.query('gate') || '';
-  const xhParam = c.req.query('xh') || '';
-  const gclid = c.req.query('gclid') || '';
-  const fbclid = c.req.query('fbclid') || '';
-  const twclid = c.req.query('twclid') || '';
-  const ttclid = c.req.query('ttclid') || '';
-  const utmSource = c.req.query('utm_source') || '';
-  const utmMedium = c.req.query('utm_medium') || '';
-  const utmCampaign = c.req.query('utm_campaign') || '';
-  const accountParam = c.req.query('account') || '';
-  const uidParam = c.req.query('uid') || '';
-  const igParam = c.req.query('ig') || '';
-  const igaParam = c.req.query('iga') || '';
-  const iganParam = c.req.query('igan') || '';
+  const q = createLiffQueryReader((key) => c.req.query(key));
+  const ref = q('ref');
+  const redirect = q('redirect');
+  const formId = q('form');
+  const gateParam = q('gate');
+  const xhParam = q('xh');
+  const gclid = q('gclid');
+  const fbclid = q('fbclid');
+  const twclid = q('twclid');
+  const ttclid = q('ttclid');
+  const utmSource = q('utm_source');
+  const utmMedium = q('utm_medium');
+  const utmCampaign = q('utm_campaign');
+  const accountParam = q('account');
+  const uidParam = q('uid');
+  const igParam = q('ig');
+  const igaParam = q('iga');
+  const iganParam = q('igan');
   let poolAccount = '';
   const baseUrl = new URL(c.req.url).origin;
 
@@ -595,7 +597,7 @@ liffRoutes.get('/auth/oauth', async (c) => {
     const account = await getLineAccountByChannelId(c.env.DB, accountParam);
     if (account?.login_channel_id) channelId = account.login_channel_id;
   } else {
-    const poolSlug = c.req.query('pool') || 'main';
+    const poolSlug = q('pool') || 'main';
     const pool = await getTrafficPoolBySlug(c.env.DB, poolSlug);
     if (pool) {
       const account = await getRandomPoolAccount(c.env.DB, pool.id);

--- a/apps/worker/src/routes/webhook.ts
+++ b/apps/worker/src/routes/webhook.ts
@@ -402,6 +402,7 @@ async function handleEvent(
     // silent + automation で「返信なしでタグだけ付ける」構成もここで成立する。
     const { matched: postbackMatched, replyTokenConsumed: postbackReplyTokenConsumed } =
       await matchAndReply(db, lineClient, friend, postbackData, event.replyToken, {
+        inputKind: 'postback',
         lineAccountId,
         workerUrl,
         liffUrl,
@@ -603,6 +604,7 @@ async function handleEvent(
       incomingText,
       event.replyToken,
       {
+        inputKind: 'text',
         lineAccountId,
         workerUrl,
         liffUrl,

--- a/apps/worker/src/services/auto-reply-normalization.test.ts
+++ b/apps/worker/src/services/auto-reply-normalization.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { URL } from 'node:url';
+import { Hono } from 'hono';
+import { sqliteD1 } from '../test-support/sqlite-d1.js';
+import { keywordMatches } from './auto-reply.js';
+import { computeUnansweredInbox } from './unanswered-inbox.js';
+import { webhook } from '../routes/webhook.js';
+
+const proxyDispatch = vi.hoisted(() => vi.fn());
+vi.mock('./local-line-proxy.js', () => ({ dispatchLineProxyLocally: proxyDispatch }));
+
+const schema = readFileSync(new URL('../../../../packages/db/bootstrap.sql', import.meta.url), 'utf8');
+const secret = 'synthetic-channel-secret';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function setup() {
+  const { db, sqlite } = sqliteD1();
+  sqlite.exec(schema);
+  sqlite.prepare('INSERT INTO line_accounts(id,channel_id,name,channel_access_token,channel_secret) VALUES(?,?,?,?,?)')
+    .run('account-a', 'synthetic-channel', 'Synthetic account', 'synthetic-token', secret);
+  sqlite.prepare('INSERT INTO friends(id,line_user_id,line_account_id,display_name,metadata) VALUES(?,?,?,?,?)')
+    .run('friend-a', 'synthetic-user', 'account-a', 'Synthetic friend', '{}');
+  const network = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No real network allowed'));
+  proxyDispatch.mockReset();
+  proxyDispatch.mockImplementation(async () => new Response('{}', { status: 200 }));
+  const app = new Hono();
+  app.route('/', webhook);
+  function rule(keyword: string, options: { silent?: boolean; id?: string; reply?: string; createdAt?: string } = {}) {
+    sqlite.prepare(`INSERT INTO auto_replies
+      (id,keyword,match_type,response_type,response_content,line_account_id,created_at)
+      VALUES(?,?,'exact',?,?,'account-a',?)`)
+      .run(options.id ?? 'rule-a', keyword, options.silent ? 'silent' : 'text',
+        options.reply ?? 'Synthetic reply', options.createdAt ?? '2020-01-01T00:00:00.000+09:00');
+  }
+  function automation(eventType: string, condition: object) {
+    sqlite.prepare("INSERT INTO tags(id,name) VALUES('tag-a','Synthetic tag')").run();
+    sqlite.prepare('INSERT INTO automations(id,name,event_type,line_account_id,conditions,actions) VALUES(?,?,?,?,?,?)')
+      .run('keyword-action', 'Synthetic keyword action', eventType, 'account-a', JSON.stringify(condition), JSON.stringify([
+        { type: 'add_tag', params: { tagId: 'tag-a' } },
+        { type: 'set_metadata', params: { data: '{"original":"{{message}}"}' } },
+      ]));
+    // Observe one tag-change event independently from the outer keyword action.
+    sqlite.prepare('INSERT INTO automations(id,name,event_type,line_account_id,conditions,actions) VALUES(?,?,?,?,?,?)')
+      .run('tag-observer', 'Synthetic tag observer', 'tag_change', 'account-a', '{"tag_id":"tag-a"}', '[]');
+  }
+  async function post(kind: 'text' | 'postback', text: string) {
+    const event = {
+      type: kind === 'text' ? 'message' : 'postback',
+      source: { type: 'user', userId: 'synthetic-user' },
+      replyToken: 'synthetic-reply-token',
+      timestamp: Date.now(),
+      mode: 'active',
+      webhookEventId: crypto.randomUUID(),
+      deliveryContext: { isRedelivery: false },
+      ...(kind === 'text' ? { message: { type: 'text', id: crypto.randomUUID(), text } } : { postback: { data: text } }),
+    };
+    const body = JSON.stringify({ destination: 'synthetic-bot', events: [event] });
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey('raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    const digest = await crypto.subtle.sign('HMAC', key, encoder.encode(body));
+    const signature = btoa(String.fromCharCode(...new Uint8Array(digest)));
+    const pending: Promise<unknown>[] = [];
+    const response = await app.request('/webhook', {
+      method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Line-Signature': signature }, body,
+    }, { DB: db, LINE_CHANNEL_SECRET: secret, LINE_CHANNEL_ACCESS_TOKEN: 'synthetic-token' }, {
+      waitUntil(promise: Promise<unknown>) { pending.push(promise); },
+      passThroughOnException() {},
+      props: {},
+    });
+    await Promise.all(pending);
+    expect(response.status).toBe(200);
+    expect(network).not.toHaveBeenCalled();
+  }
+  return { db, sqlite, rule, automation, post };
+}
+
+describe('text-only auto-reply keyword normalization (PR #230)', () => {
+  it.each([
+    ['exact', '0627', '０６２７', true],
+    ['exact', '０６２７', '06２７', true],
+    ['exact', '0627', '　 06２７ \n', true],
+    ['exact', 'カタカナ', 'ｶﾀｶﾅ', true],
+    ['contains', '0627', '０６２７お願いします', true],
+    ['exact', '0627', '０６２７お願いします', false],
+    ['exact', 'AbC', 'ＡｂＣ', true],
+    ['exact', 'ABC', 'abc', false],
+    ['contains', '[ab]', '［ａｂ］', true],
+    ['regex', '[0-9]+', '0627', false],
+    ['unknown', '0627', '0627', false],
+    ['contains', '　 ', 'anything', false],
+  ] as const)('%s keyword %s against %s keeps the intended match semantics', (match_type, keyword, text, expected) => {
+    expect(keywordMatches({ match_type, keyword }, text, { normalizeText: true })).toBe(expected);
+  });
+
+  it('keeps the raw comparator opaque unless text normalization is requested', () => {
+    expect(keywordMatches({ keyword: '0627', match_type: 'exact' }, '０６２７')).toBe(false);
+    expect(keywordMatches({ keyword: '0627', match_type: 'exact' }, ' 0627 ')).toBe(false);
+  });
+
+  it('the real text webhook replies to a width variant and stores the original incoming text', async () => {
+    const s = setup();
+    try {
+      s.rule('0627');
+      await s.post('text', '　06２７ ');
+      expect(proxyDispatch).toHaveBeenCalledTimes(1);
+      expect(s.sqlite.prepare("SELECT content FROM messages_log WHERE direction='incoming'").get())
+        .toEqual({ content: '　06２７ ' });
+      expect(s.sqlite.prepare("SELECT content,source,delivery_type FROM messages_log WHERE direction='outgoing'").get())
+        .toEqual({ content: 'Synthetic reply', source: 'auto_reply', delivery_type: 'reply' });
+    } finally { s.sqlite.close(); }
+  });
+
+  it('silent normalized text rules also suppress unanswered status without an outgoing evidence row', async () => {
+    const s = setup();
+    try {
+      s.rule('カタカナ', { silent: true });
+      await s.post('text', ' ｶﾀｶﾅ　');
+      expect(proxyDispatch).not.toHaveBeenCalled();
+      expect((await computeUnansweredInbox(s.db)).total).toBe(0);
+      expect(s.sqlite.prepare("SELECT COUNT(*) n FROM chats WHERE status='unread'").get()).toEqual({ n: 0 });
+    } finally { s.sqlite.close(); }
+  });
+
+  it.each(['keyword', 'keyword_exact'])('silent text and automation %s agree and attach a tag once with raw evidence', async condition => {
+    const s = setup();
+    try {
+      const input = '　06２７ ';
+      s.rule('0627', { silent: true });
+      s.automation('message_received', { [condition]: '０６２７' });
+      await s.post('text', input);
+      expect((await computeUnansweredInbox(s.db)).total).toBe(0);
+      expect(s.sqlite.prepare("SELECT COUNT(*) n FROM chats WHERE status='unread'").get()).toEqual({ n: 0 });
+      expect(proxyDispatch).not.toHaveBeenCalled();
+      expect(s.sqlite.prepare('SELECT friend_id,tag_id FROM friend_tags').all())
+        .toEqual([{ friend_id: 'friend-a', tag_id: 'tag-a' }]);
+      expect(s.sqlite.prepare("SELECT status FROM automation_logs WHERE automation_id='tag-observer'").all())
+        .toEqual([{ status: 'success' }]);
+      const log = s.sqlite.prepare("SELECT event_data,status FROM automation_logs WHERE automation_id='keyword-action'").get() as { event_data: string; status: string };
+      expect(log.status).toBe('success');
+      expect(JSON.parse(log.event_data).text).toBe(input);
+      expect(s.sqlite.prepare("SELECT content FROM messages_log WHERE direction='incoming'").get())
+        .toEqual({ content: input });
+      const friend = s.sqlite.prepare("SELECT metadata FROM friends WHERE id='friend-a'").get() as { metadata: string };
+      expect(JSON.parse(friend.metadata).original).toBe(input);
+    } finally { s.sqlite.close(); }
+  });
+
+  it.each([
+    ['keyword', '0627', '０６２７', false],
+    ['keyword_exact', '0627', '０６２７', false],
+    ['keyword', '０６２７', '０６２７', true],
+    ['keyword_exact', '０６２７', '　０６２７ ', true],
+  ] as const)('postback automation %s preserves raw width and existing exact trim behavior', async (condition, keyword, input, matches) => {
+    const s = setup();
+    try {
+      s.automation('postback_received', { [condition]: keyword });
+      await s.post('postback', input);
+      expect(s.sqlite.prepare('SELECT COUNT(*) n FROM friend_tags').get()).toEqual({ n: matches ? 1 : 0 });
+      expect(proxyDispatch).not.toHaveBeenCalled();
+      expect(s.sqlite.prepare("SELECT content,source FROM messages_log WHERE direction='incoming'").get())
+        .toEqual({ content: input, source: 'postback' });
+    } finally { s.sqlite.close(); }
+  });
+
+  it.each(['０６２７', ' 0627 '])('opaque postback %s is neither normalized nor trimmed', async input => {
+    const s = setup();
+    try {
+      s.rule('0627');
+      await s.post('postback', input);
+      expect(proxyDispatch).not.toHaveBeenCalled();
+      expect(s.sqlite.prepare("SELECT content,source FROM messages_log WHERE direction='incoming'").get())
+        .toEqual({ content: input, source: 'postback' });
+      expect((await computeUnansweredInbox(s.db)).total).toBe(0);
+    } finally { s.sqlite.close(); }
+  });
+
+  it('exact opaque postback matching remains available', async () => {
+    const s = setup();
+    try {
+      s.rule(' ０６２７ ');
+      await s.post('postback', ' ０６２７ ');
+      expect(proxyDispatch).toHaveBeenCalledTimes(1);
+    } finally { s.sqlite.close(); }
+  });
+
+  it('retains existing first-rule ordering when normalization makes two text rules equivalent', async () => {
+    const s = setup();
+    try {
+      s.rule('0627', { id: 'first', reply: 'First rule', createdAt: '2020-01-01T00:00:00+09:00' });
+      s.rule('０６２７', { id: 'second', reply: 'Second rule', createdAt: '2020-01-02T00:00:00+09:00' });
+      await s.post('text', '０６２７');
+      expect(s.sqlite.prepare("SELECT content FROM messages_log WHERE direction='outgoing'").get())
+        .toEqual({ content: 'First rule' });
+    } finally { s.sqlite.close(); }
+  });
+});

--- a/apps/worker/src/services/auto-reply.ts
+++ b/apps/worker/src/services/auto-reply.ts
@@ -10,19 +10,8 @@ import {
   resolveMetadata,
 } from './step-delivery.js';
 
-/**
- * exact/contains のキーワードマッチ述語。webhook のテキスト/postback 経路と
- * unanswered-inbox の「構造化メッセ除外」判定が同じルール解釈を共有する。
- * 未知の match_type はマッチなし扱い (誤マッチで inbox から隠すより安全側)。
- */
-export function keywordMatches(
-  rule: { keyword: string; match_type: string },
-  text: string,
-): boolean {
-  if (rule.match_type === 'exact') return text === rule.keyword;
-  if (rule.match_type === 'contains') return text.includes(rule.keyword);
-  return false;
-}
+import { keywordMatches } from './keyword-match.js';
+export { keywordMatches } from './keyword-match.js';
 
 /**
  * auto_reply 行の content/type を resolve する。template_id が set なら templates
@@ -96,6 +85,8 @@ export async function matchAndReply(
     liffUrl?: string;
     logContext?: string;
     replyMessage?: AutoReplySender;
+    /** Human message text is normalized; machine-defined postback data is opaque. */
+    inputKind?: 'text' | 'postback';
   } = {},
 ): Promise<MatchAndReplyResult> {
   const { lineAccountId = null, workerUrl, liffUrl, logContext, replyMessage } = opts;
@@ -112,7 +103,9 @@ export async function matchAndReply(
     .bind(lineAccountId)
     .all<AutoReply>();
 
-  const rule = autoReplies.results.find((r) => keywordMatches(r, incomingText));
+  const rule = autoReplies.results.find((r) => keywordMatches(r, incomingText, {
+    normalizeText: opts.inputKind !== 'postback',
+  }));
   if (!rule) return { matched: false, replyTokenConsumed: false };
   if (rule.response_type === 'silent') return { matched: true, replyTokenConsumed: false };
 

--- a/apps/worker/src/services/event-bus.ts
+++ b/apps/worker/src/services/event-bus.ts
@@ -22,6 +22,7 @@ import {
 import { LineClient } from '@line-crm/line-sdk';
 import type { Message } from '@line-crm/line-sdk';
 import { sendAdConversions } from './ad-conversion.js';
+import { keywordMatches } from './keyword-match.js';
 import {
   claimTagEffects,
   createTagAutomationDispatch,
@@ -191,7 +192,7 @@ async function processAutomations(
       const actions = JSON.parse(automation.actions) as Array<{ type: string; params: Record<string, string> }>;
 
       // 条件チェック（簡易版: 条件が空なら常にマッチ）
-      if (!matchConditions(conditions, payload)) continue;
+      if (!matchConditions(conditions, payload, eventType)) continue;
 
       const results: Array<{ action: string; success: boolean; error?: string }> = [];
 
@@ -225,6 +226,7 @@ async function processAutomations(
 function matchConditions(
   conditions: Record<string, unknown>,
   payload: EventPayload,
+  eventType: string,
 ): boolean {
   // 条件が空 → 常にマッチ
   if (Object.keys(conditions).length === 0) return true;
@@ -245,16 +247,20 @@ function matchConditions(
   // keyword チェック（message_received / postback_received イベント用）
   if (conditions.keyword !== undefined && payload.eventData) {
     const text = payload.eventData.text as string | undefined;
-    if (!text || !text.includes(conditions.keyword as string)) return false;
+    if (!text) return false;
+    // Only human message text shares auto-reply/inbox normalization. Postback
+    // data is opaque, and event payloads/logs must retain the original input.
+    if (eventType === 'message_received' && typeof conditions.keyword === 'string') {
+      if (!keywordMatches({ keyword: conditions.keyword, match_type: 'contains' }, text, { normalizeText: true })) return false;
+    } else if (!text.includes(conditions.keyword as string)) return false;
   }
 
   // keyword_exact（完全一致）
   if (conditions.keyword_exact) {
     const rawText = payload.eventData?.text as string | undefined;
-    const text = (rawText || '').trim();
-    if (text !== conditions.keyword_exact) {
-      return false;
-    }
+    if (eventType === 'message_received' && typeof conditions.keyword_exact === 'string') {
+      if (!keywordMatches({ keyword: conditions.keyword_exact, match_type: 'exact' }, rawText || '', { normalizeText: true })) return false;
+    } else if ((rawText || '').trim() !== conditions.keyword_exact) return false;
   }
 
   return true;

--- a/apps/worker/src/services/keyword-match.ts
+++ b/apps/worker/src/services/keyword-match.ts
@@ -1,0 +1,18 @@
+/**
+ * exact/contains のキーワードマッチ述語。webhook のテキスト/postback 経路と
+ * unanswered-inbox の「構造化メッセ除外」判定とテキスト自動化で共有する。
+ * 未知の match_type はマッチなし扱い (誤マッチで inbox から隠すより安全側)。
+ */
+export function keywordMatches(
+  rule: { keyword: string; match_type: string },
+  text: string,
+  opts: { normalizeText?: boolean } = {},
+): boolean {
+  // Unknown/regex match types stay unsupported; never reinterpret them as contains.
+  if (rule.match_type !== 'exact' && rule.match_type !== 'contains') return false;
+  const incoming = opts.normalizeText ? text.normalize('NFKC').trim() : text;
+  const keyword = opts.normalizeText ? rule.keyword.normalize('NFKC').trim() : rule.keyword;
+  // A whitespace-only rule must not become an accidental match-all after trim.
+  if (opts.normalizeText && !keyword) return false;
+  return rule.match_type === 'exact' ? incoming === keyword : incoming.includes(keyword);
+}

--- a/apps/worker/src/services/unanswered-inbox.ts
+++ b/apps/worker/src/services/unanswered-inbox.ts
@@ -40,7 +40,7 @@ function matchesAnyKeyword(
   rules: ActiveRuleRow[],
 ): boolean {
   if (messageType !== 'text') return false;
-  return rules.some((ar) => keywordMatches(ar, content));
+  return rules.some((ar) => keywordMatches(ar, content, { normalizeText: true }));
 }
 
 // 同じ incoming に対して outgoing 'auto_reply' (delivery_type='reply') が


### PR DESCRIPTION
Integrate #230 and #159 against the current common services and OAuth entrypoint, preserving the original contributor credits in separate commits.

Human text keyword matching now uses NFKC consistently for replies, unanswered classification and message_received keyword automations. Silent matches therefore cannot hide a message while leaving its corresponding automation inactive. Opaque postback comparisons retain their previous behavior; raw incoming text, message logs, event_data and template values are not rewritten. Unknown/regex types remain unsupported and normalized empty keywords cannot match every message.

The OAuth query reader recovers the supported parameters from canonical LIFF state query/path forms. Direct parameters take priority even when empty, duplicate handling remains first-wins, fragments are excluded and values are not decoded twice. The extra-question-mark case preserves standard URL query-key semantics instead of promoting `?account` to `account`. Absolute/protocol-relative/path-only state is not treated as an OAuth query. Existing authorize host, callback, scope and account selection logic remain in place.

Real HTTP/SQLite tests reproduce the former failures and verify text/postback behavior, silent automation/tag effects, direct-vs-wrapped query parity and parser boundaries. Independent review ran 60 relevant controls and typechecks in both editions; candidate full Worker suites/typechecks/builds pass. The final integration also tests these paths together with the latest tracked-chat and tag-account changes. All external fetch/LINE transport is mocked; no actual message or deployment occurs.

Only nine source/test files change. Existing tag dispatch, cycle accounting, scoped credentials, linked-recipient delivery, migrations and unrelated source are preserved.
