### PR TITLE
fix(update-ui): group progress without hiding outcomes or controls

### DIFF
--- a/apps/web/src/components/update/progress-modal-view.test.ts
+++ b/apps/web/src/components/update/progress-modal-view.test.ts
@@ -1,0 +1,84 @@
+import { Children, createElement, isValidElement, type ReactElement, type ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Button } from '@cloudflare/kumo/components/button'
+import { describe, expect, test, vi } from 'vitest'
+import { ProgressModalView, type UpdateFinalState } from './progress-modal-view'
+import { buildProgressRows } from './progress-rows'
+
+function elements(node: ReactNode): ReactElement<Record<string, unknown>>[] {
+  return Children.toArray(node).flatMap((child) => {
+    if (!isValidElement<Record<string, unknown>>(child)) return []
+    return [child, ...elements(child.props.children as ReactNode)]
+  })
+}
+const rows = buildProgressRows([
+  { step: 'preflight', status: 'done' },
+  { step: 'preflight', status: 'running', name: 'requires_secrets:ADMIN_ORIGIN,API_KEY' },
+  { step: 'migration', status: 'done', name: '001.sql (already applied)' },
+  { step: 'migration', status: 'done', name: '027.sql (adopted, not executed)' },
+  { step: 'rollback', status: 'running', error: 'original update failure' },
+  { step: 'rollback', status: 'done' },
+])
+
+describe('ProgressModalView', () => {
+  test('renders real Kumo button markup and all retained evidence through React SSR', () => {
+    const html = renderToStaticMarkup(createElement(ProgressModalView, {
+      rows, final: { status: 'rolled_back', error: 'final failure' }, mode: 'polling', titleId: 'update-title', onClose: () => {},
+    }))
+    expect(html).toContain('role="dialog"')
+    expect(html).toContain('aria-labelledby="update-title"')
+    expect(html).toContain('ADMIN_ORIGIN, API_KEY')
+    expect(html).toContain('001.sql')
+    expect(html).toContain('027.sql')
+    expect(html).toContain('適用済みのためスキップ')
+    expect(html).toContain('既存状態を確認して記録（実行なし）')
+    expect(html).toContain('original update failure')
+    expect(html).toContain('final failure')
+    expect(html).toContain('<details')
+    const button = html.match(/<button\b[^>]*>[\s\S]*?<\/button>/)?.[0]
+    expect(button).toContain('data-kumo-component="Button"')
+    expect(button).toContain('type="button"')
+    expect(button?.replace(/<[^>]*>/g, '')).toBe('閉じる')
+  })
+
+  test.each(['success', 'rolled_back', 'failed'] as const)('keeps Close outside scrolling content and wired for %s', (status) => {
+    const onClose = vi.fn()
+    const final: UpdateFinalState = { status, error: 'very-long-error-'.repeat(500) }
+    const tree = ProgressModalView({ rows, final, mode: 'sse', titleId: 'update-title', onClose })
+    const all = elements(tree)
+    const dialog = all.find((element) => element.props.role === 'dialog')!
+    const children = Children.toArray(dialog.props.children as ReactNode).filter(isValidElement<Record<string, unknown>>)
+    const scroll = children.find((child) => child.props['data-progress-scroll'] === 'true')!
+    const footer = children.find((child) => child.props['data-progress-footer'] === 'true')!
+    expect(dialog.props.className).toContain('max-h-[calc(100dvh-2rem)]')
+    expect(dialog.props.className).toContain('flex flex-col')
+    expect(scroll.props.className).toContain('min-h-0 overflow-y-auto')
+    expect(footer.props.className).toContain('shrink-0')
+    expect(children.indexOf(footer)).toBeGreaterThan(children.indexOf(scroll))
+    expect(elements(scroll).some((element) => element.type === Button)).toBe(false)
+    const close = elements(footer).find((element) => element.type === Button)!
+    expect(close.props.type).toBe('button')
+    expect(close.props.disabled).toBeUndefined()
+    ;(close.props.onClick as () => void)()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  test('does not add a close/cancel action while the update is running', () => {
+    const html = renderToStaticMarkup(createElement(ProgressModalView, {
+      rows: [], final: null, mode: 'sse', titleId: 'update-title', onClose: () => {},
+    }))
+    expect(html).toContain('接続中...')
+    expect(html).not.toContain('data-progress-footer')
+    expect(html).not.toContain('閉じる')
+  })
+
+  test('escapes error and note text while keeping it available in the scroll region', () => {
+    const unsafe = '<img src=x onerror="alert(1)">'
+    const html = renderToStaticMarkup(createElement(ProgressModalView, {
+      rows: buildProgressRows([{ step: 'worker', status: 'failed', error: unsafe }]),
+      final: { status: 'failed', error: unsafe }, mode: 'sse', titleId: 'update-title', onClose: () => {},
+    }))
+    expect(html).toContain('&lt;img')
+    expect(html).not.toContain('<img')
+  })
+})

--- a/apps/web/src/components/update/progress-modal-view.tsx
+++ b/apps/web/src/components/update/progress-modal-view.tsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import type { UpdateEvent } from '@line-harness/update-engine'
+import { Button } from '@cloudflare/kumo/components/button'
+import type { MigrationOutcome, ProgressRow, ProgressStepRow } from './progress-rows'
+
+export interface UpdateFinalState {
+  status: 'success' | 'rolled_back' | 'failed'
+  error: string | null
+}
+
+const OUTCOME_LABELS: Record<MigrationOutcome, string> = {
+  applied: '実行済み',
+  skipped: '適用済みのためスキップ',
+  adopted: '既存状態を確認して記録（実行なし）',
+}
+
+function StepDetails({ row }: { row: ProgressStepRow }) {
+  return (
+    <>
+      {row.notes.map((note) => <div key={note} className="text-xs text-gray-600 whitespace-pre-wrap break-words">{note}</div>)}
+      {row.secrets.length > 0 && (
+        <div className="text-xs text-gray-600 break-words">新しく必要になるsecret: {row.secrets.join(', ')}</div>
+      )}
+      {row.outcomeHistory.length > 0 && (
+        <div className="text-xs text-gray-600">{row.outcomeHistory.map((outcome) => OUTCOME_LABELS[outcome]).join(' → ')}</div>
+      )}
+      {row.errors.map((error) => <div key={error} className="text-xs text-red-700 whitespace-pre-wrap break-words">{error}</div>)}
+    </>
+  )
+}
+
+/** The scrollable evidence and the fixed close footer are separate flex children. */
+export function ProgressModalView({
+  rows, final, mode, titleId, onClose,
+}: {
+  rows: ProgressRow[]
+  final: UpdateFinalState | null
+  mode: 'sse' | 'polling'
+  titleId: string
+  onClose: () => void
+}) {
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+      <div role="dialog" aria-modal="true" aria-labelledby={titleId}
+        className="bg-white text-gray-900 rounded-lg shadow-xl w-full max-w-lg max-h-[calc(100dvh-2rem)] flex flex-col overflow-hidden">
+        <header className="shrink-0 px-6 pt-6 pb-3">
+          <h2 id={titleId} className="text-lg font-semibold">
+            {final ? 'アップデート結果' : 'アップデート中'}{' '}
+            {mode === 'polling' && <span className="text-xs text-gray-500">(polling)</span>}
+          </h2>
+        </header>
+        <div data-progress-scroll="true" role="region" aria-label="更新の進捗と詳細" tabIndex={0}
+          className="min-h-0 overflow-y-auto overscroll-contain px-6 pb-6 [overflow-wrap:anywhere]">
+          <ul className="space-y-2 font-mono text-sm">
+            {rows.length === 0 && <li className="text-gray-500">接続中...</li>}
+            {rows.map((row) => row.kind === 'migration-summary' ? (
+              <li key={row.key}>
+                <span aria-hidden="true">✓ </span>Migration — {row.total}件完了
+                <div className="text-xs text-gray-600">
+                  実行 {row.applied}件 / 適用済みスキップ {row.skipped}件 / 既存状態を確認して記録 {row.adopted}件
+                </div>
+                <details className="mt-1">
+                  <summary className="cursor-pointer text-xs text-gray-600">対象と処理結果を確認</summary>
+                  <ul className="mt-2 space-y-2 border-l border-gray-200 pl-3">
+                    {row.completed.map((completed) => (
+                      <li key={completed.key}>
+                        <span>{completed.name || '名前のないmigration'}</span>
+                        <StepDetails row={completed} />
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              </li>
+            ) : (
+              <li key={row.key} className="flex items-start gap-2">
+                <span aria-hidden="true" className="w-5 shrink-0">{iconFor(row.status)}</span>
+                <div className="min-w-0">
+                  {labelFor(row.step)}{row.name ? ` — ${row.name}` : ''}
+                  <span className="ml-2 text-xs text-gray-500">{statusFor(row.status, final !== null)}</span>
+                  <StepDetails row={row} />
+                </div>
+              </li>
+            ))}
+          </ul>
+          {final && (
+            <div className="mt-4 p-3 rounded bg-gray-50" role="status">
+              {final.status === 'success' && <p className="text-green-700 font-semibold">完了しました 🎉</p>}
+              {final.status === 'rolled_back' && <p className="text-amber-700">失敗。前バージョンに復旧済み。</p>}
+              {final.status === 'failed' && <p className="text-red-700">失敗 + 復旧失敗。手動対応が必要です。</p>}
+              {final.error && <p className="mt-1 text-xs text-gray-600 whitespace-pre-wrap break-words">{final.error}</p>}
+            </div>
+          )}
+        </div>
+        {final && (
+          <footer data-progress-footer="true" className="shrink-0 border-t border-gray-200 px-6 py-4">
+            <Button type="button" onClick={onClose} size="sm" variant="secondary">閉じる</Button>
+          </footer>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function iconFor(status: UpdateEvent['status']): string {
+  return status === 'done' ? '✓' : status === 'running' ? '⏳' : status === 'failed' ? '✗' : '○'
+}
+
+function statusFor(status: UpdateEvent['status'], finished: boolean): string {
+  if (status === 'running') return finished ? '未完了の記録' : '実行中'
+  return status === 'done' ? '完了' : status === 'failed' ? '失敗' : '待機中'
+}
+
+function labelFor(step: UpdateEvent['step']): string {
+  const labels: Record<UpdateEvent['step'], string> = {
+    preflight: 'Pre-flight', migration: 'Migration', worker: 'Worker デプロイ',
+    admin: 'Admin デプロイ', liff: 'LIFF デプロイ', verify: 'ヘルスチェック',
+    rollback: 'Rollback', complete: '完了',
+  }
+  return labels[step] ?? step
+}

--- a/apps/web/src/components/update/progress-modal.tsx
+++ b/apps/web/src/components/update/progress-modal.tsx
@@ -1,15 +1,16 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useId, useMemo, useState } from 'react'
 import { openUpdateStream, getUpdateStatus } from '@/lib/update-client'
 import type { UpdateEvent } from '@line-harness/update-engine'
-import { Button } from '@cloudflare/kumo/components/button'
+import { buildProgressRows } from './progress-rows'
+import { ProgressModalView, type UpdateFinalState } from './progress-modal-view'
 
 /**
  * ProgressModal — live timeline for an in-flight update.
  *
  * Subscribes to `GET /admin/update/stream/:id` (SSE) via the update-client
- * helper and renders each `progress` event as a row. When a `complete` frame
+ * helper and groups `progress` events into phase rows and migration details. When a `complete` frame
  * lands the modal pivots to a terminal panel (success / rolled_back / failed)
  * with a 閉じる button that calls `onClose`.
  *
@@ -29,10 +30,7 @@ import { Button } from '@cloudflare/kumo/components/button'
  * cannot reschedule itself after unmount (avoids the "set state after
  * unmount" warning + a timer leak on fast modal close).
  */
-interface FinalState {
-  status: 'success' | 'rolled_back' | 'failed'
-  error: string | null
-}
+type FinalState = UpdateFinalState
 
 export function ProgressModal({
   updateId,
@@ -41,9 +39,11 @@ export function ProgressModal({
   updateId: string
   onClose: () => void
 }) {
+  const titleId = useId()
   const [events, setEvents] = useState<UpdateEvent[]>([])
   const [final, setFinal] = useState<FinalState | null>(null)
   const [mode, setMode] = useState<'sse' | 'polling'>('sse')
+  const rows = useMemo(() => buildProgressRows(events), [events])
 
   useEffect(() => {
     let es: EventSource | null = null
@@ -114,88 +114,5 @@ export function ProgressModal({
     }
   }, [updateId])
 
-  return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-md p-6">
-        <h2 className="text-lg font-semibold mb-3">
-          アップデート中{' '}
-          {mode === 'polling' && (
-            <span className="text-xs text-gray-500">(polling)</span>
-          )}
-        </h2>
-        <ul className="space-y-1 font-mono text-sm">
-          {events.length === 0 && (
-            <li className="text-gray-500">接続中...</li>
-          )}
-          {events.map((e, i) => (
-            <li key={i} className="flex items-center gap-2">
-              <span className="w-5 inline-block">{iconFor(e.status)}</span>
-              <span>
-                {labelFor(e.step)}
-                {e.name ? ` — ${e.name}` : ''}
-                {e.error ? ` (${e.error})` : ''}
-              </span>
-            </li>
-          ))}
-        </ul>
-        {final && (
-          <div className="mt-4 p-3 rounded bg-gray-50">
-            {final.status === 'success' && (
-              <p className="text-green-700 font-semibold">完了しました 🎉</p>
-            )}
-            {final.status === 'rolled_back' && (
-              <p className="text-amber-700">
-                失敗。前バージョンに復旧済み。
-                {final.error && (
-                  <span className="block text-xs mt-1 text-gray-600">
-                    {final.error}
-                  </span>
-                )}
-              </p>
-            )}
-            {final.status === 'failed' && (
-              <p className="text-red-700">
-                失敗 + 復旧失敗。手動対応が必要です。
-                {final.error && (
-                  <span className="block text-xs mt-1 text-gray-600">
-                    {final.error}
-                  </span>
-                )}
-              </p>
-            )}
-            <Button
-              type="button"
-              onClick={onClose}
-              className="mt-3"
-              size="sm"
-              variant="secondary"
-            >
-              閉じる
-            </Button>
-          </div>
-        )}
-      </div>
-    </div>
-  )
-}
-
-function iconFor(s: UpdateEvent['status']): string {
-  if (s === 'done') return '✓'
-  if (s === 'running') return '⏳'
-  if (s === 'failed') return '✗'
-  return '○'
-}
-
-function labelFor(step: UpdateEvent['step']): string {
-  const map: Record<UpdateEvent['step'], string> = {
-    preflight: 'Pre-flight',
-    migration: 'Migration',
-    worker: 'Worker デプロイ',
-    admin: 'Admin デプロイ',
-    liff: 'LIFF デプロイ',
-    verify: 'ヘルスチェック',
-    rollback: 'Rollback',
-    complete: '完了',
-  }
-  return map[step] ?? step
+  return <ProgressModalView rows={rows} final={final} mode={mode} titleId={titleId} onClose={onClose} />
 }

--- a/apps/web/src/components/update/progress-rows.test.ts
+++ b/apps/web/src/components/update/progress-rows.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest'
+import type { UpdateEvent } from '@line-harness/update-engine'
+import { buildProgressRows } from './progress-rows'
+
+describe('buildProgressRows', () => {
+  test('keeps first-seen phase order and updates running rows in place', () => {
+    const rows = buildProgressRows([
+      { step: 'worker', status: 'running' }, { step: 'admin', status: 'pending' },
+      { step: 'worker', status: 'done' }, { step: 'admin', status: 'done' },
+    ])
+    expect(rows.map((row) => row.kind === 'step' && [row.step, row.status])).toEqual([
+      ['worker', 'done'], ['admin', 'done'],
+    ])
+  })
+
+  test('deduplicates completion events while retaining applied, skipped and adopted evidence', () => {
+    const events: UpdateEvent[] = [
+      { step: 'migration', status: 'running', name: '001_a.sql' },
+      { step: 'migration', status: 'done', name: '001_a.sql' },
+      { step: 'migration', status: 'running', name: '002_b.sql' },
+      { step: 'migration', status: 'done', name: '002_b.sql (already applied)' },
+      { step: 'migration', status: 'running', name: '003_c.sql' },
+      { step: 'migration', status: 'done', name: '003_c.sql (adopted, not executed)' },
+    ]
+    const rows = buildProgressRows([...events, ...events])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ kind: 'migration-summary', total: 3, applied: 1, skipped: 1, adopted: 1 })
+    if (rows[0].kind !== 'migration-summary') throw new Error('missing summary')
+    expect(rows[0].completed.map((row) => [row.name, row.outcome])).toEqual([
+      ['001_a.sql', 'applied'], ['002_b.sql', 'skipped'], ['003_c.sql', 'adopted'],
+    ])
+  })
+
+  test('keeps pending, running and failed migrations individually with their errors', () => {
+    const rows = buildProgressRows([
+      { step: 'migration', status: 'done', name: '001.sql' },
+      { step: 'migration', status: 'running', name: '002.sql' },
+      { step: 'migration', status: 'failed', name: '002.sql', error: 'constraint failed' },
+      { step: 'migration', status: 'running', name: '003.sql' },
+      { step: 'migration', status: 'pending', name: '004.sql' },
+    ])
+    expect(rows).toHaveLength(4)
+    expect(rows[1]).toMatchObject({ kind: 'step', name: '002.sql', status: 'failed', errors: ['constraint failed'] })
+    expect(rows[2]).toMatchObject({ name: '003.sql', status: 'running' })
+    expect(rows[3]).toMatchObject({ name: '004.sql', status: 'pending' })
+  })
+
+  test('does not discard a failed attempt when its retry finishes', () => {
+    const rows = buildProgressRows([
+      { step: 'migration', status: 'failed', name: '001.sql', error: 'first failure' },
+      { step: 'migration', status: 'running', name: '001.sql' },
+      { step: 'migration', status: 'done', name: '001.sql' },
+    ])
+    expect(rows[0]).toMatchObject({ kind: 'migration-summary', total: 1, completed: [{ errors: ['first failure'] }] })
+  })
+
+  test('uses the full filename, not the shared migration number', () => {
+    expect(buildProgressRows([
+      { step: 'migration', status: 'done', name: '072_broadcast_last_error.sql' },
+      { step: 'migration', status: 'done', name: '072_health_logs_composite_index.sql' },
+    ])[0]).toMatchObject({ total: 2, applied: 2 })
+  })
+
+  test('merges required secret names without regressing preflight status', () => {
+    const rows = buildProgressRows([
+      { step: 'preflight', status: 'running' },
+      { step: 'preflight', status: 'done' },
+      { step: 'preflight', status: 'running', name: 'requires_secrets: A, B,,A' },
+      { step: 'preflight', status: 'running', name: 'requires_secrets:B,C' },
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ status: 'done', secrets: ['A', 'B', 'C'], notes: [] })
+  })
+
+  test('preserves rollback causes across repeated running and empty done events', () => {
+    const rows = buildProgressRows([
+      { step: 'rollback', status: 'running', error: 'health probe failed' },
+      { step: 'rollback', status: 'running' },
+      { step: 'rollback', status: 'failed', error: 'snapshot unavailable' },
+      { step: 'rollback', status: 'done' },
+    ])
+    expect(rows[0]).toMatchObject({ status: 'done', errors: ['health probe failed', 'snapshot unavailable'] })
+  })
+
+  test('folds a skipped LIFF phase into its existing phase row and keeps the reason', () => {
+    const rows = buildProgressRows([
+      { step: 'liff', status: 'running' },
+      { step: 'liff', status: 'done', name: 'skipped (worker-assets install)' },
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ step: 'liff', status: 'done', notes: ['skipped (worker-assets install)'] })
+  })
+
+  test('retains earlier adoption evidence while counting the latest result once', () => {
+    expect(buildProgressRows([
+      { step: 'migration', status: 'done', name: '027.sql (adopted, not executed)' },
+      { step: 'migration', status: 'done', name: '027.sql (already applied)' },
+    ])[0]).toMatchObject({ total: 1, adopted: 0, skipped: 1, completed: [{ outcomeHistory: ['adopted', 'skipped'] }] })
+  })
+
+  test('does not mutate input or invent a shared identity for unnamed migrations', () => {
+    const events = Object.freeze([
+      Object.freeze({ step: 'migration', status: 'running' } as const),
+      Object.freeze({ step: 'migration', status: 'failed', error: 'unknown migration' } as const),
+    ])
+    expect(buildProgressRows(events)).toHaveLength(2)
+    expect(buildProgressRows([])).toEqual([])
+  })
+
+  test('collapses the reported 80-migration case without losing any filenames', () => {
+    const events: UpdateEvent[] = Array.from({ length: 80 }, (_, i) => [
+      { step: 'migration', status: 'running', name: `${i}_migration.sql` },
+      { step: 'migration', status: 'done', name: `${i}_migration.sql (already applied)` },
+    ] as UpdateEvent[]).flat()
+    const rows = buildProgressRows(events)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ total: 80, skipped: 80 })
+    if (rows[0].kind !== 'migration-summary') throw new Error('missing summary')
+    expect(rows[0].completed.map((row) => row.name)).toEqual(Array.from({ length: 80 }, (_, i) => `${i}_migration.sql`))
+  })
+})

--- a/apps/web/src/components/update/progress-rows.ts
+++ b/apps/web/src/components/update/progress-rows.ts
@@ -1,0 +1,108 @@
+import type { UpdateEvent } from '@line-harness/update-engine'
+
+export type MigrationOutcome = 'applied' | 'skipped' | 'adopted'
+
+export interface ProgressStepRow {
+  kind: 'step'
+  key: string
+  step: UpdateEvent['step']
+  status: UpdateEvent['status']
+  name?: string
+  notes: string[]
+  errors: string[]
+  secrets: string[]
+  outcome?: MigrationOutcome
+  outcomeHistory: MigrationOutcome[]
+}
+
+export interface MigrationSummaryRow {
+  kind: 'migration-summary'
+  key: 'migration-summary'
+  total: number
+  applied: number
+  skipped: number
+  adopted: number
+  completed: ProgressStepRow[]
+}
+
+export type ProgressRow = ProgressStepRow | MigrationSummaryRow
+
+const REQUIRES_SECRETS_PREFIX = 'requires_secrets:'
+const MIGRATION_SUFFIXES: Array<[string, MigrationOutcome]> = [
+  [' (already applied)', 'skipped'],
+  [' (adopted, not executed)', 'adopted'],
+]
+
+function migrationName(raw: string): { name: string; outcome: MigrationOutcome } {
+  for (const [suffix, outcome] of MIGRATION_SUFFIXES) {
+    if (raw.endsWith(suffix)) return { name: raw.slice(0, -suffix.length), outcome }
+  }
+  return { name: raw, outcome: 'applied' }
+}
+
+function appendUnique<T>(list: T[], value: T | undefined): void {
+  if (value !== undefined && value !== '' && !list.includes(value)) list.push(value)
+}
+
+/**
+ * Adapted from community PR #282. Keep one row per phase or migration name,
+ * with completed migrations in a summary whose details retain their evidence.
+ * Input events remain untouched; repeated SSE/polling entries do not add counts.
+ */
+export function buildProgressRows(events: readonly UpdateEvent[]): ProgressRow[] {
+  const entries = new Map<string, ProgressStepRow>()
+
+  events.forEach((event, index) => {
+    const migration = event.step === 'migration' ? migrationName(event.name ?? '') : null
+    const key = migration
+      ? JSON.stringify(migration.name ? ['migration', migration.name] : ['unnamed-migration', index])
+      : event.step
+    let row = entries.get(key)
+    if (!row) {
+      row = {
+        kind: 'step', key, step: event.step, status: event.status,
+        ...(migration ? { name: migration.name } : {}),
+        notes: [], errors: [], secrets: [], outcomeHistory: [],
+      }
+      entries.set(key, row)
+    }
+    appendUnique(row.errors, event.error)
+
+    if (event.step === 'preflight' && event.name?.startsWith(REQUIRES_SECRETS_PREFIX)) {
+      for (const secret of event.name.slice(REQUIRES_SECRETS_PREFIX.length).split(',')) {
+        appendUnique(row.secrets, secret.trim())
+      }
+      // Informational running events must not regress an already completed
+      // preflight. A real failure still needs to remain visible.
+      if (event.status === 'failed') row.status = 'failed'
+      return
+    }
+
+    row.status = event.status
+    if (migration) {
+      if (event.status === 'done') {
+        row.outcome = migration.outcome
+        appendUnique(row.outcomeHistory, migration.outcome)
+      }
+    } else {
+      appendUnique(row.notes, event.name)
+    }
+  })
+
+  const rows: ProgressRow[] = []
+  let summary: MigrationSummaryRow | undefined
+  for (const row of entries.values()) {
+    if (row.step !== 'migration' || row.status !== 'done') {
+      rows.push(row)
+      continue
+    }
+    if (!summary) {
+      summary = { kind: 'migration-summary', key: 'migration-summary', total: 0, applied: 0, skipped: 0, adopted: 0, completed: [] }
+      rows.push(summary)
+    }
+    summary.total++
+    summary[row.outcome ?? 'applied']++
+    summary.completed.push(row)
+  }
+  return rows
+}


### PR DESCRIPTION
Long update histories repeated migration rows and could push the modal controls outside the viewport. Adapt #282 to the current engine and Kumo UI: group progress by stage, retain individual migration outcomes/details, and keep the terminal Close control outside the scrolling body.

Known already-applied/adopted/skipped suffixes map to the same migration while their details remain available. Errors, earlier failure messages, required-secret names and the original rollback cause are preserved, including rollback completion events that carry no new error. Unknown stages remain visible. Close remains disabled while the update runs.

SSE/polling effect bytes are unchanged. Seventeen new grouping/React SSR/element-prop tests pass; all public Web tests (57), typecheck and build pass. Generated CSS confirms the viewport height bound, min-height/overflow constraints and non-shrinking footer. Independent review checks the actual engine event shapes and these fixtures. No browser automation or pixel/E2E claim is included.

Original #282 head and contributor tomomuran are credited in the implementation commit. This source change does not deploy the application.
