### PR TITLE
fix: pause idle polling and batch friend tags safely

### DIFF
--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -461,7 +461,7 @@ export default function ChatsPage() {
   // Previously fetched 800 friends in parallel with chats, which blocked the initial render.
   const loadAllFriends = useCallback(async () => {
     try {
-      const friendRes = await api.friends.list({ accountId: selectedAccountId || undefined, limit: '800' })
+      const friendRes = await api.friends.list({ accountId: selectedAccountId || undefined, limit: '800', includeTags: false })
       if (friendRes.success) {
         setAllFriends((friendRes.data as unknown as { items: FriendItem[] }).items)
       }

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Banner } from '@cloudflare/kumo/components/banner'
 import Header from '@/components/layout/header'
 import InboxFilters from '@/components/inbox/inbox-filters'
 import InboxList from '@/components/inbox/inbox-list'
 import InboxSummaryBar from '@/components/inbox/inbox-summary-bar'
 import { api } from '@/lib/api'
+import { useActivityPolling } from '@/hooks/use-activity-polling'
+import { PollingStatus } from '@/components/shared/polling-status'
 import type { InboxRowData } from '@/components/inbox/inbox-row'
 
 const PAGE_SIZE = 50
@@ -31,13 +33,8 @@ export default function InboxPage() {
   const [q, setQ] = useState('')
   const [account, setAccount] = useState('')
   const [overdueOnly, setOverdueOnly] = useState(false)
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [accountOptions, setAccountOptions] = useState<AccountOption[]>([])
-
-  // 重複 polling で古いレスポンスが新しいデータを上書きしないように世代管理
-  // (Codex Round 1 指摘: race condition)。
-  const requestSeqRef = useRef(0)
 
   // 検索/account/overdue を変えたらページを1に戻す
   useEffect(() => {
@@ -46,8 +43,9 @@ export default function InboxPage() {
 
   // Active なアカウントを候補に出す
   useEffect(() => {
+    let cancelled = false
     api.lineAccounts.list().then((res) => {
-      if (res.success) {
+      if (!cancelled && res.success) {
         setAccountOptions(
           res.data
             .filter((a) => a.isActive)
@@ -55,42 +53,23 @@ export default function InboxPage() {
             .sort((x, y) => x.name.localeCompare(y.name)),
         )
       }
-    })
+    }).catch(() => {})
+    return () => { cancelled = true }
   }, [])
 
-  const loadAll = useCallback(async () => {
-    const seq = ++requestSeqRef.current
-    setLoading(true)
-    setError('')
-    try {
-      const res = await api.inbox.unanswered.list({
-        page: 1,
-        pageSize: FETCH_PAGE_SIZE,
-      })
-      // 古いリクエストが新しいリクエストの後に到着したら破棄
-      if (seq !== requestSeqRef.current) return
+  const polling = useActivityPolling({
+    intervalMs: POLL_INTERVAL_MS,
+    load: (signal) => api.inbox.unanswered.list({ page: 1, pageSize: FETCH_PAGE_SIZE }, { signal }),
+    onData: (res) => {
       if (res.success) {
+        setError('')
         setAllRows(res.data.rows)
         setServerTotal(res.data.total)
-        // rows.length < total なら上限ヒット (capped)。バナーで明示。
         setTruncated(res.data.total > res.data.rows.length)
-      } else {
-        setError('取得に失敗しました')
-        // allRows は前回値を保持して stale-while-error
-      }
-    } catch {
-      if (seq !== requestSeqRef.current) return
-      setError('取得に失敗しました')
-    } finally {
-      if (seq === requestSeqRef.current) setLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    loadAll()
-    const id = setInterval(loadAll, POLL_INTERVAL_MS)
-    return () => clearInterval(id)
-  }, [loadAll])
+      } else setError('取得に失敗しました')
+    },
+    onError: () => setError('取得に失敗しました'),
+  })
 
   // ── client-side filter ──
   const filteredRows = useMemo(() => {
@@ -141,6 +120,8 @@ export default function InboxPage() {
         description="人間が返事してない LINE 会話の triage。auto_reply は人間の返事に数えない。"
       />
 
+      <PollingStatus reason={polling.reason} onResume={polling.resume} />
+
       <InboxSummaryBar
         total={summary.total}
         byAccount={summary.byAccount}
@@ -174,7 +155,7 @@ export default function InboxPage() {
         total={total}
         page={page}
         pageSize={PAGE_SIZE}
-        loading={loading}
+        loading={polling.fetching}
         onPageChange={setPage}
       />
     </div>

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -10,6 +10,8 @@ import { DropdownMenu } from '@cloudflare/kumo/components/dropdown'
 import { useAccount } from '@/contexts/account-context'
 import type { AccountWithStats } from '@/contexts/account-context'
 import { countryFlag } from '@/lib/country-flag'
+import { useActivityPolling } from '@/hooks/use-activity-polling'
+import { PollingStatus } from '@/components/shared/polling-status'
 import { UNANSWERED_REFRESH_EVENT } from '@/lib/events'
 import { getApiBase } from '@/lib/api-base'
 import { withBasePath } from '@/lib/base-path'
@@ -192,31 +194,16 @@ export default function Sidebar() {
   // チャット画面での status 変更・手動返信直後は UNANSWERED_REFRESH_EVENT で
   // 即時再取得する (ポーリング待ちだと操作してもバッジが減らないと感じるため)。
   const [unansweredCount, setUnansweredCount] = useState<number>(0)
-  useEffect(() => {
-    let cancelled = false
-    // 連続操作で fetch が並走した際、遅い古いレスポンスが新しい値を上書きしない
-    // ように発行順 seq でガードする。
-    let seq = 0
-    const fetchCount = async () => {
-      const mySeq = ++seq
-      try {
-        const { api } = await import('@/lib/api')
-        const res = await api.inbox.unanswered.count()
-        if (!cancelled && mySeq === seq && res.success) setUnansweredCount(res.data.total)
-      } catch {
-        // サイレント失敗
-      }
-    }
-    fetchCount()
-    const id = setInterval(fetchCount, 5 * 60_000)
-    const onRefresh = () => { void fetchCount() }
-    window.addEventListener(UNANSWERED_REFRESH_EVENT, onRefresh)
-    return () => {
-      cancelled = true
-      clearInterval(id)
-      window.removeEventListener(UNANSWERED_REFRESH_EVENT, onRefresh)
-    }
-  }, [])
+  const polling = useActivityPolling({
+    intervalMs: 5 * 60_000,
+    refreshEvent: UNANSWERED_REFRESH_EVENT,
+    load: async (signal) => {
+      const { api } = await import('@/lib/api')
+      return api.inbox.unanswered.count({ signal })
+    },
+    onData: (res) => { if (res.success) setUnansweredCount(res.data.total) },
+    onError: () => {}, // Keep the last count on transient failure.
+  })
 
   useEffect(() => { setIsOpen(false) }, [pathname])
   useEffect(() => {
@@ -289,6 +276,8 @@ export default function Sidebar() {
           </div>
         ))}
       </nav>
+
+      <div className="px-3 pb-3"><PollingStatus reason={polling.reason} onResume={polling.resume} /></div>
 
       {/* フッター */}
       <div className="border-t border-gray-200">

--- a/apps/web/src/components/shared/polling-status.test.ts
+++ b/apps/web/src/components/shared/polling-status.test.ts
@@ -1,0 +1,22 @@
+import { createElement, Children, isValidElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { Button } from '@cloudflare/kumo/components/button'
+import { expect, it, vi } from 'vitest'
+import { PollingStatus } from './polling-status'
+
+it.each(['idle', 'hidden'] as const)('shows the %s pause reason, stale-data explanation and an actionable resume button', (reason) => {
+  const onResume = vi.fn()
+  const html = renderToStaticMarkup(createElement(PollingStatus, { reason, onResume }))
+  expect(html).toContain('一時停止')
+  expect(html).toContain('前回取得した内容')
+  expect(html).toContain('更新を再開')
+  expect(html).toContain(reason === 'idle' ? '5分間操作がなかった' : '画面が非表示')
+  const element = PollingStatus({ reason, onResume })!
+  const children = Children.toArray(element.props.children).filter(isValidElement<{ onClick?: () => void }> )
+  const button = children.find((child) => child.type === Button)!
+  button.props.onClick!()
+  expect(onResume).toHaveBeenCalledOnce()
+})
+it('does not show a stale-data warning during normal active polling', () => {
+  expect(renderToStaticMarkup(createElement(PollingStatus, { reason: 'active', onResume: () => {} }))).toBe('')
+})

--- a/apps/web/src/components/shared/polling-status.tsx
+++ b/apps/web/src/components/shared/polling-status.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Button } from '@cloudflare/kumo/components/button'
+import type { PollingReason } from '../../lib/activity-polling'
+
+export function PollingStatus({ reason, onResume }: { reason: PollingReason; onResume: () => void }) {
+  if (reason === 'active') return null
+  return (
+    <div className="space-y-2 rounded border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600" role="status">
+      <p>{reason === 'hidden' ? '画面が非表示のため自動更新を一時停止しています。' : '5分間操作がなかったため自動更新を一時停止しています。'} 前回取得した内容を表示しています。</p>
+      <p>画面に戻って操作すると再開します。</p>
+      <Button type="button" size="sm" variant="secondary" onClick={onResume}>更新を再開</Button>
+    </div>
+  )
+}

--- a/apps/web/src/hooks/use-activity-polling.test.ts
+++ b/apps/web/src/hooks/use-activity-polling.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { useActivityPolling } from './use-activity-polling'
+
+// Hook lifecycle adapter only: no DOM/browser automation. Effects, stable refs,
+// dependency replacement and cleanup run the actual hook and polling controller.
+const hooks = vi.hoisted(() => ({ cursor: 0, slots: [] as any[], effects: [] as (() => void)[] }))
+vi.mock('react', () => ({
+  useRef(value: unknown) { const index = hooks.cursor++; return hooks.slots[index] ??= { current: value } },
+  useState(value: unknown) {
+    const index = hooks.cursor++
+    if (!(index in hooks.slots)) hooks.slots[index] = value
+    return [hooks.slots[index], (next: unknown) => { hooks.slots[index] = next }]
+  },
+  useCallback(callback: unknown) { hooks.cursor++; return callback },
+  useEffect(effect: () => () => void, deps: unknown[]) {
+    const index = hooks.cursor++, previous = hooks.slots[index]
+    if (!previous || deps.some((dep, i) => !Object.is(dep, previous.deps[i]))) {
+      hooks.effects.push(() => { previous?.cleanup(); hooks.slots[index] = { deps, cleanup: effect() } })
+    }
+  },
+}))
+function render<T>(options: Parameters<typeof useActivityPolling<T>>[0], commit = true) {
+  hooks.cursor = 0
+  const result = useActivityPolling(options)
+  if (commit) for (const effect of hooks.effects.splice(0)) effect()
+  return result
+}
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((yes) => { resolve = yes })
+  return { promise, resolve }
+}
+beforeEach(() => {
+  vi.useFakeTimers(); vi.setSystemTime(0)
+  hooks.cursor = 0; hooks.slots = []; hooks.effects = []
+  vi.stubGlobal('document', Object.assign(new EventTarget(), { visibilityState: 'visible' }))
+  vi.stubGlobal('window', new EventTarget())
+})
+afterEach(() => {
+  for (const slot of hooks.slots) slot?.cleanup?.()
+  vi.unstubAllGlobals(); vi.useRealTimers()
+})
+
+it('changing inline load/onData identities after state updates does not restart polling or create a fetch loop', async () => {
+  const requests = vi.fn(async () => 'value')
+  const initial = vi.fn(), current = vi.fn()
+  const options = (onData: typeof initial) => ({ intervalMs: 30_000, load: () => requests(), onData: (value: string) => onData(value), onError: () => {} })
+  render(options(initial)); await vi.advanceTimersByTimeAsync(0)
+  for (let i = 0; i < 20; i++) render(options(current))
+  expect(requests).toHaveBeenCalledTimes(1)
+  await vi.advanceTimersByTimeAsync(30_000)
+  expect(requests).toHaveBeenCalledTimes(2)
+  expect(initial).toHaveBeenCalledTimes(1)
+  expect(current).toHaveBeenCalledTimes(1)
+})
+
+it('a new account/resource key aborts the previous request and never commits its old data', async () => {
+  const old = deferred<string>()
+  const first = vi.fn((_signal: AbortSignal) => old.promise), second = vi.fn(async () => 'account-b')
+  const onData = vi.fn(), onError = vi.fn()
+  render({ intervalMs: 30_000, requestKey: 'a', load: first, onData, onError })
+  render({ intervalMs: 30_000, requestKey: 'b', load: second, onData, onError })
+  expect(first.mock.calls[0][0].aborted).toBe(true)
+  await vi.advanceTimersByTimeAsync(0)
+  old.resolve('account-a'); await vi.advanceTimersByTimeAsync(0)
+  expect(onData.mock.calls).toEqual([['account-b']])
+  expect(onError).not.toHaveBeenCalled()
+})
+
+it('rejects old-account data even before the replacement passive effect has cleaned up', async () => {
+  const old = deferred<string>()
+  const onData = vi.fn(), onError = vi.fn()
+  render({ intervalMs: 30_000, requestKey: 'a', load: () => old.promise, onData, onError })
+  render({ intervalMs: 30_000, requestKey: 'b', load: async () => 'b', onData, onError }, false)
+  old.resolve('a'); await vi.advanceTimersByTimeAsync(0)
+  expect(onData).not.toHaveBeenCalled()
+  for (const effect of hooks.effects.splice(0)) effect()
+  await vi.advanceTimersByTimeAsync(0)
+  expect(onData.mock.calls).toEqual([['b']])
+})
+
+it('an explicit resume restarts the mounted poller once and cleanup removes its event listeners', async () => {
+  const fetch = vi.fn(async () => 'fresh')
+  const options = { intervalMs: 30_000, load: fetch, onData: () => {}, onError: () => {}, refreshEvent: 'synthetic-refresh' }
+  const hook = render(options)
+  await vi.advanceTimersByTimeAsync(5 * 60_000)
+  const previous = fetch.mock.calls.length
+  hook.resume(); await vi.advanceTimersByTimeAsync(0)
+  expect(fetch).toHaveBeenCalledTimes(previous + 1)
+  for (const slot of hooks.slots) if (slot?.cleanup) { slot.cleanup(); delete slot.cleanup }
+  window.dispatchEvent(new Event('synthetic-refresh')); hook.resume()
+  await vi.advanceTimersByTimeAsync(60_000)
+  expect(fetch).toHaveBeenCalledTimes(previous + 1)
+})

--- a/apps/web/src/hooks/use-activity-polling.ts
+++ b/apps/web/src/hooks/use-activity-polling.ts
@@ -1,0 +1,41 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { browserPollingEnvironment, createActivityPoller, POLLING_RESUME_EVENT, type PollingState } from '../lib/activity-polling'
+
+export function useActivityPolling<T>(options: {
+  intervalMs: number
+  load: (signal: AbortSignal) => Promise<T>
+  onData: (value: T) => void
+  onError: (error: unknown) => void
+  refreshEvent?: string
+  /** Change only when the request's resource/account changes, not on render. */
+  requestKey?: string
+}) {
+  const callbacks = useRef(options)
+  callbacks.current = options
+  const [state, setState] = useState<PollingState>({ reason: 'active', fetching: true })
+  useEffect(() => {
+    const requestKey = options.requestKey
+    const currentScope = () => callbacks.current.requestKey === requestKey
+    const poller = createActivityPoller({
+      environment: browserPollingEnvironment(document, window),
+      intervalMs: options.intervalMs,
+      load: (signal) => currentScope()
+        ? callbacks.current.load(signal)
+        : Promise.reject(new DOMException('Request scope changed', 'AbortError')),
+      onData: (value) => { if (currentScope()) callbacks.current.onData(value) },
+      onError: (error) => { if (currentScope()) callbacks.current.onError(error) },
+      onState: (state) => { if (currentScope()) setState(state) },
+    })
+    const onRefresh = () => poller.refresh()
+    if (options.refreshEvent) window.addEventListener(options.refreshEvent, onRefresh)
+    return () => {
+      poller.dispose()
+      if (options.refreshEvent) window.removeEventListener(options.refreshEvent, onRefresh)
+    }
+  }, [options.intervalMs, options.refreshEvent, options.requestKey])
+  // A single explicit resume applies to both the inbox and the sidebar badge.
+  const resume = useCallback(() => window.dispatchEvent(new Event(POLLING_RESUME_EVENT)), [])
+  return { ...state, resume }
+}

--- a/apps/web/src/lib/activity-polling.test.ts
+++ b/apps/web/src/lib/activity-polling.test.ts
@@ -168,7 +168,7 @@ it('the browser event adapter observes visibility, activity, explicit resume and
   const env = browserPollingEnvironment(doc as unknown as Document, win as unknown as Window)
   const callback = vi.fn()
   const stop = env.subscribe(callback)
-  for (const event of ['pointerdown', 'pointermove', 'keydown', 'scroll', 'touchstart', 'focus']) win.dispatchEvent(new Event(event))
+  for (const event of ['pointerdown', 'pointermove', 'keydown', 'wheel', 'touchstart', 'focus']) win.dispatchEvent(new Event(event))
   doc.visibilityState = 'hidden'; doc.dispatchEvent(new Event('visibilitychange'))
   win.dispatchEvent(new Event(POLLING_RESUME_EVENT))
   expect(env.visible()).toBe(false)
@@ -194,4 +194,49 @@ it('one explicit resume wakes both mounted inbox and sidebar controllers exactly
   expect(loadInbox).toHaveBeenCalledTimes(inboxBefore + 1)
   expect(loadSidebar).toHaveBeenCalledTimes(sidebarBefore + 1)
   inbox.dispose(); sidebar.dispose()
+})
+
+it('programmatic scroll events after each refresh do not keep an unattended page polling', async () => {
+  const doc = Object.assign(new EventTarget(), { visibilityState: 'visible' })
+  const win = new EventTarget()
+  const environment = browserPollingEnvironment(doc as unknown as Document, win as unknown as Window)
+  const load = vi.fn(async () => 'fresh')
+  const states: PollingState[] = []
+  const poller = createActivityPoller({
+    environment, intervalMs: 30_000, load,
+    // Represents layout/scroll restoration effects, not a browser reproduction.
+    onData: () => win.dispatchEvent(new Event('scroll')),
+    onError: () => {}, onState: (state) => states.push(state),
+  })
+  await vi.advanceTimersByTimeAsync(POLLING_IDLE_MS)
+  expect(states.at(-1)).toEqual({ reason: 'idle', fetching: false })
+  expect(load).toHaveBeenCalledTimes(10)
+  for (let i = 0; i < 10; i++) {
+    win.dispatchEvent(new Event('scroll'))
+    await vi.advanceTimersByTimeAsync(30_000)
+  }
+  expect(load).toHaveBeenCalledTimes(10)
+  poller.dispose()
+})
+
+it('wheel input extends the idle deadline and resumes a paused page without a fetch for every wheel event', async () => {
+  const doc = Object.assign(new EventTarget(), { visibilityState: 'visible' })
+  const win = new EventTarget()
+  const environment = browserPollingEnvironment(doc as unknown as Document, win as unknown as Window)
+  const load = vi.fn(async () => 'fresh')
+  const states: PollingState[] = []
+  const poller = createActivityPoller({ environment, intervalMs: 30_000, load, onData: () => {}, onError: () => {}, onState: (state) => states.push(state) })
+  for (let i = 0; i < 6; i++) {
+    await vi.advanceTimersByTimeAsync(60_000)
+    for (let n = 0; n < 20; n++) win.dispatchEvent(new Event('wheel'))
+  }
+  expect(states.at(-1)?.reason).toBe('active')
+  expect(load).toHaveBeenCalledTimes(13)
+  await vi.advanceTimersByTimeAsync(POLLING_IDLE_MS)
+  expect(states.at(-1)?.reason).toBe('idle')
+  const previous = load.mock.calls.length
+  win.dispatchEvent(new Event('wheel')); await flush()
+  expect(states.at(-1)?.reason).toBe('active')
+  expect(load).toHaveBeenCalledTimes(previous + 1)
+  poller.dispose()
 })

--- a/apps/web/src/lib/activity-polling.test.ts
+++ b/apps/web/src/lib/activity-polling.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { browserPollingEnvironment, createActivityPoller, POLLING_IDLE_MS, POLLING_RESUME_EVENT, type PollingEnvironment, type PollingState } from './activity-polling'
+
+beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(0) })
+afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks() })
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no })
+  return { promise, resolve, reject }
+}
+function setup(load = vi.fn(async (_signal: AbortSignal) => 'fresh'), visibleInitially = true) {
+  let visible = visibleInitially
+  let notify: ((event: 'activity' | 'visibility' | 'resume') => void) | undefined
+  const unsubscribe = vi.fn(() => { notify = undefined })
+  const environment: PollingEnvironment = {
+    now: () => Date.now(), visible: () => visible,
+    setTimer: (callback, ms) => setTimeout(callback, ms), clearTimer: clearTimeout,
+    subscribe: (callback) => { notify = callback; return unsubscribe },
+  }
+  const onData = vi.fn(), onError = vi.fn(), states: PollingState[] = []
+  const poller = createActivityPoller({ environment, intervalMs: 30_000, load, onData, onError, onState: (state) => states.push(state) })
+  return { ...poller, load, onData, onError, states, unsubscribe,
+    visibility: (next: boolean) => { visible = next; notify?.('visibility') },
+    activity: () => notify?.('activity'), resume: () => notify?.('resume'),
+  }
+}
+const flush = () => vi.advanceTimersByTimeAsync(0)
+
+describe('activity-aware read polling', () => {
+  it('stops foreground polling after five idle minutes and keeps eight unattended hours quiet', async () => {
+    const s = setup()
+    await vi.advanceTimersByTimeAsync(POLLING_IDLE_MS)
+    expect(s.load).toHaveBeenCalledTimes(10) // t=0 then 30s..270s; no call at the idle boundary
+    expect(s.states.at(-1)).toEqual({ reason: 'idle', fetching: false })
+    await vi.advanceTimersByTimeAsync(8 * 60 * 60_000)
+    expect(s.load).toHaveBeenCalledTimes(10)
+    s.activity(); await flush()
+    expect(s.load).toHaveBeenCalledTimes(11)
+    expect(s.states.at(-1)?.reason).toBe('active')
+    s.dispose()
+  })
+
+  it('does not fetch in an initially hidden tab and resumes immediately when shown', async () => {
+    const s = setup(undefined, false)
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+    expect(s.load).not.toHaveBeenCalled()
+    s.resume(); s.activity(); await flush()
+    expect(s.load).not.toHaveBeenCalled()
+    s.visibility(true); await flush()
+    expect(s.load).toHaveBeenCalledTimes(1)
+    s.visibility(false)
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+    expect(s.load).toHaveBeenCalledTimes(1)
+    s.visibility(true); await flush()
+    expect(s.load).toHaveBeenCalledTimes(2)
+    s.dispose()
+  })
+
+  it('ongoing keyboard/pointer activity extends the idle deadline without an extra fetch per event', async () => {
+    const s = setup(); await flush()
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersByTimeAsync(60_000)
+      for (let n = 0; n < 100; n++) s.activity()
+    }
+    expect(s.load).toHaveBeenCalledTimes(13)
+    expect(s.states.at(-1)?.reason).toBe('active')
+    s.dispose()
+  })
+
+  it('never overlaps a slow request and waits one interval after it settles', async () => {
+    const first = deferred<string>()
+    const s = setup(vi.fn(() => first.promise))
+    await vi.advanceTimersByTimeAsync(90_000)
+    expect(s.load).toHaveBeenCalledTimes(1)
+    first.resolve('one'); await flush()
+    await vi.advanceTimersByTimeAsync(29_999)
+    expect(s.load).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(s.load).toHaveBeenCalledTimes(2)
+    s.dispose()
+  })
+
+  it('aborts on hide, ignores a stale success, and queues one fresh request after returning', async () => {
+    const first = deferred<string>()
+    const load = vi.fn<(_signal: AbortSignal) => Promise<string>>().mockImplementationOnce(() => first.promise).mockResolvedValue('current')
+    const s = setup(load)
+    s.visibility(false)
+    expect(load.mock.calls[0][0].aborted).toBe(true)
+    s.visibility(true); s.activity(); s.resume()
+    expect(load).toHaveBeenCalledTimes(1)
+    first.resolve('stale'); await flush()
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(s.onData.mock.calls).toEqual([['current']])
+    expect(s.onError).not.toHaveBeenCalled()
+    s.dispose()
+  })
+
+  it('coalesces mutation refreshes and does not let their old result overwrite fresh data', async () => {
+    const first = deferred<string>()
+    const load = vi.fn<(_signal: AbortSignal) => Promise<string>>().mockImplementationOnce(() => first.promise).mockResolvedValue('latest')
+    const s = setup(load)
+    s.refresh(); s.refresh(); s.refresh()
+    expect(load).toHaveBeenCalledTimes(1)
+    first.resolve('old'); await flush()
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(s.onData.mock.calls).toEqual([['latest']])
+    s.visibility(false); s.refresh()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(load).toHaveBeenCalledTimes(2)
+    s.visibility(true); await flush()
+    expect(load).toHaveBeenCalledTimes(3)
+    s.dispose()
+  })
+
+  it('manual resume after pointer activity reuses the request already started by that activity', async () => {
+    const slow = deferred<string>()
+    const load = vi.fn<(_signal: AbortSignal) => Promise<string>>().mockResolvedValue('first')
+    const s = setup(load)
+    await vi.advanceTimersByTimeAsync(POLLING_IDLE_MS)
+    load.mockImplementation(() => slow.promise)
+    const previous = load.mock.calls.length
+    s.activity(); s.resume(); s.resume()
+    slow.resolve('resumed'); await flush()
+    expect(load).toHaveBeenCalledTimes(previous + 1)
+    s.dispose()
+  })
+
+  it('treats pause abort as normal and ignores completion/error after disposal', async () => {
+    const first = deferred<string>()
+    const s = setup(vi.fn(() => first.promise))
+    s.visibility(false)
+    first.reject(new DOMException('Aborted', 'AbortError')); await flush()
+    expect(s.onError).not.toHaveBeenCalled()
+    s.dispose()
+    expect(s.unsubscribe).toHaveBeenCalledOnce()
+    const states = s.states.length
+    s.activity(); s.refresh(); s.resume()
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+    expect(s.states).toHaveLength(states)
+    expect(s.load).toHaveBeenCalledTimes(1)
+  })
+
+  it('unmount aborts a pending transport, ignores its result, and clears every timer', async () => {
+    const first = deferred<string>()
+    const load = vi.fn((_signal: AbortSignal) => first.promise)
+    const s = setup(load)
+    s.dispose()
+    expect(load.mock.calls[0][0].aborted).toBe(true)
+    first.resolve('too late'); await flush()
+    expect(s.onData).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps retrying real errors at the existing interval while active', async () => {
+    const load = vi.fn<(_signal: AbortSignal) => Promise<string>>().mockRejectedValueOnce(new Error('offline')).mockResolvedValue('recovered')
+    const s = setup(load); await flush()
+    expect(s.onError).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(s.onData.mock.calls).toEqual([['recovered']])
+    s.dispose()
+  })
+})
+
+it('the browser event adapter observes visibility, activity, explicit resume and cleans listeners', () => {
+  const doc = Object.assign(new EventTarget(), { visibilityState: 'visible' })
+  const win = new EventTarget()
+  const env = browserPollingEnvironment(doc as unknown as Document, win as unknown as Window)
+  const callback = vi.fn()
+  const stop = env.subscribe(callback)
+  for (const event of ['pointerdown', 'pointermove', 'keydown', 'scroll', 'touchstart', 'focus']) win.dispatchEvent(new Event(event))
+  doc.visibilityState = 'hidden'; doc.dispatchEvent(new Event('visibilitychange'))
+  win.dispatchEvent(new Event(POLLING_RESUME_EVENT))
+  expect(env.visible()).toBe(false)
+  expect(callback.mock.calls.map(([event]) => event)).toEqual(['activity', 'activity', 'activity', 'activity', 'activity', 'activity', 'visibility', 'resume'])
+  stop()
+  win.dispatchEvent(new Event('pointerdown')); doc.dispatchEvent(new Event('visibilitychange'))
+  expect(callback).toHaveBeenCalledTimes(8)
+})
+
+it('one explicit resume wakes both mounted inbox and sidebar controllers exactly once', async () => {
+  const doc = Object.assign(new EventTarget(), { visibilityState: 'visible' })
+  const win = new EventTarget()
+  const environment = browserPollingEnvironment(doc as unknown as Document, win as unknown as Window)
+  const loadInbox = vi.fn(async () => 'inbox'), loadSidebar = vi.fn(async () => 'sidebar')
+  const base = { environment, onData: () => {}, onError: () => {}, onState: () => {} }
+  const inbox = createActivityPoller({ ...base, load: loadInbox, intervalMs: 30_000 })
+  const sidebar = createActivityPoller({ ...base, load: loadSidebar, intervalMs: 5 * 60_000 })
+  await vi.advanceTimersByTimeAsync(POLLING_IDLE_MS)
+  const inboxBefore = loadInbox.mock.calls.length, sidebarBefore = loadSidebar.mock.calls.length
+  win.dispatchEvent(new Event('pointerdown'))
+  win.dispatchEvent(new Event(POLLING_RESUME_EVENT))
+  await flush()
+  expect(loadInbox).toHaveBeenCalledTimes(inboxBefore + 1)
+  expect(loadSidebar).toHaveBeenCalledTimes(sidebarBefore + 1)
+  inbox.dispose(); sidebar.dispose()
+})

--- a/apps/web/src/lib/activity-polling.ts
+++ b/apps/web/src/lib/activity-polling.ts
@@ -1,0 +1,147 @@
+/** Read-only dashboard polling. Active updates/deployments must not use this. */
+export const POLLING_IDLE_MS = 5 * 60_000
+export const POLLING_RESUME_EVENT = 'lh:polling-resume'
+export type PollingReason = 'active' | 'hidden' | 'idle'
+export interface PollingState { reason: PollingReason; fetching: boolean }
+export interface PollingEnvironment {
+  now: () => number
+  visible: () => boolean
+  setTimer: (callback: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimer: (timer: ReturnType<typeof setTimeout>) => void
+  subscribe: (callback: (event: 'activity' | 'visibility' | 'resume') => void) => () => void
+}
+
+export function createActivityPoller<T>(options: {
+  environment: PollingEnvironment
+  intervalMs: number
+  idleMs?: number
+  load: (signal: AbortSignal) => Promise<T>
+  onData: (value: T) => void
+  onError: (error: unknown) => void
+  onState: (state: PollingState) => void
+}) {
+  const { environment: env } = options
+  const idleMs = options.idleMs ?? POLLING_IDLE_MS
+  let state: PollingState = { reason: env.visible() ? 'active' : 'hidden', fetching: false }
+  let lastActivity = env.now()
+  let generation = 0
+  let disposed = false
+  let pendingRefresh = false
+  let inFlight: AbortController | null = null
+  let pollTimer: ReturnType<typeof setTimeout> | undefined
+  let idleTimer: ReturnType<typeof setTimeout> | undefined
+  const publish = () => { if (!disposed) options.onState({ ...state }) }
+  function clearPoll() { if (pollTimer !== undefined) env.clearTimer(pollTimer); pollTimer = undefined }
+  function clearIdle() { if (idleTimer !== undefined) env.clearTimer(idleTimer); idleTimer = undefined }
+  function pause(reason: 'hidden' | 'idle') {
+    clearPoll()
+    clearIdle()
+    generation++
+    inFlight?.abort()
+    state = { reason, fetching: false }
+    publish()
+  }
+  function active(): boolean {
+    if (disposed) return false
+    if (!env.visible()) { if (state.reason !== 'hidden') pause('hidden'); return false }
+    if (env.now() - lastActivity >= idleMs) { if (state.reason !== 'idle') pause('idle'); return false }
+    return state.reason === 'active'
+  }
+  function armIdle() {
+    if (idleTimer !== undefined || disposed) return
+    idleTimer = env.setTimer(() => {
+      idleTimer = undefined
+      if (active()) armIdle()
+    }, Math.max(0, idleMs - (env.now() - lastActivity)))
+  }
+  async function run() {
+    if (!active()) return
+    // A transport that ignores abort must settle before its replacement starts.
+    if (inFlight) { pendingRefresh = true; return }
+    clearPoll()
+    pendingRefresh = false
+    const controller = new AbortController()
+    inFlight = controller
+    const issued = generation
+    state.fetching = true
+    publish()
+    const current = () => !disposed && issued === generation && !controller.signal.aborted && active()
+    try {
+      const value = await options.load(controller.signal)
+      if (current()) options.onData(value)
+    } catch (error) {
+      if (current()) options.onError(error)
+    } finally {
+      inFlight = null
+      if (!disposed && state.reason === 'active') {
+        state.fetching = false
+        publish()
+        if (active()) {
+          if (pendingRefresh) void run()
+          else pollTimer = env.setTimer(() => { pollTimer = undefined; void run() }, options.intervalMs)
+        }
+      }
+    }
+  }
+  function activity(manual = false) {
+    if (disposed || !env.visible()) return
+    const wasPaused = state.reason !== 'active'
+    lastActivity = env.now()
+    state.reason = 'active'
+    armIdle()
+    if (wasPaused) { publish(); void run() }
+    // pointerdown may already have resumed the same request before a button's
+    // click. Reuse it instead of aborting/repeating the just-started fetch.
+    else if (manual && !inFlight) void run()
+  }
+  const unsubscribe = env.subscribe((event) => {
+    if (event === 'visibility' && !env.visible()) pause('hidden')
+    else activity(event === 'resume')
+  })
+  publish()
+  if (state.reason === 'active') { armIdle(); void run() }
+  return {
+    /** Mutation notifications invalidate an old result, but do not wake a hidden/idle tab. */
+    refresh() {
+      if (disposed) return
+      generation++
+      pendingRefresh = true
+      inFlight?.abort()
+      if (active()) void run()
+    },
+    dispose() {
+      disposed = true
+      generation++
+      clearPoll()
+      clearIdle()
+      unsubscribe()
+      inFlight?.abort()
+    },
+  }
+}
+
+/** Adapter is injectable so visibility/activity are tested without a browser. */
+export function browserPollingEnvironment(doc: Document, win: Window): PollingEnvironment {
+  return {
+    now: () => Date.now(),
+    visible: () => doc.visibilityState !== 'hidden',
+    setTimer: (callback, ms) => setTimeout(callback, ms),
+    clearTimer: (timer) => clearTimeout(timer),
+    subscribe(callback) {
+      const activity = () => callback('activity')
+      const visibility = () => callback('visibility')
+      const resume = () => callback('resume')
+      const events = ['pointerdown', 'pointermove', 'keydown', 'scroll', 'touchstart'] as const
+      for (const event of events) win.addEventListener(event, activity, { passive: true, capture: true })
+      win.addEventListener('focus', activity)
+      win.addEventListener(POLLING_RESUME_EVENT, resume)
+      doc.addEventListener('visibilitychange', visibility)
+      return () => {
+        for (const event of events) win.removeEventListener(event, activity, { capture: true })
+        win.removeEventListener('focus', activity)
+        win.removeEventListener(POLLING_RESUME_EVENT, resume)
+        doc.removeEventListener('visibilitychange', visibility)
+      }
+    },
+  }
+}

--- a/apps/web/src/lib/activity-polling.ts
+++ b/apps/web/src/lib/activity-polling.ts
@@ -131,7 +131,10 @@ export function browserPollingEnvironment(doc: Document, win: Window): PollingEn
       const activity = () => callback('activity')
       const visibility = () => callback('visibility')
       const resume = () => callback('resume')
-      const events = ['pointerdown', 'pointermove', 'keydown', 'scroll', 'touchstart'] as const
+      // Scroll events also come from layout shifts, anchor adjustment and
+      // scrollTo(). Only input events may extend the idle deadline; otherwise
+      // a refresh that adjusts scrolling could keep its own polling alive.
+      const events = ['pointerdown', 'pointermove', 'keydown', 'wheel', 'touchstart'] as const
       for (const event of events) win.addEventListener(event, activity, { passive: true, capture: true })
       win.addEventListener('focus', activity)
       win.addEventListener(POLLING_RESUME_EVENT, resume)

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1255,7 +1255,7 @@ export const api = {
         minWaitMinutes?: number;
         page?: number;
         pageSize?: number;
-      }) => {
+      }, request?: Pick<RequestInit, 'signal'>) => {
         const p = new URLSearchParams();
         if (opts?.q) p.set('q', opts.q);
         if (opts?.account) p.set('account', opts.account);
@@ -1279,14 +1279,14 @@ export const api = {
             lastIncomingType: string;
             lastIncomingContent: string;
           }>;
-        }>>(`/api/inbox/unanswered${qs ? `?${qs}` : ''}`);
+        }>>(`/api/inbox/unanswered${qs ? `?${qs}` : ''}`, request);
       },
-      count: () =>
+      count: (request?: Pick<RequestInit, 'signal'>) =>
         fetchApi<ApiResponse<{
           total: number;
           byAccount: Array<{ accountId: string; accountName: string; count: number }>;
           oldestWaitMinutes: number | null;
-        }>>('/api/inbox/unanswered/count'),
+        }>>('/api/inbox/unanswered/count', request),
     },
   },
   richMenuGroups: {

--- a/apps/worker/src/routes/friends-list-tags.test.ts
+++ b/apps/worker/src/routes/friends-list-tags.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { URL } from 'node:url';
+import { Hono } from 'hono';
+import { getFriendTagsByIds } from '@line-crm/db';
+import { sqliteD1 } from '../test-support/sqlite-d1.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { friends } from './friends.js';
+import type { Env } from '../index.js';
+
+const schema = readFileSync(new URL('../../../../packages/db/bootstrap.sql', import.meta.url), 'utf8');
+afterEach(() => { vi.restoreAllMocks(); });
+function setup() {
+  const { db, sqlite } = sqliteD1();
+  sqlite.exec(schema);
+  vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('No external network permitted'));
+  sqlite.exec("INSERT INTO line_accounts(id,channel_id,name,channel_access_token,channel_secret) VALUES('a','synthetic-a','a','synthetic-token','synthetic-secret'),('b','synthetic-b','b','synthetic-token','synthetic-secret')");
+  const insert = sqlite.prepare('INSERT INTO friends(id,line_user_id,line_account_id,display_name,created_at) VALUES(?,?,?,?,?)');
+  for (let i = 0; i < 205; i++) insert.run(`f-${String(i).padStart(3, '0')}`, `synthetic-user-${i}`, 'a', `Synthetic ${i}`, `2020-01-01T00:${String(Math.floor(i / 60)).padStart(2, '0')}:${String(i % 60).padStart(2, '0')}`);
+  insert.run('other-account', 'synthetic-other', 'b', 'Other synthetic friend', '2021-01-01');
+  sqlite.exec("INSERT INTO tags(id,name,color) VALUES('z','Zebra','#112233'),('a','Alpha','#445566'),('private-tag','Other account tag','#778899')");
+  const attach = sqlite.prepare('INSERT INTO friend_tags(friend_id,tag_id) VALUES(?,?)');
+  for (let i = 0; i < 204; i++) { attach.run(`f-${String(i).padStart(3, '0')}`, 'z'); attach.run(`f-${String(i).padStart(3, '0')}`, 'a'); }
+  attach.run('other-account', 'private-tag');
+  const statements: Array<{ sql: string; args: unknown[] }> = [];
+  const prepare = db.prepare.bind(db);
+  vi.spyOn(db, 'prepare').mockImplementation((sql) => {
+    const entry = { sql, args: [] as unknown[] }; statements.push(entry);
+    const statement = prepare(sql), bind = statement.bind.bind(statement);
+    statement.bind = (...args: unknown[]) => {
+      entry.args = args;
+      if (args.length > 100) throw new Error('D1 bind limit exceeded');
+      return bind(...args);
+    };
+    return statement;
+  });
+  const tagQueries = () => statements.filter(({ sql }) => /JOIN (?:friend_tags|tags) /i.test(sql) && /ft.friend_id/.test(sql));
+  const app = new Hono<Env>();
+  app.use('*', authMiddleware);
+  app.route('/', friends);
+  async function list(query: string, authorized = true) {
+    const response = await app.request(`/api/friends?${query}`, { headers: authorized ? { Authorization: 'Bearer synthetic-owner-key' } : {} }, { DB: db, API_KEY: 'synthetic-owner-key' } as Env['Bindings']);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    return response;
+  }
+  return { db, sqlite, statements, tagQueries, list };
+}
+
+describe('friend list page-scoped tag enrichment (Issue #331)', () => {
+  it('uses one tag query for a page and preserves account, pagination, item order and tag shape/name order', async () => {
+    const s = setup();
+    try {
+      const response = await s.list('lineAccountId=a&sort=oldest&limit=2&offset=1');
+      expect(response.status).toBe(200);
+      const body = await response.json() as { data: { items: Array<{ id: string; tags: Array<{ id: string; name: string; color: string; createdAt: string }> }>; total: number } };
+      expect(body.data.total).toBe(205);
+      expect(body.data.items.map((friend) => friend.id)).toEqual(['f-001', 'f-002']);
+      expect(body.data.items[0].tags.map((tag) => [tag.id, tag.name, tag.color])).toEqual([['a', 'Alpha', '#445566'], ['z', 'Zebra', '#112233']]);
+      expect(Object.keys(body.data.items[0].tags[0]).sort()).toEqual(['color', 'createdAt', 'id', 'name']);
+      expect(s.tagQueries()).toHaveLength(1);
+      expect(s.tagQueries()[0].args).toEqual(['f-001', 'f-002']);
+    } finally { s.sqlite.close(); }
+  });
+
+  it.each([100, 101, 205])('limits every bind list to 100 for a %i-friend page', async (limit) => {
+    const s = setup();
+    try {
+      const response = await s.list(`lineAccountId=a&sort=oldest&limit=${limit}`);
+      expect(response.status).toBe(200);
+      const body = await response.json() as { data: { items: Array<{ id: string; tags: unknown[] }> } };
+      expect(body.data.items).toHaveLength(limit);
+      expect(s.tagQueries()).toHaveLength(Math.ceil(limit / 100));
+      expect(s.tagQueries().every((query) => query.args.length <= 100)).toBe(true);
+      expect(s.tagQueries().flatMap((query) => query.args)).not.toContain('other-account');
+      if (limit === 205) expect(body.data.items[204].tags).toEqual([]);
+    } finally { s.sqlite.close(); }
+  });
+
+  it('does no tag reads for includeTags=false or an empty selected page', async () => {
+    const s = setup();
+    try {
+      const response = await s.list('lineAccountId=a&includeTags=false&limit=2');
+      const body = await response.json() as { data: { items: Array<{ tags: unknown[] }> } };
+      expect(body.data.items.every((friend) => friend.tags.length === 0)).toBe(true);
+      await s.list('lineAccountId=a&offset=999&limit=2');
+      expect(s.tagQueries()).toHaveLength(0);
+    } finally { s.sqlite.close(); }
+  });
+
+  it('preserves tag filtering and rejects unauthenticated access before the list query', async () => {
+    const s = setup();
+    try {
+      expect((await s.list('lineAccountId=a&tagId=a&limit=2', false)).status).toBe(401);
+      expect(s.tagQueries()).toHaveLength(0);
+      const response = await s.list('lineAccountId=b&tagId=private-tag&limit=2');
+      const body = await response.json() as { data: { items: Array<{ id: string; tags: Array<{ id: string }> }> } };
+      expect(body.data.items.map((friend) => friend.id)).toEqual(['other-account']);
+      expect(body.data.items[0].tags.map((tag) => tag.id)).toEqual(['private-tag']);
+    } finally { s.sqlite.close(); }
+  });
+
+  it('the bulk helper deduplicates requested IDs and includes empty results without reading unrelated tags', async () => {
+    const s = setup();
+    try {
+      expect((await getFriendTagsByIds(s.db, [])).size).toBe(0);
+      const result = await getFriendTagsByIds(s.db, ['f-204', 'f-000', 'f-000']);
+      expect(result.get('f-204')).toEqual([]);
+      expect(result.get('f-000')?.map((tag) => tag.name)).toEqual(['Alpha', 'Zebra']);
+      expect(result.has('other-account')).toBe(false);
+      expect(s.tagQueries()).toHaveLength(1);
+      expect(s.tagQueries()[0].args).toEqual(['f-204', 'f-000']);
+    } finally { s.sqlite.close(); }
+  });
+});

--- a/apps/worker/src/routes/friends.ts
+++ b/apps/worker/src/routes/friends.ts
@@ -6,6 +6,7 @@ import {
   addTagToFriend,
   removeTagFromFriend,
   getFriendTags,
+  getFriendTagsByIds,
   getFormSubmissionsByFriend,
   getScenarios,
   enrollFriendInScenario,
@@ -90,8 +91,7 @@ friends.get('/api/friends', async (c) => {
     const tagId = c.req.query('tagId');
     const lineAccountId = c.req.query('lineAccountId');
     const search = c.req.query('search');
-    // ?includeTags=false skips per-row tag enrichment (N+1 of getFriendTags
-    // → ~50 extra D1 reads on a wide list query). The list view needs tags
+    // ?includeTags=false skips tag enrichment. The list view needs tags
     // for filter chips, but autocomplete-style consumers (test-recipient
     // picker, broadcast recipient picker) only render id/displayName/picture
     // and pay the cost for nothing. Default true to keep the historical
@@ -237,17 +237,13 @@ friends.get('/api/friends', async (c) => {
     const listResult = await listStmt.bind(...listBinds).all<DbFriend>();
     const items = listResult.results;
 
-    // Fetch tags for each friend in parallel so the list response includes tags.
-    // Skipped when ?includeTags=false (autocomplete consumers don't render
-    // tags and would otherwise pay N D1 reads per keystroke).
-    let itemsWithTags = includeTags
-      ? await Promise.all(
-          items.map(async (friend) => {
-            const tags = await getFriendTags(db, friend.id);
-            return { ...serializeFriendListRow(friend, includeChatStatus), tags: tags.map(serializeTag) };
-          }),
-        )
-      : items.map((friend) => ({ ...serializeFriendListRow(friend, includeChatStatus), tags: [] }));
+    // Enrich only IDs selected by the existing filters and pagination. Chunked
+    // bulk lookup preserves friend order and tag-name order without N+1 queries.
+    const tagsByFriend = includeTags ? await getFriendTagsByIds(db, items.map((friend) => friend.id)) : new Map<string, DbTag[]>();
+    let itemsWithTags = items.map((friend) => ({
+      ...serializeFriendListRow(friend, includeChatStatus),
+      tags: (tagsByFriend.get(friend.id) ?? []).map(serializeTag),
+    }));
 
     // Optional: hydrate chat status (latest in/out message, active scenario,
     // derived "handled" flag). Three batched queries instead of N×3 to keep

--- a/packages/db/src/tags.ts
+++ b/packages/db/src/tags.ts
@@ -237,6 +237,26 @@ export async function getFriendTags(
   return result.results;
 }
 
+/** Read tags only for an already-selected page. D1 allows 100 binds per query. */
+export async function getFriendTagsByIds(
+  db: D1Database,
+  friendIds: readonly string[],
+): Promise<Map<string, Tag[]>> {
+  const ids = [...new Set(friendIds)];
+  const byFriend = new Map<string, Tag[]>(ids.map((id) => [id, []]));
+  for (let offset = 0; offset < ids.length; offset += 100) {
+    const chunk = ids.slice(offset, offset + 100);
+    const result = await db.prepare(
+      `SELECT ft.friend_id, t.* FROM friend_tags ft
+       INNER JOIN tags t ON t.id = ft.tag_id
+       WHERE ft.friend_id IN (${chunk.map(() => '?').join(',')})
+       ORDER BY t.name ASC`,
+    ).bind(...chunk).all<Tag & { friend_id: string }>();
+    for (const { friend_id, ...tag } of result.results) byFriend.get(friend_id)?.push(tag);
+  }
+  return byFriend;
+}
+
 import type { Friend } from './friends';
 
 export async function getFriendsByTag(


### PR DESCRIPTION
Notifications and the sidebar continued polling while hidden or unattended, and a page of friends issued one tag query per friend.

Pause those two polling loops while hidden or after five minutes without user input; resume on user activity, visibility, or the visible manual control. Cancel superseded requests and discard stale results, while preserving the current inbox/account filtering behavior. Programmatic scrolling does not reset the idle timer.

Load tags in bounded batches for only the friends on the selected page, preserving the existing response shape and authorization checks. The chat recipient picker opts out of unused tags.

Validation: polling controller, hook lifecycle mock, server-rendered controls, and seven SQLite-backed friend/tag route cases pass; Web and Worker type checks pass. Browser automation was not used, and no production database cost measurement is claimed.

Closes #331.
