### PR TITLE
fix(release): align capability and package versions with v0.24.1

### DIFF
--- a/apps/worker/src/routes/capabilities.ts
+++ b/apps/worker/src/routes/capabilities.ts
@@ -3,7 +3,7 @@ import type { Env } from '../index.js';
 
 // Kept in lockstep with root package.json by scripts/sync-versions.sh, which the
 // pre-push hook verifies. Bumping this by hand alone will fail that check.
-export const HARNESS_VERSION = '0.24.0';
+export const HARNESS_VERSION = '0.24.1';
 export const API_VERSION = 1;
 export const CONNECTOR_VERSION = '2026-05-20';
 export const MIN_APP_VERSION = '1.0.0';

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/mcp-server",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "MCP server for L Harness — operate a LINE official account from AI agents over MCP",
   "type": "module",
   "bin": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line-harness/sdk",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "AI-native SDK for L Harness — programmatic LINE official account automation",
   "type": "module",
   "exports": {


### PR DESCRIPTION
The v0.24.1 release still reports 0.24.0 from `/api/capabilities`, and its SDK/MCP source versions fail the existing umbrella version check. Align these three version values with the root, Worker and Admin release metadata.

Validation: Node20.20.2 SDK/MCP builds and typechecks,71 existing tests, and the capabilities response/root-version assertion pass. The existing version synchronization check passes; lockfile changes are unnecessary because the SDK dependency remains a workspace link.
