### PR TITLE
fix(webinar): 相談枠の案内文を「15分」固定から予約メニューの所要時間に合わせる

### DIFF
--- a/apps/worker/src/client/webinar/main.tsx
+++ b/apps/worker/src/client/webinar/main.tsx
@@ -1293,7 +1293,9 @@ function FormSheet({
                 <p className="text-2xl">🎉</p>
                 <p className="mt-2 text-lg font-bold">回答を送信しました</p>
                 <p className="mt-1 text-sm text-gray-500">
-                  空いている15分枠を1つ選んでください。
+                  {consultation
+                    ? `空いている${consultation.menu.durationMinutes}分枠を1つ選んでください。`
+                    : '空いている枠を1つ選んでください。'}
                 </p>
                 {(consultation?.fallbackUrl || completionUrl) && (
                   <button
@@ -1492,7 +1494,7 @@ function FormSheet({
                     : `あと${remainingRequiredCount}項目を選択`}
               </button>
               <p className="mt-2 text-center text-xs text-gray-500">
-                送信後、空いている15分枠を選べます
+                送信後、空いている枠を選べます
               </p>
             </div>
           </div>


### PR DESCRIPTION
## 変更内容

ライブCTA（`apps/worker/src/client/webinar/main.tsx`）の案内文2か所が「15分枠」と固定で表示されるため、予約メニューの所要時間が15分以外（例: 30分）のとき実際の枠と食い違います。

- 送信後の案内: 取得済みの `consultation.menu.durationMinutes` を表示します（未取得時は「空いている枠を1つ選んでください。」）
- 送信前のフッター: この時点では所要時間が未確定なので「送信後、空いている枠を選べます」にしました

## 確認

- v0.24.1 の自前環境（所要時間30分の予約メニュー）で、フォーム送信→枠選択→確定まで動作することを確認したうえで、文言だけを変更しています
- ロジック・APIの変更はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)